### PR TITLE
fix(dashboard): prevent freeze when page is hidden

### DIFF
--- a/frontend/interface/src/provider/index.tsx
+++ b/frontend/interface/src/provider/index.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { ClashWSProvider } from './clash-ws-provider'
+import { ClashWSProvider, useClashWSContext } from './clash-ws-provider'
 import { MutationProvider } from './mutation-provider'
 
 const queryClient = new QueryClient()
@@ -14,3 +14,5 @@ export const NyanpasuProvider = ({ children }: PropsWithChildren) => {
     </QueryClientProvider>
   )
 }
+
+export { useClashWSContext }

--- a/frontend/nyanpasu/src/components/dashboard/data-panel.tsx
+++ b/frontend/nyanpasu/src/components/dashboard/data-panel.tsx
@@ -20,7 +20,7 @@ import {
   useSetting,
 } from '@nyanpasu/interface'
 
-export const DataPanel = () => {
+export const DataPanel = ({ visible = true }: { visible?: boolean }) => {
   const { t } = useTranslation()
 
   const { data: clashTraffic } = useClashTraffic()
@@ -40,7 +40,7 @@ export const DataPanel = () => {
       .fill(0)
       .concat(data.slice(-max))
 
-  const Datalines: DatalineProps[] = [
+  const Datalines: (DatalineProps & { visible?: boolean })[] = [
     {
       data: padData(
         clashTraffic?.map((item) => item.down),
@@ -50,6 +50,7 @@ export const DataPanel = () => {
       title: t('Download Traffic'),
       total: clashConnections?.at(-1)?.downloadTotal,
       type: 'speed',
+      visible,
     },
     {
       data: padData(
@@ -60,6 +61,7 @@ export const DataPanel = () => {
       title: t('Upload Traffic'),
       total: clashConnections?.at(-1)?.uploadTotal,
       type: 'speed',
+      visible,
     },
     {
       data: padData(
@@ -69,6 +71,7 @@ export const DataPanel = () => {
       icon: SettingsEthernet,
       title: t('Active Connections'),
       type: 'raw',
+      visible,
     },
   ]
 
@@ -80,6 +83,7 @@ export const DataPanel = () => {
       ),
       icon: MemoryOutlined,
       title: t('Memory'),
+      visible,
     })
   }
 

--- a/frontend/nyanpasu/src/components/dashboard/dataline.tsx
+++ b/frontend/nyanpasu/src/components/dashboard/dataline.tsx
@@ -12,6 +12,7 @@ export interface DatalineProps {
   title: string
   total?: number
   type?: 'speed' | 'raw'
+  visible?: boolean
 }
 
 export const Dataline: FC<DatalineProps> = ({
@@ -21,12 +22,17 @@ export const Dataline: FC<DatalineProps> = ({
   total,
   type,
   className,
+  visible = true,
 }) => {
   const { t } = useTranslation()
 
   return (
     <Paper className={cn('relative !rounded-3xl', className)}>
-      <Sparkline data={data} className="absolute rounded-3xl" />
+      <Sparkline
+        data={data}
+        className="absolute rounded-3xl"
+        {...(visible !== undefined ? { visible } : {})}
+      />
 
       <div className="absolute top-0 flex h-full flex-col justify-between gap-4 p-4">
         <div className="flex items-center gap-2">

--- a/frontend/nyanpasu/src/pages/dashboard.tsx
+++ b/frontend/nyanpasu/src/pages/dashboard.tsx
@@ -3,7 +3,9 @@ import DataPanel from '@/components/dashboard/data-panel'
 import HealthPanel from '@/components/dashboard/health-panel'
 import ProxyShortcuts from '@/components/dashboard/proxy-shortcuts'
 import ServiceShortcuts from '@/components/dashboard/service-shortcuts'
+import { useVisibility } from '@/hooks/use-visibility'
 import Grid from '@mui/material/Grid'
+import { useClashWSContext } from '@nyanpasu/interface'
 import { BasePage } from '@nyanpasu/ui'
 import { createFileRoute } from '@tanstack/react-router'
 
@@ -13,11 +15,17 @@ export const Route = createFileRoute('/dashboard')({
 
 function Dashboard() {
   const { t } = useTranslation()
+  const visible = useVisibility()
+  const { setRecordTraffic } = useClashWSContext()
+
+  // When the page is not visible, reduce the traffic data update frequency
+  // to prevent performance issues when the page is restored
+  setRecordTraffic(visible)
 
   return (
     <BasePage title={t('Dashboard')}>
       <Grid container spacing={2}>
-        <DataPanel />
+        <DataPanel visible={visible} />
 
         <HealthPanel />
 

--- a/frontend/ui/src/chart/sparkline.tsx
+++ b/frontend/ui/src/chart/sparkline.tsx
@@ -7,9 +7,15 @@ interface SparklineProps {
   data: number[]
   className?: string
   style?: CSSProperties
+  visible?: boolean
 }
 
-export const Sparkline: FC<SparklineProps> = ({ data, className, style }) => {
+export const Sparkline: FC<SparklineProps> = ({
+  data,
+  className,
+  style,
+  visible = true,
+}) => {
   const theme = useTheme()
   const { mode } = useColorScheme()
 
@@ -97,6 +103,14 @@ export const Sparkline: FC<SparklineProps> = ({ data, className, style }) => {
       .attr('d', line)
 
     const updateChart = () => {
+      // Skip animation if component is not visible to prevent performance issues
+      if (!visible) {
+        // Update without animation
+        svg.select('.area').datum(data).attr('d', area)
+        svg.select('.line').datum(data).attr('d', line)
+        return
+      }
+
       xScale.domain([0, data.length - 1])
       yScale.domain([0, d3.max(data) ?? 0])
 
@@ -123,7 +137,7 @@ export const Sparkline: FC<SparklineProps> = ({ data, className, style }) => {
     }
 
     updateChart()
-  }, [data, lineColor, areaColor])
+  }, [data, lineColor, areaColor, visible])
 
   return (
     <svg


### PR DESCRIPTION
### 优化 Dashboard 页面性能，防止页面冻结

**变更内容：**

1. 导出 `useClashWSContext`，便于在组件中获取 WebSocket 数据上下文。
    
2. 添加 `visible` 属性，用于控制数据面板及其子组件的显示。
    
3. 优化 Sparkline 图表性能，减少不必要的渲染开销。
    

**目的：**  
当页面不可见（例如失去焦点或切换到其他标签页）时，减少数据更新和图表动画，防止页面冻结，提升性能和用户体验。