### PR TITLE
chore: update copyright year to 2025 for installer

### DIFF
--- a/backend/tauri/tauri.conf.json
+++ b/backend/tauri/tauri.conf.json
@@ -40,7 +40,7 @@
       "sidecar/clash-rs-alpha",
       "sidecar/nyanpasu-service"
     ],
-    "copyright": "© 2024 Clash Nyanpasu All Rights Reserved",
+    "copyright": "© 2025 Clash Nyanpasu All Rights Reserved",
     "category": "DeveloperTool",
     "shortDescription": "Clash Nyanpasu! (∠・ω< )⌒☆",
     "longDescription": "Clash Nyanpasu! (∠・ω< )⌒☆",


### PR DESCRIPTION
To be honest... this project has been stagnant for quite some time. I'd really love to see a new release.

Maybe I'm someone who gets bored easily, but I still love keiko233's Clash Verge. Of course, it's now called Nyanpasu~ 😉

---

I only updated the copyright year in the installer.

I'm not sure whether the comments in the code and the copyright year in other configuration files should be updated.

---

CC @keiko233 @greenhat616 