### PR TITLE
chore: update copyright year

### DIFF
--- a/backend/tauri/tauri.conf.json
+++ b/backend/tauri/tauri.conf.json
@@ -40,7 +40,7 @@
       "sidecar/clash-rs-alpha",
       "sidecar/nyanpasu-service"
     ],
-    "copyright": "© 2025 Clash Nyanpasu All Rights Reserved",
+    "copyright": "© 2024-2026 Clash Nyanpasu All Rights Reserved",
     "category": "DeveloperTool",
     "shortDescription": "Clash Nyanpasu! (∠・ω< )⌒☆",
     "longDescription": "Clash Nyanpasu! (∠・ω< )⌒☆",


### PR DESCRIPTION
We are now at 2026.