### PR TITLE
feat(clash): add default core secret and impl port checker before clash start

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -723,6 +723,7 @@ dependencies = [
  "tracing-futures",
  "tracing-log",
  "tracing-subscriber",
+ "uuid",
  "warp",
  "which 6.0.0",
  "window-shadows",

--- a/backend/tauri/Cargo.toml
+++ b/backend/tauri/Cargo.toml
@@ -83,6 +83,7 @@ tracing-appender = { version = "0.2", features = ["parking_lot"] }
 base64 = "0.21"
 single-instance = "0.3.3"
 tauri-plugin-deep-link = { path = "../tauri-plugin-deep-link", version = "0.1.2" }
+uuid = "1.7.0"
 
 [target.'cfg(windows)'.dependencies]
 deelevate = "0.2.0"

--- a/backend/tauri/src/cmds.rs
+++ b/backend/tauri/src/cmds.rs
@@ -192,7 +192,7 @@ pub async fn patch_verge_config(payload: IVerge) -> CmdResult {
 }
 
 #[tauri::command]
-pub async fn change_clash_core(clash_core: Option<ClashCore>) -> CmdResult {
+pub async fn change_clash_core(clash_core: Option<nyanpasu::ClashCore>) -> CmdResult {
     wrap_err!(CoreManager::global().change_core(clash_core).await)
 }
 
@@ -272,7 +272,7 @@ pub async fn fetch_latest_core_versions() -> CmdResult<ManifestVersionLatest> {
 }
 
 #[tauri::command]
-pub async fn get_core_version(core_type: ClashCore) -> CmdResult<String> {
+pub async fn get_core_version(core_type: nyanpasu::ClashCore) -> CmdResult<String> {
     match tokio::task::spawn_blocking(move || resolve::resolve_core_version(&core_type)).await {
         Ok(Ok(version)) => Ok(version),
         Ok(Err(err)) => Err(format!("{err}")),
@@ -305,7 +305,7 @@ pub async fn collect_logs() -> CmdResult {
 }
 
 #[tauri::command]
-pub async fn update_core(core_type: ClashCore) -> CmdResult {
+pub async fn update_core(core_type: nyanpasu::ClashCore) -> CmdResult {
     wrap_err!(
         updater::Updater::global()
             .read()

--- a/backend/tauri/src/config/clash.rs
+++ b/backend/tauri/src/config/clash.rs
@@ -32,7 +32,10 @@ impl IClashTemp {
         map.insert("external-controller".into(), "127.0.0.1:9872".into());
         #[cfg(not(debug_assertions))]
         map.insert("external-controller".into(), "127.0.0.1:17650".into());
-        map.insert("secret".into(), "".into());
+        map.insert(
+            "secret".into(),
+            uuid::Uuid::new_v4().to_string().to_lowercase().into(), // generate a uuid v4 as default secret to secure the communication between clash and the client
+        );
         #[cfg(feature = "default-meta")]
         map.insert("unified-delay".into(), true.into());
         #[cfg(feature = "default-meta")]

--- a/backend/tauri/src/config/mod.rs
+++ b/backend/tauri/src/config/mod.rs
@@ -1,9 +1,11 @@
 mod clash;
 mod core;
 mod draft;
-mod nyanpasu;
+pub mod nyanpasu;
 mod prfitem;
 mod profiles;
 mod runtime;
 
-pub use self::{clash::*, core::*, draft::*, nyanpasu::*, prfitem::*, profiles::*, runtime::*};
+pub use self::{clash::*, core::*, draft::*, prfitem::*, profiles::*, runtime::*};
+
+pub use self::nyanpasu::IVerge;

--- a/backend/tauri/src/config/nyanpasu/clash_strategy.rs
+++ b/backend/tauri/src/config/nyanpasu/clash_strategy.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct ClashStrategy {
+    pub external_controller_port_strategy: ExternalControllerPortStrategy,
+}
+
+#[derive(Default, Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalControllerPortStrategy {
+    Fixed,
+    Random,
+    #[default]
+    AllowFallback,
+}
+
+impl super::IVerge {
+    pub fn get_external_controller_port_strategy(&self) -> ExternalControllerPortStrategy {
+        self.clash_strategy
+            .as_ref()
+            .unwrap_or(&ClashStrategy::default())
+            .external_controller_port_strategy
+            .to_owned()
+    }
+}

--- a/backend/tauri/src/config/nyanpasu/mod.rs
+++ b/backend/tauri/src/config/nyanpasu/mod.rs
@@ -3,7 +3,11 @@ use anyhow::Result;
 // use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 
+mod clash_strategy;
 pub mod logging;
+
+pub use self::clash_strategy::{ClashStrategy, ExternalControllerPortStrategy};
+pub use logging::LoggingLevel;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub enum ClashCore {
@@ -133,7 +137,7 @@ pub struct IVerge {
 
     /// 日志清理
     /// 分钟数； 0 为不清理
-    #[deprecated(note = "use `window_size_state` instead")]
+    #[deprecated(note = "use `max_log_files` instead")]
     pub auto_log_clean: Option<i64>,
     /// 日记轮转时间，单位：天
     pub max_log_files: Option<usize>,
@@ -152,7 +156,10 @@ pub struct IVerge {
     pub verge_mixed_port: Option<u16>,
 
     /// Check update when app launch
-    pub disbale_auto_check_update: Option<bool>,
+    pub disable_auto_check_update: Option<bool>,
+
+    /// Clash 相关策略
+    pub clash_strategy: Option<ClashStrategy>,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
@@ -219,7 +226,7 @@ impl IVerge {
             page_transition_animation: Some("slide".into()),
             // auto_log_clean: Some(60 * 24 * 7), // 7 days 自动清理日记
             max_log_files: Some(7), // 7 days
-            disbale_auto_check_update: Some(true),
+            disable_auto_check_update: Some(true),
             ..Self::default()
         }
     }
@@ -247,7 +254,7 @@ impl IVerge {
         patch!(traffic_graph);
         patch!(enable_memory_usage);
         patch!(page_transition_animation);
-        patch!(disbale_auto_check_update);
+        patch!(disable_auto_check_update);
 
         patch!(enable_tun_mode);
         patch!(enable_service_mode);
@@ -273,5 +280,6 @@ impl IVerge {
 
         patch!(max_log_files);
         patch!(window_size_state);
+        patch!(clash_strategy);
     }
 }

--- a/backend/tauri/src/core/updater.rs
+++ b/backend/tauri/src/core/updater.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, io::Cursor, path::Path, sync::OnceLock};
 
 use super::CoreManager;
-use crate::config::ClashCore;
+use crate::config::nyanpasu::ClashCore;
 use anyhow::{anyhow, Result};
 use gunzip::Decompressor;
 use log::{debug, warn};

--- a/backend/tauri/src/core/win_service.rs
+++ b/backend/tauri/src/core/win_service.rs
@@ -1,7 +1,7 @@
 #![cfg(target_os = "windows")]
 
 use crate::{
-    config::{ClashCore, Config},
+    config::{nyanpasu::ClashCore, Config},
     utils::dirs,
 };
 use anyhow::{bail, Context, Result};

--- a/backend/tauri/src/enhance/chain.rs
+++ b/backend/tauri/src/enhance/chain.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{ClashCore, PrfItem},
+    config::{nyanpasu::ClashCore, PrfItem},
     utils::{dirs, help},
 };
 use serde_yaml::Mapping;

--- a/backend/tauri/src/utils/init/logging.rs
+++ b/backend/tauri/src/utils/init/logging.rs
@@ -17,7 +17,7 @@ use tracing_appender::{
 };
 use tracing_subscriber::{filter, fmt, layer::SubscriberExt, reload, EnvFilter};
 
-pub type ReloadSignal = (Option<config::logging::LoggingLevel>, Option<usize>);
+pub type ReloadSignal = (Option<config::nyanpasu::LoggingLevel>, Option<usize>);
 
 struct Channel(Option<Sender<ReloadSignal>>);
 impl Channel {

--- a/backend/tauri/src/utils/resolve.rs
+++ b/backend/tauri/src/utils/resolve.rs
@@ -1,5 +1,8 @@
 use crate::{
-    config::{ClashCore, Config, IVerge, WindowState},
+    config::{
+        nyanpasu::{ClashCore, WindowState},
+        Config, IVerge,
+    },
     core::{
         tasks::{jobs::ProfilesJobGuard, JobsManager},
         tray::proxies,

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,8 @@
     },
     {
       "matchManagers": ["cargo"],
-      "rangeStrategy": "update-lockfile"
+      "rangeStrategy": "update-lockfile",
+      "platformAutomerge": false
     },
     {
       "groupName": "Bundler packages",

--- a/src/components/layout/update-button.tsx
+++ b/src/components/layout/update-button.tsx
@@ -1,10 +1,10 @@
-import useSWR from "swr";
-import { useRef } from "react";
+import { useVerge } from "@/hooks/use-verge";
 import { Button } from "@mui/material";
 import { checkUpdate } from "@tauri-apps/api/updater";
-import { UpdateViewer } from "../setting/mods/update-viewer";
+import { useRef } from "react";
+import useSWR from "swr";
 import { DialogRef } from "../base";
-import { useVerge } from "@/hooks/use-verge";
+import { UpdateViewer } from "../setting/mods/update-viewer";
 
 interface Props {
   className?: string;
@@ -17,11 +17,11 @@ export const UpdateButton = (props: Props) => {
 
   const { verge } = useVerge();
 
-  const { disbale_auto_check_update } = verge ?? {};
+  const { disable_auto_check_update } = verge ?? {};
 
   const { data: updateInfo } = useSWR(
-    disbale_auto_check_update ? null : "checkUpdate",
-    disbale_auto_check_update ? null : checkUpdate,
+    disable_auto_check_update ? null : "checkUpdate",
+    disable_auto_check_update ? null : checkUpdate,
     {
       errorRetryCount: 2,
       revalidateIfStale: false,

--- a/src/components/setting/setting-verge.tsx
+++ b/src/components/setting/setting-verge.tsx
@@ -23,6 +23,7 @@ import { checkUpdate } from "@tauri-apps/api/updater";
 import { useLockFn } from "ahooks";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import MDYSwitch from "../common/mdy-switch";
 import { ConfigViewer } from "./mods/config-viewer";
 import { GuardState } from "./mods/guard-state";
 import { HotkeyViewer } from "./mods/hotkey-viewer";
@@ -33,7 +34,6 @@ import { TasksViewer } from "./mods/tasks-viewer";
 import { ThemeModeSwitch } from "./mods/theme-mode-switch";
 import { ThemeViewer } from "./mods/theme-viewer";
 import { UpdateViewer } from "./mods/update-viewer";
-import MDYSwitch from "../common/mdy-switch";
 
 interface Props {
   onError?: (err: Error) => void;
@@ -45,7 +45,7 @@ const SettingVerge = ({ onError }: Props) => {
   const { t } = useTranslation();
 
   const { verge, patchVerge } = useVerge();
-  const { theme_mode, language, disbale_auto_check_update } = verge ?? {};
+  const { theme_mode, language, disable_auto_check_update } = verge ?? {};
 
   const [loading, setLoading] = useState({
     theme_mode: false,
@@ -275,11 +275,11 @@ const SettingVerge = ({ onError }: Props) => {
 
           <SettingItem label={t("Auto Check Updates")}>
             <GuardState
-              value={!disbale_auto_check_update}
+              value={!disable_auto_check_update}
               valueProps="checked"
               onFormat={onSwitchFormat}
               onCatch={onError}
-              onGuard={(e) => patchVerge({ disbale_auto_check_update: !e })}
+              onGuard={(e) => patchVerge({ disable_auto_check_update: !e })}
             >
               <MDYSwitch edge="end" />
             </GuardState>

--- a/src/services/types.d.ts
+++ b/src/services/types.d.ts
@@ -193,6 +193,10 @@ interface IVergeConfig {
   enable_clash_fields?: boolean;
   enable_builtin_enhanced?: boolean;
   proxy_layout_column?: number;
+
+  clash_strategy?: {
+    external_controller_port_strategy: "fixed" | "random" | "allow_fallback";
+  };
 }
 
 type IClashConfigValue = any;

--- a/src/services/types.d.ts
+++ b/src/services/types.d.ts
@@ -161,7 +161,7 @@ interface IVergeConfig {
   traffic_graph?: boolean;
   enable_memory_usage?: boolean;
   page_transition_animation?: keyof typeof import("@/components/layout/page-transition").pageTransitionVariants;
-  disbale_auto_check_update?: boolean;
+  disable_auto_check_update?: boolean;
   enable_tun_mode?: boolean;
   enable_auto_launch?: boolean;
   enable_service_mode?: boolean;


### PR DESCRIPTION
Close https://github.com/LibNyanpasu/clash-nyanpasu/issues/242

* [x] 初始化 Clash 配置时提供默认 core secret
* [x] 完成 #242 提及的 3 个选项

TODO:

将 AllowFallback、Fixed 所需的 Port 分离到 app config 中，避免造成歧义。