### PR TITLE
fix(nsis): default cross-version upgrade to in-place update instead of uninstall-first

### DIFF
--- a/backend/tauri/templates/installer.nsi
+++ b/backend/tauri/templates/installer.nsi
@@ -307,7 +307,17 @@ Function PageReinstall
     ; Check the first radio button if this the first time
     ; we enter this page or if the second button wasn't
     ; selected the last time we were on this page
-    ${If} $ReinstallPageCheck <> 2
+    ;
+    ; Clash Nyanpasu: on first entry, default to the second radio "don't uninstall"
+    ; (direct in-place update) for a cross-version UPGRADE ($R0 = 1), instead of
+    ; upstream's default of "uninstall before installing". Same-version and downgrade
+    ; keep the upstream default (downgrade's "don't uninstall" may even be disabled).
+    ; The decision is still read live from $R2 in PageLeaveReinstall, so leaving
+    ; $ReinstallPageCheck at 0 here is fine.
+    ${If} $ReinstallPageCheck = 0
+    ${AndIf} $R0 = 1
+      SendMessage $R3 ${BM_SETCHECK} ${BST_CHECKED} 0
+    ${ElseIf} $ReinstallPageCheck <> 2
       SendMessage $R2 ${BM_SETCHECK} ${BST_CHECKED} 0
     ${Else}
       SendMessage $R3 ${BM_SETCHECK} ${BST_CHECKED} 0


### PR DESCRIPTION
## Summary

Follow-up to #4805. On the reinstall maintenance page (`PageReinstall`), when an existing install of a **different (older) version** is detected, default the selection to **"don't uninstall" (direct in-place update)** for an **upgrade**, instead of upstream's default of **"uninstall before installing"**.

## Why

A cross-version upgrade does not need a full uninstall+reinstall cycle — `Section Install` already overwrites files in place and migrates shortcuts. Defaulting to uninstall-first is slower, tears down the service / autostart / protocol integrations mid-upgrade, and is riskier than a straight overwrite. Defaulting to an in-place update also matches what auto-updates (`/UPDATE`) already do.

## Scope

| Detected state | Default selection | Status |
| --- | --- | --- |
| **Upgrade** (`$R0 = 1`) | "don't uninstall" → in-place update | **changed** |
| Same version (`$R0 = 0`) | "add/reinstall" (already not an uninstall) | unchanged |
| Downgrade (`$R0 = -1`) | "uninstall before installing" | unchanged |

Downgrade intentionally keeps the upstream default: overwriting a newer install with an older one in place is riskier, and the "don't uninstall" radio is disabled anyway when downgrades are not allowed.

- Only the **first-entry default** changes; the user's explicit radio choice and back/forward navigation are preserved.
- The decision is still read live from the radio control in `PageLeaveReinstall`, so leaving `$ReinstallPageCheck` at its initial value is fine.
- Auto-updates (`/UPDATE`) already short-circuit to a direct update in `PageLeaveReinstall`, so this only affects a **manual, interactive** cross-version upgrade.
- Marked inline with a `Clash Nyanpasu:` comment so future upstream syncs can identify it.

## Testing

- [x] Static/structural review (`${If}`/`${EndIf}` balance, live-state read trace through `PageLeaveReinstall`).
- [ ] **TODO:** manual Windows installer run over an older install to confirm the upgrade radio defaults to in-place update.
