### PR TITLE
fix(frontend): correct patchClashConfig payload keys to snake_case

### DIFF
--- a/frontend/nyanpasu/src/pages/(main)/main/settings/clash/_modules/allow-lan-switch.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/settings/clash/_modules/allow-lan-switch.tsx
@@ -19,7 +19,7 @@ export default function AllowLanSwitch() {
   const handleAllowLan = useLockFn(async (input: boolean) => {
     try {
       await upsert.mutateAsync({
-        'allow-lan': input,
+        allow_lan: input,
       })
     } catch (error) {
       message(`Activation Allow LAN failed!\n Error: ${formatError(error)}`, {

--- a/frontend/nyanpasu/src/pages/(main)/main/settings/clash/_modules/log-level-selector.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/settings/clash/_modules/log-level-selector.tsx
@@ -37,7 +37,7 @@ export default function LogLevelSelector() {
   const handleLogLevelChange = useCallback(
     async (value: string) => {
       await upsert.mutateAsync({
-        'log-level': value as string,
+        log_level: value as string,
       })
     },
     [upsert],

--- a/frontend/nyanpasu/src/pages/(main)/main/settings/clash/_modules/mixed-port-config.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/settings/clash/_modules/mixed-port-config.tsx
@@ -65,7 +65,7 @@ export default function MixedPortConfig() {
   const handleSubmit = form.handleSubmit(async (data) => {
     try {
       await clashConfig.upsert.mutateAsync({
-        'mixed-port': data.mixedPort,
+        mixed_port: data.mixedPort,
       })
       await mixedPort.upsert(data.mixedPort)
 

--- a/frontend/nyanpasu/src/pages/(main)/main/settings/web-ui/_modules/external-controller-config.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/settings/web-ui/_modules/external-controller-config.tsx
@@ -62,7 +62,7 @@ export default function ExternalControllerConfig() {
     async (data) => {
       try {
         await upsert.mutateAsync({
-          'external-controller': data.externalController,
+          external_controller: data.externalController,
         })
         await refetch()
 


### PR DESCRIPTION
The IPC PatchRuntimeConfig type expects snake_case keys (allow_lan, log_level, etc.), but several frontend components were sending kebab-case keys ('allow-lan', 'log-level', etc.). This caused the backend to silently ignore these fields during deserialization.

Fixed components:

- allow-lan-switch.tsx: 'allow-lan' -> allow_lan

- log-level-selector.tsx: 'log-level' -> log_level

- mixed-port-config.tsx: 'mixed-port' -> mixed_port

- external-controller-config.tsx: 'external-controller' -> external_controller