### PR TITLE
fix(tray): prevent multiple checked proxies in tray menu

### DIFF
--- a/backend/tauri/src/core/tray/proxies.rs
+++ b/backend/tauri/src/core/tray/proxies.rs
@@ -193,9 +193,8 @@ pub async fn proxies_updated_receiver() {
                     TrayUpdateType::Part(action_list) => {
                         debug!("should do partial update, op list: {:?}", action_list);
                         tray_proxies_holder = current_tray_proxies;
-                        debug!("todo: platform_impl::update_selected_proxies(&action_list)");
-                        // platform_impl::update_selected_proxies(&action_list);
-                        // debug!("update selected proxies success");
+                        platform_impl::update_selected_proxies(&action_list);
+                        debug!("update selected proxies success");
                     }
                     _ => {}
                 }


### PR DESCRIPTION
**Issue**  
托盘菜单中的代理项使用 `CheckMenuItem` 而非 `RadioMenuItem`，点击后不会自动取消先前勾选项，同时“部分更新”逻辑被注释，导致旧代理不会取消勾选，从而出现多个 √。

**Fix**

- 启用托盘菜单“部分更新”逻辑，在代理切换时取消旧代理勾选并勾选新代理。
    
- 修改 `backend/tauri/src/core/tray/proxies.rs`：
    
    - 在 `proxies_updated_receiver` 中，当 `diff_proxies` 返回 `TrayUpdateType::Part(action_list)` 时，调用 `platform_impl::update_selected_proxies(&action_list)` 执行 UI 更新。
        
    - `update_selected_proxies` 会定位对应分组下的 `CheckMenuItem`，对 `From` 取消勾选，对 `To` 勾选，并防止重入。
        

**Changes**

- 文件：`backend/tauri/src/core/tray/proxies.rs`
    
- 关键改动：启用 `update_selected_proxies(&action_list)` 执行托盘菜单部分更新