### PR TITLE
fix: prevent NaN% in progress display

### DIFF
--- a/frontend/nyanpasu/src/components/profiles/profile-item.tsx
+++ b/frontend/nyanpasu/src/components/profiles/profile-item.tsx
@@ -80,7 +80,7 @@ export const ProfileItem = memo(function ProfileItem({
 
       used = download + upload
 
-      progress = (used / total) * 100
+      progress = (used / (total || 1)) * 100
     }
 
     return { progress, total, used }
@@ -284,9 +284,7 @@ export const ProfileItem = memo(function ProfileItem({
             </div>
 
             <Tooltip title={`${parseTraffic(used)} / ${parseTraffic(total)}`}>
-              <div className="text-sm font-bold">
-                {((used / total) * 100).toFixed(2)}%
-              </div>
+              <div className="text-sm font-bold">{progress.toFixed(2)}%</div>
             </Tooltip>
           </div>
 

--- a/frontend/nyanpasu/src/components/providers/proxies-provider-traffic.tsx
+++ b/frontend/nyanpasu/src/components/providers/proxies-provider-traffic.tsx
@@ -30,9 +30,7 @@ export const ProxiesProviderTraffic = ({ provider }: ProxiesProviderProps) => {
       </div>
 
       <Tooltip title={`${parseTraffic(used)} / ${parseTraffic(total)}`}>
-        <div className="text-sm font-bold">
-          {((used / total) * 100).toFixed(2)}%
-        </div>
+        <div className="text-sm font-bold">{progress.toFixed(2)}%</div>
       </Tooltip>
     </div>
   )


### PR DESCRIPTION
# 修复进度百分比显示问题

修复 `proxies-provider-traffic.tsx` 和 `profile-item.tsx` 中进度计算可能产生 `NaN%` 的问题。

## 修改内容

- 使用安全的 `progress` 计算，处理 `total` 为 0 或 null 的情况
    
- 显示阶段统一使用已计算的 `progress` 值，避免重复计算
    

**效果**：界面不会再显示 `NaN%`，当 `total` 为 0 或 undefined 时显示 0%。