### PR TITLE
fix: reload clash config from file on core restart to persist user mode preference

### DIFF
--- a/backend/tauri/src/config/draft.rs
+++ b/backend/tauri/src/config/draft.rs
@@ -69,6 +69,16 @@ draft_define!(IClashTemp);
 draft_define!(IRuntime);
 draft_define!(IVerge);
 
+impl Draft<IClashTemp> {
+    /// Reload configuration from file
+    pub fn reload(&self) {
+        let new_config = IClashTemp::new();
+        let mut inner = self.inner.lock();
+        inner.0 = new_config;
+        inner.1 = None; // Clear any draft
+    }
+}
+
 #[test]
 fn test_draft() {
     let verge = IVerge {

--- a/backend/tauri/src/core/clash/core.rs
+++ b/backend/tauri/src/core/clash/core.rs
@@ -457,6 +457,13 @@ impl CoreManager {
             }
         }
 
+        // Reload clash config from file to get latest user preferences (e.g., mode)
+        Config::clash().reload();
+        log::debug!(target: "app", "reloaded clash config from file");
+
+        // Regenerate runtime config with the reloaded settings
+        Config::generate().await?;
+
         // 检查端口是否可用
         Config::clash()
             .latest()


### PR DESCRIPTION
## Summary

Fixed a bug where the user's proxy mode preference (Rule/Global/Direct) was not correctly restored after restarting the application or clash core.

## Problem

When users changed the proxy mode (Rule/Global/Direct) in the GUI and then:
1. Restarted the application, or
2. Restarted the clash core

The GUI would display a fixed default mode instead of the user's saved preference. The mode setting was being saved to file correctly, but not reloaded when the core restarted.

## Solution

Added a reload mechanism in `CoreManager::run_core()` to:
1. Reload the clash config from file before starting the core (`Config::clash().reload()`)
2. Regenerate runtime config with the reloaded settings (`Config::generate().await`)

This ensures that user preferences persisted to disk are properly loaded and applied when the core restarts.

## Changes

- `backend/tauri/src/config/draft.rs`: Added `reload()` method to `Draft<IClashTemp>` to reload configuration from file
- `backend/tauri/src/core/clash/core.rs`: Call `reload()` and `generate()` before core startup in `run_core()`

## Testing

- [x] Changed proxy mode in GUI (Rule → Global → Direct)
- [x] Restarted application - mode persisted correctly
- [x] Restarted clash core - mode persisted correctly
- [x] Switched pages and returned - mode displayed correctly
- [x] Tested on Windows - working as expected