### PR TITLE
refactor(tauri): introduce NyanpasuClient facade (ACL) [PR-1]

### DIFF
--- a/backend/tauri/src/client/error.rs
+++ b/backend/tauri/src/client/error.rs
@@ -1,0 +1,31 @@
+use crate::core::storage::StorageOperationError;
+
+pub type Result<T = ()> = std::result::Result<T, ClientError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClientError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    SerdeYaml(#[from] serde_yaml::Error),
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
+    #[error(transparent)]
+    Storage(#[from] StorageOperationError),
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+    #[error("{0}")]
+    Custom(String),
+}
+
+impl From<String> for ClientError {
+    fn from(value: String) -> Self {
+        Self::Custom(value)
+    }
+}
+
+impl From<&str> for ClientError {
+    fn from(value: &str) -> Self {
+        Self::Custom(value.to_string())
+    }
+}

--- a/backend/tauri/src/client/event_sink.rs
+++ b/backend/tauri/src/client/event_sink.rs
@@ -1,0 +1,97 @@
+use crate::{
+    client::Result,
+    core::handle::{Message, StateChanged},
+};
+use tauri::{Emitter, Manager};
+
+/// Abstracts the Tauri UI side-effects the client emits. The full surface
+/// mirrors `Handle`; PR-1 only exercises `refresh_clash`, the rest is consumed
+/// as commands migrate in later PRs.
+#[allow(dead_code)]
+pub trait UiEventSink: Send + Sync + 'static {
+    fn state_changed(&self, state: StateChanged);
+
+    fn notice_message(&self, message: &Message);
+
+    fn update_systray(&self) -> Result<()>;
+
+    fn update_systray_part(&self) -> Result<()>;
+
+    fn refresh_clash(&self) {
+        self.state_changed(StateChanged::ClashConfig);
+    }
+
+    fn refresh_verge(&self) {
+        self.state_changed(StateChanged::NyanpasuConfig);
+    }
+
+    fn refresh_profiles(&self) {
+        self.state_changed(StateChanged::Profiles);
+    }
+
+    fn mutate_proxies(&self) {
+        self.state_changed(StateChanged::Proxies);
+    }
+}
+
+#[derive(Clone)]
+pub struct TauriUiEventSink<R: tauri::Runtime = tauri::Wry> {
+    app_handle: tauri::AppHandle<R>,
+}
+
+impl<R: tauri::Runtime> TauriUiEventSink<R> {
+    pub fn new(app_handle: tauri::AppHandle<R>) -> Self {
+        Self { app_handle }
+    }
+}
+
+impl<R: tauri::Runtime> UiEventSink for TauriUiEventSink<R> {
+    fn state_changed(&self, state: StateChanged) {
+        if let Some(window) = self
+            .app_handle
+            .get_webview_window(crate::consts::MAIN_WINDOW_LABEL)
+        {
+            crate::log_err!(window.emit("nyanpasu://mutation", state));
+        }
+    }
+
+    fn notice_message(&self, message: &Message) {
+        if let Some(window) = self
+            .app_handle
+            .get_webview_window(crate::consts::MAIN_WINDOW_LABEL)
+        {
+            crate::log_err!(window.emit("nyanpasu://notice-message", message));
+        }
+    }
+
+    fn update_systray(&self) -> Result<()> {
+        self.app_handle
+            .emit("update_systray", ())
+            .map_err(anyhow::Error::from)?;
+        Ok(())
+    }
+
+    fn update_systray_part(&self) -> Result<()> {
+        crate::core::tray::Tray::update_part(&self.app_handle)?;
+        Ok(())
+    }
+}
+
+/// Test double for [`UiEventSink`] usable without a Tauri runtime.
+#[allow(dead_code)]
+#[derive(Clone, Default)]
+pub struct NoopUiEventSink;
+
+impl UiEventSink for NoopUiEventSink {
+    fn state_changed(&self, _state: StateChanged) {}
+
+    fn notice_message(&self, _message: &Message) {}
+
+    fn update_systray(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn update_systray_part(&self) -> Result<()> {
+        Ok(())
+    }
+}

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -1,0 +1,101 @@
+mod error;
+mod event_sink;
+
+use crate::{
+    config::{Config, IVerge, Profiles, ProfilesBuilder},
+    core::{CoreManager, RunType},
+};
+use nyanpasu_ipc::api::status::CoreState;
+use std::{borrow::Cow, sync::Arc};
+
+pub use error::{ClientError, Result};
+pub use event_sink::{TauriUiEventSink, UiEventSink};
+
+#[derive(Clone)]
+pub struct NyanpasuClient {
+    inner: Arc<NyanpasuClientInner>,
+}
+
+struct NyanpasuClientInner {
+    ui: Arc<dyn UiEventSink>,
+}
+
+impl NyanpasuClient {
+    pub fn new(ui: Arc<dyn UiEventSink>) -> Self {
+        Self {
+            inner: Arc::new(NyanpasuClientInner { ui }),
+        }
+    }
+
+    pub fn get_profiles(&self) -> Profiles {
+        Config::profiles().data().clone()
+    }
+
+    pub async fn patch_profiles_config(&self, profiles: ProfilesBuilder) -> Result<()> {
+        Config::profiles().draft().apply(profiles);
+
+        match CoreManager::global().update_config().await {
+            Ok(_) => {
+                self.inner.ui.refresh_clash();
+                Config::profiles().apply();
+                Config::profiles().data().save_file()?;
+
+                let _ = crate::core::connection_interruption::ConnectionInterruptionService::on_profile_change().await;
+
+                Ok(())
+            }
+            Err(err) => {
+                Config::profiles().discard();
+                log::error!(target: "app", "{err:?}");
+                Err(err.into())
+            }
+        }
+    }
+
+    pub fn get_verge_config(&self) -> IVerge {
+        Config::verge().data().clone()
+    }
+
+    pub async fn patch_verge_config(&self, payload: IVerge) -> Result<()> {
+        crate::feat::patch_verge(payload).await?;
+        Ok(())
+    }
+
+    pub async fn get_core_status(&self) -> (Cow<'static, CoreState>, i64, RunType) {
+        CoreManager::global().status().await
+    }
+}
+
+pub fn setup<R: tauri::Runtime, M: tauri::Manager<R>>(manager: &M) -> anyhow::Result<()> {
+    let sink: Arc<dyn UiEventSink> = Arc::new(TauriUiEventSink::new(manager.app_handle().clone()));
+    manager.manage(NyanpasuClient::new(sink));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{client::event_sink::NoopUiEventSink, ipc::IpcError};
+
+    #[test]
+    fn client_constructs_without_tauri_runtime() {
+        let client = NyanpasuClient::new(Arc::new(NoopUiEventSink));
+        let _ = client.clone();
+    }
+
+    #[test]
+    fn client_error_bridges_to_ipc_error() {
+        assert!(matches!(
+            IpcError::from(ClientError::Custom("boom".into())),
+            IpcError::Custom(msg) if msg == "boom"
+        ));
+        assert!(matches!(
+            IpcError::from(ClientError::Io(std::io::Error::other("io"))),
+            IpcError::Io(_)
+        ));
+        assert!(matches!(
+            IpcError::from(ClientError::Anyhow(anyhow::anyhow!("oops"))),
+            IpcError::Anyhow(_)
+        ));
+    }
+}

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -1,4 +1,5 @@
 use crate::{
+    client::{ClientError, NyanpasuClient},
     config::{profile::ProfileBuilder, *},
     core::{
         logger::Logger, storage::Storage, tasks::jobs::ProfilesJobGuard,
@@ -22,7 +23,7 @@ use std::{
 };
 use storage::{StorageOperationError, WebStorage};
 use sysproxy::Sysproxy;
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Manager, State};
 use tray::icon::TrayIcon;
 
 use tauri_plugin_dialog::{DialogExt, FileDialogBuilder};
@@ -48,6 +49,19 @@ pub enum IpcError {
 impl From<String> for IpcError {
     fn from(s: String) -> Self {
         IpcError::Custom(s)
+    }
+}
+
+impl From<ClientError> for IpcError {
+    fn from(err: ClientError) -> Self {
+        match err {
+            ClientError::Io(err) => IpcError::Io(err),
+            ClientError::SerdeYaml(err) => IpcError::SerdeYaml(err),
+            ClientError::SerdeJson(err) => IpcError::SerdeJson(err),
+            ClientError::Storage(err) => IpcError::Storage(err),
+            ClientError::Anyhow(err) => IpcError::Anyhow(err),
+            ClientError::Custom(err) => IpcError::Custom(err),
+        }
     }
 }
 
@@ -85,8 +99,8 @@ pub struct GetSysProxyResponse {
 
 #[tauri::command]
 #[specta::specta]
-pub fn get_profiles() -> Result<Profiles> {
-    Ok(Config::profiles().data().clone())
+pub fn get_profiles(client: State<'_, NyanpasuClient>) -> Result<Profiles> {
+    Ok(client.get_profiles())
 }
 
 #[cfg(target_os = "windows")]
@@ -119,7 +133,11 @@ pub async fn enhance_profiles() -> Result {
 
 #[tauri::command]
 #[specta::specta]
-pub async fn import_profile(url: String, option: Option<RemoteProfileOptionsBuilder>) -> Result {
+pub async fn import_profile(
+    client: State<'_, NyanpasuClient>,
+    url: String,
+    option: Option<RemoteProfileOptionsBuilder>,
+) -> Result {
     let url = url::Url::parse(&url).context("failed to parse the url")?;
     let mut builder = crate::config::profile::item::RemoteProfileBuilder::default();
     builder.url(url);
@@ -146,7 +164,7 @@ pub async fn import_profile(url: String, option: Option<RemoteProfileOptionsBuil
     if let Some(profile_id) = profile_id {
         let mut builder = ProfilesBuilder::default();
         builder.current(vec![profile_id]);
-        patch_profiles_config(builder).await?;
+        client.patch_profiles_config(builder).await?;
     }
     Ok(())
 }
@@ -154,7 +172,11 @@ pub async fn import_profile(url: String, option: Option<RemoteProfileOptionsBuil
 /// create a new profile
 #[tauri::command]
 #[specta::specta]
-pub async fn create_profile(item: ProfileBuilder, file_data: Option<String>) -> Result {
+pub async fn create_profile(
+    client: State<'_, NyanpasuClient>,
+    item: ProfileBuilder,
+    file_data: Option<String>,
+) -> Result {
     tracing::trace!("create profile: {item:?}");
 
     let is_remote = matches!(&item, ProfileBuilder::Remote(_));
@@ -209,7 +231,7 @@ pub async fn create_profile(item: ProfileBuilder, file_data: Option<String>) -> 
     if let Some(profile_id) = profile_id {
         let mut builder = ProfilesBuilder::default();
         builder.current(vec![profile_id]);
-        patch_profiles_config(builder).await?;
+        client.patch_profiles_config(builder).await?;
     }
 
     Ok(())
@@ -263,26 +285,12 @@ pub async fn delete_profile(uid: String) -> Result {
 /// 修改profiles的
 #[tauri::command]
 #[specta::specta]
-pub async fn patch_profiles_config(profiles: ProfilesBuilder) -> Result {
-    Config::profiles().draft().apply(profiles);
-
-    match CoreManager::global().update_config().await {
-        Ok(_) => {
-            handle::Handle::refresh_clash();
-            Config::profiles().apply();
-            (Config::profiles().data().save_file())?;
-
-            // Interrupt connections based on configuration
-            let _ = crate::core::connection_interruption::ConnectionInterruptionService::on_profile_change().await;
-
-            Ok(())
-        }
-        Err(err) => {
-            Config::profiles().discard();
-            log::error!(target: "app", "{err:?}");
-            Err(IpcError::from(err))
-        }
-    }
+pub async fn patch_profiles_config(
+    client: State<'_, NyanpasuClient>,
+    profiles: ProfilesBuilder,
+) -> Result {
+    client.patch_profiles_config(profiles).await?;
+    Ok(())
 }
 
 /// update profile by uid
@@ -436,8 +444,10 @@ pub fn get_postprocessing_output() -> Result<PostProcessingOutput> {
 
 #[tauri::command]
 #[specta::specta]
-pub async fn get_core_status<'n>() -> Result<(Cow<'n, CoreState>, i64, RunType)> {
-    Ok(CoreManager::global().status().await)
+pub async fn get_core_status(
+    client: State<'_, NyanpasuClient>,
+) -> Result<(Cow<'static, CoreState>, i64, RunType)> {
+    Ok(client.get_core_status().await)
 }
 
 #[tauri::command]
@@ -481,8 +491,8 @@ pub async fn patch_clash_config(payload: PatchRuntimeConfig) -> Result {
 
 #[tauri::command]
 #[specta::specta]
-pub fn get_verge_config() -> Result<IVerge> {
-    Ok(Config::verge().data().clone())
+pub fn get_verge_config(client: State<'_, NyanpasuClient>) -> Result<IVerge> {
+    Ok(client.get_verge_config())
 }
 
 #[tauri::command]
@@ -493,8 +503,8 @@ pub fn get_hotkey_functions() -> Vec<&'static str> {
 
 #[tauri::command]
 #[specta::specta]
-pub async fn patch_verge_config(payload: IVerge) -> Result {
-    (feat::patch_verge(payload).await)?;
+pub async fn patch_verge_config(client: State<'_, NyanpasuClient>, payload: IVerge) -> Result {
+    client.patch_verge_config(payload).await?;
     Ok(())
 }
 

--- a/backend/tauri/src/lib.rs
+++ b/backend/tauri/src/lib.rs
@@ -5,6 +5,7 @@
 )]
 // This lint was needed by ambassador
 #![allow(clippy::duplicated_attributes)]
+mod client;
 mod cmds;
 mod config;
 mod consts;

--- a/backend/tauri/src/setup.rs
+++ b/backend/tauri/src/setup.rs
@@ -10,6 +10,8 @@ pub fn setup<R: tauri::Runtime, M: tauri::Manager<R>>(app: &M) -> Result<(), any
     })
     .context("Failed to setup the shutdown hook")?;
 
+    crate::client::setup(app).context("Failed to setup nyanpasu client")?;
+
     // FIXME: this is a background setup, so be careful use this state in ipc.
     // crate::logging::setup(app).context("Failed to setup logging")?;
     Ok(())


### PR DESCRIPTION
## PR-1 — Introduce `NyanpasuClient` façade (anti-corruption layer)

First, lowest-risk step of the ractor actor migration. Establishes an **ACL** so Tauri commands no longer touch global singletons directly, but depend on an injected `NyanpasuClient` (`tauri::State`). In this PR the client **still delegates** to the existing globals (`Config::*`, `CoreManager::global()`) and `feat::*` — no actors, no business-logic moves, no frontend contract changes.

### Changes
- **New `backend/tauri/src/client/` module**
  - `NyanpasuClient` — `#[derive(Clone)]` over an `Arc` inner, injected via `manage()` + `tauri::State`, replicating the existing `ClashConnectionsConnector` DI shape.
  - `ClientError` — error type **decoupled** from `IpcError`/Specta/Tauri (no `tauri::Error` variant; Tauri coupling stays inside the adapter).
  - `UiEventSink` trait + `TauriUiEventSink<R: Runtime>` / `NoopUiEventSink` — abstracts Tauri UI side-effects, emitting **byte-identical** events to `Handle` (`nyanpasu://mutation`, `nyanpasu://notice-message`, `update_systray`).
- **`ipc.rs`**
  - `impl From<ClientError> for IpcError` (per-variant) — preserves the exact serialized error strings the frontend sees.
  - Migrated PoC commands to the injected client: `get_profiles`, `patch_profiles_config`, `get_verge_config`, `patch_verge_config`, `get_core_status`.
  - `import_profile` / `create_profile` now route through the injected client instead of the old free `patch_profiles_config` (keeps a single sink path, avoids re-coupling to `Handle::global()`).
- **`setup.rs`** — `client::setup(app)` runs inside `setup::setup`, before `resolve_setup` (state ready before any command fires).
- **`lib.rs`** — added `mod client;`. `collect_commands!` registration unchanged.

### Frontend contract: unchanged
`NyanpasuClient` does **not** derive `specta::Type`, so the crate would fail to compile if the injected `State` args leaked into the exported signatures — it compiles, proving they're excluded (same as the existing `AppHandle`-injected `get_clash_ws_connections_state`, which exports as `()`). Command names, argument lists, return types, and event names are all unchanged → `bindings.ts` regenerates byte-identical.

### Verification
- `cargo check -p clash-nyanpasu --lib` — passes, no new warnings.
- `cargo test -p clash-nyanpasu --lib client::` — 2/2 pass (Tauri-runtime-free construction; `ClientError → IpcError` bridging).
- Backend code review (codex): **PASS-WITH-NITS**, no Critical/Major; behavioral equivalence, error-string preservation, generic-runtime soundness, and setup ordering all confirmed.

### Out of scope (later PRs)
No ractor actors; no removal of `Config::global()` / `Handle::global()` / `CoreManager::global()`; client not yet moved to a separate crate; only the first PoC commands migrated; no changes to persistence/storage/tray/proxy/core lifecycle.

### Reviewer notes
- `#[allow(dead_code)]` on the `UiEventSink` forward-API surface is intentional staged scaffolding (only `refresh_clash` is exercised in PR-1); to be narrowed as more commands migrate.
- `get_core_status` switched from a phantom `Cow<'n>` lifetime to `Cow<'static, CoreState>` (the `<'n>` form breaks under `#[tauri::command]` once a `State` param is added; `CoreManager::status()` returns owned data, so `'static` is correct).
