### PR TITLE
fix(state): keep verge actor in sync for window saves

### DIFF
--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -9,11 +9,21 @@ use crate::{
     state::verge::VergeMirror,
 };
 use nyanpasu_ipc::api::status::CoreState;
-use std::{borrow::Cow, future::Future, sync::Arc};
+use std::{
+    borrow::Cow,
+    future::Future,
+    sync::{
+        Arc, Mutex as StdMutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 use tokio::sync::Mutex;
 
 pub use error::{ClientError, Result};
 pub use event_sink::{TauriUiEventSink, UiEventSink};
+
+const WINDOW_STATE_SAVE_DEBOUNCE: Duration = Duration::from_millis(500);
 
 #[derive(Clone)]
 pub struct NyanpasuClient {
@@ -27,6 +37,8 @@ struct NyanpasuClientInner {
     /// legacy reseeds). The actor serializes its own state, but the legacy path holds
     /// `Config::verge()` draft across awaits, so client-level mutations must not interleave.
     verge_update_lock: Mutex<()>,
+    window_state_save_generation: AtomicU64,
+    window_state_save_lock: StdMutex<()>,
 }
 
 impl NyanpasuClient {
@@ -42,6 +54,8 @@ impl NyanpasuClient {
                 ui,
                 state,
                 verge_update_lock: Mutex::new(()),
+                window_state_save_generation: AtomicU64::new(0),
+                window_state_save_lock: StdMutex::new(()),
             }),
         }
     }
@@ -56,8 +70,8 @@ impl NyanpasuClient {
         Ok(())
     }
 
-    /// Run a legacy mutation that writes `Config::verge()` directly (e.g. core change,
-    /// window-state save), then reseed the actor from the post-mutation legacy state.
+    /// Run a legacy mutation that writes `Config::verge()` directly, then reseed the actor
+    /// from the post-mutation legacy state.
     /// Every legacy verge writer that bypasses the actor must go through this, otherwise
     /// a later actor commit would persist a stale snapshot and clobber the legacy change.
     pub async fn run_legacy_verge_mutation<F, Fut>(&self, mutate: F) -> Result<()>
@@ -66,11 +80,74 @@ impl NyanpasuClient {
         Fut: Future<Output = anyhow::Result<()>>,
     {
         let _guard = self.inner.verge_update_lock.lock().await;
-        mutate().await?;
+        let legacy_result = mutate().await;
         // Bind the clone to a local so the `Config::verge()` guard is dropped before the
         // await (a held parking_lot guard would make this future !Send).
         let committed = Config::verge().data().clone();
-        self.replace_verge_unlocked(committed).await
+        let sync_result = self.replace_verge_unlocked(committed).await;
+
+        match (legacy_result, sync_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(legacy), Ok(())) => Err(legacy.into()),
+            (Ok(()), Err(sync)) => Err(sync),
+            (Err(legacy), Err(sync)) => Err(anyhow::anyhow!(
+                "legacy verge mutation failed: {legacy:#}; actor reseed also failed: {sync:#}"
+            )
+            .into()),
+        }
+    }
+
+    pub fn schedule_window_state_save(&self, app_handle: tauri::AppHandle) {
+        let generation = self
+            .inner
+            .window_state_save_generation
+            .fetch_add(1, Ordering::AcqRel)
+            + 1;
+
+        let client = self.clone();
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(WINDOW_STATE_SAVE_DEBOUNCE).await;
+
+            if client
+                .inner
+                .window_state_save_generation
+                .load(Ordering::Acquire)
+                != generation
+            {
+                return;
+            }
+
+            let Ok(_save_guard) = client.inner.window_state_save_lock.lock() else {
+                log::error!(target: "app", "window state save lock poisoned");
+                return;
+            };
+
+            if client
+                .inner
+                .window_state_save_generation
+                .load(Ordering::Acquire)
+                != generation
+            {
+                return;
+            }
+
+            if let Err(err) = crate::utils::resolve::save_window_state(&app_handle, false) {
+                log::error!(target: "app", "failed to save debounced window state: {err:?}");
+            }
+        });
+    }
+
+    pub fn flush_window_state_save(&self, app_handle: &tauri::AppHandle) -> Result<()> {
+        self.inner
+            .window_state_save_generation
+            .fetch_add(1, Ordering::AcqRel);
+        let _save_guard = self
+            .inner
+            .window_state_save_lock
+            .lock()
+            .map_err(|_| anyhow::anyhow!("window state save lock poisoned"))?;
+        crate::utils::resolve::save_window_state(app_handle, false)?;
+        Ok(())
     }
 
     pub fn get_profiles(&self) -> Profiles {
@@ -133,8 +210,10 @@ pub fn setup<R: tauri::Runtime, M: tauri::Manager<R>>(manager: &M) -> anyhow::Re
 /// performs the atomic disk write, so the mirror must not call `save_file` again.
 fn legacy_verge_mirror() -> VergeMirror {
     Arc::new(|state| {
-        *Config::verge().draft() = state;
-        Config::verge().apply();
+        let discarded = Config::verge().replace_committed(state);
+        if discarded.is_some() {
+            log::warn!(target: "app", "discarded pending legacy verge draft while mirroring actor state");
+        }
         Ok(())
     })
 }

--- a/backend/tauri/src/client/state.rs
+++ b/backend/tauri/src/client/state.rs
@@ -73,29 +73,34 @@ impl StateClient {
     }
 
     pub async fn get_verge(&self) -> anyhow::Result<IVerge> {
-        Ok(self.call(StateActorMessage::GetVerge).await?.state)
+        Ok(self
+            .call_with_timeout(StateActorMessage::GetVerge, Some(STATE_RPC_TIMEOUT))
+            .await?
+            .state)
     }
 
     pub async fn patch_verge(&self, patch: IVerge) -> anyhow::Result<VergeStateSnapshot> {
-        self.call(|reply| StateActorMessage::PatchVerge { patch, reply })
+        self.call_with_timeout(|reply| StateActorMessage::PatchVerge { patch, reply }, None)
             .await
     }
 
     pub async fn replace_verge(&self, state: IVerge) -> anyhow::Result<VergeStateSnapshot> {
-        self.call(|reply| StateActorMessage::ReplaceVerge { state, reply })
-            .await
+        self.call_with_timeout(
+            |reply| StateActorMessage::ReplaceVerge { state, reply },
+            None,
+        )
+        .await
     }
 
-    async fn call<F>(&self, make: F) -> anyhow::Result<VergeStateSnapshot>
+    async fn call_with_timeout<F>(
+        &self,
+        make: F,
+        timeout: Option<Duration>,
+    ) -> anyhow::Result<VergeStateSnapshot>
     where
         F: FnOnce(RpcReplyPort<anyhow::Result<VergeStateSnapshot>>) -> StateActorMessage,
     {
-        match self
-            .inner
-            .actor_ref
-            .call(make, Some(STATE_RPC_TIMEOUT))
-            .await?
-        {
+        match self.inner.actor_ref.call(make, timeout).await? {
             CallResult::Success(result) => result,
             CallResult::SenderError => anyhow::bail!("state actor reply dropped"),
             CallResult::Timeout => anyhow::bail!("state actor call timed out"),

--- a/backend/tauri/src/config/draft.rs
+++ b/backend/tauri/src/config/draft.rs
@@ -69,6 +69,15 @@ draft_define!(IClashTemp);
 draft_define!(IRuntime);
 draft_define!(IVerge);
 
+impl Draft<IVerge> {
+    pub fn replace_committed(&self, state: IVerge) -> Option<IVerge> {
+        let mut inner = self.inner.lock();
+        let discarded = inner.1.take();
+        inner.0 = state;
+        discarded
+    }
+}
+
 impl Draft<IClashTemp> {
     /// Reload configuration from file
     pub fn reload(&self) {

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -1261,19 +1261,13 @@ pub async fn save_window_size_state(
     app_handle: AppHandle,
     label: String,
 ) -> Result<()> {
-    // Window-state save writes `Config::verge().window_size_state` directly; reseed the
-    // actor so a later pure patch does not revert the saved geometry.
-    client
-        .run_legacy_verge_mutation(|| async move {
-            match label.as_str() {
-                crate::consts::MAIN_WINDOW_LABEL => {
-                    resolve::save_main_window_state(&app_handle, true)?;
-                }
-                _ => log::warn!("Unknown window label: {}", label),
-            }
-            Ok(())
-        })
-        .await?;
+    match label.as_str() {
+        crate::consts::MAIN_WINDOW_LABEL => {
+            client.flush_window_state_save(&app_handle)?;
+        }
+        _ => log::warn!("Unknown window label: {}", label),
+    }
+
     Ok(())
 }
 

--- a/backend/tauri/src/lib.rs
+++ b/backend/tauri/src/lib.rs
@@ -455,7 +455,13 @@ pub fn run() -> std::io::Result<()> {
             }
             tauri::WindowEvent::CloseRequested { .. } => {
                 log::debug!(target: "app", "window close requested");
-                let _ = resolve::save_window_state(app_handle, true);
+                let client = app_handle
+                    .state::<crate::client::NyanpasuClient>()
+                    .inner()
+                    .clone();
+                if let Err(err) = client.flush_window_state_save(app_handle) {
+                    log::error!(target: "app", "failed to flush window state: {err:?}");
+                }
                 #[cfg(target_os = "macos")]
                 crate::utils::dock::macos::hide_dock_icon();
             }
@@ -465,8 +471,11 @@ pub fn run() -> std::io::Result<()> {
             }
             tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_) => {
                 log::debug!(target: "app", "window moved or resized");
-                std::thread::sleep(std::time::Duration::from_nanos(1));
-                let _ = resolve::save_window_state(app_handle, false);
+                let client = app_handle
+                    .state::<crate::client::NyanpasuClient>()
+                    .inner()
+                    .clone();
+                client.schedule_window_state_save(app_handle.clone());
             }
             _ => {}
         },

--- a/backend/tauri/src/utils/help.rs
+++ b/backend/tauri/src/utils/help.rs
@@ -247,7 +247,18 @@ pub fn get_max_scale_factor() -> f64 {
 
 #[instrument(skip(app_handle))]
 pub fn cleanup_processes(app_handle: &AppHandle) {
-    let _ = super::resolve::save_window_state(app_handle, true);
+    if let Some(client) = app_handle.try_state::<crate::client::NyanpasuClient>() {
+        let client = client.inner().clone();
+        if let Err(err) = client.flush_window_state_save(app_handle) {
+            log::error!(target: "app", "failed to flush window state during cleanup: {err:?}");
+        }
+    } else {
+        log::warn!(
+            target: "app",
+            "NyanpasuClient unavailable during cleanup; using legacy window save"
+        );
+        let _ = super::resolve::save_window_state(app_handle, true);
+    }
     super::resolve::resolve_reset();
     let widget_manager = app_handle.state::<crate::widget::WidgetManager>();
     let _ = nyanpasu_utils::runtime::block_on(async {

--- a/backend/tauri/src/utils/resolve.rs
+++ b/backend/tauri/src/utils/resolve.rs
@@ -302,11 +302,26 @@ impl AppWindow for MainWindow {
         Config::verge().latest().window_size_state.clone()
     }
 
-    fn set_window_state(&self, state: Option<WindowState>) {
-        Config::verge().data().patch_config(IVerge {
+    fn set_window_state(&self, state: Option<WindowState>) -> Result<()> {
+        let patch = IVerge {
             window_size_state: state,
             ..IVerge::default()
-        });
+        };
+
+        let app_handle = crate::core::handle::Handle::global()
+            .app_handle
+            .lock()
+            .clone();
+        if let Some(app_handle) = app_handle
+            && let Some(client) = app_handle.try_state::<crate::client::NyanpasuClient>()
+        {
+            let client = client.inner().clone();
+            nyanpasu_utils::runtime::block_on_anywhere(client.patch_verge_config(patch))?;
+            return Ok(());
+        }
+
+        Config::verge().data().patch_config(patch);
+        Ok(())
     }
 }
 
@@ -417,8 +432,9 @@ impl AppWindow for EditorWindow {
         None
     }
 
-    fn set_window_state(&self, _state: Option<WindowState>) {
+    fn set_window_state(&self, _state: Option<WindowState>) -> Result<()> {
         // EditorWindow does not remember window state
+        Ok(())
     }
 }
 
@@ -497,7 +513,9 @@ impl AppWindow for TrayMenuWindow {
         None
     }
 
-    fn set_window_state(&self, _state: Option<WindowState>) {}
+    fn set_window_state(&self, _state: Option<WindowState>) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Register a window event handler that hides or closes the tray menu window on

--- a/backend/tauri/src/window.rs
+++ b/backend/tauri/src/window.rs
@@ -418,7 +418,7 @@ pub trait AppWindow {
     fn get_window_state(&self) -> Option<WindowState>;
 
     /// Set window state to config
-    fn set_window_state(&self, state: Option<WindowState>);
+    fn set_window_state(&self, state: Option<WindowState>) -> Result<()>;
 
     fn reset_window_open_counter(&self) {
         OPEN_WINDOWS_COUNTER.fetch_sub(1, Ordering::Release);
@@ -847,7 +847,7 @@ pub trait AppWindow {
             None => None,
         };
 
-        self.set_window_state(state);
+        self.set_window_state(state)?;
 
         if save_to_file {
             Config::verge().data().save_file()?;


### PR DESCRIPTION
## Summary

- Route main-window geometry saves through `NyanpasuClient` / `StateActor` pure verge patches instead of direct legacy `Config::verge()` mutation.
- Debounce move/resize window-state saves and flush pending saves on close / cleanup / IPC save.
- Remove ractor reply timeout from mutating state RPCs while retaining read timeout.
- Reseed the actor after legacy verge mutations even when the legacy path returns an error.
- Mirror actor state into committed legacy memory without applying pending drafts.

## Validation

- `cargo fmt --manifest-path "backend/tauri/Cargo.toml"`
- `git diff --check`
- `node "/home/f4o3/.claude/skills/ccg/run_skill.js" verify-change`
- `node "/home/f4o3/.claude/skills/ccg/run_skill.js" verify-quality backend/tauri/src`
- `node "/home/f4o3/.claude/skills/ccg/run_skill.js" verify-security backend/tauri/src`
- Commit hook: `cargo clippy --manifest-path=./backend/Cargo.toml --all-targets --all-features`
- Commit hook: `cargo fmt --manifest-path ./backend/Cargo.toml --all`

## Notes

`cargo test --manifest-path "backend/tauri/Cargo.toml" client::state` could not complete in the local WSL environment because required Tauri Linux system libraries were missing (`libsoup-3.0`, `javascriptcoregtk-4.1`, `webkit2gtk-4.1`).
