### PR TITLE
feat: add enable_tray_text option

### DIFF
--- a/backend/tauri/src/config/nyanpasu/mod.rs
+++ b/backend/tauri/src/config/nyanpasu/mod.rs
@@ -277,6 +277,11 @@ pub struct IVerge {
     /// 是否启用网络统计信息浮窗
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_statistic_widget: Option<NetworkStatisticWidgetConfig>,
+
+    /// enable tray text display on Linux systems
+    /// When enabled, shows proxy and TUN mode status as text next to the tray icon
+    /// When disabled, only shows status via icon changes (prevents text display issues on Wayland)
+    pub enable_tray_text: Option<bool>,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize, Type)]
@@ -345,6 +350,10 @@ impl IVerge {
             config.break_when_mode_change = template.break_when_mode_change;
         }
 
+        if config.enable_tray_text.is_none() {
+            config.enable_tray_text = template.enable_tray_text;
+        }
+
         config
     }
 
@@ -379,6 +388,7 @@ impl IVerge {
             clash_tray_selector: Some(ProxiesSelectorMode::default()),
             enable_service_mode: Some(false),
             always_on_top: Some(false),
+            enable_tray_text: Some(false),
             ..Self::default()
         }
     }

--- a/backend/tauri/src/core/tray/mod.rs
+++ b/backend/tauri/src/core/tray/mod.rs
@@ -328,12 +328,14 @@ impl Tray {
                 .and_then(|item| item.as_check_menuitem()?.set_checked(mode == "script").ok());
         }
 
-        let (system_proxy, tun_mode) = {
+        #[allow(unused_variables)]
+        let (system_proxy, tun_mode, enable_tray_text) = {
             let verge = Config::verge();
             let verge = verge.latest();
             (
                 *verge.enable_system_proxy.as_ref().unwrap_or(&false),
                 *verge.enable_tun_mode.as_ref().unwrap_or(&false),
+                *verge.enable_tray_text.as_ref().unwrap_or(&false),
             )
         };
 
@@ -378,13 +380,17 @@ impl Tray {
         }
         #[cfg(target_os = "linux")]
         {
-            let _ = tray.set_title(Some(&format!(
-                "{}: {}\n{}: {}",
-                t!("tray.system_proxy"),
-                switch_map[&system_proxy],
-                t!("tray.tun_mode"),
-                switch_map[&tun_mode]
-            )));
+            if enable_tray_text {
+                let _ = tray.set_title(Some(&format!(
+                    "{}: {}\n{}: {}",
+                    t!("tray.system_proxy"),
+                    switch_map[&system_proxy],
+                    t!("tray.tun_mode"),
+                    switch_map[&tun_mode]
+                )));
+            } else {
+                let _ = tray.set_title(None);
+            }
         }
 
         Ok(())

--- a/backend/tauri/src/feat.rs
+++ b/backend/tauri/src/feat.rs
@@ -291,6 +291,7 @@ pub async fn patch_verge(patch: IVerge) -> Result<()> {
     let log_level = patch.app_log_level;
     let log_max_files = patch.max_log_files;
     let enable_tray_selector = patch.clash_tray_selector;
+    let enable_tray_text = patch.enable_tray_text;
     let network_statistic_widget = patch.network_statistic_widget;
     let res = || async move {
         let service_mode = patch.enable_service_mode;
@@ -356,7 +357,7 @@ pub async fn patch_verge(patch: IVerge) -> Result<()> {
         if language.is_some() {
             rust_i18n::set_locale(language.unwrap().as_str());
             handle::Handle::update_systray()?;
-        } else if system_proxy.or(tun_mode).is_some() {
+        } else if system_proxy.or(tun_mode).or(enable_tray_text).is_some() {
             handle::Handle::update_systray_part()?;
         }
 

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -1025,6 +1025,12 @@ export type IVerge = {
    * 是否启用网络统计信息浮窗
    */
   network_statistic_widget?: NetworkStatisticWidgetConfig | null
+  /**
+   * enable tray text display on Linux systems
+   * When enabled, shows proxy and TUN mode status as text next to the tray icon
+   * When disabled, only shows status via icon changes (prevents text display issues on Wayland)
+   */
+  enable_tray_text: boolean | null
 }
 export type JsonValue =
   | null

--- a/frontend/interface/src/service/types.ts
+++ b/frontend/interface/src/service/types.ts
@@ -48,6 +48,7 @@ export interface VergeConfig {
   clash_strategy?: {
     external_controller_port_strategy: 'fixed' | 'random' | 'allow_fallback'
   }
+  enable_tray_text?: boolean
   tun_stack?: 'system' | 'gvisor' | 'mixed'
   always_on_top?: boolean
 }


### PR DESCRIPTION
### 修复 Linux 托盘文字显示问题

新增 `enable_tray_text` 配置选项，可在 Linux（含 Ubuntu 24.04 Wayland）上控制托盘文字显示。默认禁用文字以防 Wayland 问题，同时保留图标状态。配置可通过 `nyanpasu-config.yaml` 或现有 API 调整。

**兼容性说明**：仅影响 Linux 系统，Windows/macOS 继续使用 tooltip，保持原有行为。

涉及文件：`nyanpasu/mod.rs`、`tray/mod.rs`、`feat.rs`。