### PR TITLE
feat: tooltips display

### DIFF
--- a/frontend/nyanpasu/src/components/app/modules/route-list-item.tsx
+++ b/frontend/nyanpasu/src/components/app/modules/route-list-item.tsx
@@ -2,7 +2,7 @@ import { createElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { languageQuirks } from '@/utils/language'
 import { SvgIconComponent } from '@mui/icons-material'
-import { Box, ListItemButton, ListItemIcon } from '@mui/material'
+import { Box, ListItemButton, ListItemIcon, Tooltip } from '@mui/material'
 import { useSetting } from '@nyanpasu/interface'
 import { alpha, cn } from '@nyanpasu/ui'
 import { useMatch, useNavigate } from '@tanstack/react-router'
@@ -29,7 +29,7 @@ export const RouteListItem = ({
 
   const { value: language } = useSetting('language')
 
-  return (
+  const listItemButton = (
     <ListItemButton
       className={cn(
         onlyIcon ? '!mx-auto !size-16 !rounded-3xl' : '!rounded-full !pr-14',
@@ -76,6 +76,12 @@ export const RouteListItem = ({
         </Box>
       )}
     </ListItemButton>
+  )
+
+  return onlyIcon ? (
+    <Tooltip title={t(`label_${name}`)}>{listItemButton}</Tooltip>
+  ) : (
+    listItemButton
   )
 }
 


### PR DESCRIPTION
为 `RouteListItem` 组件新增 tooltip 功能，解决仅图标导航模式下无法显示标签的问题。

### 修改内容

1. 从 `@mui/material` 导入 `Tooltip`
    
2. 将 `ListItemButton` 提取到变量 `listItemButton`，便于条件包裹
    
3. 当 `onlyIcon = true` 时，用 `Tooltip` 包裹 `ListItemButton`
    
4. tooltip 内容使用现有翻译 key
    

### 功能说明

- **仅图标模式**：悬停图标显示对应标签的 tooltip
    
- **完整模式**：正常显示文本，无 tooltip
    

### 效果

用户启用“图标导航栏”后，悬停侧边栏图标即可看到提示标签，提升可访问性和可用性，同时保持现有功能不变。
![PixPin_2025-09-20_08-47-05](https://github.com/user-attachments/assets/4ebb34d0-8d63-4f6b-b5e7-f32963e8ba10)
