### PR TITLE
fix: proxy chain ui

### DIFF
--- a/frontend/nyanpasu/src/components/profiles/modules/chain-item.tsx
+++ b/frontend/nyanpasu/src/components/profiles/modules/chain-item.tsx
@@ -112,7 +112,7 @@ export const ChainItem = memo(function ChainItem({
               )}
               {context?.scope === 'scoped' && (
                 <span className="rounded bg-green-500 px-1 py-0.5 text-xs text-white">
-                  L
+                  S
                 </span>
               )}
             </div>

--- a/frontend/nyanpasu/src/components/profiles/modules/chain-item.tsx
+++ b/frontend/nyanpasu/src/components/profiles/modules/chain-item.tsx
@@ -9,7 +9,8 @@ import { alpha, cleanDeepClickEvent } from '@nyanpasu/ui'
 const longPressDelay = 200
 
 interface Context {
-  scope: 'global' | 'scoped'
+  global: boolean
+  scoped: boolean
 }
 
 export const ChainItem = memo(function ChainItem({
@@ -105,12 +106,12 @@ export const ChainItem = memo(function ChainItem({
           <div className="truncate py-1">
             <span>{item.name}</span>
             <div className="mt-1 flex gap-1">
-              {context?.scope === 'global' && (
+              {context?.global && (
                 <span className="rounded bg-blue-500 px-1 py-0.5 text-xs text-white">
                   G
                 </span>
               )}
-              {context?.scope === 'scoped' && (
+              {context?.scoped && (
                 <span className="rounded bg-green-500 px-1 py-0.5 text-xs text-white">
                   S
                 </span>

--- a/frontend/nyanpasu/src/components/profiles/modules/chain-item.tsx
+++ b/frontend/nyanpasu/src/components/profiles/modules/chain-item.tsx
@@ -8,18 +8,20 @@ import { alpha, cleanDeepClickEvent } from '@nyanpasu/ui'
 
 const longPressDelay = 200
 
+interface Context {
+  scope: 'global' | 'scoped'
+}
+
 export const ChainItem = memo(function ChainItem({
   item,
   selected,
-  usedInGlobal,
-  usedInCurrentProfile,
+  context,
   onClick,
   onChainEdit,
 }: {
   item: ProfileQueryResultItem
   selected?: boolean
-  usedInGlobal?: boolean
-  usedInCurrentProfile?: boolean
+  context?: Context
   onClick: () => Promise<void>
   onChainEdit: () => void
 }) {
@@ -103,12 +105,12 @@ export const ChainItem = memo(function ChainItem({
           <div className="truncate py-1">
             <span>{item.name}</span>
             <div className="mt-1 flex gap-1">
-              {usedInGlobal && (
+              {context?.scope === 'global' && (
                 <span className="rounded bg-blue-500 px-1 py-0.5 text-xs text-white">
                   G
                 </span>
               )}
-              {usedInCurrentProfile && (
+              {context?.scope === 'scoped' && (
                 <span className="rounded bg-green-500 px-1 py-0.5 text-xs text-white">
                   L
                 </span>

--- a/frontend/nyanpasu/src/components/profiles/modules/chain-item.tsx
+++ b/frontend/nyanpasu/src/components/profiles/modules/chain-item.tsx
@@ -11,11 +11,15 @@ const longPressDelay = 200
 export const ChainItem = memo(function ChainItem({
   item,
   selected,
+  usedInGlobal,
+  usedInCurrentProfile,
   onClick,
   onChainEdit,
 }: {
   item: ProfileQueryResultItem
   selected?: boolean
+  usedInGlobal?: boolean
+  usedInCurrentProfile?: boolean
   onClick: () => Promise<void>
   onChainEdit: () => void
 }) {
@@ -98,6 +102,18 @@ export const ChainItem = memo(function ChainItem({
         >
           <div className="truncate py-1">
             <span>{item.name}</span>
+            <div className="mt-1 flex gap-1">
+              {usedInGlobal && (
+                <span className="rounded bg-blue-500 px-1 py-0.5 text-xs text-white">
+                  G
+                </span>
+              )}
+              {usedInCurrentProfile && (
+                <span className="rounded bg-green-500 px-1 py-0.5 text-xs text-white">
+                  L
+                </span>
+              )}
+            </div>
           </div>
 
           <Button

--- a/frontend/nyanpasu/src/components/profiles/modules/side-chain.tsx
+++ b/frontend/nyanpasu/src/components/profiles/modules/side-chain.tsx
@@ -101,10 +101,11 @@ export const SideChain = ({ onChainEdit }: SideChainProps) => {
             : currentProfile?.chain?.includes(item.uid)
 
           // Check if chain is used in global context
-          const usedInGlobal = profiles?.chain?.includes(item.uid)
+          const usedInGlobal = profiles?.chain?.includes(item.uid) ?? false
 
           // Check if chain is used in current profile context
-          const usedInCurrentProfile = currentProfile?.chain?.includes(item.uid)
+          const usedInCurrentProfile =
+            currentProfile?.chain?.includes(item.uid) ?? false
 
           return (
             <ChainItem
@@ -112,11 +113,8 @@ export const SideChain = ({ onChainEdit }: SideChainProps) => {
               item={item}
               selected={selected}
               context={{
-                scope: usedInGlobal
-                  ? 'global'
-                  : usedInCurrentProfile
-                    ? 'scoped'
-                    : 'global',
+                global: usedInGlobal,
+                scoped: usedInCurrentProfile,
               }}
               onClick={async () => await handleChainClick(item.uid)}
               onChainEdit={() => onChainEdit(item)}

--- a/frontend/nyanpasu/src/components/profiles/modules/side-chain.tsx
+++ b/frontend/nyanpasu/src/components/profiles/modules/side-chain.tsx
@@ -34,6 +34,18 @@ export const SideChain = ({ onChainEdit }: SideChainProps) => {
     return clash?.find((item) => item.uid === currentProfileUid) as ClashProfile
   }, [clash, currentProfileUid])
 
+  // Filter chains to show only relevant ones based on global/local context
+  const filteredChains = useMemo(() => {
+    if (isGlobalChainCurrent) {
+      // When in global chain mode, show all chain profiles
+      return chain || []
+    } else {
+      // In local chain mode, show all chain profiles so user can add them to the current profile's chain
+      // This is the expected behavior for local chains - users should see all available chains to choose from
+      return chain || []
+    }
+  }, [chain, isGlobalChainCurrent])
+
   const handleChainClick = useLockFn(async (uid: string) => {
     const chains = isGlobalChainCurrent
       ? (profiles?.chain ?? [])
@@ -67,8 +79,8 @@ export const SideChain = ({ onChainEdit }: SideChainProps) => {
   })
 
   const reorderValues = useMemo(
-    () => chain?.map((item) => item.uid) || [],
-    [chain],
+    () => filteredChains?.map((item) => item.uid) || [],
+    [filteredChains],
   )
 
   return (
@@ -83,16 +95,24 @@ export const SideChain = ({ onChainEdit }: SideChainProps) => {
         layoutScroll
         style={{ overflowY: 'scroll' }}
       >
-        {chain?.map((item, index) => {
+        {filteredChains?.map((item, index) => {
           const selected = isGlobalChainCurrent
             ? profiles?.chain?.includes(item.uid)
             : currentProfile?.chain?.includes(item.uid)
+
+          // Check if chain is used in global context
+          const usedInGlobal = profiles?.chain?.includes(item.uid)
+
+          // Check if chain is used in current profile context
+          const usedInCurrentProfile = currentProfile?.chain?.includes(item.uid)
 
           return (
             <ChainItem
               key={index}
               item={item}
               selected={selected}
+              usedInGlobal={usedInGlobal}
+              usedInCurrentProfile={usedInCurrentProfile}
               onClick={async () => await handleChainClick(item.uid)}
               onChainEdit={() => onChainEdit(item)}
             />

--- a/frontend/nyanpasu/src/components/profiles/modules/side-chain.tsx
+++ b/frontend/nyanpasu/src/components/profiles/modules/side-chain.tsx
@@ -111,8 +111,13 @@ export const SideChain = ({ onChainEdit }: SideChainProps) => {
               key={index}
               item={item}
               selected={selected}
-              usedInGlobal={usedInGlobal}
-              usedInCurrentProfile={usedInCurrentProfile}
+              context={{
+                scope: usedInGlobal
+                  ? 'global'
+                  : usedInCurrentProfile
+                    ? 'scoped'
+                    : 'global',
+              }}
               onClick={async () => await handleChainClick(item.uid)}
               onChainEdit={() => onChainEdit(item)}
             />

--- a/frontend/nyanpasu/src/components/profiles/profile-side.tsx
+++ b/frontend/nyanpasu/src/components/profiles/profile-side.tsx
@@ -10,7 +10,6 @@ import { SideChain } from './modules/side-chain'
 import { SideLog } from './modules/side-log'
 import { atomChainsSelected, atomGlobalChainCurrent } from './modules/store'
 import { ScriptDialog } from './script-dialog'
-import { filterProfiles } from './utils'
 
 export interface ProfileSideProps {
   onClose: () => void
@@ -42,12 +41,14 @@ export const ProfileSide = ({ onClose }: ProfileSideProps) => {
     <div className="absolute h-full w-full">
       <div className="flex items-start justify-between p-4 pr-2">
         <div>
-          <div className="text-xl font-bold">{t('Proxy Chains')}</div>
-
-          <div className="truncate">
+          <div className="text-xl font-bold">
             {isGlobalChainCurrent
               ? t('Global Proxy Chains')
-              : currentProfile?.name}
+              : t('Proxy Chains')}
+          </div>
+
+          <div className="truncate">
+            {isGlobalChainCurrent ? t('All Profiles') : currentProfile?.name}
           </div>
         </div>
 

--- a/frontend/nyanpasu/src/locales/zh-CN.json
+++ b/frontend/nyanpasu/src/locales/zh-CN.json
@@ -49,7 +49,7 @@
   "Select": "使用",
   "Applying Profile": "正在应用配置……",
   "Edit Info": "编辑信息",
-  "Proxy Chains": "代理链",
+  "Proxy Chains": "局部链",
   "Global Proxy Chains": "全局链",
   "New Chain": "添加新链",
   "New Script": "新脚本",


### PR DESCRIPTION
## **修复全局链与本地链的 UI 混淆问题**

### 问题

UI 展示所有链配置时，没有区分全局链和个人配置（本地链），导致用户无法清晰判断每条链所属的上下文。

### 解决方案

- **增强数据传递**：修改 `SideChain` 组件，为每个 `ChainItem` 提供额外的上下文信息。
    
- **视觉标识**：在 `ChainItem` 上增加徽章，清楚标示链是全局链还是本地链。
    
- **保持核心功能**：保留原有的选中高亮机制，同时增加新的视觉区分。
    

### 改进效果

- 消除全局链与本地链的混淆。
    
- 提供明确的视觉反馈，直观显示链的上下文。
    
- 保持功能完整，同时提升用户体验清晰度。
    
- 用户可一眼区分全局链和本地链。

---

https://github.com/user-attachments/assets/8e36ebcb-b799-4c00-a83e-43de9723c295