### PR TITLE
fix: avoid crash while using app

### DIFF
--- a/backend/tauri/src/core/tray/proxies.rs
+++ b/backend/tauri/src/core/tray/proxies.rs
@@ -193,8 +193,9 @@ pub async fn proxies_updated_receiver() {
                     TrayUpdateType::Part(action_list) => {
                         debug!("should do partial update, op list: {:?}", action_list);
                         tray_proxies_holder = current_tray_proxies;
-                        platform_impl::update_selected_proxies(&action_list);
-                        debug!("update selected proxies success");
+                        debug!("todo: platform_impl::update_selected_proxies(&action_list)");
+                        // platform_impl::update_selected_proxies(&action_list);
+                        // debug!("update selected proxies success");
                     }
                     _ => {}
                 }


### PR DESCRIPTION
The real cause is that there is a function named `fn find_check_item` that causes an error when executed.