### PR TITLE
fix(build): embed app manifest into test binaries on Windows

### DIFF
--- a/backend/tauri/build.rs
+++ b/backend/tauri/build.rs
@@ -103,5 +103,37 @@ fn main() {
             None => "Unknown".to_string(),
         }
     );
-    tauri_build::build()
+
+    // On Windows (MSVC), tauri-build embeds the application manifest via
+    // `rustc-link-arg-bins`, so the Common-Controls v6 dependency required by our
+    // dialog stack (rfd `common-controls-v6`) is linked into the binaries only,
+    // never into the test executables. Without that manifest the loader resolves
+    // ComCtl5 instead of ComCtl6 and the test process aborts at load time with
+    // `STATUS_ENTRYPOINT_NOT_FOUND` (0xc0000139) before any test code runs.
+    //
+    // Work around it by disabling tauri's manifest injection and embedding the
+    // manifest ourselves with `/MANIFEST:EMBED`, which is a plain `rustc-link-arg`
+    // and therefore applies to every artifact — binaries, tests and benches alike.
+    // See https://github.com/tauri-apps/tauri/issues/13419
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_os == "windows" && target_env == "msvc" {
+        let manifest = env::current_dir()
+            .expect("failed to resolve build script working directory")
+            .join("windows-app-manifest.xml");
+        println!("cargo:rerun-if-changed={}", manifest.display());
+        println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+        println!(
+            "cargo:rustc-link-arg=/MANIFESTINPUT:{}",
+            manifest
+                .to_str()
+                .expect("windows-app-manifest.xml path is not valid UTF-8")
+        );
+
+        let attributes = tauri_build::Attributes::new()
+            .windows_attributes(tauri_build::WindowsAttributes::new_without_app_manifest());
+        tauri_build::try_build(attributes).expect("failed to run tauri-build");
+    } else {
+        tauri_build::build();
+    }
 }

--- a/backend/tauri/windows-app-manifest.xml
+++ b/backend/tauri/windows-app-manifest.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>


### PR DESCRIPTION
## Problem

On Windows, `cargo test` aborts with exit code `0xc0000139`
(`STATUS_ENTRYPOINT_NOT_FOUND`) **before any test code runs** — the test
process dies during image load.

## Root cause

`rfd` is built with `common-controls-v6`, so our binaries statically
import ComCtl**6** entry points (e.g. `TaskDialogIndirect`). `tauri-build`
embeds the application manifest that pins Common-Controls v6 through
`embed_resource::compile()`, which emits `cargo:rustc-link-arg-bins` —
i.e. the manifest is linked **only into application binaries, not into
test executables**. Without the manifest the loader resolves the
ComCtl**5** stub from `System32` (the v6 entry points live in the WinSxS
ComCtl6 assembly, which is only activated by the manifest), so the import
cannot be bound and the process fails to start.

This is the issue tracked upstream in
[tauri-apps/tauri#13419](https://github.com/tauri-apps/tauri/issues/13419).

## Why the `__TAURI_WORKSPACE__=true` workaround does not help here

The commonly suggested fix is to copy tauri's
[`.cargo/config.toml`](https://github.com/tauri-apps/tauri/blob/dev/.cargo/config.toml)
which sets `__TAURI_WORKSPACE__ = "true"`. That variable **is** still read
— but only by the `tauri` crate's own `build.rs`
([v2.11.3 `build.rs#L280`](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.3/crates/tauri/build.rs)),
where it calls `embed_manifest_for_tests()` and emits the very same
`/MANIFEST:EMBED` + `/MANIFESTINPUT:` link args we use. It still does not
fix a downstream project's tests, for two compounding reasons:

1. **Scope (the decisive one).** Those `rustc-link-arg` directives are
   emitted by the **`tauri` dependency's** build script, and a build
   script's link args only apply to the **emitting package's own**
   linkable targets — they do not propagate to a dependent crate. When
   `tauri` is consumed from the registry it is compiled to an `rlib` with
   no bin/test artifact in that link step, so the flag lands on nothing
   and never reaches *our* test executable.
2. **Path.** `embed_manifest_for_tests()` resolves the manifest as
   `current_dir()/../tauri-build/src/windows-app-manifest.xml`, which only
   exists inside the tauri monorepo (where `tauri` and `tauri-build` are
   sibling source dirs). From the registry the directory is the
   version-suffixed `tauri-build-<ver>`, so that relative path does not
   exist.

The mechanism is explicitly scoped to "the examples in this workspace"
(tauri's own monorepo) and structurally cannot affect a downstream crate's
test binaries. This PR re-implements the same idea with the correct scope
(our own `build.rs`) and a local manifest file.

## Fix

On the `windows`/`msvc` target only:

- disable tauri's bin-only manifest injection with
  `WindowsAttributes::new_without_app_manifest()`;
- embed the manifest ourselves via `/MANIFEST:EMBED` +
  `/MANIFESTINPUT:`, which are plain `rustc-link-arg`s (not
  `-arg-bins`) and therefore apply to **every** artifact of *this* crate
  — binaries, tests and benches alike.

`windows-app-manifest.xml` is byte-for-byte the manifest tauri ships by
default (the Common-Controls v6 dependency), so application binaries are
unchanged. Non-Windows / non-MSVC targets keep the original
`tauri_build::build()` path untouched.

## Validation

Local `cargo test --manifest-path ./backend/tauri/Cargo.toml --lib`:

- before: crashes at load with `0xc0000139`
- after: **107 passed; 0 failed; 2 ignored**