### PR TITLE
chore(i18n): fix a typesetting in zh-cn

### DIFF
--- a/frontend/nyanpasu/src/locales/zh-CN.json
+++ b/frontend/nyanpasu/src/locales/zh-CN.json
@@ -271,7 +271,7 @@
   "service": "服务",
   "UI": "用户界面",
   "Service Manual Tips": "有关服务的提示",
-  "Unable to operation the service automatically": "无法自动{{operation}}服务。请导航到内核所在目录，在 Windows 上以管理员身份打开 PowerShell或在 macOS/Linux 上打开终端仿真器，然后执行以下命令：",
+  "Unable to operation the service automatically": "无法自动{{operation}}服务。请导航到内核所在目录，在 Windows 上以管理员身份打开 PowerShell 或在 macOS/Linux 上打开终端仿真器，然后执行以下命令：",
   "Successfully switched to the clash core": "成功切换至 {{core}} 内核。",
   "Failed to switch. You could see the details in the log": "切换失败，可以在日志中查看详细信息。\n错误：{{error}}",
   "Successfully restarted the core": "重启内核成功。",


### PR DESCRIPTION
I remember noticing it several times, but forgetting to fix it in previous PRs.