### PR TITLE
refactor(backend): route verge config through ractor StateActor

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1839,6 +1839,7 @@ dependencies = [
  "nix 0.31.3",
  "notify",
  "notify-debouncer-full",
+ "nyanpasu-core",
  "nyanpasu-egui",
  "nyanpasu-ipc",
  "nyanpasu-macro",

--- a/backend/tauri/Cargo.toml
+++ b/backend/tauri/Cargo.toml
@@ -29,6 +29,7 @@ nyanpasu-ipc = { git = "https://github.com/libnyanpasu/nyanpasu-service.git", fe
   "specta",
 ] } # IPC bridge between the UI process and service process
 nyanpasu-macro = { path = "../nyanpasu-macro" }
+nyanpasu-core = { path = "../nyanpasu-core" }
 nyanpasu-utils = { workspace = true }
 nyanpasu-egui = { path = "../nyanpasu-egui" }
 

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -1,12 +1,16 @@
 mod error;
 mod event_sink;
+mod state;
 
+use self::state::{StateClient, VergePatchRoute, route_verge_patch};
 use crate::{
     config::{Config, IVerge, Profiles, ProfilesBuilder},
     core::{CoreManager, RunType},
+    state::verge::VergeMirror,
 };
 use nyanpasu_ipc::api::status::CoreState;
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, future::Future, sync::Arc};
+use tokio::sync::Mutex;
 
 pub use error::{ClientError, Result};
 pub use event_sink::{TauriUiEventSink, UiEventSink};
