### PR TITLE
fix(ci): use tilde-separated version for Linux nightly RPM/DEB packages

### DIFF
--- a/.github/workflows/deps-build-linux.yaml
+++ b/.github/workflows/deps-build-linux.yaml
@@ -134,7 +134,7 @@ jobs:
       - name: Nightly Prepare
         if: ${{ inputs.nightly == true }}
         run: |
-          pnpm prepare:nightly ${{ inputs.arch != 'x86_64' && '--disable-updater'}}
+          pnpm prepare:nightly --linux ${{ inputs.arch != 'x86_64' && '--disable-updater'}}
 
       - name: Build UI
         run: pnpm -F ui build

--- a/scripts/prepare-nightly.ts
+++ b/scripts/prepare-nightly.ts
@@ -25,6 +25,7 @@ const ROOT_PACKAGE_JSON_PATH = path.join(cwd, "package.json");
 
 const isNSIS = Deno.args.includes("--nsis");
 const isMSI = Deno.args.includes("--msi");
+const isLinux = Deno.args.includes("--linux");
 const fixedWebview = Deno.args.includes("--fixed-webview");
 const disableUpdater = Deno.args.includes("--disable-updater");
 
@@ -82,9 +83,16 @@ async function main() {
   consola.debug(`Current git short hash: ${GIT_SHORT_HASH}`);
 
   const version = `${tauriConf.version}-alpha+${GIT_SHORT_HASH}`;
+  // RPM/DEB forbid `-` in the version string and use `~` to mark pre-releases
+  // (sorts before the final release). See #3850.
+  const linuxVersion = `${tauriConf.version}~alpha.${GIT_SHORT_HASH}`;
 
   consola.debug("Write tauri version to tauri.nightly.conf.json");
-  if (!isNSIS && !isMSI) tauriConf.version = version;
+  if (isLinux) {
+    tauriConf.version = linuxVersion;
+  } else if (!isNSIS && !isMSI) {
+    tauriConf.version = version;
+  }
   await Deno.writeTextFile(
     TAURI_DEV_APP_CONF_PATH,
     JSON.stringify(tauriConf, null, 2),


### PR DESCRIPTION
The nightly RPM package cannot be installed on Fedora Silverblue because its version string contains a `-` (dash), which the RPM spec forbids in the version field. Both RPM and DEB use `~` to denote pre-releases, which also sorts before the final release so upgrades resolve correctly.

Add a `--linux` flag to prepare-nightly that writes `X.Y.Z~alpha.<hash>` into the bundler config, and pass it from the Linux nightly workflow. macOS and Windows build paths are untouched, and the semver-formatted package.json versions used by the updater are left unchanged.

Fixes #3850