### PR TITLE
fix: show TUN permission warning only when TUN is enabled

### DIFF
--- a/backend/tauri/src/enhance/advice.rs
+++ b/backend/tauri/src/enhance/advice.rs
@@ -9,7 +9,7 @@ pub fn chain_advice(config: &Mapping) -> ProcessOutput {
     let mut logs = Logs::default();
     if config.get("tun").is_some_and(|val| {
         val.is_mapping()
-            && !val
+            && val
                 .as_mapping()
                 .unwrap()
                 .get("enable")


### PR DESCRIPTION
当前在tun的enable字段未设置或为false时会触发TUN权限警告 看上去貌似是判断写反了...?

以及这个警告会阻止Clash启动 在开机自启时会导致代理断网 感觉这条应该额外拿出来发个Issue 不会修(
