### PR TITLE
feat(backend): route profiles index through ractor StateActor (PR-3)

### DIFF
--- a/backend/tauri/src/client/event_sink.rs
+++ b/backend/tauri/src/client/event_sink.rs
@@ -13,6 +13,12 @@ pub trait UiEventSink: Send + Sync + 'static {
 
     fn notice_message(&self, message: &Message);
 
+    /// Forwards the legacy `SetConfig` notice, preserving `feat::update_core_config`'s
+    /// behaviour without coupling the client to the global `Handle`.
+    fn notice_set_config(&self, result: std::result::Result<(), String>) {
+        self.notice_message(&Message::SetConfig(result));
+    }
+
     fn update_systray(&self) -> Result<()>;
 
     fn update_systray_part(&self) -> Result<()>;

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -1,12 +1,19 @@
 mod error;
 mod event_sink;
+mod profiles_state;
 mod state;
 
-use self::state::{StateClient, VergePatchRoute, route_verge_patch};
+use self::{
+    profiles_state::ProfilesStateClient,
+    state::{StateClient, VergePatchRoute, route_verge_patch},
+};
 use crate::{
-    config::{Config, IVerge, Profiles, ProfilesBuilder},
-    core::{CoreManager, RunType},
-    state::verge::VergeMirror,
+    config::{
+        Config, IVerge, Profile, ProfileCleanup, ProfileMetaGetter, Profiles, ProfilesBuilder,
+        RemoteProfileOptionsBuilder, profile::ProfileBuilder,
+    },
+    core::{CoreManager, RunType, connection_interruption::ConnectionInterruptionService},
+    state::{profiles::ProfilesMirror, verge::VergeMirror},
 };
 use nyanpasu_ipc::api::status::CoreState;
 use std::{borrow::Cow, future::Future, sync::Arc};
