### PR TITLE
feat(enhance): add include-all field support for proxy groups

### DIFF
--- a/backend/tauri/src/enhance/mod.rs
+++ b/backend/tauri/src/enhance/mod.rs
@@ -12,7 +12,7 @@ use crate::config::{Config, ProfileMetaGetter, nyanpasu::ClashCore};
 pub use chain::PostProcessingOutput;
 use futures::future::join_all;
 use indexmap::IndexMap;
-use serde_yaml::Mapping;
+use serde_yaml::{Mapping, Value};
 use std::collections::HashSet;
 pub use utils::{Logs, LogsExt};
 use utils::{merge_profiles, process_chain};
@@ -145,6 +145,7 @@ pub async fn enhance() -> (Mapping, Vec<String>, PostProcessingOutput) {
 
     config = use_whitelist_fields_filter(config, &clash_fields, enable_filter);
     config = use_tun(config, enable_tun);
+    config = use_include_all_proxy_groups(config);
     config = use_cache(config);
     config = use_sort(config, enable_filter);
 
@@ -156,6 +157,94 @@ pub async fn enhance() -> (Mapping, Vec<String>, PostProcessingOutput) {
     exists_keys = exists_set.into_iter().collect();
 
     (config, exists_keys, postprocessing_output)
+}
+
+/// Process proxy groups with include-all field
+fn use_include_all_proxy_groups(mut config: Mapping) -> Mapping {
+    // Collect all proxy names from proxies and proxy-providers first (before mutable borrow)
+    let mut all_proxy_names = Vec::new();
+
+    // Collect from proxies section
+    if let Some(proxies_value) = config.get("proxies") {
+        if let Some(proxies_seq) = proxies_value.as_sequence() {
+            for proxy in proxies_seq {
+                if let Some(proxy_map) = proxy.as_mapping() {
+                    if let Some(name_value) = proxy_map.get("name") {
+                        if let Some(name) = name_value.as_str() {
+                            all_proxy_names.push(name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Collect from proxy-providers section
+    if let Some(providers_value) = config.get("proxy-providers") {
+        if let Some(providers_map) = providers_value.as_mapping() {
+            for (provider_name, _) in providers_map {
+                if let Some(name) = provider_name.as_str() {
+                    all_proxy_names.push(name.to_string());
+                }
+            }
+        }
+    }
+
+    // Check if we have proxy-groups field
+    if let Some(proxy_groups_value) = config.get_mut("proxy-groups") {
+        if let Some(proxy_groups) = proxy_groups_value.as_sequence_mut() {
+            // Process each proxy group
+            for group in proxy_groups.iter_mut() {
+                if let Some(group_map) = group.as_mapping_mut() {
+                    // Check if this group has include-all: true
+                    if let Some(include_all_value) = group_map.get("include-all") {
+                        if include_all_value.as_bool().unwrap_or(false) {
+                            // Check if this is the GLOBAL group or any group with include-all
+                            if let Some(name_value) = group_map.get("name") {
+                                let _name = name_value.as_str().unwrap_or("");
+                                // Preserve existing proxies
+                                let mut existing_proxies = Vec::new();
+                                if let Some(existing) = group_map.get("proxies") {
+                                    if let Some(existing_seq) = existing.as_sequence() {
+                                        for proxy in existing_seq {
+                                            if let Some(proxy_str) = proxy.as_str() {
+                                                existing_proxies.push(proxy_str.to_string());
+                                            }
+                                        }
+                                    }
+                                }
+
+                                // Create new proxies list with all proxies
+                                let mut new_proxies = Vec::new();
+
+                                // Add all collected proxy names
+                                for proxy_name in &all_proxy_names {
+                                    new_proxies.push(Value::String(proxy_name.clone()));
+                                }
+
+                                // Add existing proxies that aren't in the all list
+                                for existing_proxy in existing_proxies {
+                                    if !all_proxy_names.contains(&existing_proxy) {
+                                        new_proxies.push(Value::String(existing_proxy));
+                                    }
+                                }
+
+                                // Update the proxies field
+                                group_map.insert(
+                                    Value::String("proxies".to_string()),
+                                    Value::Sequence(new_proxies),
+                                );
+
+                                // Remove the include-all field since it's been processed
+                                group_map.remove("include-all");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    config
 }
 
 fn use_cache(mut config: Mapping) -> Mapping {
@@ -199,5 +288,80 @@ mod tests {
                 .unwrap()
                 .contains_key("do-not-override")
         );
+    }
+
+    #[test]
+    fn test_use_include_all_proxy_groups() {
+        let yaml = r#"
+proxies:
+  - name: "Proxy1"
+    type: ss
+    server: server.com
+    port: 443
+  - name: "Proxy2"
+    type: vmess
+    server: server2.com
+    port: 8080
+proxy-providers:
+  provider1:
+    type: http
+    url: "http://example.com/provider1.yaml"
+    interval: 3600
+  provider2:
+    type: file
+    path: ./providers/provider2.yaml
+proxy-groups:
+  - name: GLOBAL
+    type: select
+    include-all: true
+    proxies:
+      - DIRECT
+  - name: Proxies
+    type: select
+    proxies:
+      - DIRECT
+"#;
+        let config: Mapping = serde_yaml::from_str(yaml).unwrap();
+        let result = use_include_all_proxy_groups(config);
+
+        // Check that GLOBAL group now contains all proxies
+        let proxy_groups = result.get("proxy-groups").unwrap().as_sequence().unwrap();
+        let global_group = proxy_groups
+            .iter()
+            .find(|group| {
+                if let Some(mapping) = group.as_mapping() {
+                    if let Some(name) = mapping.get("name") {
+                        return name.as_str().unwrap() == "GLOBAL";
+                    }
+                }
+                false
+            })
+            .unwrap();
+
+        // Check that include-all field was removed
+        assert!(
+            global_group
+                .as_mapping()
+                .unwrap()
+                .get("include-all")
+                .is_none()
+        );
+
+        let global_proxies = global_group
+            .as_mapping()
+            .unwrap()
+            .get("proxies")
+            .unwrap()
+            .as_sequence()
+            .unwrap();
+        let proxy_names: Vec<&str> = global_proxies.iter().map(|p| p.as_str().unwrap()).collect();
+
+        // Should contain all proxies from the config
+        assert!(proxy_names.contains(&"Proxy1"));
+        assert!(proxy_names.contains(&"Proxy2"));
+        assert!(proxy_names.contains(&"provider1"));
+        assert!(proxy_names.contains(&"provider2"));
+        // Should still contain original proxies
+        assert!(proxy_names.contains(&"DIRECT"));
     }
 }


### PR DESCRIPTION
**描述:**  
该 PR 实现了 Clash Nyanpasu 配置增强系统中代理组对 `include-all: true` 字段的支持。带有该字段的代理组将自动包含配置中所有可用代理（来自 `proxies` 和 `proxy-providers`），同时保留组内已有代理。处理完成后，`include-all` 字段会被移除以避免冲突。

**实现细节:**

1. 新增 `use_include_all_proxy_groups` 函数，用于处理 `include-all` 代理组。
    
2. 将该函数集成到增强流水线中（在 `tun` 处理后，缓存处理前调用）。
    
3. 支持从 `proxies` 和 `proxy-providers` 收集代理。
    
4. 保留不在“所有代理”集合中的已有代理。
    
5. 处理完成后移除 `include-all` 字段。
    

**配置示例:**
```yaml
proxy-groups:
  - name: GLOBAL
    type: select
    include-all: true
    proxies:
      - DIRECT

```

该配置会自动将 `GLOBAL` 组填充所有可用代理，同时保留 `DIRECT`。

**测试:**

- 验证了从 `proxies` 和 `proxy-providers` 正确收集代理名称。
    
- 确认 `include-all` 字段处理正确。
    
- 确认保留已有代理。
    
- 检查处理完成后移除了 `include-all` 字段。
    

**影响:**

- 用户现在可以轻松配置代理组以自动包含所有可用代理。
    
- 提高了配置灵活性，减少了手动维护代理列表的工作量。