@@ -18,13 +22,55 @@ pub struct NyanpasuClient {
 
 struct NyanpasuClientInner {
     ui: Arc<dyn UiEventSink>,
+    state: StateClient,
+    /// Serializes all verge mutations funneled through this client (IPC patches,
+    /// legacy reseeds). The actor serializes its own state, but the legacy path holds
+    /// `Config::verge()` draft across awaits, so client-level mutations must not interleave.
+    verge_update_lock: Mutex<()>,
 }
 
 impl NyanpasuClient {
-    pub fn new(ui: Arc<dyn UiEventSink>) -> Self {
+    pub fn try_new(ui: Arc<dyn UiEventSink>) -> anyhow::Result<Self> {
+        let initial = Config::verge().data().clone();
+        let state = StateClient::new(initial, legacy_verge_mirror())?;
+        Ok(Self::with_state(ui, state))
+    }
+
+    fn with_state(ui: Arc<dyn UiEventSink>, state: StateClient) -> Self {
         Self {
-            inner: Arc::new(NyanpasuClientInner { ui }),
+            inner: Arc::new(NyanpasuClientInner {
+                ui,
+                state,
+                verge_update_lock: Mutex::new(()),
+            }),
         }
+    }
+
+    pub async fn replace_verge_config(&self, state: IVerge) -> Result<()> {
+        let _guard = self.inner.verge_update_lock.lock().await;
+        self.replace_verge_unlocked(state).await
+    }
+
+    async fn replace_verge_unlocked(&self, state: IVerge) -> Result<()> {
+        self.inner.state.replace_verge(state).await?;
+        Ok(())
+    }
+
+    /// Run a legacy mutation that writes `Config::verge()` directly (e.g. core change,
+    /// window-state save), then reseed the actor from the post-mutation legacy state.
+    /// Every legacy verge writer that bypasses the actor must go through this, otherwise
+    /// a later actor commit would persist a stale snapshot and clobber the legacy change.
+    pub async fn run_legacy_verge_mutation<F, Fut>(&self, mutate: F) -> Result<()>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = anyhow::Result<()>>,
+    {
+        let _guard = self.inner.verge_update_lock.lock().await;
+        mutate().await?;
+        // Bind the clone to a local so the `Config::verge()` guard is dropped before the
+        // await (a held parking_lot guard would make this future !Send).
+        let committed = Config::verge().data().clone();
+        self.replace_verge_unlocked(committed).await
     }
 
     pub fn get_profiles(&self) -> Profiles {
@@ -52,12 +98,23 @@ impl NyanpasuClient {
         }
     }
 
-    pub fn get_verge_config(&self) -> IVerge {
-        Config::verge().data().clone()
+    pub async fn get_verge_config(&self) -> Result<IVerge> {
+        Ok(self.inner.state.get_verge().await?)
     }
 
     pub async fn patch_verge_config(&self, payload: IVerge) -> Result<()> {
-        crate::feat::patch_verge(payload).await?;
+        // Each path locks exactly once: PureConfig locks here; LegacySideEffects locks
+        // inside `run_legacy_verge_mutation` (the lock is not reentrant).
+        match route_verge_patch(&payload) {
+            VergePatchRoute::PureConfig => {
+                let _guard = self.inner.verge_update_lock.lock().await;
+                self.inner.state.patch_verge(payload).await?;
+            }
+            VergePatchRoute::LegacySideEffects => {
+                self.run_legacy_verge_mutation(|| crate::feat::patch_verge(payload))
+                    .await?;
+            }
+        }
         Ok(())
     }
 
@@ -68,18 +125,41 @@ impl NyanpasuClient {
 
 pub fn setup<R: tauri::Runtime, M: tauri::Manager<R>>(manager: &M) -> anyhow::Result<()> {
     let sink: Arc<dyn UiEventSink> = Arc::new(TauriUiEventSink::new(manager.app_handle().clone()));
-    manager.manage(NyanpasuClient::new(sink));
+    manager.manage(NyanpasuClient::try_new(sink)?);
     Ok(())
+}
+
+/// Production mirror: only updates the in-memory `Config::verge()`. The actor already
+/// performs the atomic disk write, so the mirror must not call `save_file` again.
+fn legacy_verge_mirror() -> VergeMirror {
+    Arc::new(|state| {
+        *Config::verge().draft() = state;
+        Config::verge().apply();
+        Ok(())
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{client::event_sink::NoopUiEventSink, ipc::IpcError};
+    use camino::Utf8PathBuf;
+    use tempfile::tempdir;
+
+    fn test_state_client() -> (StateClient, tempfile::TempDir) {
+        let dir = tempdir().expect("tempdir should be created");
+        let path = Utf8PathBuf::from_path_buf(dir.path().join("nyanpasu-config.yaml"))
+            .expect("temp path should be UTF-8");
+        let mirror: VergeMirror = Arc::new(|_| Ok(()));
+        let state = StateClient::new_with_path(path, IVerge::default(), mirror)
+            .expect("state client should be created");
+        (state, dir)
+    }
 
     #[test]
     fn client_constructs_without_tauri_runtime() {
-        let client = NyanpasuClient::new(Arc::new(NoopUiEventSink));
+        let (state, _dir) = test_state_client();
+        let client = NyanpasuClient::with_state(Arc::new(NoopUiEventSink), state);
         let _ = client.clone();
     }
 

--- a/backend/tauri/src/client/state.rs
+++ b/backend/tauri/src/client/state.rs
@@ -1,0 +1,363 @@
+use std::{sync::Arc, time::Duration};
+
+use anyhow::Context as _;
+use camino::Utf8PathBuf;
+use ractor::{Actor, ActorRef, RpcReplyPort, rpc::CallResult};
+
+use crate::{
+    config::IVerge,
+    state::verge::{
+        StateActor, StateActorArgs, StateActorMessage, VergeMirror, VergeStateSnapshot,
+    },
+    utils::dirs,
+};
+use nyanpasu_core::state::PersistentStateManagerSetup;
+
+const STATE_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+/// Must match the prefix used by the legacy `IVerge::save_file` so both writers
+/// produce an identical header for `nyanpasu-config.yaml`.
+const VERGE_CONFIG_PREFIX: &str = "# Clash Nyanpasu Config";
+
+#[derive(Clone)]
+pub struct StateClient {
+    inner: Arc<StateClientInner>,
+}
+
+struct StateClientInner {
+    actor_ref: ActorRef<StateActorMessage>,
+}
+
+impl StateClient {
+    /// Production entry point: real `nyanpasu-config.yaml` + injected legacy mirror.
+    pub fn new(initial: IVerge, mirror: VergeMirror) -> anyhow::Result<Self> {
+        let path = Utf8PathBuf::from_path_buf(dirs::nyanpasu_config_path()?).map_err(|path| {
+            anyhow::anyhow!("nyanpasu config path is not UTF-8: {}", path.display())
+        })?;
+        Self::new_with_path(path, initial, mirror)
+    }
+
+    /// Test/internal entry point: explicit config path (e.g. a tempdir).
+    pub(crate) fn new_with_path(
+        config_path: Utf8PathBuf,
+        initial: IVerge,
+        mirror: VergeMirror,
+    ) -> anyhow::Result<Self> {
+        // Mirror `ClashConnectionsConnector::new`: block_on initialization + spawn in a
+        // synchronous context so the client can be constructed during Tauri setup.
+        let manager = tauri::async_runtime::block_on(
+            PersistentStateManagerSetup::<IVerge>::builder()
+                .config_path(config_path)
+                .config_prefix(VERGE_CONFIG_PREFIX.to_string())
+                .assemble()
+                .from_state(initial),
+        )
+        .context("failed to initialize verge persistent state manager")?;
+
+        // Spawn anonymously: the client holds the `ActorRef` directly and never resolves
+        // the actor by name, so a globally-registered name would only risk registry
+        // collisions (e.g. across parallel tests or a client re-spawn).
+        let actor_ref = tauri::async_runtime::block_on(Actor::spawn(
+            None,
+            StateActor,
+            StateActorArgs { manager, mirror },
+        ))
+        .context("failed to spawn nyanpasu state actor")?
+        .0;
+
+        Ok(Self {
+            inner: Arc::new(StateClientInner { actor_ref }),
+        })
+    }
+
+    pub async fn get_verge(&self) -> anyhow::Result<IVerge> {
+        Ok(self.call(StateActorMessage::GetVerge).await?.state)
+    }
+
+    pub async fn patch_verge(&self, patch: IVerge) -> anyhow::Result<VergeStateSnapshot> {
+        self.call(|reply| StateActorMessage::PatchVerge { patch, reply })
+            .await
+    }
+
+    pub async fn replace_verge(&self, state: IVerge) -> anyhow::Result<VergeStateSnapshot> {
+        self.call(|reply| StateActorMessage::ReplaceVerge { state, reply })
+            .await
+    }
+
+    async fn call<F>(&self, make: F) -> anyhow::Result<VergeStateSnapshot>
+    where
+        F: FnOnce(RpcReplyPort<anyhow::Result<VergeStateSnapshot>>) -> StateActorMessage,
+    {
+        match self
+            .inner
+            .actor_ref
+            .call(make, Some(STATE_RPC_TIMEOUT))
+            .await?
+        {
+            CallResult::Success(result) => result,
+            CallResult::SenderError => anyhow::bail!("state actor reply dropped"),
+            CallResult::Timeout => anyhow::bail!("state actor call timed out"),
+        }
+    }
+}
+
+impl Drop for StateClientInner {
+    fn drop(&mut self) {
+        self.actor_ref.stop(None);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VergePatchRoute {
+    PureConfig,
+    LegacySideEffects,
+}
+
+/// Pure classifier (infallible). Validation is delegated to the actor (`PatchVerge`)
+/// or to `feat::patch_verge`. The side-effect field set mirrors `feat::patch_verge`.
+pub fn route_verge_patch(patch: &IVerge) -> VergePatchRoute {
+    let legacy = patch.enable_service_mode.is_some()
+        || patch.enable_tun_mode.is_some()
+        || patch.enable_auto_launch.is_some()
+        || patch.enable_system_proxy.is_some()
+        || patch.system_proxy_bypass.is_some()
+        || patch.enable_proxy_guard.is_some()
+        || patch.hotkeys.is_some()
+        || patch.language.is_some()
+        || patch.app_log_level.is_some()
+        || patch.max_log_files.is_some()
+        || patch.clash_tray_selector.is_some()
+        || patch.enable_tray_text.is_some()
+        || patch.tray_menu_mode.is_some()
+        || patch.network_statistic_widget.is_some();
+
+    if legacy {
+        VergePatchRoute::LegacySideEffects
+    } else {
+        VergePatchRoute::PureConfig
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::nyanpasu::{
+        ClashCore, LoggingLevel, NetworkStatisticWidgetConfig, ProxiesSelectorMode, TrayMenuMode,
+    };
+    use std::sync::Mutex;
+    use tempfile::{TempDir, tempdir};
+
+    fn temp_config_path(dir: &TempDir) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(dir.path().join("nyanpasu-config.yaml"))
+            .expect("temp path should be UTF-8")
+    }
+
+    fn capture_mirror() -> (VergeMirror, Arc<Mutex<Option<IVerge>>>) {
+        let captured = Arc::new(Mutex::new(None::<IVerge>));
+        let mirror_capture = captured.clone();
+        let mirror: VergeMirror = Arc::new(move |state| {
+            *mirror_capture
+                .lock()
+                .expect("mirror lock should not poison") = Some(state);
+            Ok(())
+        });
+        (mirror, captured)
+    }
+
+    fn test_client(
+        initial: IVerge,
+    ) -> (
+        StateClient,
+        TempDir,
+        Utf8PathBuf,
+        Arc<Mutex<Option<IVerge>>>,
+    ) {
+        let dir = tempdir().expect("tempdir should be created");
+        let path = temp_config_path(&dir);
+        let (mirror, captured) = capture_mirror();
+        let client = StateClient::new_with_path(path.clone(), initial, mirror)
+            .expect("state client should be created");
+        (client, dir, path, captured)
+    }
+
+    #[test]
+    fn get_verge_returns_initial_state() {
+        let initial = IVerge {
+            theme_color: Some("#010203".into()),
+            ..IVerge::default()
+        };
+        let (client, _dir, _path, _captured) = test_client(initial);
+
+        tauri::async_runtime::block_on(async {
+            let verge = client.get_verge().await.expect("get should succeed");
+            assert_eq!(verge.theme_color.as_deref(), Some("#010203"));
+        });
+    }
+
+    #[test]
+    fn pure_patch_persists_and_mirrors() {
+        let (client, _dir, path, captured) = test_client(IVerge::default());
+
+        tauri::async_runtime::block_on(async {
+            let snapshot = client
+                .patch_verge(IVerge {
+                    theme_color: Some("#112233".into()),
+                    ..IVerge::default()
+                })
+                .await
+                .expect("patch should succeed");
+
+            assert_eq!(snapshot.state.theme_color.as_deref(), Some("#112233"));
+            assert!(snapshot.version > 0);
+        });
+
+        let contents =
+            std::fs::read_to_string(path.as_std_path()).expect("config should be written");
+        assert!(contents.contains(VERGE_CONFIG_PREFIX));
+        assert!(contents.contains("#112233"));
+
+        let mirrored = captured
+            .lock()
+            .expect("mirror lock should not poison")
+            .clone()
+            .expect("mirror should be called");
+        assert_eq!(mirrored.theme_color.as_deref(), Some("#112233"));
+    }
+
+    #[test]
+    fn invalid_theme_color_does_not_commit() {
+        let (client, _dir, path, captured) = test_client(IVerge::default());
+
+        let err = tauri::async_runtime::block_on(async {
+            client
+                .patch_verge(IVerge {
+                    theme_color: Some("red".into()),
+                    ..IVerge::default()
+                })
+                .await
+                .expect_err("invalid color should fail")
+        });
+
+        assert!(err.to_string().contains("Invalid theme color"));
+        assert!(!path.as_std_path().exists());
+        assert!(
+            captured
+                .lock()
+                .expect("mirror lock should not poison")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn replace_verge_persists_and_mirrors() {
+        let (client, _dir, path, captured) = test_client(IVerge::default());
+
+        tauri::async_runtime::block_on(async {
+            let snapshot = client
+                .replace_verge(IVerge {
+                    theme_mode: Some("dark".into()),
+                    ..IVerge::default()
+                })
+                .await
+                .expect("replace should succeed");
+
+            assert_eq!(snapshot.state.theme_mode.as_deref(), Some("dark"));
+            assert!(snapshot.version > 0);
+        });
+
+        let contents =
+            std::fs::read_to_string(path.as_std_path()).expect("config should be written");
+        assert!(contents.contains("dark"));
+
+        let mirrored = captured
+            .lock()
+            .expect("mirror lock should not poison")
+            .clone()
+            .expect("mirror should be called");
+        assert_eq!(mirrored.theme_mode.as_deref(), Some("dark"));
+    }
+
+    /// Regression: a legacy writer (e.g. `change_clash_core`, window-state save, or a
+    /// tray/hotkey toggle) reseeds the actor via `replace_verge`; a subsequent pure patch
+    /// must NOT revert the reseeded field. This is the invariant the `run_legacy_verge_mutation`
+    /// / `patch_verge_entrypoint` reseed paths rely on.
+    #[test]
+    fn reseed_then_pure_patch_preserves_reseeded_fields() {
+        let (client, _dir, _path, _captured) = test_client(IVerge::default());
+
+        tauri::async_runtime::block_on(async {
+            // Out-of-band legacy mutation pushed into the actor.
+            client
+                .replace_verge(IVerge {
+                    clash_core: Some(ClashCore::Mihomo),
+                    ..IVerge::default()
+                })
+                .await
+                .expect("reseed should succeed");
+
+            // A pure patch on an unrelated field.
+            let snapshot = client
+                .patch_verge(IVerge {
+                    theme_color: Some("#445566".into()),
+                    ..IVerge::default()
+                })
+                .await
+                .expect("patch should succeed");
+
+            assert_eq!(snapshot.state.theme_color.as_deref(), Some("#445566"));
+            // The reseeded clash_core must survive the pure patch.
+            assert_eq!(snapshot.state.clash_core, Some(ClashCore::Mihomo));
+
+            let verge = client.get_verge().await.expect("get should succeed");
+            assert_eq!(verge.clash_core, Some(ClashCore::Mihomo));
+        });
+    }
+
+    #[test]
+    fn route_verge_patch_classifies_pure_fields() {
+        macro_rules! assert_pure {
+            ($field:ident: $value:expr) => {{
+                let mut patch = IVerge::default();
+                patch.$field = Some($value);
+                assert_eq!(
+                    route_verge_patch(&patch),
+                    VergePatchRoute::PureConfig,
+                    stringify!($field)
+                );
+            }};
+        }
+
+        assert_pure!(theme_color: "#112233".to_string());
+        assert_pure!(traffic_graph: true);
+        assert_pure!(theme_mode: "dark".to_string());
+    }
+
+    #[test]
+    fn route_verge_patch_classifies_side_effect_fields() {
+        macro_rules! assert_legacy {
+            ($field:ident: $value:expr) => {{
+                let mut patch = IVerge::default();
+                patch.$field = Some($value);
+                assert_eq!(
+                    route_verge_patch(&patch),
+                    VergePatchRoute::LegacySideEffects,
+                    stringify!($field)
+                );
+            }};
+        }
+
+        assert_legacy!(enable_service_mode: true);
+        assert_legacy!(enable_tun_mode: true);
+        assert_legacy!(enable_auto_launch: true);
+        assert_legacy!(enable_system_proxy: true);
+        assert_legacy!(system_proxy_bypass: "localhost".to_string());
+        assert_legacy!(enable_proxy_guard: true);
+        assert_legacy!(hotkeys: Vec::<String>::new());
+        assert_legacy!(language: "en".to_string());
+        assert_legacy!(app_log_level: LoggingLevel::default());
+        assert_legacy!(max_log_files: 7usize);
+        assert_legacy!(clash_tray_selector: ProxiesSelectorMode::default());
+        assert_legacy!(enable_tray_text: true);
+        assert_legacy!(tray_menu_mode: TrayMenuMode::default());
+        assert_legacy!(network_statistic_widget: NetworkStatisticWidgetConfig::default());
+    }
+}

--- a/backend/tauri/src/client/state.rs
+++ b/backend/tauri/src/client/state.rs
@@ -16,7 +16,10 @@ use nyanpasu_core::state::PersistentStateManagerSetup;
 const STATE_RPC_TIMEOUT: Duration = Duration::from_secs(5);
 /// Must match the prefix used by the legacy `IVerge::save_file` so both writers
 /// produce an identical header for `nyanpasu-config.yaml`.
-const VERGE_CONFIG_PREFIX: &str = "# Clash Nyanpasu Config";
+/// The trailing `\n` ensures that `YamlFormat` (which calls `writeln!`) emits a
+/// blank line between the prefix and the YAML body, matching `save_yaml`'s
+/// `"{prefix}\n\n{data}"` layout.
+const VERGE_CONFIG_PREFIX: &str = "# Clash Nyanpasu Config\n";
 
 #[derive(Clone)]
 pub struct StateClient {

--- a/backend/tauri/src/feat.rs
+++ b/backend/tauri/src/feat.rs
@@ -114,13 +114,28 @@ pub fn change_clash_mode(mode: String) {
     });
 }
 
+/// Route a verge patch through the managed `NyanpasuClient` when it is available, so
+/// the state actor is reseeded after a legacy side-effect write. Falls back to a direct
+/// `patch_verge` before the client is managed (early startup), where no actor exists yet.
+async fn patch_verge_entrypoint(patch: IVerge) -> Result<()> {
+    let app_handle = handle::Handle::global().app_handle.lock().clone();
+    if let Some(app_handle) = app_handle
+        && let Some(client) = app_handle.try_state::<crate::client::NyanpasuClient>()
+    {
+        let client = client.inner().clone();
+        client.patch_verge_config(patch).await?;
+        return Ok(());
+    }
+    patch_verge(patch).await
+}
+
 // 切换系统代理
 pub fn toggle_system_proxy() {
     let enable = Config::verge().draft().enable_system_proxy;
     let enable = enable.unwrap_or(false);
 
     tauri::async_runtime::spawn(async move {
-        match patch_verge(IVerge {
+        match patch_verge_entrypoint(IVerge {
             enable_system_proxy: Some(!enable),
             ..IVerge::default()
         })
@@ -135,7 +150,7 @@ pub fn toggle_system_proxy() {
 // 打开系统代理
 pub fn enable_system_proxy() {
     tauri::async_runtime::spawn(async {
-        match patch_verge(IVerge {
+        match patch_verge_entrypoint(IVerge {
             enable_system_proxy: Some(true),
             ..IVerge::default()
         })
@@ -150,7 +165,7 @@ pub fn enable_system_proxy() {
 // 关闭系统代理
 pub fn disable_system_proxy() {
     tauri::async_runtime::spawn(async {
-        match patch_verge(IVerge {
+        match patch_verge_entrypoint(IVerge {
             enable_system_proxy: Some(false),
             ..IVerge::default()
         })
@@ -168,7 +183,7 @@ pub fn toggle_tun_mode() {
     let enable = enable.unwrap_or(false);
 
     tauri::async_runtime::spawn(async move {
-        match patch_verge(IVerge {
+        match patch_verge_entrypoint(IVerge {
             enable_tun_mode: Some(!enable),
             ..IVerge::default()
         })
@@ -183,7 +198,7 @@ pub fn toggle_tun_mode() {
 // 打开tun模式
 pub fn enable_tun_mode() {
     tauri::async_runtime::spawn(async {
-        match patch_verge(IVerge {
+        match patch_verge_entrypoint(IVerge {
             enable_tun_mode: Some(true),
             ..IVerge::default()
         })
@@ -198,7 +213,7 @@ pub fn enable_tun_mode() {
 // 关闭tun模式
 pub fn disable_tun_mode() {
     tauri::async_runtime::spawn(async {
-        match patch_verge(IVerge {
+        match patch_verge_entrypoint(IVerge {
             enable_tun_mode: Some(false),
             ..IVerge::default()
         })

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -491,8 +491,8 @@ pub async fn patch_clash_config(payload: PatchRuntimeConfig) -> Result {
 
 #[tauri::command]
 #[specta::specta]
-pub fn get_verge_config(client: State<'_, NyanpasuClient>) -> Result<IVerge> {
-    Ok(client.get_verge_config())
+pub async fn get_verge_config(client: State<'_, NyanpasuClient>) -> Result<IVerge> {
+    Ok(client.get_verge_config().await?)
 }
 
 #[tauri::command]
@@ -510,8 +510,17 @@ pub async fn patch_verge_config(client: State<'_, NyanpasuClient>, payload: IVer
 
 #[tauri::command]
 #[specta::specta]
-pub async fn change_clash_core(clash_core: Option<nyanpasu::ClashCore>) -> Result {
-    (CoreManager::global().change_core(clash_core).await)?;
+pub async fn change_clash_core(
+    client: State<'_, NyanpasuClient>,
+    clash_core: Option<nyanpasu::ClashCore>,
+) -> Result {
+    // `change_core` writes `Config::verge().clash_core` directly; reseed the actor so a
+    // later pure patch does not persist a stale snapshot and revert the core change.
+    client
+        .run_legacy_verge_mutation(
+            || async move { CoreManager::global().change_core(clash_core).await },
+        )
+        .await?;
     Ok(())
 }
 
@@ -1247,15 +1256,24 @@ pub async fn check_update(webview: tauri::Webview) -> Result<Option<UpdateWrappe
 
 #[tauri::command]
 #[specta::specta]
-pub fn save_window_size_state(app_handle: AppHandle, label: String) -> Result<()> {
-    match label.as_str() {
-        crate::consts::MAIN_WINDOW_LABEL => {
-            resolve::save_main_window_state(&app_handle, true)?;
-        }
-        _ => {
-            log::warn!("Unknown window label: {}", label);
-        }
-    }
+pub async fn save_window_size_state(
+    client: State<'_, NyanpasuClient>,
+    app_handle: AppHandle,
+    label: String,
+) -> Result<()> {
+    // Window-state save writes `Config::verge().window_size_state` directly; reseed the
+    // actor so a later pure patch does not revert the saved geometry.
+    client
+        .run_legacy_verge_mutation(|| async move {
+            match label.as_str() {
+                crate::consts::MAIN_WINDOW_LABEL => {
+                    resolve::save_main_window_state(&app_handle, true)?;
+                }
+                _ => log::warn!("Unknown window label: {}", label),
+            }
+            Ok(())
+        })
+        .await?;
     Ok(())
 }
 

--- a/backend/tauri/src/lib.rs
+++ b/backend/tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod ipc;
 mod logging;
 mod server;
 mod setup;
+mod state;
 
 #[cfg(windows)]
 mod shutdown_hook;
@@ -33,7 +34,7 @@ use crate::{
 };
 use anyhow::Context;
 use specta_typescript::Typescript;
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 use tauri_specta::{collect_commands, collect_events};
 use utils::resolve::{is_window_opened, reset_window_open_counter};
 
@@ -385,6 +386,16 @@ pub fn run() -> std::io::Result<()> {
             }
 
             resolve::resolve_setup(app);
+
+            // The state actor is seeded before resolve_setup, while resolve_setup always
+            // patches and saves verge_mixed_port. Sync the actor with the post-resolve
+            // legacy state before any later actor upsert can persist a stale port.
+            {
+                let client = app.state::<crate::client::NyanpasuClient>().inner().clone();
+                let verge = Config::verge().data().clone();
+                tauri::async_runtime::block_on(client.replace_verge_config(verge))
+                    .context("Failed to sync verge state after resolve setup")?;
+            }
 
             // setup custom scheme
             let handle = app.handle().clone();

--- a/backend/tauri/src/state/mod.rs
+++ b/backend/tauri/src/state/mod.rs
@@ -1,0 +1,1 @@
+pub mod verge;

--- a/backend/tauri/src/state/verge.rs
+++ b/backend/tauri/src/state/verge.rs
@@ -1,0 +1,168 @@
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+
+use crate::config::{IVerge, nyanpasu::is_hex_color};
+use nyanpasu_core::state::PersistentStateManager;
+
+/// Injected legacy mirror hook: production updates the in-memory `Config::verge()`,
+/// tests capture the committed state. Keeps the actor decoupled from the global config.
+pub type VergeMirror = Arc<dyn Fn(IVerge) -> anyhow::Result<()> + Send + Sync + 'static>;
+
+#[derive(Debug, Clone)]
+pub struct VergeStateSnapshot {
+    pub state: IVerge,
+    /// Monotonic state version. Surfaced for callers/tests to observe commits; the
+    /// event-system PRs will consume it, so production reads are not present yet.
+    #[allow(dead_code)]
+    pub version: u64,
+}
+
+pub struct StateActorArgs {
+    pub manager: PersistentStateManager<IVerge>,
+    pub mirror: VergeMirror,
+}
+
+pub struct StateActorState {
+    manager: PersistentStateManager<IVerge>,
+    mirror: VergeMirror,
+}
+
+#[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
+pub enum StateActorMessage {
+    GetVerge(RpcReplyPort<anyhow::Result<VergeStateSnapshot>>),
+    PatchVerge {
+        patch: IVerge,
+        reply: RpcReplyPort<anyhow::Result<VergeStateSnapshot>>,
+    },
+    ReplaceVerge {
+        state: IVerge,
+        reply: RpcReplyPort<anyhow::Result<VergeStateSnapshot>>,
+    },
+}
+
+pub struct StateActor;
+
+impl StateActor {
+    fn snapshot(state: &StateActorState) -> VergeStateSnapshot {
+        let snapshot = state.manager.snapshot_handle().load();
+        VergeStateSnapshot {
+            state: snapshot.state.clone(),
+            version: *snapshot.version.as_ref(),
+        }
+    }
+
+    /// Atomically persist the next state and sync the legacy mirror. Validation is the
+    /// caller's responsibility (`PatchVerge` validates, trusted paths do not).
+    async fn commit(
+        state: &mut StateActorState,
+        next: IVerge,
+    ) -> anyhow::Result<VergeStateSnapshot> {
+        state
+            .manager
+            .upsert(next.clone())
+            .await
+            .context("failed to persist verge state")?;
+        (state.mirror)(next).context("failed to sync legacy verge mirror")?;
+        Ok(Self::snapshot(state))
+    }
+}
+
+impl Actor for StateActor {
+    type Msg = StateActorMessage;
+    type State = StateActorState;
+    type Arguments = StateActorArgs;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(StateActorState {
+            manager: args.manager,
+            mirror: args.mirror,
+        })
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            StateActorMessage::GetVerge(reply) => {
+                let _ = reply.send(Ok(Self::snapshot(state)));
+            }
+            // PatchVerge originates from untrusted IPC: validate, merge, then persist + mirror.
+            StateActorMessage::PatchVerge { patch, reply } => {
+                let result = async {
+                    validate_verge_patch(&patch)?;
+                    let mut next = state.manager.snapshot_handle().load().state.clone();
+                    next.patch_config(patch);
+                    Self::commit(state, next).await
+                }
+                .await;
+                let _ = reply.send(result);
+            }
+            // ReplaceVerge originates from trusted internal state (legacy/startup): no validation.
+            StateActorMessage::ReplaceVerge { state: next, reply } => {
+                let _ = reply.send(Self::commit(state, next).await);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Preserves the `theme_color` validation from `feat::patch_verge`.
+pub fn validate_verge_patch(verge: &IVerge) -> anyhow::Result<()> {
+    if let Some(theme_color) = &verge.theme_color
+        && !theme_color.is_empty()
+        && !is_hex_color(theme_color)
+    {
+        anyhow::bail!("Invalid theme color: {}", theme_color);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_verge_patch_accepts_valid_theme_colors() {
+        assert!(
+            validate_verge_patch(&IVerge {
+                theme_color: Some(String::new()),
+                ..IVerge::default()
+            })
+            .is_ok()
+        );
+        assert!(
+            validate_verge_patch(&IVerge {
+                theme_color: Some("#0a1B2c".into()),
+                ..IVerge::default()
+            })
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_verge_patch_rejects_invalid_theme_colors() {
+        let short = validate_verge_patch(&IVerge {
+            theme_color: Some("#abc".into()),
+            ..IVerge::default()
+        })
+        .expect_err("short hex should fail");
+        assert!(short.to_string().contains("Invalid theme color"));
+
+        let non_hex = validate_verge_patch(&IVerge {
+            theme_color: Some("#GGGGGG".into()),
+            ..IVerge::default()
+        })
+        .expect_err("non-hex color should fail");
+        assert!(non_hex.to_string().contains("Invalid theme color"));
+    }
+}


### PR DESCRIPTION
## Summary

PR-2 of the state-actor migration. Routes **app/verge config** reads/writes through a new ractor `StateActor` (`NyanpasuClient → StateClient → StateActor`), backed by `nyanpasu_core::state::PersistentStateManager<IVerge>`, instead of touching the global `Config` directly. Legacy side-effect paths are preserved and bridged so existing behavior (CoreManager / Sysopt / Hotkey / tray / widget / logger) is untouched.

## What changed

- **`state/verge.rs`** (new): native-async ractor `StateActor`; `commit` = atomic `upsert` + injected legacy mirror; `theme_color` validated on patch. Trusted `ReplaceVerge` skips validation.
- **`client/state.rs`** (new): `StateClient` with 5s-timeout RPC, **anonymous spawn** (no registry-name collisions), stops the actor on drop. `route_verge_patch` classifies the **14 side-effect fields** to the legacy path; everything else is a pure actor commit.
- **`client/mod.rs`**: pure patches → actor; side-effect patches → legacy `feat::patch_verge` then **reseed the actor**. `verge_update_lock` serializes all client-driven verge mutations. `run_legacy_verge_mutation` is the single funnel for legacy writers (lock → mutate → reseed). `try_new` propagates init errors instead of panicking.
- **`lib.rs`**: forced **StartupSync** after `resolve_setup` so the actor adopts the post-resolve `verge_mixed_port` instead of clobbering it.
- **`feat.rs`**: `patch_verge_entrypoint` funnels tray/hotkey toggles through the client so those legacy writers reseed the actor.
- **`ipc.rs`**: `get_verge_config` → async; `change_clash_core` and `save_window_size_state` reseed via `run_legacy_verge_mutation` so a later pure patch can't revert them.

## Design notes

- Actor never holds `AppHandle` / touches `CoreManager`/`Sysopt`/`Hotkey`/tray/`Config` — the legacy mirror is **injected**, keeping the actor unit-testable.
- Same file + prefix as legacy (`nyanpasu-config.yaml`, `# Clash Nyanpasu Config`); `PersistentStateManager` uses atomic writes.
- Frontend: **zero changes** — `get_verge_config` sync→async does not change the generated TS signature; existing callers already `await`.

## Testing

- `state::` 10/10, `client::` 9/9 (incl. `reseed_then_pure_patch_preserves_reseeded_fields` regression test) — local `rustc 1.98`.
- `cargo build -p clash-nyanpasu` clean; `cargo clippy --all-targets --all-features` clean (pre-commit hook).

## Review

Multi-model review loop converged: round 1 surfaced legacy-writer staleness (fixed via the reseed funnel), round 2 → **PASS, no Critical, no Major**.

## Known follow-up (PR-3)

Non-IPC window-state saves (window event/close/shutdown handlers) still bypass the actor reseed. Impact is limited to **same-session** window geometry and **self-heals on restart** (the actor re-seeds from disk at startup). Reviewer explicitly deemed this non-blocking; closing it cleanly needs reworking the window-manager/shutdown paths.