@@ -27,21 +34,32 @@ struct NyanpasuClientInner {
     /// legacy reseeds). The actor serializes its own state, but the legacy path holds
     /// `Config::verge()` draft across awaits, so client-level mutations must not interleave.
     verge_update_lock: Mutex<()>,
+    profiles: ProfilesStateClient,
+    /// Guards the "index commit + core reload" window for every profiles mutation. Network
+    /// IO stays outside this lock (two-phase). Non-reentrant: each method locks exactly once.
+    profiles_update_lock: Mutex<()>,
 }
 
 impl NyanpasuClient {
     pub fn try_new(ui: Arc<dyn UiEventSink>) -> anyhow::Result<Self> {
-        let initial = Config::verge().data().clone();
-        let state = StateClient::new(initial, legacy_verge_mirror())?;
-        Ok(Self::with_state(ui, state))
+        let verge = StateClient::new(Config::verge().data().clone(), legacy_verge_mirror())?;
+        let profiles =
+            ProfilesStateClient::new(Config::profiles().data().clone(), legacy_profiles_mirror())?;
+        Ok(Self::with_state(ui, verge, profiles))
     }
 
-    fn with_state(ui: Arc<dyn UiEventSink>, state: StateClient) -> Self {
+    fn with_state(
+        ui: Arc<dyn UiEventSink>,
+        state: StateClient,
+        profiles: ProfilesStateClient,
+    ) -> Self {
         Self {
             inner: Arc::new(NyanpasuClientInner {
                 ui,
                 state,
                 verge_update_lock: Mutex::new(()),
+                profiles,
+                profiles_update_lock: Mutex::new(()),
             }),
         }
     }
@@ -73,29 +91,213 @@ impl NyanpasuClient {
         self.replace_verge_unlocked(committed).await
     }
 
-    pub fn get_profiles(&self) -> Profiles {
-        Config::profiles().data().clone()
+    /// Read the profiles index through the actor (consistent with `Config::profiles()`).
+    /// On an actor RPC error, fall back to the committed `Config` value, which is never
+    /// stale (the actor and `Config` stay in lockstep, §3-H).
+    pub async fn get_profiles(&self) -> Result<Profiles> {
+        match self.inner.profiles.get_profiles().await {
+            Ok(profiles) => Ok(profiles),
+            Err(err) => {
+                log::error!(target: "app", "profiles actor read failed, fallback to Config: {err:#}");
+                Ok(Config::profiles().data().clone())
+            }
+        }
     }
 
-    pub async fn patch_profiles_config(&self, profiles: ProfilesBuilder) -> Result<()> {
-        Config::profiles().draft().apply(profiles);
+    // —— Commit primitives (all assume the `profiles_update_lock` is held). Each command
+    //    picks one to preserve its current error semantics (§9). ——
 
+    /// Persist the index only (no reload). On `upsert` failure `Config` is unchanged and the
+    /// command returns `Err` (the mirror never runs).
+    async fn persist(&self, next: Profiles) -> Result<()> {
+        debug_assert!(
+            !Config::profiles().is_dirty(),
+            "no pending profiles draft expected before commit"
+        );
+        self.inner.profiles.commit(next).await?;
+        Ok(())
+    }
+
+    /// persist-first: commit the index (failure = `Err`), then reload the core; a reload
+    /// failure is `Err` when `reload_strict`, otherwise log-only. Matches today's
+    /// delete / update / patch_profile (persist, then strict/best-effort reload).
+    async fn persist_then_reload(&self, next: Profiles, reload_strict: bool) -> Result<()> {
+        self.persist(next).await?;
         match CoreManager::global().update_config().await {
             Ok(_) => {
                 self.inner.ui.refresh_clash();
-                Config::profiles().apply();
-                Config::profiles().data().save_file()?;
-
-                let _ = crate::core::connection_interruption::ConnectionInterruptionService::on_profile_change().await;
-
                 Ok(())
             }
             Err(err) => {
+                if reload_strict {
+                    Err(err.into())
+                } else {
+                    log::error!(target: "app", "{err:?}");
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    /// reload-first transaction: expose `next` to `enhance` via the draft, reload, and only
+    /// commit the index on success; any failure discards the draft (nothing persisted).
+    /// Matches today's patch_profiles_config / create-activation (reload failure rolls back).
+    async fn reload_then_persist(&self, next: Profiles) -> Result<()> {
+        // The draft guard is a temporary dropped at the end of this statement, so it is
+        // never held across the await below.
+        *Config::profiles().draft() = next.clone();
+        match CoreManager::global().update_config().await {
+            Ok(_) => {
+                self.inner.ui.refresh_clash();
+                match self.inner.profiles.commit(next).await {
+                    Ok(_) => Ok(()),
+                    Err(err) => {
+                        Config::profiles().discard();
+                        Err(err.into())
+                    }
+                }
+            }
+            Err(err) => {
                 Config::profiles().discard();
-                log::error!(target: "app", "{err:?}");
                 Err(err.into())
             }
         }
+    }
+
+    pub async fn reorder_profile(&self, active_id: String, over_id: String) -> Result<()> {
+        let _guard = self.inner.profiles_update_lock.lock().await;
+        let mut next = Config::profiles().data().clone();
+        crate::config::reorder_items(&mut next.items, &active_id, &over_id);
+        self.persist(next).await
+    }
+
+    pub async fn reorder_profiles_by_list(&self, order: Vec<String>) -> Result<()> {
+        let _guard = self.inner.profiles_update_lock.lock().await;
+        let mut next = Config::profiles().data().clone();
+        crate::config::reorder_items_by_list(&mut next.items, &order);
+        self.persist(next).await
+    }
+
+    pub async fn patch_profiles_config(&self, patch: ProfilesBuilder) -> Result<()> {
+        let _guard = self.inner.profiles_update_lock.lock().await;
+        let mut next = Config::profiles().data().clone();
+        next.apply(patch);
+        self.reload_then_persist(next).await?;
+        drop(_guard);
+        // §3-I: run the interruption side-effect outside the commit window.
+        let _ = ConnectionInterruptionService::on_profile_change().await;
+        Ok(())
+    }
+
+    pub async fn patch_profile(
+        &self,
+        uid: String,
+        profile: ProfileBuilder,
+    ) -> Result<ProfileMutationReport> {
+        let _guard = self.inner.profiles_update_lock.lock().await;
+        let mut next = Config::profiles().data().clone();
+        next.apply_item_patch(uid.clone(), profile)?;
+        if profile_in_active_chain(&next, &uid) {
+            // §9: today's patch_profile reloads best-effort (commit failure = Err, reload
+            // failure = log-only / command Ok).
+            self.persist_then_reload(next, false).await?;
+        } else {
+            self.persist(next).await?;
+        }
+        Ok(ProfileMutationReport { refresh_jobs: true })
+    }
+
+    pub async fn update_profile(
+        &self,
+        uid: String,
+        opts: Option<RemoteProfileOptionsBuilder>,
+    ) -> Result<()> {
+        // §3-D: the network download runs before the lock is taken.
+        let prepared = crate::feat::prepare_profile_update(&uid, opts).await?;
+        let _guard = self.inner.profiles_update_lock.lock().await;
+        let mut next = Config::profiles().data().clone();
+        // §3-E: TOCTOU fingerprint check + pure in-memory write into `next`.
+        let reload = crate::feat::commit_profile_update(&mut next, prepared)?;
+        if reload {
+            // §9: today's update is persist-first + strict reload + SetConfig notice.
+            self.persist(next).await?;
+            match CoreManager::global().update_config().await {
+                Ok(_) => {
+                    self.inner.ui.refresh_clash();
+                    self.inner.ui.notice_set_config(Ok(()));
+                    Ok(())
+                }
+                Err(err) => {
+                    self.inner.ui.notice_set_config(Err(format!("{err:?}")));
+                    Err(err.into())
+                }
+            }
+        } else {
+            self.persist(next).await
+        }
+    }
+
+    pub async fn create_profile(&self, item: Profile, activate_if_first: bool) -> Result<()> {
+        // `item` was built (incl. remote download / file IO) outside the lock. The activation
+        // decision happens inside the lock so concurrent creates cannot both claim "first".
+        let _guard = self.inner.profiles_update_lock.lock().await;
+        let mut next = Config::profiles().data().clone();
+        let uid = item.uid().to_string();
+        let activate =
+            activate_if_first && next.current.is_empty() && (item.is_local() || item.is_remote());
+        next.push_item(item);
+        if activate {
+            next.set_current(vec![uid]);
+            // Merge append + activation into a single reload-first transaction (reload
+            // failure rolls the whole creation back).
+            self.reload_then_persist(next).await?;
+        } else {
+            self.persist(next).await?;
+        }
+        drop(_guard);
+        if activate {
+            let _ = ConnectionInterruptionService::on_profile_change().await;
+        }
+        Ok(())
+    }
+
+    pub async fn delete_profile(&self, uid: String) -> Result<()> {
+        let _guard = self.inner.profiles_update_lock.lock().await;
+        let mut next = Config::profiles().data().clone();
+        let (removed, was_current) = next.remove_item(&uid);
+        // Persist the index removal first (state failure = Err, nothing changed).
+        self.persist(next).await?;
+        // §9: today's delete reloads strictly when the active profile changed. Capture the
+        // reload result instead of `?`-ing so the content file is still removed below (§5:
+        // the index commit stands even on reload failure).
+        let reload_result = if was_current {
+            match CoreManager::global().update_config().await {
+                Ok(_) => {
+                    self.inner.ui.refresh_clash();
+                    Ok(())
+                }
+                Err(err) => Err(err.into()),
+            }
+        } else {
+            Ok(())
+        };
+        drop(_guard);
+        // Delete the content file after the index commit regardless of the reload outcome
+        // (orphan-safe); failure is log-only and the index removal stands.
+        if let Some(mut item) = removed
+            && let Err(err) = item.remove_file().await
+        {
+            log::error!(target: "app", "failed to remove profile file: {err:?}");
+        }
+        reload_result
+    }
+
+    pub async fn enhance_profiles(&self) -> Result<()> {
+        // §3-I: reload only, no commit and no version bump.
+        let _guard = self.inner.profiles_update_lock.lock().await;
+        CoreManager::global().update_config().await?;
+        self.inner.ui.refresh_clash();
+        Ok(())
     }
 
     pub async fn get_verge_config(&self) -> Result<IVerge> {
@@ -139,6 +341,40 @@ fn legacy_verge_mirror() -> VergeMirror {
     })
 }
 
+/// Result of a profile mutation that the IPC layer must act on without coupling the client
+/// to Tauri (`patch_profile` asks the command to refresh the scheduled jobs).
+pub struct ProfileMutationReport {
+    pub refresh_jobs: bool,
+}
+
+/// Whether `uid` participates in the active configuration, so a patch to it must reload the
+/// core. Mirrors the legacy `ipc::patch_profile` `need_update` check, evaluated against `next`.
+fn profile_in_active_chain(profiles: &Profiles, uid: &str) -> bool {
+    if profiles.chain.iter().any(|u| u == uid) || profiles.current.iter().any(|u| u == uid) {
+        return true;
+    }
+    profiles
+        .current
+        .iter()
+        .any(|chain_uid| match profiles.get_item(chain_uid) {
+            Ok(item) if item.is_local() => item.as_local().unwrap().chain.iter().any(|u| u == uid),
+            Ok(item) if item.is_remote() => {
+                item.as_remote().unwrap().chain.iter().any(|u| u == uid)
+            }
+            _ => false,
+        })
+}
+
+/// Production mirror: only swaps the in-memory `Config::profiles()`. The actor already
+/// performs the atomic disk write, so the mirror must not call `save_file` again. Infallible
+/// by design (§3-J).
+fn legacy_profiles_mirror() -> ProfilesMirror {
+    Arc::new(|state| {
+        *Config::profiles().draft() = state;
+        Config::profiles().apply();
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,21 +382,89 @@ mod tests {
     use camino::Utf8PathBuf;
     use tempfile::tempdir;
 
-    fn test_state_client() -> (StateClient, tempfile::TempDir) {
+    fn test_state_clients() -> (StateClient, ProfilesStateClient, tempfile::TempDir) {
         let dir = tempdir().expect("tempdir should be created");
-        let path = Utf8PathBuf::from_path_buf(dir.path().join("nyanpasu-config.yaml"))
+        let verge_path = Utf8PathBuf::from_path_buf(dir.path().join("nyanpasu-config.yaml"))
             .expect("temp path should be UTF-8");
-        let mirror: VergeMirror = Arc::new(|_| Ok(()));
-        let state = StateClient::new_with_path(path, IVerge::default(), mirror)
+        let verge_mirror: VergeMirror = Arc::new(|_| Ok(()));
+        let state = StateClient::new_with_path(verge_path, IVerge::default(), verge_mirror)
             .expect("state client should be created");
-        (state, dir)
+
+        let profiles_path = Utf8PathBuf::from_path_buf(dir.path().join("profiles.yaml"))
+            .expect("temp path should be UTF-8");
+        let profiles_mirror: ProfilesMirror = Arc::new(|_| {});
+        let profiles =
+            ProfilesStateClient::new_with_path(profiles_path, Profiles::default(), profiles_mirror)
+                .expect("profiles state client should be created");
+        (state, profiles, dir)
     }
 
     #[test]
     fn client_constructs_without_tauri_runtime() {
-        let (state, _dir) = test_state_client();
-        let client = NyanpasuClient::with_state(Arc::new(NoopUiEventSink), state);
+        let (state, profiles, _dir) = test_state_clients();
+        let client = NyanpasuClient::with_state(Arc::new(NoopUiEventSink), state, profiles);
         let _ = client.clone();
+    }
+
+    /// Architecture guard: the actor is the sole persister of the profiles index. Only the
+    /// sanctioned legacy bridge in `client/mod.rs` (the reload-first transaction + the
+    /// infallible mirror) may drive `Config::profiles()` draft/commit primitives directly.
+    /// Any other direct writer would bypass the actor and let `get_profiles` reads go stale.
+    #[test]
+    fn profiles_writers_are_confined_to_the_bridge() {
+        use std::path::Path;
+
+        const FORBIDDEN: [&str; 10] = [
+            // Direct draft/commit primitives on the global profiles state.
+            "Config::profiles().draft",
+            "Config::profiles().apply",
+            "Config::profiles().discard",
+            "Config::profiles().auto_commit",
+            // Legacy `save_file`-backed index mutators; every writer must go through the
+            // actor instead, so these must not be invoked anywhere outside their definitions.
+            ".append_item(",
+            ".patch_item(",
+            ".replace_item(",
+            ".delete_item(",
+            ".reorder(",
+            ".reorder_by_list(",
+        ];
+        // Paths (relative to `src/`) sanctioned to host the bridge primitives. `profiles.rs`
+        // *defines* the legacy wrappers (`fn append_item(` — no leading dot) so it does not
+        // match the call-site needles above and need not be allow-listed.
+        const ALLOWED: [&str; 1] = ["client/mod.rs"];
+
+        fn scan(dir: &Path, src_root: &Path, offenders: &mut Vec<String>) {
+            for entry in std::fs::read_dir(dir).expect("read_dir should succeed") {
+                let path = entry.expect("dir entry should be readable").path();
+                if path.is_dir() {
+                    scan(&path, src_root, offenders);
+                } else if path.extension().is_some_and(|ext| ext == "rs") {
+                    let rel = path
+                        .strip_prefix(src_root)
+                        .expect("path is under src_root")
+                        .to_string_lossy()
+                        .replace('\\', "/");
+                    if ALLOWED.contains(&rel.as_str()) {
+                        continue;
+                    }
+                    let contents = std::fs::read_to_string(&path).expect("source should be UTF-8");
+                    for needle in FORBIDDEN {
+                        if contents.contains(needle) {
+                            offenders.push(format!("{rel}: {needle}"));
+                        }
+                    }
+                }
+            }
+        }
+
+        let src_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut offenders = Vec::new();
+        scan(&src_root, &src_root, &mut offenders);
+        assert!(
+            offenders.is_empty(),
+            "direct Config::profiles() writers must go through the actor bridge; offenders: {offenders:#?}"
+        );
     }
 
     #[test]

--- a/backend/tauri/src/client/profiles_state.rs
+++ b/backend/tauri/src/client/profiles_state.rs
@@ -1,0 +1,189 @@
+use std::{sync::Arc, time::Duration};
+
+use anyhow::Context as _;
+use camino::Utf8PathBuf;
+use ractor::{Actor, ActorRef, RpcReplyPort, rpc::CallResult};
+
+use crate::{
+    config::Profiles,
+    state::profiles::{
+        ProfilesMirror, ProfilesStateActor, ProfilesStateActorArgs, ProfilesStateMessage,
+        ProfilesStateSnapshot,
+    },
+    utils::dirs,
+};
+use nyanpasu_core::state::PersistentStateManagerSetup;
+
+/// Reads only touch the in-memory snapshot, so a short timeout is enough.
+const PROFILES_READ_TIMEOUT: Duration = Duration::from_secs(5);
+/// Commits perform a local `upsert` (disk write) + mirror; allow more headroom. A
+/// `Timeout` is treated as unknown by the caller — the next absolute commit corrects it.
+const PROFILES_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
+/// Must match the prefix used by the legacy `Profiles::save_file` so both writers
+/// produce an identical header for `profiles.yaml`. The trailing `\n` ensures
+/// `YamlFormat` (which calls `writeln!`) emits a blank line between the prefix and the
+/// YAML body, matching `save_yaml`'s `"{prefix}\n\n{data}"` layout.
+const PROFILES_CONFIG_PREFIX: &str = "# Profiles Config for Clash Nyanpasu\n";
+
+#[derive(Clone)]
+pub struct ProfilesStateClient {
+    inner: Arc<ProfilesStateClientInner>,
+}
+
+struct ProfilesStateClientInner {
+    actor_ref: ActorRef<ProfilesStateMessage>,
+}
+
+impl ProfilesStateClient {
+    /// Production entry point: real `profiles.yaml` + injected legacy mirror.
+    pub fn new(initial: Profiles, mirror: ProfilesMirror) -> anyhow::Result<Self> {
+        let path = Utf8PathBuf::from_path_buf(dirs::profiles_path()?).map_err(|path| {
+            anyhow::anyhow!("profiles config path is not UTF-8: {}", path.display())
+        })?;
+        Self::new_with_path(path, initial, mirror)
+    }
+
+    /// Test/internal entry point: explicit config path (e.g. a tempdir).
+    pub(crate) fn new_with_path(
+        config_path: Utf8PathBuf,
+        initial: Profiles,
+        mirror: ProfilesMirror,
+    ) -> anyhow::Result<Self> {
+        // Mirror `StateClient::new_with_path`: block_on initialization + spawn in a
+        // synchronous context so the client can be constructed during Tauri setup.
+        let manager = tauri::async_runtime::block_on(
+            PersistentStateManagerSetup::<Profiles>::builder()
+                .config_path(config_path)
+                .config_prefix(PROFILES_CONFIG_PREFIX.to_string())
+                .assemble()
+                .from_state(initial),
+        )
+        .context("failed to initialize profiles persistent state manager")?;
+
+        // Spawn anonymously: the client holds the `ActorRef` directly and never resolves
+        // the actor by name, avoiding registry collisions across tests / re-spawns.
+        let actor_ref = tauri::async_runtime::block_on(Actor::spawn(
+            None,
+            ProfilesStateActor,
+            ProfilesStateActorArgs { manager, mirror },
+        ))
+        .context("failed to spawn nyanpasu profiles state actor")?
+        .0;
+
+        Ok(Self {
+            inner: Arc::new(ProfilesStateClientInner { actor_ref }),
+        })
+    }
+
+    pub async fn get_profiles(&self) -> anyhow::Result<Profiles> {
+        Ok(self
+            .call(ProfilesStateMessage::GetProfiles, PROFILES_READ_TIMEOUT)
+            .await?
+            .state)
+    }
+
+    pub async fn commit(&self, state: Profiles) -> anyhow::Result<ProfilesStateSnapshot> {
+        self.call(
+            |reply| ProfilesStateMessage::CommitProfiles { state, reply },
+            PROFILES_WRITE_TIMEOUT,
+        )
+        .await
+    }
+
+    async fn call<F>(&self, make: F, timeout: Duration) -> anyhow::Result<ProfilesStateSnapshot>
+    where
+        F: FnOnce(RpcReplyPort<anyhow::Result<ProfilesStateSnapshot>>) -> ProfilesStateMessage,
+    {
+        match self.inner.actor_ref.call(make, Some(timeout)).await? {
+            CallResult::Success(result) => result,
+            CallResult::SenderError => anyhow::bail!("profiles state actor reply dropped"),
+            CallResult::Timeout => anyhow::bail!("profiles state actor call timed out"),
+        }
+    }
+}
+
+impl Drop for ProfilesStateClientInner {
+    fn drop(&mut self) {
+        self.actor_ref.stop(None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tempfile::{TempDir, tempdir};
+
+    fn temp_path(dir: &TempDir) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(dir.path().join("profiles.yaml"))
+            .expect("temp path should be UTF-8")
+    }
+
+    fn capture_mirror() -> (ProfilesMirror, Arc<Mutex<Option<Profiles>>>) {
+        let captured = Arc::new(Mutex::new(None::<Profiles>));
+        let mirror_capture = captured.clone();
+        let mirror: ProfilesMirror = Arc::new(move |state| {
+            *mirror_capture
+                .lock()
+                .expect("mirror lock should not poison") = Some(state);
+        });
+        (mirror, captured)
+    }
+
+    fn test_client(
+        initial: Profiles,
+    ) -> (
+        ProfilesStateClient,
+        TempDir,
+        Utf8PathBuf,
+        Arc<Mutex<Option<Profiles>>>,
+    ) {
+        let dir = tempdir().expect("tempdir should be created");
+        let path = temp_path(&dir);
+        let (mirror, captured) = capture_mirror();
+        let client = ProfilesStateClient::new_with_path(path.clone(), initial, mirror)
+            .expect("profiles state client should be created");
+        (client, dir, path, captured)
+    }
+
+    #[test]
+    fn get_profiles_returns_initial_state() {
+        let mut initial = Profiles::default();
+        initial.set_current(vec!["seed".into()]);
+        let (client, _dir, _path, _captured) = test_client(initial);
+
+        tauri::async_runtime::block_on(async {
+            let profiles = client.get_profiles().await.expect("get should succeed");
+            assert_eq!(profiles.current, vec!["seed".to_string()]);
+        });
+    }
+
+    #[test]
+    fn commit_persists_mirrors_and_round_trips() {
+        let (client, _dir, path, captured) = test_client(Profiles::default());
+
+        tauri::async_runtime::block_on(async {
+            let mut next = Profiles::default();
+            next.set_current(vec!["active".into()]);
+            let snapshot = client.commit(next).await.expect("commit should succeed");
+            assert_eq!(snapshot.state.current, vec!["active".to_string()]);
+            assert!(snapshot.version > 0);
+        });
+
+        let contents =
+            std::fs::read_to_string(path.as_std_path()).expect("config should be written");
+        assert!(contents.contains("# Profiles Config for Clash Nyanpasu"));
+
+        // The actor's output parses back through the legacy reader (semantic round-trip).
+        let parsed: Profiles = crate::utils::help::read_yaml(path.as_std_path())
+            .expect("legacy reader should parse the actor output");
+        assert_eq!(parsed.current, vec!["active".to_string()]);
+
+        let mirrored = captured
+            .lock()
+            .expect("mirror lock should not poison")
+            .clone()
+            .expect("mirror should be called");
+        assert_eq!(mirrored.current, vec!["active".to_string()]);
+    }
+}

--- a/backend/tauri/src/config/profile/profiles.rs
+++ b/backend/tauri/src/config/profile/profiles.rs
@@ -61,6 +61,10 @@ impl Profiles {
         }
     }
 
+    // Legacy persistence bridge. PR-3 routes every profiles writer through the actor (the
+    // sole persister), so these `save_file`-backed helpers currently have no callers; they are
+    // retained as thin wrappers for any future un-migrated path.
+    #[allow(dead_code)]
     pub fn save_file(&self) -> Result<()> {
         help::save_yaml(
             &dirs::profiles_path()?,
@@ -86,56 +90,35 @@ impl Profiles {
             .ok_or_else(|| anyhow::anyhow!("failed to get the profile item \"uid:{uid}\""))
     }
 
-    /// append new item
-    pub fn append_item(&mut self, item: Profile) -> Result<()> {
+    /// append a new item (pure, in-memory only)
+    pub fn push_item(&mut self, item: Profile) {
         self.items.push(item);
+    }
+
+    /// append a new item and persist (legacy bridge for un-migrated callers)
+    #[allow(dead_code)]
+    pub fn append_item(&mut self, item: Profile) -> Result<()> {
+        self.push_item(item);
         self.save_file()
     }
 
-    /// reorder items
+    /// reorder items and persist (legacy bridge for un-migrated callers)
+    #[allow(dead_code)]
     pub fn reorder(&mut self, active_id: String, over_id: String) -> Result<()> {
-        let items = &mut self.items;
-        let mut old_index = None;
-        let mut new_index = None;
-
-        for (i, item) in items.iter().enumerate() {
-            if item.uid() == active_id {
-                old_index = Some(i);
-            }
-            if item.uid() == over_id {
-                new_index = Some(i);
-            }
-        }
-
-        if old_index.is_none() || new_index.is_none() {
-            return Ok(());
-        }
-        let item = items.remove(old_index.unwrap());
-        items.insert(new_index.unwrap(), item);
+        reorder_items(&mut self.items, &active_id, &over_id);
         self.save_file()
     }
 
-    /// reorder items with the full order list
+    /// reorder items with the full order list and persist (legacy bridge)
+    #[allow(dead_code)]
     pub fn reorder_by_list<T: Borrow<String>>(&mut self, order: &[T]) -> Result<()> {
-        let mut items = std::mem::take(&mut self.items);
-        let mut new_items = Vec::with_capacity(items.len());
-
-        for uid in order {
-            if let Some(index) = items.iter().position(|e| e.uid() == uid.borrow()) {
-                new_items.push(items.remove(index));
-            }
-        }
-
-        // Keep unmatched items to avoid accidental data loss when order is partial.
-        new_items.extend(items);
-        self.items = new_items;
-
+        reorder_items_by_list(&mut self.items, order);
         self.save_file()
     }
 
-    /// update the item value
+    /// update the item value in place (pure, in-memory only)
     #[instrument]
-    pub fn patch_item(&mut self, uid: String, patch: ProfileBuilder) -> Result<()> {
+    pub fn apply_item_patch(&mut self, uid: String, patch: ProfileBuilder) -> Result<()> {
         tracing::debug!("patch item: {uid} with {patch:?}");
 
         let item = self
@@ -156,55 +139,78 @@ impl Profiles {
             _ => bail!("profile type mismatch when patching"),
         };
 
+        Ok(())
+    }
+
+    /// update the item value and persist (legacy bridge for un-migrated callers)
+    #[allow(dead_code)]
+    pub fn patch_item(&mut self, uid: String, patch: ProfileBuilder) -> Result<()> {
+        self.apply_item_patch(uid, patch)?;
         self.save_file()
     }
 
-    /// replace item
+    /// replace an item in place (pure, in-memory only)
+    pub fn set_item<T: Borrow<String>>(&mut self, uid: T, item: Profile) {
+        let uid = uid.borrow();
+        if let Some(index) = self.items.iter().position(|e| e.uid() == uid) {
+            self.items[index] = item;
+        }
+    }
+
+    /// replace an item and persist (legacy bridge for un-migrated callers)
+    #[allow(dead_code)]
     pub fn replace_item<T: Borrow<String>>(&mut self, uid: T, item: Profile) -> Result<()> {
-        let uid = uid.borrow();
-
-        let index = self.items.iter().position(|e| e.uid() == uid);
-        if let Some(index) = index {
-            unsafe {
-                *self.items.get_unchecked_mut(index) = item;
-            }
-        }
-
+        self.set_item(uid, item);
         self.save_file()
     }
 
-    /// delete item
-    /// if delete the current then return true
-    pub async fn delete_item<T: Borrow<String>>(&mut self, uid: T) -> Result<bool> {
-        let uid = uid.borrow();
-        let items = &mut self.items;
+    /// overwrite the current selection (pure, in-memory only)
+    pub fn set_current(&mut self, current: Vec<ProfileUid>) {
+        self.current = current;
+    }
 
-        // get the index
-        let index = items.iter().position(|e| e.uid() == uid);
-        if let Some(index) = index {
-            let mut profile = items.remove(index);
-            profile.remove_file().await?;
-        }
+    /// remove the index entry and fix up `current`, returning the removed item and
+    /// whether the removed uid was part of `current`.
+    /// Pure: no file IO, no persistence (the caller persists the index and deletes
+    /// the content file separately).
+    pub fn remove_item<T: Borrow<String>>(&mut self, uid: T) -> (Option<Profile>, bool) {
+        let uid: &str = uid.borrow();
 
-        // delete the original uid
+        let removed = self
+            .items
+            .iter()
+            .position(|e| e.uid() == uid)
+            .map(|index| self.items.remove(index));
+
         let mut current = self
             .current
             .iter()
-            .filter(|e| e != &uid)
+            .filter(|e| e.as_str() != uid)
             .cloned()
             .collect::<Vec<_>>();
-        let is_current = self.current != current;
+        let was_current = self.current != current;
+
         // 尝试激活存在的第一个配置
-        if current.is_empty() {
-            let item = items.iter().find(|e| e.is_local() || e.is_remote());
-            if let Some(item) = item {
-                current.push(item.uid().to_string());
-            }
+        if current.is_empty()
+            && let Some(item) = self.items.iter().find(|e| e.is_local() || e.is_remote())
+        {
+            current.push(item.uid().to_string());
         }
         self.current = current;
 
+        (removed, was_current)
+    }
+
+    /// delete item, remove its content file, and persist (legacy bridge).
+    /// if delete the current then return true
+    #[allow(dead_code)]
+    pub async fn delete_item<T: Borrow<String>>(&mut self, uid: T) -> Result<bool> {
+        let (removed, was_current) = self.remove_item(uid);
+        if let Some(mut profile) = removed {
+            profile.remove_file().await?;
+        }
         self.save_file()?;
-        Ok(is_current)
+        Ok(was_current)
     }
 
     /// 获取current指向的配置内容
@@ -232,5 +238,138 @@ impl Profiles {
         }
         let map = IndexMap::from_iter(successes);
         Ok(map)
+    }
+}
+
+/// reorder items in place (pure, in-memory only)
+pub fn reorder_items(items: &mut [Profile], active_id: &str, over_id: &str) {
+    let mut old_index = None;
+    let mut new_index = None;
+
+    for (i, item) in items.iter().enumerate() {
+        if item.uid() == active_id {
+            old_index = Some(i);
+        }
+        if item.uid() == over_id {
+            new_index = Some(i);
+        }
+    }
+
+    if let (Some(old_index), Some(new_index)) = (old_index, new_index) {
+        // `[T]::rotate_*` keeps the move in-bounds without reallocating the slice.
+        if old_index < new_index {
+            items[old_index..=new_index].rotate_left(1);
+        } else if old_index > new_index {
+            items[new_index..=old_index].rotate_right(1);
+        }
+    }
+}
+
+/// reorder items with the full order list (pure, in-memory only)
+pub fn reorder_items_by_list<T: Borrow<String>>(items: &mut Vec<Profile>, order: &[T]) {
+    let mut old = std::mem::take(items);
+    let mut new_items = Vec::with_capacity(old.len());
+
+    for uid in order {
+        if let Some(index) = old.iter().position(|e| e.uid() == uid.borrow()) {
+            new_items.push(old.remove(index));
+        }
+    }
+
+    // Keep unmatched items to avoid accidental data loss when order is partial.
+    new_items.extend(old);
+    *items = new_items;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Profiles, reorder_items, reorder_items_by_list};
+    use crate::config::profile::{
+        builder::ProfileBuilder,
+        item::{LocalProfileBuilder, Profile, ProfileSharedBuilder, prelude::ProfileMetaGetter},
+    };
+
+    fn local(uid: &str) -> Profile {
+        serde_yaml::from_str(&format!(
+            "type: local\nuid: \"{uid}\"\nname: \"{uid}\"\nfile: {uid}.yaml\nupdated: 0\n"
+        ))
+        .expect("local profile yaml should parse")
+    }
+
+    fn profiles_with(uids: &[&str]) -> Profiles {
+        let mut profiles = Profiles::default();
+        for uid in uids {
+            profiles.push_item(local(uid));
+        }
+        profiles
+    }
+
+    fn uids(profiles: &Profiles) -> Vec<&str> {
+        profiles.items.iter().map(|item| item.uid()).collect()
+    }
+
+    #[test]
+    fn reorder_items_moves_forward_and_backward() {
+        let mut profiles = profiles_with(&["a", "b", "c", "d"]);
+        reorder_items(&mut profiles.items, "a", "c");
+        assert_eq!(uids(&profiles), ["b", "c", "a", "d"]);
+        reorder_items(&mut profiles.items, "a", "b");
+        assert_eq!(uids(&profiles), ["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn reorder_items_missing_id_is_noop() {
+        let mut profiles = profiles_with(&["a", "b"]);
+        reorder_items(&mut profiles.items, "a", "missing");
+        assert_eq!(uids(&profiles), ["a", "b"]);
+    }
+
+    #[test]
+    fn reorder_items_by_list_keeps_unmatched_tail() {
+        let mut profiles = profiles_with(&["a", "b", "c"]);
+        reorder_items_by_list(&mut profiles.items, &["c".to_string(), "a".to_string()]);
+        assert_eq!(uids(&profiles), ["c", "a", "b"]);
+    }
+
+    #[test]
+    fn remove_item_reactivates_first_when_current_emptied() {
+        let mut profiles = profiles_with(&["a", "b"]);
+        profiles.set_current(vec!["a".into()]);
+        let (removed, was_current) = profiles.remove_item("a".to_string());
+        assert!(was_current);
+        assert_eq!(removed.expect("removed").uid(), "a");
+        assert_eq!(profiles.current, vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn remove_item_non_current_keeps_current() {
+        let mut profiles = profiles_with(&["a", "b"]);
+        profiles.set_current(vec!["a".into()]);
+        let (_removed, was_current) = profiles.remove_item("b".to_string());
+        assert!(!was_current);
+        assert_eq!(profiles.current, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn set_item_replaces_in_place_only_when_present() {
+        let mut profiles = profiles_with(&["a", "b"]);
+        profiles.set_item("a".to_string(), local("a"));
+        assert_eq!(uids(&profiles), ["a", "b"]);
+        // unknown uid is a no-op
+        profiles.set_item("missing".to_string(), local("missing"));
+        assert_eq!(uids(&profiles), ["a", "b"]);
+    }
+
+    #[test]
+    fn apply_item_patch_is_pure_and_matches_type() {
+        let mut profiles = profiles_with(&["a"]);
+        let mut shared_builder = ProfileSharedBuilder::default();
+        shared_builder.name("renamed".to_string());
+        let mut local_builder = LocalProfileBuilder::default();
+        local_builder.shared(shared_builder);
+        profiles
+            .apply_item_patch("a".to_string(), ProfileBuilder::Local(local_builder))
+            .expect("patch should apply");
+        assert_eq!(profiles.get_item("a").unwrap().name(), "renamed");
     }
 }

--- a/backend/tauri/src/core/state.rs
+++ b/backend/tauri/src/core/state.rs
@@ -45,12 +45,17 @@ impl<T> ManagedState<T>
 where
     T: Clone + Sync + Send,
 {
-    /// to auto commit the state when it is dropped
-    pub fn auto_commit(&self) -> ManagedStateAutoCommit<T> {
+    /// to auto commit the state when it is dropped.
+    ///
+    /// Retained for any un-migrated path: PR-2/PR-3 moved every verge/profiles writer to the
+    /// state actors, so this draft-and-commit-on-drop helper currently has no callers.
+    #[allow(dead_code)]
+    pub fn auto_commit(&self) -> ManagedStateAutoCommit<'_, T> {
         ManagedStateAutoCommit(self)
     }
 }
 
+#[allow(dead_code)]
 pub struct ManagedStateAutoCommit<'a, T: Clone + Send + Sync>(&'a ManagedState<T>);
 
 impl<T> Deref for ManagedStateAutoCommit<'_, T>

--- a/backend/tauri/src/core/tasks/jobs/mod.rs
+++ b/backend/tauri/src/core/tasks/jobs/mod.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use anyhow::anyhow;
 use parking_lot::RwLock;
-pub use profiles::ProfilesJobGuard;
+pub use profiles::{ProfilesJobGuard, ProfilesUpdateGate};
 use std::sync::Arc;
 pub trait JobExt {
     fn name(&self) -> &'static str;

--- a/backend/tauri/src/core/tasks/jobs/profiles.rs
+++ b/backend/tauri/src/core/tasks/jobs/profiles.rs
@@ -3,8 +3,8 @@ use super::super::{
     task::{Task, TaskID, TaskManager, TaskSchedule},
 };
 use crate::{
+    client::NyanpasuClient,
     config::{Config, ProfileMetaGetter},
-    feat,
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -16,21 +16,42 @@ const INITIAL_TASK_ID: TaskID = 10000000; // 留一个初始的 TaskID，避免�
 type Minutes = u64;
 type ProfileUID = String;
 
+/// Narrow, non-Tauri gate the scheduled updater uses to funnel profile updates through the
+/// client, so the actor and `Config::profiles()` stay in sync. One-way dependency: job → client.
+#[async_trait]
+pub trait ProfilesUpdateGate: Send + Sync {
+    async fn update_profile(&self, uid: String) -> Result<()>;
+}
+
+#[async_trait]
+impl ProfilesUpdateGate for NyanpasuClient {
+    async fn update_profile(&self, uid: String) -> Result<()> {
+        NyanpasuClient::update_profile(self, uid, None)
+            .await
+            .map_err(anyhow::Error::from)
+    }
+}
+
 #[derive(Clone)]
-pub struct ProfileUpdater(ProfileUID);
+pub struct ProfileUpdater {
+    uid: ProfileUID,
+    gate: Arc<dyn ProfilesUpdateGate>,
+}
 
 impl ProfileUpdater {
-    #[allow(dead_code)]
-    pub fn new(profile_uid: &str) -> Self {
-        Self(profile_uid.to_string())
+    pub fn new(uid: &str, gate: Arc<dyn ProfilesUpdateGate>) -> Self {
+        Self {
+            uid: uid.to_string(),
+            gate,
+        }
     }
 }
 
 #[async_trait]
 impl AsyncJobExecutor for ProfileUpdater {
     async fn execute(&self) -> Result<()> {
-        log::info!(target: "app", "running timer task `{}`", self.0);
-        match feat::update_profile(self.0.clone(), None).await {
+        log::info!(target: "app", "running timer task `{}`", self.uid);
+        match self.gate.update_profile(self.uid.clone()).await {
             Ok(_) => Ok(()),
             Err(err) => {
                 log::error!(target: "app", "failed to update profile: {err:?}");
@@ -49,6 +70,7 @@ enum ProfileTaskOp {
 pub struct ProfilesJob {
     task_map: HashMap<ProfileUID, (TaskID, u64)>,
     task_manager: Arc<RwLock<TaskManager>>,
+    gate: Arc<dyn ProfilesUpdateGate>,
     // next_id: TaskID,
 }
 
@@ -57,9 +79,9 @@ pub struct ProfilesJobGuard {
 }
 
 impl ProfilesJobGuard {
-    pub fn new(task_manager: Arc<RwLock<TaskManager>>) -> Self {
+    pub fn new(task_manager: Arc<RwLock<TaskManager>>, gate: Arc<dyn ProfilesUpdateGate>) -> Self {
         Self {
-            job: Arc::new(RwLock::new(ProfilesJob::new(task_manager))),
+            job: Arc::new(RwLock::new(ProfilesJob::new(task_manager, gate))),
         }
     }
 }
@@ -73,10 +95,11 @@ impl Deref for ProfilesJobGuard {
 }
 
 impl ProfilesJob {
-    pub fn new(task_manager: Arc<RwLock<TaskManager>>) -> Self {
+    pub fn new(task_manager: Arc<RwLock<TaskManager>>, gate: Arc<dyn ProfilesUpdateGate>) -> Self {
         Self {
             task_map: HashMap::new(),
             task_manager,
+            gate,
         }
     }
 
@@ -120,7 +143,7 @@ impl ProfilesJob {
         for (uid, diff) in diff_map.into_iter() {
             match diff {
                 ProfileTaskOp::Add(task_id, interval) => {
-                    let task = new_task(task_id, &uid, interval);
+                    let task = new_task(task_id, &uid, interval, self.gate.clone());
                     crate::log_err!(self.task_manager.write().add_task(task));
                     self.task_map.insert(uid, (task_id, interval));
                 }
@@ -130,7 +153,7 @@ impl ProfilesJob {
                 }
                 ProfileTaskOp::Update(task_id, interval) => {
                     crate::log_err!(self.task_manager.write().remove_task(task_id));
-                    let task = new_task(task_id, &uid, interval);
+                    let task = new_task(task_id, &uid, interval, self.gate.clone());
                     crate::log_err!(self.task_manager.write().add_task(task));
                     self.task_map.insert(uid, (task_id, interval));
                 }
@@ -201,11 +224,16 @@ fn get_task_id(uid: &str) -> TaskID {
     }
 }
 
-fn new_task(task_id: TaskID, profile_uid: &str, interval: Minutes) -> Task {
+fn new_task(
+    task_id: TaskID,
+    profile_uid: &str,
+    interval: Minutes,
+    gate: Arc<dyn ProfilesUpdateGate>,
+) -> Task {
     Task {
         id: task_id,
         name: format!("profile-updater-{profile_uid}"),
-        executor: TaskExecutor::Async(Box::new(ProfileUpdater(profile_uid.to_owned().to_string()))),
+        executor: TaskExecutor::Async(Box::new(ProfileUpdater::new(profile_uid, gate))),
         schedule: TaskSchedule::Interval(Duration::from_secs(interval * 60)),
         ..Task::default()
     }

--- a/backend/tauri/src/core/tasks/mod.rs
+++ b/backend/tauri/src/core/tasks/mod.rs
@@ -21,8 +21,10 @@ pub fn setup<R: tauri::Runtime, M: tauri::Manager<R>>(
     job_manager.setup().context("failed to setup job manager")?;
     let job_manager = std::sync::Arc::new(RwLock::new(job_manager));
     app.manage(job_manager);
-    // profiles job
-    let profiles_job = jobs::ProfilesJobGuard::new(task_manager.clone());
+    // profiles job — funnel scheduled updates through the client (actor + Config stay in sync)
+    let gate: std::sync::Arc<dyn jobs::ProfilesUpdateGate> =
+        std::sync::Arc::new(app.state::<crate::client::NyanpasuClient>().inner().clone());
+    let profiles_job = jobs::ProfilesJobGuard::new(task_manager.clone(), gate);
     {
         let mut profiles_job = profiles_job.write();
         profiles_job.init()?;

--- a/backend/tauri/src/feat.rs
+++ b/backend/tauri/src/feat.rs
@@ -4,8 +4,6 @@
 //! - timer 定时器
 //! - cmds 页面调用
 //!
-use std::borrow::Borrow;
-
 use crate::{
     config::{
         profile::{
@@ -21,7 +19,7 @@ use crate::{
     log_err,
     utils::{self, help::get_clash_external_port, resolve},
 };
-use anyhow::{Result, bail};
+use anyhow::{Context as _, Result, bail};
 use handle::Message;
 use nyanpasu_ipc::api::status::CoreState;
 use serde::{Deserialize, Serialize};
@@ -436,63 +434,112 @@ pub async fn patch_verge(patch: IVerge) -> Result<()> {
     }
 }
 
-/// 更新某个profile
-/// 如果更新当前配置就激活配置
-pub async fn update_profile<T: Borrow<String>>(
-    uid: T,
-    opts: Option<RemoteProfileOptionsBuilder>,
-) -> Result<()> {
-    let uid = uid.borrow();
-    let profile_item = Config::profiles().latest().get_item(uid)?.clone();
-    let is_remote = profile_item.is_remote();
+/// A snapshot of a pending `update_profile`: the network/IO phase ran outside the
+/// `profiles_update_lock`, and `base_hash` pins the baseline item so the commit phase
+/// can reject a concurrent edit instead of clobbering it (TOCTOU guard).
+pub struct PreparedProfileUpdate {
+    uid: String,
+    /// Canonical full-value hash of the baseline item. `updated()` alone is insufficient:
+    /// it is a second-granularity timestamp that `patch_item` does not bump, so a concurrent
+    /// `patch_profile` (URL/options/name/chain) would slip past an `updated`-only comparison.
+    base_hash: u64,
+    kind: PreparedKind,
+}
 
-    let should_update = if is_remote {
-        let mut item = profile_item.as_remote().unwrap().clone();
+enum PreparedKind {
+    /// A freshly downloaded remote profile, ready to replace the baseline item.
+    Remote(Box<Profile>),
+    /// A non-remote profile whose timestamp should be bumped in place.
+    LocalTouch,
+}
 
-        item.subscribe(opts).await?;
-        let committer = Config::profiles().auto_commit();
-        let mut profiles = committer.draft();
-        profiles.replace_item(uid, item.into())?;
-        profiles.get_current().contains(uid)
-    } else {
-        // For local profiles, we need to update the timestamp
-        let committer = Config::profiles().auto_commit();
-        let mut profiles = committer.draft();
+/// Canonical full-value fingerprint of a profile item (serialize, then hash).
+/// Fails closed: a serialization error propagates instead of collapsing to a shared hash,
+/// so the TOCTOU guard can never be defeated by two items that both fail to serialize.
+fn profile_fingerprint(item: &Profile) -> Result<u64> {
+    let serialized =
+        serde_yaml::to_string(item).context("failed to serialize profile for fingerprint")?;
+    Ok(seahash::hash(serialized.as_bytes()))
+}
 
-        // Create a builder to update the timestamp
-        match profile_item {
-            Profile::Local(_) => {
-                let mut shared_builder = ProfileSharedBuilder::default();
-                shared_builder.updated(chrono::Local::now().timestamp() as usize);
-                let mut builder = LocalProfileBuilder::default();
-                builder.shared(shared_builder);
-                profiles.patch_item(uid.to_string(), ProfileBuilder::Local(builder))?;
-            }
-            Profile::Merge(_) => {
-                let mut shared_builder = ProfileSharedBuilder::default();
-                shared_builder.updated(chrono::Local::now().timestamp() as usize);
-                let mut builder = MergeProfileBuilder::default();
-                builder.shared(shared_builder);
-                profiles.patch_item(uid.to_string(), ProfileBuilder::Merge(builder))?;
-            }
-            Profile::Script(_) => {
-                let mut shared_builder = ProfileSharedBuilder::default();
-                shared_builder.updated(chrono::Local::now().timestamp() as usize);
-                let mut builder = ScriptProfileBuilder::default();
-                builder.shared(shared_builder);
-                profiles.patch_item(uid.to_string(), ProfileBuilder::Script(builder))?;
-            }
-            _ => {}
+/// Build the timestamp-bump patch for a non-remote profile; `None` for remote items.
+fn touch_profile_builder(item: &Profile) -> Option<ProfileBuilder> {
+    let mut shared_builder = ProfileSharedBuilder::default();
+    shared_builder.updated(chrono::Local::now().timestamp() as usize);
+    match item {
+        Profile::Local(_) => {
+            let mut builder = LocalProfileBuilder::default();
+            builder.shared(shared_builder);
+            Some(ProfileBuilder::Local(builder))
         }
+        Profile::Merge(_) => {
+            let mut builder = MergeProfileBuilder::default();
+            builder.shared(shared_builder);
+            Some(ProfileBuilder::Merge(builder))
+        }
+        Profile::Script(_) => {
+            let mut builder = ScriptProfileBuilder::default();
+            builder.shared(shared_builder);
+            Some(ProfileBuilder::Script(builder))
+        }
+        Profile::Remote(_) => None,
+    }
+}
 
-        profiles.get_current().contains(uid)
+/// Phase 1 of `update_profile`: perform the network download (remote) outside any lock,
+/// and pin the baseline fingerprint for the later TOCTOU check.
+///
+/// SCOPE NOTE (PR-3): `RemoteProfile::subscribe` writes the *content file* to disk as part of
+/// fetching (`remote.rs`), exactly as the legacy `feat::update_profile` did. PR-3 only takes
+/// over the profiles *index*; content-file IO stays in the legacy layer. Consequently a later
+/// TOCTOU rejection in `commit_profile_update` (or a failed index persist) leaves the freshly
+/// downloaded content file in place while the index is unchanged — the same residual window
+/// documented in the plan (§5). True all-or-nothing for content files requires the
+/// `ProfileFileService` / 2PC introduced in PR-4/PR-5 and is intentionally out of scope here.
+pub async fn prepare_profile_update(
+    uid: &str,
+    opts: Option<RemoteProfileOptionsBuilder>,
+) -> Result<PreparedProfileUpdate> {
+    let item = Config::profiles().data().get_item(uid)?.clone();
+    let base_hash = profile_fingerprint(&item)?;
+    let kind = if item.is_remote() {
+        let mut remote = item.as_remote().unwrap().clone();
+        remote.subscribe(opts).await?;
+        PreparedKind::Remote(Box::new(remote.into()))
+    } else {
+        PreparedKind::LocalTouch
     };
+    Ok(PreparedProfileUpdate {
+        uid: uid.to_string(),
+        base_hash,
+        kind,
+    })
+}
 
-    if should_update {
-        update_core_config().await?;
+/// Phase 2 of `update_profile`: pure, in-memory write into `next`. Returns whether the
+/// updated profile is active (so the caller knows to reload the core). Called by the client
+/// inside `profiles_update_lock`. Rejects (Err) if the baseline changed concurrently.
+pub fn commit_profile_update(next: &mut Profiles, prepared: PreparedProfileUpdate) -> Result<bool> {
+    let PreparedProfileUpdate {
+        uid,
+        base_hash,
+        kind,
+    } = prepared;
+
+    if profile_fingerprint(next.get_item(&uid)?)? != base_hash {
+        bail!("profile {uid} changed during update; aborting to avoid overwrite");
     }
 
-    Ok(())
+    match kind {
+        PreparedKind::Remote(item) => next.set_item(&uid, *item),
+        PreparedKind::LocalTouch => {
+            if let Some(builder) = touch_profile_builder(next.get_item(&uid)?) {
+                next.apply_item_patch(uid.clone(), builder)?;
+            }
+        }
+    }
+
+    Ok(next.get_current().contains(&uid))
 }
 
 /// 更新配置
@@ -572,4 +619,53 @@ pub fn update_proxies_buff(rx: Option<tokio::sync::oneshot::Receiver<()>>) {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PreparedKind, PreparedProfileUpdate, commit_profile_update, profile_fingerprint};
+    use crate::config::{Profiles, profile::item::Profile};
+
+    fn local(uid: &str, updated: usize) -> Profile {
+        serde_yaml::from_str(&format!(
+            "type: local\nuid: \"{uid}\"\nname: \"{uid}\"\nfile: {uid}.yaml\nupdated: {updated}\n"
+        ))
+        .expect("local profile yaml should parse")
+    }
+
+    /// TOCTOU guard: a baseline that changed between prepare and commit must be rejected
+    /// instead of overwriting the concurrent edit.
+    #[test]
+    fn commit_profile_update_rejects_on_baseline_change() {
+        let base_hash = profile_fingerprint(&local("a", 0)).expect("fingerprint");
+        let prepared = PreparedProfileUpdate {
+            uid: "a".to_string(),
+            base_hash,
+            kind: PreparedKind::LocalTouch,
+        };
+
+        let mut next = Profiles::default();
+        next.push_item(local("a", 999)); // concurrently changed → different fingerprint
+
+        let err = commit_profile_update(&mut next, prepared).expect_err("should reject");
+        assert!(err.to_string().contains("changed during update"));
+    }
+
+    /// Happy path: an unchanged baseline commits and reports `true` when the profile is active.
+    #[test]
+    fn commit_profile_update_applies_and_reports_active() {
+        let mut next = Profiles::default();
+        next.push_item(local("a", 0));
+        next.set_current(vec!["a".into()]);
+        let base_hash =
+            profile_fingerprint(next.get_item("a").expect("item")).expect("fingerprint");
+        let prepared = PreparedProfileUpdate {
+            uid: "a".to_string(),
+            base_hash,
+            kind: PreparedKind::LocalTouch,
+        };
+
+        let reload = commit_profile_update(&mut next, prepared).expect("should apply");
+        assert!(reload, "active profile update should request a reload");
+    }
 }

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -99,8 +99,8 @@ pub struct GetSysProxyResponse {
 
 #[tauri::command]
 #[specta::specta]
-pub fn get_profiles(client: State<'_, NyanpasuClient>) -> Result<Profiles> {
-    Ok(client.get_profiles())
+pub async fn get_profiles(client: State<'_, NyanpasuClient>) -> Result<Profiles> {
+    Ok(client.get_profiles().await?)
 }
 
 #[cfg(target_os = "windows")]
@@ -125,9 +125,8 @@ pub fn is_portable() -> Result<bool> {
 
 #[tauri::command]
 #[specta::specta]
-pub async fn enhance_profiles() -> Result {
-    CoreManager::global().update_config().await?;
-    handle::Handle::refresh_clash();
+pub async fn enhance_profiles(client: State<'_, NyanpasuClient>) -> Result {
+    client.enhance_profiles().await?;
     Ok(())
 }
 
@@ -148,24 +147,8 @@ pub async fn import_profile(
         .build_no_blocking()
         .await
         .context("failed to build a remote profile")?;
-    // 根据是否为 Some(uid) 来判断是否要激活配置
-    let profile_id = {
-        if Config::profiles().draft().current.is_empty() {
-            Some(profile.uid().to_string())
-        } else {
-            None
-        }
-    };
-    {
-        let committer = Config::profiles().auto_commit();
-        (committer.draft().append_item(profile.into()))?;
-    }
-    // TODO: 使用 activate_profile 来激活配置
-    if let Some(profile_id) = profile_id {
-        let mut builder = ProfilesBuilder::default();
-        builder.current(vec![profile_id]);
-        client.patch_profiles_config(builder).await?;
-    }
+    // The client decides activation under its lock (activate when no profile is current yet).
+    client.create_profile(profile.into(), true).await?;
     Ok(())
 }
 
@@ -211,74 +194,48 @@ pub async fn create_profile(
         profile.save_file(file_data)?;
     }
 
-    // 根据是否为 Some(uid) 来判断是否要激活配置
-    let profile_id = {
-        if (profile.is_local() || profile.is_remote())
-            && Config::profiles().draft().current.is_empty()
-        {
-            Some(profile.uid().to_string())
-        } else {
-            None
-        }
-    };
-
-    // Save the profile
-    {
-        let committer = Config::profiles().auto_commit();
-        committer.draft().append_item(profile)?;
-    };
-    // TODO: 使用 activate_profile 来激活配置
-    if let Some(profile_id) = profile_id {
-        let mut builder = ProfilesBuilder::default();
-        builder.current(vec![profile_id]);
-        client.patch_profiles_config(builder).await?;
-    }
+    // The client appends + (conditionally) activates atomically under its lock.
+    client.create_profile(profile, true).await?;
 
     Ok(())
 }
 
 #[tauri::command]
 #[specta::specta]
-pub async fn reorder_profile(active_id: String, over_id: String) -> Result {
-    let committer = Config::profiles().auto_commit();
-    (committer.draft().reorder(active_id, over_id))?;
+pub async fn reorder_profile(
+    client: State<'_, NyanpasuClient>,
+    active_id: String,
+    over_id: String,
+) -> Result {
+    client.reorder_profile(active_id, over_id).await?;
     Ok(())
 }
 
 #[tauri::command]
 #[specta::specta]
-pub fn reorder_profiles_by_list(list: Vec<String>) -> Result {
-    let committer = Config::profiles().auto_commit();
-    (committer.draft().reorder_by_list(&list))?;
+pub async fn reorder_profiles_by_list(
+    client: State<'_, NyanpasuClient>,
+    list: Vec<String>,
+) -> Result {
+    client.reorder_profiles_by_list(list).await?;
     Ok(())
 }
 
 #[tauri::command]
 #[specta::specta]
-pub async fn update_profile(uid: String, option: Option<RemoteProfileOptionsBuilder>) -> Result {
-    (feat::update_profile(uid, option).await)?;
+pub async fn update_profile(
+    client: State<'_, NyanpasuClient>,
+    uid: String,
+    option: Option<RemoteProfileOptionsBuilder>,
+) -> Result {
+    client.update_profile(uid, option).await?;
     Ok(())
 }
 
 #[tauri::command]
 #[specta::specta]
-pub async fn delete_profile(uid: String) -> Result {
-    let should_update = tokio::task::spawn_blocking(move || {
-        #[allow(clippy::let_and_return)] // a bug in clippy
-        nyanpasu_utils::runtime::block_on_current_thread(async move {
-            let committer = Config::profiles().auto_commit();
-            let x = committer.draft().delete_item(&uid).await;
-            x
-        })
-    })
-    .await
-    .context("failed to join the task")?
-    .context("failed to delete the profile")?;
-
-    if should_update {
-        (CoreManager::global().update_config().await)?;
-        handle::Handle::refresh_clash();
-    }
+pub async fn delete_profile(client: State<'_, NyanpasuClient>, uid: String) -> Result {
+    client.delete_profile(uid).await?;
     Ok(())
 }
 
@@ -296,46 +253,16 @@ pub async fn patch_profiles_config(
 /// update profile by uid
 #[tauri::command]
 #[specta::specta]
-pub async fn patch_profile(app_handle: AppHandle, uid: String, profile: ProfileBuilder) -> Result {
+pub async fn patch_profile(
+    app_handle: AppHandle,
+    client: State<'_, NyanpasuClient>,
+    uid: String,
+    profile: ProfileBuilder,
+) -> Result {
     tracing::debug!("patch profile: {uid} with {profile:?}");
-    {
-        let committer = Config::profiles().auto_commit();
-        (committer.draft().patch_item(uid.clone(), profile))?;
-    }
-    {
-        let profiles_jobs = app_handle.state::<ProfilesJobGuard>();
-        profiles_jobs.write().refresh();
-    }
-    let need_update = {
-        let profiles = Config::profiles();
-        let profiles = profiles.latest();
-        match (&profiles.chain, &profiles.current) {
-            (chains, _) if chains.contains(&uid) => true,
-            (_, current_chain) if current_chain.contains(&uid) => true,
-            (_, current_chain) => {
-                current_chain
-                    .iter()
-                    .any(|chain_uid| match profiles.get_item(chain_uid) {
-                        Ok(item) if item.is_local() => {
-                            item.as_local().unwrap().chain.contains(&uid)
-                        }
-                        Ok(item) if item.is_remote() => {
-                            item.as_remote().unwrap().chain.contains(&uid)
-                        }
-                        _ => false,
-                    })
-            }
-        }
-    };
-    if need_update {
-        match CoreManager::global().update_config().await {
-            Ok(_) => {
-                handle::Handle::refresh_clash();
-            }
-            Err(err) => {
-                log::error!(target: "app", "{err:?}");
-            }
-        }
+    let report = client.patch_profile(uid, profile).await?;
+    if report.refresh_jobs {
+        app_handle.state::<ProfilesJobGuard>().write().refresh();
     }
     Ok(())
 }

--- a/backend/tauri/src/state/mod.rs
+++ b/backend/tauri/src/state/mod.rs
@@ -1,1 +1,2 @@
+pub mod profiles;
 pub mod verge;

--- a/backend/tauri/src/state/profiles.rs
+++ b/backend/tauri/src/state/profiles.rs
@@ -1,0 +1,108 @@
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+
+use crate::config::Profiles;
+use nyanpasu_core::state::PersistentStateManager;
+
+/// Injected legacy mirror hook: production overwrites the in-memory `Config::profiles()`,
+/// tests capture the committed state. Keeps the actor decoupled from the global config.
+///
+/// Unlike the verge mirror, this hook is infallible: the production mirror only swaps the
+/// in-memory draft (`*draft() = state; apply()`), which cannot fail. Making it infallible
+/// rules out the "upsert succeeded but mirror errored" window where the actor/disk would be
+/// committed while `Config::profiles()` stayed stale.
+pub type ProfilesMirror = Arc<dyn Fn(Profiles) + Send + Sync + 'static>;
+
+#[derive(Debug, Clone)]
+pub struct ProfilesStateSnapshot {
+    pub state: Profiles,
+    /// Monotonic state version. Surfaced for callers/tests to observe commits; the
+    /// event-system PRs will consume it, so production reads are not present yet.
+    #[allow(dead_code)]
+    pub version: u64,
+}
+
+pub struct ProfilesStateActorArgs {
+    pub manager: PersistentStateManager<Profiles>,
+    pub mirror: ProfilesMirror,
+}
+
+pub struct ProfilesStateActorState {
+    manager: PersistentStateManager<Profiles>,
+    mirror: ProfilesMirror,
+}
+
+#[derive(Debug)]
+pub enum ProfilesStateMessage {
+    GetProfiles(RpcReplyPort<anyhow::Result<ProfilesStateSnapshot>>),
+    /// Absolute, idempotent commit of the whole profiles index: `upsert` (disk) + mirror
+    /// (sets `Config::profiles()`). The client is the sole persister of the index.
+    CommitProfiles {
+        state: Profiles,
+        reply: RpcReplyPort<anyhow::Result<ProfilesStateSnapshot>>,
+    },
+}
+
+pub struct ProfilesStateActor;
+
+impl ProfilesStateActor {
+    fn snapshot(state: &ProfilesStateActorState) -> ProfilesStateSnapshot {
+        let snapshot = state.manager.snapshot_handle().load();
+        ProfilesStateSnapshot {
+            state: snapshot.state.clone(),
+            version: *snapshot.version.as_ref(),
+        }
+    }
+
+    /// Atomically persist the absolute next index, then sync the legacy mirror.
+    /// If `upsert` fails the mirror is never invoked, so `Config::profiles()` and disk
+    /// both keep their previous value ("all or nothing").
+    async fn commit(
+        state: &mut ProfilesStateActorState,
+        next: Profiles,
+    ) -> anyhow::Result<ProfilesStateSnapshot> {
+        state
+            .manager
+            .upsert(next.clone())
+            .await
+            .context("failed to persist profiles state")?;
+        (state.mirror)(next);
+        Ok(Self::snapshot(state))
+    }
+}
+
+impl Actor for ProfilesStateActor {
+    type Msg = ProfilesStateMessage;
+    type State = ProfilesStateActorState;
+    type Arguments = ProfilesStateActorArgs;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(ProfilesStateActorState {
+            manager: args.manager,
+            mirror: args.mirror,
+        })
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            ProfilesStateMessage::GetProfiles(reply) => {
+                let _ = reply.send(Ok(Self::snapshot(state)));
+            }
+            ProfilesStateMessage::CommitProfiles { state: next, reply } => {
+                let _ = reply.send(Self::commit(state, next).await);
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

PR-3 of the actor migration: the profiles **index** (`current`/`chain`/`valid`/`items`) now flows through a ractor-backed `ProfilesStateActor` as the **sole persister**, mirroring PR-2's verge actor. Reads go through the actor (with a committed-`Config` fallback); every write path is funneled through `NyanpasuClient` under a single non-reentrant lock.

Commit model is **all-or-nothing**: pure in-memory mutators build an absolute `next: Profiles` from the freshest committed state, and the actor commits it via `upsert` + an infallible mirror. This eliminates the v2 partial-commit hazard, stale-snapshot overwrites, and double-writes.

## Changes

- **`state/profiles.rs`** *(new)* — `ProfilesStateActor`: `GetProfiles` + `CommitProfiles` (upsert + infallible mirror).
- **`client/profiles_state.rs`** *(new)* — `ProfilesStateClient` (prefix-aligned, 5s read / 10s write).
- **`config/profile/profiles.rs`** — pure mutators (`push_item`/`set_item`/`apply_item_patch`/`remove_item`/`set_current`) + free `reorder_items`/`reorder_items_by_list`; legacy `save_file`-backed methods kept as thin bridges.
- **`client/mod.rs`** — `NyanpasuClient` owns all writes via three commit primitives (`persist` / `persist_then_reload` / `reload_then_persist`) under one `profiles_update_lock`; `get_profiles` reads the actor with a `Config` fallback. Per-command error semantics preserved.
- **`feat.rs`** — two-phase `update_profile`: network download outside the lock + fail-closed content-hash TOCTOU guard.
- **`ipc.rs`** — profile commands slimmed to client calls; `get_profiles` / `reorder_profiles_by_list` become `async` (TS bindings unchanged).
- **`jobs/profiles.rs` + `tasks/mod.rs`** — scheduled updates funnel through a narrow `ProfilesUpdateGate` injected from the client (one-way job → client dependency).

## Scope boundary

Content-file IO (download/read/write/delete) stays in the legacy layer — only the index is actor-owned. The residual reload-ok/persist-fail window and the remote-update TOCTOU-reject content residue are documented; true content-file atomicity is deferred to PR-4 (`ProfileFileService` / 2PC).

## Frontend

**Zero changes** — `sync→async` IPC is transparent to tauri-specta; no `bindings.ts` diff.

## Testing

- `cargo check --all-targets`: 0 errors
- Full lib suite: **108 passed / 0 failed**
- New unit tests: pure mutators, actor commit/get + legacy round-trip, TOCTOU reject/accept, and an **architecture guard** confining direct `Config::profiles()` writers to the bridge
- No new clippy warnings in touched files

## Review

Reviewed via codex over 2 rounds (final verdict: PASS for PR-3 scope). High/Medium/Low findings fixed; the Critical was accepted as the documented content-file scope boundary.