### PR TITLE
fix: mac x64 mihomo使用compatible内核

### DIFF
--- a/manifest/version.json
+++ b/manifest/version.json
@@ -12,14 +12,14 @@
       "linux-aarch64": "mihomo-linux-arm64-{}.gz",
       "linux-amd64": "mihomo-linux-amd64-compatible-{}.gz",
       "darwin-arm64": "mihomo-darwin-arm64-{}.gz",
-      "darwin-x64": "mihomo-darwin-amd64-{}.gz"
+      "darwin-x64": "mihomo-darwin-amd64-compatible-{}.gz"
     },
     "mihomo_alpha": {
       "windows-x86_64": "mihomo-windows-amd64-compatible-{}.zip",
       "linux-aarch64": "mihomo-linux-arm64-{}.gz",
       "linux-amd64": "mihomo-linux-amd64-compatible-{}.gz",
       "darwin-arm64": "mihomo-darwin-arm64-{}.gz",
-      "darwin-x64": "mihomo-darwin-amd64-{}.gz"
+      "darwin-x64": "mihomo-darwin-amd64-compatible-{}.gz"
     },
     "clash_rs": {
       "windows-x86_64": "clash-x86_64-pc-windows-msvc.exe",

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -72,7 +72,7 @@ const MIHOMO_VERSION = versionManifest.latest.mihomo;
 const MIHOMO_URL_PREFIX = `https://github.com/MetaCubeX/mihomo/releases/download/${MIHOMO_VERSION}`;
 const MIHOMO_MAP = {
   "win32-x64": "mihomo-windows-amd64-compatible",
-  "darwin-x64": "mihomo-darwin-amd64",
+  "darwin-x64": "mihomo-darwin-amd64-compatible",
   "darwin-arm64": "mihomo-darwin-arm64",
   "linux-x64": "mihomo-linux-amd64-compatible",
   "linux-arm64": "mihomo-linux-arm64",
@@ -85,7 +85,7 @@ let MIHOMO_ALPHA_VERSION = versionManifest.latest.mihomo_alpha;
 const MIHOMO_ALPHA_URL_PREFIX = `https://github.com/MetaCubeX/mihomo/releases/download/Prerelease-Alpha`;
 const MIHOMO_ALPHA_MAP = {
   "win32-x64": "mihomo-windows-amd64-compatible",
-  "darwin-x64": "mihomo-darwin-amd64",
+  "darwin-x64": "mihomo-darwin-amd64-compatible",
   "darwin-arm64": "mihomo-darwin-arm64",
   "linux-x64": "mihomo-linux-amd64-compatible",
   "linux-arm64": "mihomo-linux-arm64",

--- a/scripts/generate-latest-version.ts
+++ b/scripts/generate-latest-version.ts
@@ -72,7 +72,7 @@ const resolveMihomo: LatestVersionResolver = async () => {
     [SupportedArch.LinuxAarch64]: "mihomo-linux-arm64-{}.gz",
     [SupportedArch.LinuxAmd64]: "mihomo-linux-amd64-compatible-{}.gz",
     [SupportedArch.DarwinArm64]: "mihomo-darwin-arm64-{}.gz",
-    [SupportedArch.DarwinX64]: "mihomo-darwin-amd64-{}.gz",
+    [SupportedArch.DarwinX64]: "mihomo-darwin-amd64-compatible-{}.gz",
   } satisfies ArchMapping;
   return {
     name: "mihomo",
@@ -95,7 +95,7 @@ const resolveMihomoAlpha: LatestVersionResolver = async () => {
     [SupportedArch.LinuxAarch64]: "mihomo-linux-arm64-{}.gz",
     [SupportedArch.LinuxAmd64]: "mihomo-linux-amd64-compatible-{}.gz",
     [SupportedArch.DarwinArm64]: "mihomo-darwin-arm64-{}.gz",
-    [SupportedArch.DarwinX64]: "mihomo-darwin-amd64-{}.gz",
+    [SupportedArch.DarwinX64]: "mihomo-darwin-amd64-compatible-{}.gz",
   } satisfies ArchMapping;
   return {
     name: "mihomo_alpha",


### PR DESCRIPTION
This program can only be run on AMD64 processors with v3 microarchitecture support.
#16 