### PR TITLE
fix: remote profile traffic and local file size display

### DIFF
--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/_modules/local-profile-button.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/_modules/local-profile-button.tsx
@@ -241,7 +241,12 @@ export default function LocalProfileButton({ children }: PropsWithChildren) {
 
                         <div className="text-on-surface max-w-full truncate text-sm font-medium">
                           {m.profile_import_local_file_size_label({
-                            size: filesize(profileContent?.length ?? 0),
+                            size: filesize(
+                              profileContent
+                                ? new Blob([profileContent]).size
+                                : 0,
+                              { standard: 'iec' },
+                            ),
                           })}
                         </div>
                       </FileDropZoneFileSelected>

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/subscription-card.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/subscription-card.tsx
@@ -107,7 +107,8 @@ export const SubscriptionCard = ({
           <div className="text-sm font-bold">{progress.toFixed(2)}%</div>
 
           <div className="text-sm font-bold">
-            {filesize(used)} / {filesize(total)}
+            {filesize(used, { standard: 'iec' })} /
+            {filesize(total, { standard: 'iec' })}
           </div>
         </div>
 


### PR DESCRIPTION
- Remote profile traffic was previously displayed using decimal units, causing inconsistency with proxy vendors and other apps. Fixed by explicitly using the IEC standard.
- The file size shown in the local profile import dialog didn’t match the system’s calculation. This PR resolves the issue.

CC @keiko233 @greenhat616
I hope this PR can be merged as soon as possible.