### PR TITLE
fix(singleton): isolate Windows singleton per user/config and unify cross-platform behavior

### DIFF
--- a/backend/tauri/src/cmds/migrate.rs
+++ b/backend/tauri/src/cmds/migrate.rs
@@ -128,7 +128,7 @@ pub fn migrate_home_dir_handler(target_path: &str) -> anyhow::Result<()> {
 
     // 1. waiting for app exited
     println!("waiting for app exited.");
-    let placeholder = dirs::get_single_instance_placeholder();
+    let placeholder = dirs::get_single_instance_placeholder()?;
     let mut single_instance: single_instance::SingleInstance;
     loop {
         single_instance = single_instance::SingleInstance::new(&placeholder)

--- a/backend/tauri/src/utils/init/mod.rs
+++ b/backend/tauri/src/utils/init/mod.rs
@@ -265,7 +265,7 @@ pub fn init_service() -> Result<()> {
 }
 
 pub fn check_singleton() -> Result<Option<single_instance::SingleInstance>> {
-    let placeholder = super::dirs::get_single_instance_placeholder();
+    let placeholder = super::dirs::get_single_instance_placeholder()?;
     for i in 0..5 {
         let instance = single_instance::SingleInstance::new(&placeholder)
             .context("failed to create single instance")?;

--- a/backend/tauri/src/utils/mod.rs
+++ b/backend/tauri/src/utils/mod.rs
@@ -17,3 +17,7 @@ pub mod open;
 
 pub mod dock;
 pub mod sudo;
+
+#[cfg(test)]
+#[cfg(windows)]
+mod winreg_test;

--- a/backend/tauri/src/utils/winreg.rs
+++ b/backend/tauri/src/utils/winreg.rs
@@ -43,3 +43,63 @@ pub fn set_app_dir(path: &Path) -> Result<()> {
     key.set_value("AppDir", &path)?;
     Ok(())
 }
+
+/// Get current Windows user SID
+#[cfg(windows)]
+pub fn get_current_user_sid() -> Result<String> {
+    use std::process::Command;
+
+    // Try PowerShell method first (more reliable)
+    let output = Command::new("powershell")
+        .args(&[
+            "-Command",
+            "[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value",
+        ])
+        .output();
+
+    if let Ok(output) = output {
+        if output.status.success() {
+            let sid = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !sid.is_empty() {
+                return Ok(sid);
+            }
+        }
+    }
+
+    // Fallback to WMIC method
+    let output = Command::new("wmic")
+        .args(&[
+            "useraccount",
+            "where",
+            "name='%username%'",
+            "get",
+            "sid",
+            "/value",
+        ])
+        .output();
+
+    if let Ok(output) = output {
+        if output.status.success() {
+            let result = String::from_utf8_lossy(&output.stdout);
+            for line in result.lines() {
+                if line.starts_with("SID=") {
+                    let sid = line[4..].trim().to_string();
+                    if !sid.is_empty() {
+                        return Ok(sid);
+                    }
+                }
+            }
+        }
+    }
+
+    // If both methods fail, fall back to the config dir hashing approach
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+    let cfg_dir = super::dirs::app_config_dir()?;
+    let mut hasher = DefaultHasher::new();
+    cfg_dir.to_string_lossy().hash(&mut hasher);
+    let hash = hasher.finish();
+    Ok(format!("{:x}", hash))
+}

--- a/backend/tauri/src/utils/winreg.rs
+++ b/backend/tauri/src/utils/winreg.rs
@@ -28,7 +28,12 @@ pub fn get_app_dir() -> Result<Option<PathBuf>> {
     if path.is_empty() {
         return Ok(None);
     }
-    Ok(Some(PathBuf::from(path)))
+    let path = PathBuf::from(path);
+    // Basic validation: ensure absolute path
+    if !path.is_absolute() {
+        return Ok(None);
+    }
+    Ok(Some(path))
 }
 
 pub fn set_app_dir(path: &Path) -> Result<()> {

--- a/backend/tauri/src/utils/winreg_test.rs
+++ b/backend/tauri/src/utils/winreg_test.rs
@@ -1,0 +1,30 @@
+#[cfg(test)]
+mod tests {
+    use crate::utils::{dirs::get_single_instance_placeholder, winreg::get_current_user_sid};
+
+    #[test]
+    #[cfg(windows)]
+    fn test_get_current_user_sid() {
+        let sid = get_current_user_sid();
+        assert!(sid.is_ok());
+        let sid = sid.unwrap();
+        assert!(!sid.is_empty());
+        // SID should start with "S-" followed by numbers
+        assert!(sid.starts_with("S-"));
+        println!("Current user SID: {}", sid);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_get_single_instance_placeholder_with_sid() {
+        let placeholder = get_single_instance_placeholder();
+        assert!(placeholder.is_ok());
+        let placeholder = placeholder.unwrap();
+        assert!(!placeholder.is_empty());
+        // Should contain the app name
+        assert!(
+            placeholder.contains("clash-nyanpasu") || placeholder.contains("clash-nyanpasu-dev")
+        );
+        println!("Single instance placeholder: {}", placeholder);
+    }
+}


### PR DESCRIPTION
## Overview

- Fixes the issue where multiple Windows users cannot open the GUI simultaneously (singleton lock conflicts across users)
    
- Implements a consistent, cross-platform singleton detection scoped by user/configuration
    
- Improves error handling and log output
    

## Fixed Issues

1. **Windows singleton lock was system-wide**
    
    - Changed to include user/config directory scope, supporting portable mode and custom AppDir
        
    - File: `backend/tauri/src/utils/dirs.rs`
        
2. **Non-Windows unwrap could panic**
    
    - Removed unwrap, propagate `Result` instead
        
3. **Singleton semantics inconsistent across platforms**
    
    - Windows: named mutex with config directory hash
        
    - Non-Windows: lock file path in config directory
        
    - Files: `backend/tauri/src/utils/dirs.rs`, `backend/tauri/src/utils/init/mod.rs`
        
4. **Portable mode & custom AppDir not isolated on Windows**
    
    - Singleton ID now based on the resolved config directory
        
5. **Insufficient error handling & logging for singleton check**
    
    - Explicit branch handling for lock check results with logs (info/warn/error)
        
    - File: `backend/tauri/src/lib.rs`
        
6. **Security: cross-user DoS risk**
    
    - Isolation by user/config prevents mutual blocking
        
7. **Registry AppDir lacked validation**
    
    - Must be an absolute path; invalid paths are ignored
        
    - File: `backend/tauri/src/utils/winreg.rs`
        

## Behavioral Changes

|Platform|Singleton ID|Scope|
|---|---|---|
|Windows|`Local{APP_NAME}-{config_dir_hash}`|Isolated by user/config (supports portable & custom AppDir)|
|Non-Windows|`{app_config_dir}/instance.lock`|Maintains lock file semantics, avoids panic|

- API: `get_single_instance_placeholder` return type changed from `String` → `Result`
    
- Lock check errors are logged as `error` but startup continues (best-effort mode)
    
- Portable, multi-config, and different users do not interfere
    
- Resolves cross-user DoS risk
---
## 概述

- 修复了 Windows 上多用户无法同时打开 GUI 的问题（单例锁跨用户冲突）
    
- 实现跨平台一致、按用户/按配置隔离的单例检测方案
    
- 改进错误处理和日志输出
    

## 已修复问题

1. **Windows 单例锁为系统级**
    
    - 改为包含用户/配置目录的标识，支持便携模式和自定义 AppDir
        
    - 文件：`backend/tauri/src/utils/dirs.rs`
        
2. **非 Windows unwrap 可能 panic**
    
    - 去除 unwrap，改为传播 Result
        
3. **单例跨平台语义不一致**
    
    - Windows：命名互斥量（含配置目录哈希）
        
    - 非 Windows：配置目录锁文件路径
        
    - 文件：`backend/tauri/src/utils/dirs.rs`、`backend/tauri/src/utils/init/mod.rs`
        
4. **便携模式与自定义 AppDir 未参与 Windows 单例隔离**
    
    - 基于实际解析配置目录构建单例标识
        
5. **单例检查错误处理与日志不足**
    
    - 显式分支处理锁检查结果并输出日志（info/warn/error）
        
    - 文件：`backend/tauri/src/lib.rs`
        
6. **安全性：跨用户 DoS 风险**
    
    - 按用户/按配置隔离消除互相阻塞
        
7. **注册表 AppDir 缺乏校验**
    
    - 必须为绝对路径，不合法忽略
        
    - 文件：`backend/tauri/src/utils/winreg.rs`
        

## 行为变化

|平台|单例标识|作用域|
|---|---|---|
|Windows|`Local{APP_NAME}-{config_dir_hash}`|按用户/按配置目录隔离（支持 portable & 自定义 AppDir）|
|非 Windows|`{app_config_dir}/instance.lock`|保持锁文件语义，避免 panic|

- API：`get_single_instance_placeholder` 返回类型由 `String` 改为 `Result`
    
- 锁检查错误时记录 `error` 后继续启动（尽力模式）
    
- 便携版、多配置目录、不同用户互不干扰
    
- 解决跨用户 DoS 风险