### PR TITLE
docs(actor-migration): add v2 roadmap and PR-2b/PR-3 design notes

### DIFF
--- a/docs/design/actor-migration-roadmap.md
+++ b/docs/design/actor-migration-roadmap.md
@@ -1,0 +1,692 @@
+# Clash Nyanpasu Actor 迁移路线图(v2,基于代码库实测修正)
+
+**日期:** 2026-07-04
+**基准:** 分支 `refactor/runtime-snapshot-store-v2` @ `d0b3cf6ac`(= main `b5b168627` + snapshot store v2)
+**来源:** 外部审查文档(ChatGPT 深度分析,PR-1~PR-7 拆分)+ 仓库既有设计文档 + 三份代码库实测报告(nyanpasu-config/core 地图、tauri 新架构面、遗留全局调用网络)
+**定位:** 修正并取代外部文档的迁移拆分,作为后续实施的唯一路线图。所有断言均带 `file:line` 证据。
+
+**关联文档:**
+
+- `docs/superpowers/specs/2026-06-27-three-stateactors-nyanpasu-config-design.md` — PR-2b 蓝图(已批准)
+- `docs/superpowers/specs/2026-06-28-nyanpasu-config-profiles-type-migration-design.md` — PR-3 前置(已实施)
+- `docs/design/profile-composition-clean-design.md` / `profile-patch-interface.md` — profiles 域模型(已实施)
+- `docs/design/profile-tauri-migration-guide.md` — PR-3 逐命令迁移指南
+- `docs/design/profile-snapshot-store-migration.md` — snapshot store v2 迁移说明(§6 清单 1–5 已实施)
+
+---
+
+## 1. 迁移原则(已锁定,回应 BC 决策)
+
+采纳「**可迁移的破坏性改动优先于兼容层**」(CLAUDE.md §11),具体化为三条铁律:
+
+1. **运行期共存只允许出现在独立桥层。** 所有新旧双向同步代码集中在 `backend/tauri/src/bridge/`(实现)+ `state/mirror.rs`(Tauri-free trait),逐条标 `TODO(actor-migration)`,注明删除条件;**PR-7 整体清零**。桥层之外的任何文件不得出现新旧互写逻辑。
+2. **数据兼容只走 migration V2 一次性迁移。** 新类型(`nyanpasu-config`)永不解析旧 wire 格式(#4840 已确立);所有落盘格式转换注册为 `core/migration/` 的 step,在 actor spawn **之前**(migrate 子进程内)执行完毕。
+3. **前端 BC 与后端同 PR 落地。** specta/TS 绑定的破坏性变更(如 `current: string[] → string|null`)随后端切换同步更新,不留 `*_v1` 命令别名;确实阻塞时别名必须标 `TODO(actor-migration)` 并给删除条件。
+
+> **现状违规项(需在 PR-2b 收敛):** 目前存在 **5 处未标记的桥接缝**,散落在桥层之外(见 §5 台账)。全仓库只有 1 处合规标记(`core/hotkey.rs:199`)。
+
+### 1.1 单个配置域的迁移生命周期(图示)
+
+三条铁律对应两种推进模式:**配置三域**(verge 应用配置/窗口会话/clash overrides)调用点多,走「桥接共存 → 分批切换 → PR-7 清算」;**profiles 与服务单例域**调用面可一次覆盖,走「同 PR 一次性 BC 切换」,不建桥。任何模式下,落盘格式转换都只走 migration V2(spawn 前,铁律 2)。
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    state "① 旧全局独占" as legacy
+    state "② Actor+双向桥共存" as bridged
+    state "③ 纯净端态" as clean
+
+    [*] --> legacy
+    legacy --> bridged : 配置三域,PR-2b 建 Actor+桥(B1/B7)
+    bridged --> clean : 调用点分批切换(PR-5/6),PR-7 清算删桥与旧全局
+    legacy --> clean : 一次性 BC 切换,actor 化+全切调用+删全局同 PR 完成(PR-3 profiles/PR-5 core/PR-6a–d)
+    clean --> [*]
+
+    note right of legacy
+        读写都经 Config::* 与 ::global()
+        落盘为旧 wire 格式
+    end note
+    note right of bridged
+        Actor = source of truth
+        正向 mirror 喂旧读者(B1/B7)
+        旧写点 reseed 回 Actor(B2)
+        桥只存在于 bridge/ + state/mirror.rs(铁律 1)
+    end note
+    note right of clean
+        无桥 commit
+        副作用走 actor 消息(§4.0.4)
+    end note
+```
+
+---
+
+## 2. 现状地图(实测,2026-07-04)
+
+### 2.1 已合并 / 进行中
+
+| 阶段           | 内容                                                    | 状态                  | 证据                                                     |
+| -------------- | ------------------------------------------------------- | --------------------- | -------------------------------------------------------- |
+| **PR-1**       | `NyanpasuClient` facade(ACL)                            | ✅ 已合并             | `8d22e2596` (#4764),commit 标题自带 `[PR-1]`             |
+| **PR-2a**      | verge 配置接入 ractor `StateActor`                      | ✅ 已合并             | `f903be837` (#4778)                                      |
+| 基建           | `PathResolver`                                          | ✅ 已合并             | `1085d36c7` (#4828),`utils/path.rs:40`                   |
+| 基建           | **migration 子系统 V2**(store/runner/registry + 3 模块) | ✅ **已合并**(squash) | `5ae2c004a` (#4824),`core/migration/`                    |
+| 基建           | nyanpasu-core 状态管理器(MVCC/持久化)                   | ✅ 已合并             | #3656,`nyanpasu-core/src/state/`                         |
+| **PR-3 前置①** | profiles clean 组合域模型 + 三份迁移文档                | ✅ 已合并             | `ee197a55e` (#4840)                                      |
+| **PR-3 前置②** | runtime snapshot store v2(图/失效/归档)                 | 🔄 当前分支待提 PR    | `d0b3cf6ac`,仅改 `nyanpasu-config/src/runtime/`          |
+| **PR-2b**      | 三 StateActor 基础设施                                  | 📐 设计已批准,待实施  | 2026-06-27 spec(**文件尚未提交**,`git status` untracked) |
+
+> ⚠️ **进度账本更正:** 本地 `.ccg` 任务状态(「migration V2 待推送 review-fix」)已过期——#4824 已 squash 合并进 main;本地 `refactor/migration-service-v2` 分支(3 个 pre-squash 提交)可以删除,该任务可关闭。
+
+### 2.2 新架构已落地面(tauri 侧)
+
+- **Actor ×2:** `StateActor`(拥有 `PersistentStateManager<IVerge>` + `VergeMirror`,消息 `GetVerge/PatchVerge/ReplaceVerge`,`state/verge.rs:34,73`);`ClashConnectionsActor`(WS 流,`core/clash/ws.rs:609`)。
+- **Facade:** `NyanpasuClient { ui: Arc<dyn UiEventSink>, state: StateClient, verge_update_lock }`(`client/mod.rs:19-30`),`client::setup()` 在 `setup.rs:13` app.manage。
+- **已迁移 IPC 面仅 7 条命令:** `get_verge_config`、`patch_verge_config`、`get_profiles`、`patch_profiles_config`(+`import/create_profile` 的激活分支)、`get_core_status`、`change_clash_core`、`save_window_size_state`——其中后 5 条 client 内部仍委托旧全局(ACL 模式)。其余 ~70 条命令直连全局。
+- **读写超时未分离:** `STATE_RPC_TIMEOUT = 5s` 读写共用(`client/state.rs:16`),spec §7 要求「写无超时、读 5s」尚未实施。
+- **`bridge/` 与 `state/mirror.rs` 不存在**;`client/mod.rs` 尚 import `Config`/`CoreManager`(违反未来 Tauri-free 可抽取边界,预期中)。
+
+### 2.3 nyanpasu-config / nyanpasu-core(域层)
+
+- **`nyanpasu-config` 处于「暗启动」状态:全仓库零消费者**——连 tauri 都未依赖它(`backend/tauri/Cargo.toml` 无此项)。纯类型 crate,无 ractor/tokio/文件 IO(仅端口探测与系统 locale 两处例外)。
+- 五个域模块齐备:`application`(`NyanpasuAppConfig` 实测 32 字段 + Patch;spec 记 38 已过时)、`clash`(`ClashConfig`/overrides/端口策略)、`profile`(clean 组合模型全套 + validate/sanitize/依赖索引/分层 patch)、`state`(`PersistentState{window_state}`)、`runtime`(见下)。
+- **runtime 模块 = 数据结构 + 失效计算,无执行器**:`ConfigSnapshotsBuilder` 自述为「pure recorder for the pipeline executor」(`runtime/snapshot.rs:354`);`BuiltinStepKind{GuardOverrides,WhitelistFieldFilter,Finalizing}` 仅是 tag(`:72`);**没有任何代码读 profile 文件、应用 Overlay、跑 JS/Lua、合并 proxies、过滤 whitelist**。失效机制 `invalidate_profile()`(`runtime/invalidation.rs:38`)已实现,重建策略锁定为整图全量重建 current(`SnapshotRebuild::FullCurrent`)。
+- **`nyanpasu-core` 已承载生产流量:** `PersistentStateManager<IVerge>` 是现 StateActor 的持久层(`client/state.rs:51`);manager 家族(Persistent/WeakPersistent/Simple/PersistentBuilt)+ `StateCoordinator` MVCC(prepare/commit/rollback、ack 订阅、`with_pending_state` 效果钩子、atomicwrites 原子落盘)完整,测试 ~92 项。
+
+### 2.4 遗留面(待拆除)
+
+- **`Config::*()` 共 153 处 / 31 文件**(含少量注释误计):`verge()` 84/27 文件、`clash()` 30/12、`profiles()` 23/5、`runtime()` 10/4;`generate()` 6 处。热点:`feat.rs` 28、`ipc.rs` 22、`core/clash/core.rs` 19、`utils/resolve.rs` 16、`core/sysopt.rs` 9。
+- **`::global()` 单例 8 个:** `Config`(`config/core.rs:23`)、`CoreManager`(`core/clash/core.rs:387`)、`Sysopt`(`core/sysopt.rs:60`)、`Hotkey`(`core/hotkey.rs:169`)、`ProxiesGuard`(`core/clash/proxies.rs:204`)、`Logger`(`core/logger.rs:12`)、`UpdaterManager`(`core/updater/mod.rs:143`)、`Handle`(`core/handle.rs:33`);另有 `WindowManager`(`window.rs:30`)、`consts::app_handle()`(`consts.rs:54`,第二个 AppHandle 全局)。
+- **`enhance::enhance()` 直读三个全局**(`enhance/mod.rs:22`):`Config::clash().latest()` + `Config::verge().latest()`(clash_core/tun/builtin/clash_fields 四字段)+ `Config::profiles().latest()`;产物写入 `Config::runtime().draft()`(`config/core.rs:88`)→ `generate_file` 落 `clash-config.yaml`(`:70`)→ CoreManager 只认这个文件路径(`core/clash/core.rs:97,605`)。
+- **`feat.rs` = 编排中心**:`patch_verge`(`feat.rs:310`)在 draft→apply 之间内联 9 组副作用(service/tun/auto-launch/sysproxy/hotkey/locale/tray/logger/widget);`patch_clash`(`:229`)同构。这正是「commit 后副作用」模型要取代的形态。
+- **已符合 DI 的先例(不需再迁):** `Storage`(redb,Tauri manage)、`WidgetManager`、`TrayState`/`Tray`(薄适配)、`ClashConnectionsActor`。
+
+### 2.5 现状架构图(§2.2–2.4 一图速览)
+
+```mermaid
+flowchart TB
+    subgraph FRONT["IPC 面"]
+        IPC7["已迁移命令 ×7"]
+        IPC70["未迁移命令 ×~70"]
+    end
+
+    subgraph ISLAND["新架构岛(已落地,§2.2)"]
+        NC["NyanpasuClient facade<br/>ui: UiEventSink + state: StateClient + verge_update_lock"]
+        SC["StateClient<br/>读写共用 5s 超时(待分离)"]
+        SA["StateActor(owns IVerge)"]
+        PSM["PersistentStateManager&lt;IVerge&gt;<br/>nyanpasu-core:MVCC+原子落盘"]
+        VY["verge.yaml"]
+        WSA["ClashConnectionsActor(WS 流)"]
+        OKDI["已符合 DI:Storage(redb)/Tray/WidgetManager"]
+    end
+
+    subgraph LEG["遗留调用网(§2.4:Config::* 153 处/31 文件)"]
+        FEAT["feat.rs 编排中心<br/>patch_verge/patch_clash:draft→内联 9 组副作用→apply"]
+        CFG["Config::global() god-object<br/>verge()×84·clash()×30·profiles()×23·runtime()×10"]
+        SING["服务单例 ×7:CoreManager/Sysopt/Hotkey/ProxiesGuard/<br/>Logger/UpdaterManager/Handle<br/>(另有 WindowManager、consts::app_handle)"]
+    end
+
+    subgraph GEN["旧配置生成链"]
+        ENH["enhance()<br/>直读 verge+clash+profiles 三全局"]
+        RT["Config::runtime() draft"]
+        YML["clash-config.yaml"]
+        CM["CoreManager::global()"]
+        PROC["mihomo / clash-rs 子进程"]
+    end
+
+    DARK["nyanpasu-config(暗启动,§2.3)<br/>五域类型齐备但全仓库零消费者<br/>runtime 缺执行半"]
+
+    IPC7 --> NC
+    NC --> SC --> SA --> PSM --> VY
+    SA -. "mirror 写回(B1,未标记)" .-> CFG
+    NC -. "5/7 命令内部仍委托旧全局(ACL)" .-> CFG
+    FEAT -. "reseed:run_legacy_verge_mutation(B2)" .-> NC
+    IPC70 --> FEAT
+    IPC70 --> CFG
+    FEAT --> CFG
+    FEAT -->|"9 组副作用 fan-out"| SING
+    CFG --> ENH
+    ENH --> RT
+    RT -- "generate_file" --> YML
+    YML -- "只认此文件路径" --> CM
+    CM --> PROC
+    WSA -. "WS 订阅(external controller)" .-> PROC
+
+    classDef island fill:#e8f5e9,stroke:#2e7d32;
+    classDef legacyC fill:#ffebee,stroke:#c62828;
+    classDef darkC fill:#f5f5f5,stroke:#9e9e9e,stroke-dasharray:4 4;
+    class NC,SC,SA,PSM,VY,WSA,OKDI island;
+    class FEAT,CFG,SING,ENH,RT,YML,CM legacyC;
+    class DARK darkC;
+```
+
+> 图注:绿 = 已落地新架构面;红 = 待拆遗留面;灰虚线 = 暗启动(零消费者)。核心子进程本身不迁移,只换持有者(PR-5 起归 CoreActor)。
+
+---
+
+## 3. 对外部方案(ChatGPT PR-1~7)的修正
+
+| #   | 原建议                                                                                               | 修正                                                                                                                                                                                                                                                                                                             | 依据                                                                              |
+| --- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| C1  | PR-2 建单一 `NyanpasuStateActor`,消息含 `GetProfiles/ApplyProfilesOp/PatchClashBase/GenerateRuntime` | **三个独立对等 Actor**(Application/SessionState/ClashConfig),profiles 单独成 actor(PR-3),runtime 是**派生物**不进任何 actor 状态                                                                                                                                                                                 | 已批准 spec D2/D9;避免 god-actor 复刻 `Config` god-object(`config/core.rs:15-48`) |
+| C2  | PR-2 渐进式「先迁 theme/language/log level 少量字段」                                                | **已被现实超越**:`route_verge_patch`(`client/state.rs:120`)已把全部纯配置字段走 Actor;剩余是 14 个 `LegacySideEffects` 字段,靠「commit 后副作用」模型整体迁移,配套 **IVerge 字段映射表(100% 覆盖 + 覆盖率单测)**                                                                                                 | #4778 已合并;spec §11                                                             |
+| C3  | 「兼容旧 schema:LegacyVergeCompat loader + `LegacyCompatibilityFields`」                             | **否决(BC 决策)**:新类型不加旧字段兼容位;IVerge-only 字段(实测 ~44 vs 新 32)逐项显式归属〔App\|Session\|Clash\|丢弃〕;落盘转换全走 migration V2                                                                                                                                                                  | #4840 确立「新类型不兼容旧 wire」;spec D3/D8                                      |
+| C4  | PR-3「保留旧 schema conversion」                                                                     | **否决**:conversion 只存在于 migration V2 step(Value 层操作),运行代码零兼容                                                                                                                                                                                                                                      | `profile-tauri-migration-guide.md` §6                                             |
+| C5  | PR-4(RuntimeBuilder)排在 PR-3 之后                                                                   | **依赖反转(本文档最重要的修正)**:runtime 派生化的「数据结构半」已提前落地(snapshot store v2);「执行半」(pipeline executor)**必须先于 PR-3 的 tauri 切换**——profiles.yaml 一旦迁移为新 schema,旧 `enhance()`(消费 legacy `Profiles`)立即失读,应用无法生成运行配置                                                 | `enhance/mod.rs:22` 直读 legacy profiles;新类型拒绝旧格式                         |
+| C6  | (未提及)                                                                                             | **补齐遗漏工作项:** SessionState(窗口)与 ClashConfig 域的一次性数据搬迁(D8)、字段映射表交付物、读写分离超时、Tauri-free 可抽取边界(未来 `nyanpasu-client` crate)、mixed_port reseed 竞态(`lib.rs:390-398`)、`tasks/jobs/profiles.rs` 定时订阅任务、`ConnectionInterruptionService`、PAC、service-mode IPC 命令组 | spec §4-10;实测报告                                                               |
+| C7  | `Logger` → LogActor 或 BufferService                                                                 | **降级为注入式 sink**:100 条环形缓冲(`core/logger.rs:12`)唯一写者是 CoreManager stdio 循环 → 作为 `LogSink` 注入 CoreActor,读端 `get_clash_logs` 走 client;不单独立 actor                                                                                                                                        | 实测:单写单读,无生命周期                                                          |
+| C8  | `WindowManager/tray` → UiActor façade                                                                | 维持**适配器**判定:`Tray` 已是 Tauri-managed 薄适配(`core/tray/mod.rs:36`);`WindowManager` 归 UI 适配层,不 actor 化;`server::SERVER_PORT`(`Lazy<u16>`)属可接受的进程级常量                                                                                                                                       | CLAUDE.md §7 例外条款                                                             |
+| C9  | PR-7 只删 `Config::global()` + `Handle::global()`                                                    | **扩大清算范围**:同时删除 `bridge/` 全部桥、`Draft/ManagedState`、`run_legacy_*_mutation`/`route_verge_patch`/`patch_verge_entrypoint`、`consts::app_handle()`、legacy 四类型,并解散 `feat.rs` 编排                                                                                                              | 用户 BC 决策:「流程结束后完全移除」                                               |
+
+---
+
+## 4. 修正后的 PR 路径
+
+### 4.0 端态架构总览(迁移终点)
+
+本节四张图描述 PR-7 完成后的目标形态;§4.1 起的 PR 路径即通往此形态的施工顺序。图中消息名为示意,以各 PR spec 为准。
+
+#### 4.0.1 目标模块图
+
+```mermaid
+flowchart TB
+    subgraph FE["frontend/(React/TS monorepo)"]
+        UI["nyanpasu 页面 + specta 生成的 TS 绑定"]
+    end
+
+    subgraph TAURI["backend/tauri(宿主 crate)"]
+        IPCL["ipc.rs 薄命令层 📐<br/>解析 DTO → 调 facade → 映射错误"]
+        subgraph EXT["可抽取边界(Tauri-free,未来 nyanpasu-client crate)"]
+            CL["client/:NyanpasuClient facade ✅<br/>+ 各域 typed client 📐"]
+            ST["state/:各域 actor 📐<br/>Application·SessionState·ClashConfig·Profiles<br/>Core·SystemProxy·Hotkey·Proxies·Updater"]
+            MR["state/mirror.rs:*LegacyBridge traits ☠"]
+        end
+        RB["纯 service 📐:RuntimeBuilder(装配 executor 输入)<br/>ProfileFileService(物化文件/订阅下载)"]
+        BRG["bridge/:桥实现 ☠(PR-7 删)"]
+        AD["适配器:TauriUiEventSink ✅·LogSink 📐<br/>ContentSource/ScriptRunner(boa_utils/mlua)📐<br/>OS proxy·ProcessRunner·http 📐"]
+        MG["core/migration:V2 步骤 ✅(migrate 子进程执行)"]
+        PT["utils/PathResolver ✅(composition root 单实例)"]
+        LG2["legacy:config/·enhance/·feat.rs ☠(PR-3~7 逐步删)"]
+    end
+
+    subgraph NCFG["backend/nyanpasu-config(纯类型+纯逻辑,无 tokio/IO/Tauri)"]
+        DOM["application ✅·clash ✅·profile ✅·state ✅"]
+        RTM["runtime:snapshot store v2 🔄(当前分支)<br/>+ executor 📐(PR-3-pre②,含 ports)"]
+    end
+
+    subgraph NCORE["backend/nyanpasu-core ✅"]
+        MGR["Persistent/Weak/Simple StateManager<br/>StateCoordinator(MVCC)·atomicwrites"]
+    end
+
+    UI -->|"IPC 命令 / 事件"| IPCL
+    IPCL --> CL
+    CL --> ST
+    CL --> RB
+    ST --> MGR
+    ST -->|"域类型"| DOM
+    ST --> AD
+    RB -->|"execute()"| RTM
+    AD -. "impl ports" .-> RTM
+    ST -. "commit 钩子(过渡)" .-> MR
+    MR -. "impl" .-> BRG
+    BRG -.-> LG2
+    PT -->|"派生路径注入"| ST
+    PT --> MG
+
+    classDef done fill:#e8f5e9,stroke:#2e7d32;
+    classDef wip fill:#e3f2fd,stroke:#1565c0;
+    classDef plan fill:#fff8e1,stroke:#f9a825;
+    classDef del fill:#ffebee,stroke:#c62828,stroke-dasharray:4 4;
+    class MG,PT,MGR,DOM done;
+    class RTM wip;
+    class IPCL,CL,ST,RB,AD plan;
+    class MR,BRG,LG2 del;
+```
+
+> 图例:✅ 已落地 · 🔄 进行中 · 📐 待实施 · ☠ 过渡产物,PR-7 前后删除。「可抽取边界」内只允许依赖 `nyanpasu-config` + `nyanpasu-core` + `ractor`(2026-06-27 spec §5);未来抽 crate = 机械搬移 `state/` + `client/`。
+
+#### 4.0.2 端态运行时架构与通信模型(参考微服务通信)
+
+```mermaid
+flowchart LR
+    FE2["前端 UI"]
+
+    subgraph GW["门面层(≈API Gateway)"]
+        CMD["Tauri 命令(薄适配)"]
+        NC2["NyanpasuClient<br/>稳定 async API·跨域顺序编排(D9)<br/>commit 后副作用分发·持有 RuntimeArtifact(PR-4)"]
+    end
+
+    subgraph ACTORS["actor 服务群(≈微服务:独占状态+独占落盘)"]
+        AA2["ApplicationActor<br/>NyanpasuAppConfig"]
+        SS2["SessionStateActor<br/>PersistentState(窗口)"]
+        CC2["ClashConfigActor<br/>ClashConfig(overrides/端口)"]
+        PA2["ProfilesActor<br/>Profiles + 订阅调度/文件监听子任务"]
+        CO2["CoreActor<br/>核心进程生命周期 + LogSink"]
+        SP2["SystemProxyActor<br/>sysproxy/自启 + guard 定时"]
+        HK2["HotkeyActor"]
+        PX2["ProxiesActor<br/>缓存/订阅/select"]
+        UP2["UpdaterActor<br/>下载长任务"]
+    end
+
+    RB2["纯服务:RuntimeBuilder → runtime executor<br/>(nyanpasu-config,文件/脚本经 ports 注入)"]
+
+    subgraph INFRA["适配器 / 基础设施"]
+        UIS2["UiEventSink(事件推送)"]
+        FS2["PersistentStateManager + PathResolver<br/>(各域 yaml,独占写)"]
+        OS2["OS API:sysproxy/自启/全局快捷键"]
+        PR2["ProcessRunner(mihomo/clash-rs 子进程)"]
+        NET2["HTTP(订阅下载/更新)"]
+    end
+
+    FE2 -->|"① 命令 = 同步请求"| CMD --> NC2
+    NC2 -->|"② call:读 Some(5s)/写 None"| AA2 & SS2 & CC2 & PA2 & CO2 & PX2 & UP2
+    NC2 -.->|"③ cast:commit 后副作用"| SP2 & HK2
+    NC2 -->|"④ 组装输入(快照+预读文件+预解析端口)"| RB2
+    AA2 & SS2 & CC2 & PA2 --> FS2
+    CO2 --> PR2
+    SP2 --> OS2
+    HK2 --> OS2
+    HK2 -.->|"快捷键回调 → facade 方法(斩断 feat::* 反向依赖)"| NC2
+    PA2 --> NET2
+    UP2 --> NET2
+    CO2 & SP2 & UP2 & NC2 -.->|"⑤ 事件"| UIS2
+    UIS2 -.-> FE2
+```
+
+通信语义对照(为什么像微服务、哪里不像):
+
+| 本架构                       | 微服务类比                  | 语义                                                                                      |
+| ---------------------------- | --------------------------- | ----------------------------------------------------------------------------------------- |
+| `NyanpasuClient` facade      | API Gateway / BFF           | 唯一入口;跨域编排只在此层顺序进行(D9),**禁止 actor↔actor 同步调用环**                     |
+| 每个 actor                   | 一个微服务                  | 独占可变状态 + 「私有数据库」(各域 yaml 文件);外界只能发类型化消息                        |
+| `call`(RpcReplyPort)         | 同步 RPC                    | 读 `Some(5s)` 可超时降级;写 `None` 无超时,事务必须成败分明(写 handler 禁无界 I/O,spec §7) |
+| `cast`                       | 异步消息 / 领域事件         | commit 后副作用、失效通知;失败 → 降级通知,**不回滚已提交状态**                            |
+| `UiEventSink`                | 事件总线 → 客户端推送       | 后端主动通知前端刷新(PR-7 起全量接管 `Handle::global()` 职责)                             |
+| migration V2(migrate 子进程) | init job / schema migration | actor spawn 之前一次性完成落盘格式迁移(铁律 2)                                            |
+| composition root(`setup.rs`) | 装配 / 部署编排             | 构造 PathResolver → spawn 全部 actor → 装配 facade → `app.manage`(时序见 §4.2 末)         |
+| 本质差异                     | —                           | 全部进程内:消息类型化零序列化、无网络分区,故写路径敢用无超时 RPC                          |
+
+#### 4.0.3 actor/service 关系视图(数据依赖与触发链)
+
+§4.0.2 是「分层通道」视角(谁经什么通道说话);本图是「服务协作」视角:各 actor/纯服务之间**逻辑上**谁消费谁的数据、谁的 commit 触发谁。物理上所有跨域边都经 `NyanpasuClient` 顺序编排或 cast 分发(D9),actor 之间零直接调用——本图省略 facade 中转:
+
+```mermaid
+flowchart LR
+    subgraph STATE["配置状态域(source of truth ×4)"]
+        AA4["ApplicationActor<br/>NyanpasuAppConfig"]
+        CC4["ClashConfigActor<br/>ClashConfig"]
+        PA4["ProfilesActor<br/>Profiles<br/>(+订阅调度/外部文件监听子任务)"]
+        SS4["SessionStateActor<br/>PersistentState(窗口)<br/>叶子域:无跨域下游"]
+    end
+
+    subgraph DERIVE["派生管线(runtime = 纯派生物,永不为 actor 状态)"]
+        RB4["RuntimeBuilder + executor(纯服务)"]
+        ART["RuntimeArtifact<br/>(facade 持有,SimpleStateManager,PR-4)"]
+    end
+
+    subgraph SIDE["副作用消费域"]
+        SP4["SystemProxyActor"]
+        HK4["HotkeyActor"]
+        MISC["其余消费者:tray/locale/logger/widget<br/>(facade 编排,PR-7 #6)"]
+    end
+
+    subgraph CORE["核心域"]
+        CO4["CoreActor"]
+        PROC4["mihomo/clash-rs 进程"]
+        API4["external controller API"]
+    end
+
+    subgraph DATA["数据面(读运行中的核心)"]
+        PX4["ProxiesActor<br/>缓存/订阅/select"]
+        WS4["ClashConnectionsActor<br/>WS 流"]
+    end
+
+    UP4["UpdaterActor(下载长任务)"]
+    PFS["ProfileFileService(纯 service+适配)<br/>物化文件读写·订阅下载"]
+
+    %% ── 数据依赖(实线):箭头 = 数据流向 ──
+    PA4 -->|"Profiles 快照 + 文件内容"| RB4
+    CC4 -->|"guard overrides·tun·端口策略"| RB4
+    AA4 -->|"core + enable_builtin → builtin 列表"| RB4
+    RB4 -->|"产物"| ART
+    ART -->|"UpdateConfig(artifact/path)"| CO4
+    AA4 -->|"ClashCore 选择·enable_service_mode(RunType 参数化,PR-5③)"| CO4
+    CC4 -->|"mixed_port → 系统代理地址(sysopt.rs:92)"| SP4
+    CC4 -->|"external_controller/secret 连接参数"| PX4
+    CC4 -->|"external_controller/secret 连接参数"| WS4
+    PA4 <-->|"物化/删除/订阅下载"| PFS
+    CO4 -->|"spawn/监督,stdio→LogSink"| PROC4
+    PROC4 --- API4
+    PX4 --> API4
+    WS4 --> API4
+
+    %% ── 触发链(虚线):commit 后副作用/失效/生命周期事件,均异步 ──
+    AA4 -.->|"commit→cast:sysproxy/自启"| SP4
+    AA4 -.->|"commit→cast:注册表重载"| HK4
+    AA4 -.->|"commit→副作用"| MISC
+    PA4 -.->|"commit→invalidate→FullCurrent 重建"| RB4
+    CC4 -.->|"overrides 变更→重建(PR-4④)"| RB4
+    CO4 -.->|"核心重启/就绪→刷新缓存"| PX4
+    CO4 -.->|"核心重启/就绪→重连"| WS4
+    UP4 -.->|"新核心就绪→换核/重启"| CO4
+    HK4 -.->|"快捷键回调 = facade 方法(toggle_system_proxy→patch_app_config)"| AA4
+
+    classDef stateC fill:#e8f5e9,stroke:#2e7d32;
+    classDef pureC fill:#e3f2fd,stroke:#1565c0;
+    classDef coreC fill:#fff8e1,stroke:#f9a825;
+    class AA4,CC4,PA4,SS4 stateC;
+    class RB4,PFS pureC;
+    class CO4,PROC4,API4 coreC;
+```
+
+> 读图规则:**实线 = 数据依赖**(快照/产物作为输入,经 facade `call` 取数或传参);**虚线 = 触发链**(commit 后 `cast`/事件,失败降级不回滚)。`HotkeyActor→ApplicationActor→SystemProxyActor` 构成一条**异步**环(回调→patch→cast),不违反「无同步调用环」约束。`SessionStateActor` 刻意无出边——窗口态是叶子域,仅被窗口适配层消费。
+
+#### 4.0.4 端态写路径时序(「commit 后副作用」模型)
+
+此模型取代 feat.rs 在 draft→apply 之间内联 9 组副作用的旧形态(§2.4),是 PR-6a 的第一个消费场景:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Cmd as Tauri 命令(薄)
+    participant NC as NyanpasuClient
+    participant AA as ApplicationActor
+    participant M as PersistentStateManager
+    participant SP as SystemProxyActor 等副作用消费者
+    participant UI as UiEventSink
+
+    Cmd->>NC: patch_app_config(patch)
+    NC->>AA: call(Patch, None) —— 写无超时
+    AA->>AA: validate(patch) → 计算新快照
+    AA->>M: 原子落盘(atomicwrites)
+    M-->>AA: Ok
+    AA-->>NC: Ok(新快照 Arc) —— 状态先提交
+    NC--)SP: cast(配置变更通知) —— fire-and-forget
+    NC--)UI: 状态变更事件 → 前端刷新
+    NC-->>Cmd: Ok —— 答复不被副作用阻塞
+    SP->>SP: 应用 sysproxy / auto-launch / …
+    alt 副作用失败
+        SP--)UI: 降级通知(不回滚已提交状态)
+    end
+    Note over NC,SP: 过渡期(PR-7 前)在「状态先提交」之后多一步 bridge.mirror 写回旧全局,见 §5.1
+```
+
+### 4.1 依赖图
+
+```mermaid
+flowchart LR
+  PR1["PR-1 facade ✅ #4764"] --> PR2a["PR-2a verge StateActor ✅ #4778"]
+  MIG["migration V2 ✅ #4824"] --> PR2b
+  PATH["PathResolver ✅ #4828"] --> PR2b
+  PR2a --> PR2b["PR-2b 三 StateActor 基础设施(进行中)"]
+  P3P1["PR-3-pre① snapshot store v2(当前分支)"] --> P3P2
+  MODEL["profiles 域模型 ✅ #4840"] --> P3P1
+  MODEL --> P3P2["PR-3-pre② runtime pipeline executor"]
+  P3P2 --> PR3["PR-3 profiles 域切换(tauri)"]
+  MIG --> PR3
+  PR2b -. 推荐先行,非硬依赖 .-> PR3
+  PR3 --> PR4["PR-4 runtime 派生化收尾"]
+  PR2b --> PR5["PR-5 CoreActor"]
+  PR4 --> PR5
+  PR5 --> PR6["PR-6 外围 actor ×4"]
+  PR2b --> PR6
+  PR6 --> PR7["PR-7 清算:删全局与桥层"]
+  PR3 --> PR7
+```
+
+**并行性:** PR-2b(tauri + bridge)与 PR-3-pre②(纯 nyanpasu-config)零文件重叠,**可并行推进**。PR-3 对 PR-2b 无硬依赖(executor 输入显式,取数点可暂用旧全局),但推荐 PR-2b 先合——`ClashConfigActor` 就位后 RuntimeBuilder 的 overrides 输入直接来自新域类型,免一次返工。
+
+### 4.2 PR-2b — 三 StateActor 基础设施(进行中)
+
+**目标:** 按已批准 spec 建 `ApplicationActor`/`SessionStateActor`/`ClashConfigActor` + 三 typed client + 双向桥,`NyanpasuClient` 暴露三域 API;旧全局保持一致可读;**不**在本 PR 切换 153 处调用点。
+
+**可执行任务:**
+
+| #     | 任务                                                                                                                                                                                                                                                                                                                                                                                                                                  | 关键落点                                                               | 验证                                                               |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| T2.1  | **先分析后实现:** 产出 `docs/architecture/legacy-iverge-call-network.md`——153 处调用清单(按 accessor/域/热点分组)+ IVerge(~44 字段)→〔App\|Session\|Clash\|丢弃〕映射表 **100% 覆盖** + 分批切换建议(注:spec 记字段数 40/38,实测 44/32,以逐项清点为准)                                                                                                                                                                                | 新文档                                                                 | 映射覆盖率单测(枚举 IVerge 字段名断言全部归属)                     |
+| T2.2  | 提交 2026-06-27 spec 文件(当前 untracked);把三 StateActor 设计入库                                                                                                                                                                                                                                                                                                                                                                    | `docs/superpowers/specs/`                                              | git tracked                                                        |
+| T2.3  | **PathResolver 提升到 composition root**:`client::setup` 改为接收注入的 `PathResolver`(替代 `dirs::nyanpasu_config_path()`,`client/state.rs:36`);migration `Ctx` 与 client 共享同一实例                                                                                                                                                                                                                                               | `setup.rs`/`client/mod.rs`                                             | 单实例断言;`dirs::` 在 state/client 路径零残留                     |
+| T2.4  | **migration V2 增量 step ×2**(在 `core/migration/modules/`):① `app_config` 新 revision:`window_size_state` 从 `verge.yaml` 搬到独立 session-state 文件,并从 verge.yaml 剥离该键;② 新模块 `clash_config`:从裸 `IClashTemp` Mapping 提取 typed `ClashConfig` overrides 文件                                                                                                                                                             | `modules/app_config.rs`、新 `modules/clash_config.rs`、`registry.rs:4` | fixtures 往返测试(仿 `runner.rs:366` 的 1.6.1→2.0 端到端);幂等重入 |
+| T2.5  | `state/mirror.rs`:三个 Tauri-free trait `VergeLegacyBridge`/`WindowLegacyBridge`/`ClashLegacyBridge`(`mirror` 正向 + `snapshot_legacy` 反向,`mockall::automock`)                                                                                                                                                                                                                                                                      | 新文件                                                                 | trait 无 `tauri::*`/`crate::config` import                         |
+| T2.6  | `bridge/`:三个具体实现(触碰 `IVerge`/`IClashTemp`),**各只镜像自己字段**;把现有 `legacy_verge_mirror()`(`client/mod.rs:134`)收编进来;逐条标 `TODO(actor-migration)`                                                                                                                                                                                                                                                                    | 新 `bridge/{verge,window,clash}.rs`                                    | 双向 round-trip 测试                                               |
+| T2.7  | **三 Actor**:`state/{application,session_state,clash_config}.rs`,同构 `Get/Patch/Replace` + `RpcReplyPort`,Args 注入 `{PathResolver 派生路径, bridge, initial}`;Application/Clash 用 `PersistentStateManager<T>`;**Session 的 manager 选型(Persistent vs WeakPersistent)在实施时确认**——窗口态 best-effort 语义与 `WeakPersistentStateManager`(`nyanpasu-core/.../weak_persistent_state.rs:155`)吻合,但 spec D4 写的是泛型 Persistent | 新 3 文件                                                              | 每 actor:mock bridge + tempdir spawn,断言三消息;不 sleep           |
+| T2.8  | **三 client + facade 方法**:`get/patch_app_config`、`get/patch_clash_config`、`get/patch_session_state`、`run_legacy_{verge,clash}_mutation`;**读写分离超时**(读 `Some(5s)` 每域常量、写 `None`),替换统一 `STATE_RPC_TIMEOUT`                                                                                                                                                                                                         | `client/{application,session_state,clash_config}.rs`、`client/mod.rs`  | 断言写路径 `call(_, None)`、读路径超时可返回错误                   |
+| T2.9  | **composition root 重排**(`lib.rs`/`setup.rs`):顺序 = PathResolver → (migration 已在子进程完成,`lib.rs:120`) → spawn 三 actor → 构造 facade → manage;**消除 mixed_port 竞态**:把随机端口解析(`utils/resolve.rs:170-177`)挪到 actor spawn 之前,或保留一次显式 reseed 并标 TODO(现状 `lib.rs:390-398`)                                                                                                                                  | `lib.rs:362-398`                                                       | 启动冒烟;顺序断言测试                                              |
+| T2.10 | **`route_verge_patch` 三域化**:IVerge patch(IPC 入参暂不变)→ 分解为 App/Session/Clash 三个 patch 分发;`patch_verge_entrypoint`(`feat.rs:120`)改走新 facade;旧 `StateActor`/`StateClient`(IVerge 版)退役,`verge.yaml` 由 ApplicationActor 独占写(被 reseed 包住的旧 `save_file` no-op 化,D7)                                                                                                                                           | `client/state.rs:120`、`feat.rs:120`、`state/verge.rs` 删除            | 编译零引用;行为冒烟                                                |
+
+**成功判据**(spec §15 摘要):三 actor 经 composition root spawn;facade 无 service-locator API;写 `call(_,None)`/读 `call(_,Some)` 有断言;commit 后旧全局一致;字段映射 100%;`state/`+`client/` 无 `tauri::*`/`crate::config::Config` import;`cargo build`+`test` 绿。
+
+**明确不做:** 切换 153 处旧调用(留给 PR-5/6/7 按域分批)、profiles/runtime actor 化、删任何旧全局。
+
+#### PR-2b 合并后的启动时序(composition root,对应 T2.9)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Main as 主进程(lib.rs)
+    participant Mig as migrate 子进程(migration V2)
+    participant CR as composition root(setup.rs / client::setup)
+    participant Act as 三 StateActor
+    participant TR as Tauri runtime
+
+    Main->>Mig: 启动并等待(lib.rs:120)
+    Mig->>Mig: PathResolver → registry 逐 step 执行<br/>(app_config 窗口搬迁·clash_config 提取·PR-3 起 profiles rev3)
+    Mig->>Mig: 幂等可重入；歧义显式失败 .bak 备份
+    Mig-->>Main: 退出码 OK(落盘已是新格式)
+    Main->>CR: 进入装配
+    CR->>CR: 构造 PathResolver 单实例(T2.3,migration 与 client 共享)
+    CR->>CR: 随机端口解析前移(消除 mixed_port 竞态,T2.9)
+    CR->>Act: spawn ×3(Args = 派生路径 + bridge + initial)
+    Act->>Act: 各自加载 typed 文件(缺失则默认或一次性导入)
+    CR->>CR: 构造三 typed client + NyanpasuClient(注入 UiEventSink/三 bridge)
+    CR->>TR: app.manage(NyanpasuClient)
+    Note over Mig,Act: 顺序铁律:migration 完成后才允许 spawn actor(D8)；<br/>PR-5/6 在同一装配点继续 spawn CoreActor 与外围 actor
+```
+
+### 4.3 PR-3-pre① — snapshot store v2 收尾(当前分支)
+
+**目标:** 把 `d0b3cf6ac` 提为 PR 并合并。代码已完成(OperatorTag 六变体、`SnapshotNodeKey`、`SnapshotBaseline`、`invalidate_profile`、archive v2、+18 测试)。
+
+**剩余可执行任务:** ① 自查 `snapshot-persistence` feature 默认关闭、v1/malformed 归档解码必失败的测试在位(已有);② 提 PR、过 review;③ 合并后在 `profile-snapshot-store-migration.md` 状态行更新。
+
+### 4.4 PR-3-pre② — runtime pipeline executor(纯,nyanpasu-config)
+
+**目标:** 补上 snapshot store 缺失的「执行半」:给定 Profiles 快照 + 文件内容 + overrides,真正执行处理管线,产出最终配置 + snapshot 图 + 步骤日志。**这是 PR-3 的硬前置(修正 C5)。**
+
+**可执行任务:**
+
+| #     | 任务                                                                                                                                                                                                                                                                                                                                                  | 说明                                                                                      |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| T3p.1 | 定义执行器输入 ports(crate 内 trait,调用方实现):`ProfileContentSource`(按 `ManagedProfilePath` 读物化文件内容——保持 crate 无 IO)、`ScriptRunner`(`run(runtime: ScriptRuntime, source: &str, config: ConfigValue) -> Result<(ConfigValue, Vec<LogEntry>)>`)                                                                                            | tauri 侧适配现有 `enhance/script/{js,lua,runner}.rs` 的 boa/lua 运行器                    |
+| T3p.2 | 实现五种处理顺序(clean-design §7.1–7.5):FileConfig-as-current、FileConfig-as-member(scoped result,不跑 global)、Composition with base、Composition clean-seed(`proxies: []`)、`extend_proxies_from` 11 条追加规则                                                                                                                                     | 每步经 `ConfigSnapshotsBuilder::push/attach_independent_branch` 记录,tag 用新六变体       |
+| T3p.3 | 实现三个 BuiltinStep 的真实逻辑:`GuardOverrides` = 应用 `ClashGuardOverrides`(对应旧 `HANDLE_FIELDS` overlay);`WhitelistFieldFilter` = `Profiles.valid` + `enable_clash_fields` 语义(对应旧 `use_keys`/whitelist);`Finalizing` = 旧 `use_tun`/`use_include_all_proxy_groups`/`use_cache`/`use_sort` 的去留逐项决策(tun 参数来自 `ClashConfig` 域输入) | 决策点:哪些旧 `use_*` 进 executor、哪些留 tauri finalize——实施时以「确定性、无 IO」为准绳 |
+| T3p.4 | 内建增强脚本(`meta_hy_alpn.js`/`meta_guard.js`/`config_fixer.js`/`clash_rs_comp.lua`,按 `ClashCore` bitflags 门控,`enhance/chain.rs:145`)建模为**调用方组装的 builtin transform 列表参数**,executor 保持纯                                                                                                                                            | 不把 core 类型判断埋进 executor                                                           |
+| T3p.5 | 输出类型 `RuntimeArtifact { final_config: ConfigValue, graph: ConfigSnapshotsGraph, step_logs(以 SnapshotNodeKey 锚定), applied_fields }` —— 覆盖旧 `IRuntime{config, exists_keys, postprocessing_output}` 三元组的消费需求(前端 `get_postprocessing_output` 依赖脚本日志)                                                                            | 不引入 StepId(设计非目标),日志锚定用 `node_key()`                                         |
+| T3p.6 | 测试:五顺序 golden 测试(对照 clean-design §6.1 YAML 示例)、与失效机制的集成(`invalidate_profile` → FullCurrent 重建)、**与旧 `enhance()` 行为对照 fixtures**(同输入产出等价配置,防语义漂移——tauri 迁移指南 §7.4 列为最高风险)                                                                                                                         | `cargo test -p nyanpasu-config` 全绿                                                      |
+
+### 4.5 PR-3 — profiles 域切换(tauri,BC)
+
+**目标:** tauri 接入 `nyanpasu-config`,profiles 域一次性切换:数据迁移 + `ProfilesActor` + 全部 profile IPC 重写(BC)+ `enhance()` 替换为 executor + 删除 legacy profiles 类型。**不留新旧双轨。**
+
+**可执行任务**(逐命令签名草图见 `profile-tauri-migration-guide.md` §5,此处为工程序列):
+
+| #    | 任务                                                                                                                                                                                                                                                                                                                                                                               | 关键落点                                  |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| T3.1 | `backend/tauri/Cargo.toml` 加 `nyanpasu-config`;specta 导出新类型(嵌套 tagged enum **逐 variant 单独命名导出**,规避 specta 2.x 递归内联限制)                                                                                                                                                                                                                                       | Cargo.toml、`lib.rs` specta builder       |
+| T3.2 | migration V2 `profiles` 模块新增 revision 3:legacy `profiles.yaml` → clean schema(Value 层;映射规则 = guide §6:type 映射、`chain→transforms/global_transforms`、multi-current→`CompositionConfig{base:Some(a), extend:[b,c]}`、URL-file→Remote、`extra.expire:0→None`、`update_interval→update_interval_minutes`);**迁移前写 `.bak` 备份,任何歧义显式失败**(带 uid+字段路径)       | `modules/profiles.rs`、fixtures           |
+| T3.3 | `ProfilesActor` + `ProfilesClient`:拥有 `PersistentStateManager<Profiles>`;消息按事务流程(clone→mutate→`validate()`→原子持久化→commit→重建 `ProfileDependencyIndex`→reconcile);消息集 = `Get/Add/Delete(引用保护)/Reorder(ByList)/PatchMetadata/PatchRemoteOptions/ReplaceDefinition/SetCurrent/SetGlobalTransforms/Replace`                                                       | `state/profiles.rs`、`client/profiles.rs` |
+| T3.4 | `ProfileFileService`(纯 service + 适配器):物化文件读/写/删、订阅下载(http client 注入)、路径来自 PathResolver;Remote 更新器写入前校验目标非意外符号链接(design §9)                                                                                                                                                                                                                 | 新 service 文件                           |
+| T3.5 | `RemoteUpdateScheduler` + External Symlink/Mirror watcher:定时订阅刷新(取代 `core/tasks/jobs/profiles.rs`)、外部文件监听(design §10);实现为 ProfilesActor 的子任务或独立 actor,commit 后按 diff reconcile                                                                                                                                                                          | `state/profiles.rs` 子任务                |
+| T3.6 | **IPC 全量 BC 切换**(13 条,guide §5):`patch_profiles_config` 拆为 `activate_profile` + `set_global_transforms`;`patch_profile` 拆为 metadata/options/definition 三层;`delete_profile` 引用保护(拒删被 current/base/extend/transforms 引用者);`view/read/save_profile_file` 对 Composition 返回 `ProfileHasNoFile`;前端 TS + UI 同步(`current` 单值化、多选交互改 Composition 管理) | `ipc.rs`、前端                            |
+| T3.7 | `enhance()` → `RuntimeBuilder`(pure service,组装 executor 输入:Profiles 快照 + 文件内容 + `ClashGuardOverrides` + builtin 列表;PR-2b 已合则从 `ClashConfigActor`/`ApplicationActor` 取数,否则暂读旧全局并标 TODO);`Config::generate()` 改调 RuntimeBuilder,产物仍写 `Config::runtime()`(runtime 全删留给 PR-4,控制本 PR 半径)                                                      | `enhance/` 重写为适配层                   |
+| T3.8 | **删除 legacy**:`config/profile/**` 全目录、`ManagedState<Profiles>`、`Config::profiles()` accessor、`ProfilesBuilder/ProfileBuilder`、`ProfilesJobGuard`                                                                                                                                                                                                                          | 编译期保证零残留                          |
+| T3.9 | 测试:migration fixtures(覆盖 guide §6 全规则 + design §18 第 24-27 条)、actor 事务/引用保护/重排、调度 reconcile、IPC 集成、前端冒烟                                                                                                                                                                                                                                               | —                                         |
+
+**验证:** `grep -r "Config::profiles()"` 零命中;旧 profiles.yaml 样本经 migrate 子进程 → 新 schema → 应用可启动并生成运行配置;前端 profiles 页全功能可用。
+
+### 4.6 PR-4 — runtime 派生化收尾
+
+**目标:** 消灭「可写的 runtime 状态」:删 `Config::runtime()`/`IRuntime`,runtime 成为纯派生快照。
+
+**可执行任务:** ① `RuntimeArtifact` 存放点 = `SimpleStateManager<RuntimeArtifact>`(内存,重启重建;`snapshot-persistence` 归档为后续可选项),由 facade 持有,`client.rebuild_running_config()` 统一重建入口;② `clash-config.yaml` 继续落盘但降级为「产物」,写入走 atomicwrites;③ 四条 IPC(`get_runtime_config/yaml/exists/postprocessing_output`,`ipc.rs:405-441`)改读 artifact;④ `feat::patch_clash` 内 `runtime().latest().patch_config`(`feat.rs:276`;仅 allow-lan/ipv6/log-level/mode)改为把这四字段并入 rebuild 输入;⑤ 删 `Config::runtime()`、`IRuntime`、`Config::generate()`/`generate_file()`(重建+落盘逻辑归 RuntimeBuilder + CoreActor 输入)。
+**验证:** `grep "Config::runtime\(\)"` 零命中;`enhance_profiles` IPC 行为不变。
+
+### 4.7 PR-5 — CoreManager → CoreActor
+
+**目标:** 核心进程生命周期 actor 化,消费显式 runtime 快照。
+
+**可执行任务:** ① 消息集 `Status/Start/Stop/Restart/ChangeCore/UpdateConfig(artifact 或 path)/CheckConfig/ChangeDns(mac)`(request/reply,写无超时);`Recover` 用 actor 内部消息重入替代裸 spawn;② `Instance::{Child,Service}`(`core/clash/core.rs:70`)与 `run_lock` 收进 actor state(串行化天然取代 `tokio::Mutex`);③ `RunType` 决策参数化——`enable_service_mode` 来自 `ApplicationClient` 快照传参,替代 `RunType::default()` 内读 `Config::verge()`(`:51-67`);④ stdio 日志循环写入注入的 `LogSink`(收编 `Logger::global()` 写端,修正 C7),`get_clash_logs` 走 client;⑤ 调用方切换:`feat::restart_clash_core/update_core_config`、`ipc::restart_sidecar/enhance_profiles`、service-mode 命令组(`ipc.rs:925-1000`)、`client.get_core_status` 去委托化;⑥ 删 `CoreManager::global()`。
+**验证:** 核心启停/换核/配置热更新冒烟;`grep "CoreManager::global"` 零命中。
+
+#### 配置生效闭环时序(PR-3/4/5 汇合)
+
+从「用户切换 profile」到「核心进程吃到新配置」的端到端链路。PR-3 建立 ProfilesActor + RuntimeBuilder/executor 接线(彼时产物仍写 `Config::runtime()` + 文件,由旧 CoreManager 消费);PR-4 换 artifact 存放点;PR-5 换消费者——闭环在 PR-5 合并后完整成形:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant FE as 前端
+    participant NC as NyanpasuClient
+    participant PA as ProfilesActor
+    participant CC as ClashConfigActor
+    participant AA as ApplicationActor
+    participant RB as RuntimeBuilder + executor(纯)
+    participant CO as CoreActor
+    participant P as mihomo/clash-rs 进程
+
+    FE->>NC: activate_profile(id)
+    NC->>PA: call(SetCurrent, None)
+    PA->>PA: clone → mutate → validate() → 原子落盘 → commit
+    PA->>PA: 重建依赖索引 → invalidate_profile → FullCurrent
+    PA-->>NC: Ok(含失效结果)
+    NC->>NC: rebuild_running_config() 统一重建入口
+    NC->>PA: call(Get, Some 5s) —— Profiles 快照
+    NC->>CC: call(Get, Some 5s) —— guard overrides/tun/端口策略
+    NC->>AA: call(Get, Some 5s) —— core + enable_builtin → 组装 builtin 列表
+    NC->>NC: 预读 profile 文件内容·预解析端口(IO 全部在 executor 之外)
+    NC->>RB: RuntimePipelineInputs
+    RB->>RB: execute():五种处理顺序 + 共享尾部(整体 spawn_blocking)
+    RB-->>NC: RuntimeArtifact(final_config·graph·step_logs·applied_fields)
+    NC->>NC: SimpleStateManager 原子替换 artifact(PR-4) + 落盘 clash-config.yaml(降级为产物)
+    NC->>CO: call(UpdateConfig(artifact/path), None)
+    CO->>P: 配置热更新 / 重启核心
+    P-->>CO: 就绪
+    CO-->>NC: Ok
+    NC--)FE: UiEventSink 刷新事件(副作用失败 → 降级通知)
+    NC-->>FE: IPC 返回 Ok
+```
+
+### 4.8 PR-6 — 外围 actor 批次(可拆 4 个小 PR)
+
+| 子 PR                 | 现状                                                                                                                  | 目标形态                                                                                                             | 关键点                                                                   |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| 6a `SystemProxyActor` | `Sysopt`(`core/sysopt.rs:60`):cur/old sysproxy、auto_launch、guard 循环;重度读 `Config::verge()`(7 处)                | actor:拥有代理/自启状态 + guard 定时任务;输入 = AppConfig 快照订阅或显式参数;PAC(`core/pac.rs`)归入                  | commit 后副作用模型的第一个消费者(`patch_app_config` post-commit → cast) |
+| 6b `HotkeyActor`      | `Hotkey`(`core/hotkey.rs:169`):注册表 + AppHandle;`HotkeyFunc::execute` 直调 `feat::*`(`:102`);唯一 TODO 标记(`:199`) | actor + 全局快捷键适配 trait;execute 改发 `NyanpasuClient` 方法(斩断反向依赖);KV-storage 桥收敛                      | 主线程约束走适配器                                                       |
+| 6c `ProxiesActor`     | `ProxiesGuard`(`core/clash/proxies.rs:204`):缓存+checksum+broadcast                                                   | actor:缓存/订阅/select;tray/proxies 与 IPC(`get_proxies/mutate_proxies/select_proxy/update_proxy_provider`)走 client | broadcast → actor 订阅消息或保留 tokio broadcast 为实现细节              |
+| 6d `UpdaterActor`     | `UpdaterManager`(`core/updater/mod.rs:143`):manifest+`DashMap` 下载实例                                               | actor:长任务下载 + 进度事件经 `UiEventSink`                                                                          | `update_core/inspect_updater` IPC 走 client                              |
+
+每个子 PR 结束条件:对应 `::global()` 删除,调用方全部走 client/注入。
+
+### 4.9 PR-7 — 清算(兼容层归零)
+
+**目标:** 兑现「流程结束后完全移除」。逐项删除并以 grep 断言零残留:
+
+1. `bridge/` 全目录 + `state/mirror.rs` traits + 三 actor 的 bridge 注入位(改为直接无桥 commit);
+2. `run_legacy_*_mutation`、`route_verge_patch`、`patch_verge_entrypoint`、`lib.rs` reseed 段;
+3. `Config::global()` + `Draft<T>`(`config/draft.rs`)+ `core/state.rs ManagedState`;
+4. legacy 类型:`IVerge`(`config/nyanpasu/`)、`IClashTemp`(`config/clash/`)——IPC DTO 换 `NyanpasuAppConfigPatch`/`ClashConfigPatch`(前端 TS 同步);
+5. `Handle::global()` → `UiEventSink` 全量接管(`refresh_*`/`notice_message`/`update_systray*`/`emit` 全部调用点盘点后切换);`consts::app_handle()`(widget 取用点 `feat.rs:409` 改注入);
+6. `feat.rs` 解散:编排逻辑上移为 facade 方法(`toggle_system_proxy` 等)+ actor post-commit 副作用;
+7. 终检:CLAUDE.md §16 checklist + `grep -rn "::global()" backend/tauri/src` 仅剩允许的常量类例外(`SERVER_PORT` 等)。
+
+---
+
+## 5. 兼容层台账(唯一允许的桥,全部有删除条件)
+
+| #   | 桥                                      | 位置                                     | 方向                | 状态            | 删除条件(负责 PR)                                         |
+| --- | --------------------------------------- | ---------------------------------------- | ------------------- | --------------- | --------------------------------------------------------- |
+| B1  | `VergeMirror` / `legacy_verge_mirror()` | `state/verge.rs:11`、`client/mod.rs:134` | Actor→旧全局(内存)  | **在用,未标记** | PR-2b 收编进 `bridge/verge.rs` 并标 TODO;PR-7 删除        |
+| B2  | `run_legacy_verge_mutation()`           | `client/mod.rs:63`                       | 旧写点→Actor reseed | **在用,未标记** | 最后一个 LegacySideEffects 字段迁完(PR-6 末)即删          |
+| B3  | `route_verge_patch`                     | `client/state.rs:120`                    | patch 分流          | **在用,未标记** | PR-2b 三域化;PR-6 后无 Legacy 路由可走,PR-7 删            |
+| B4  | `patch_verge_entrypoint`                | `feat.rs:120`                            | 早期启动回退        | **在用,未标记** | composition root 保证 client 先于一切调用方就绪后删(PR-7) |
+| B5  | mixed_port 启动 reseed                  | `lib.rs:390-398`                         | 旧启动写→Actor      | **在用,未标记** | PR-2b T2.9 消除或标记;PR-7 前删                           |
+| B6  | hotkey KV/verge 双读                    | `core/hotkey.rs:199`                     | 存储桥              | ✅ 已标记       | PR-6b                                                     |
+| B7  | 三域 `*LegacyBridge`(mirror+reseed)     | 未来 `bridge/{verge,window,clash}.rs`    | 双向                | PR-2b 新建      | PR-7 整体删除                                             |
+| B8  | RuntimeBuilder 暂读旧全局取数           | PR-3 T3.7                                | 输入装配            | 视 PR-2b 时序   | PR-2b 合并后改走新 client 即删                            |
+
+**规则:** 台账之外不得新增桥;每条桥的代码处必须有 `TODO(actor-migration)` + 删除条件注释。
+
+### 5.1 桥接双向数据流(图示)
+
+```mermaid
+flowchart LR
+    subgraph NEWS["新架构侧(source of truth)"]
+        NC6["NyanpasuClient"]
+        ACT6["ApplicationActor /<br/>SessionStateActor / ClashConfigActor"]
+        TY["typed yaml 文件(各域独占写,D7)"]
+    end
+
+    subgraph BRL["桥层 = bridge/ + state/mirror.rs(PR-7 整体删除)"]
+        B7N["bridge/verge·window·clash<br/>impl *LegacyBridge(B1 收编 → B7)"]
+        OTHER["其余桥缝:B3 route_verge_patch 分流<br/>B4 patch_verge_entrypoint 启动回退<br/>B5 mixed_port reseed·B6 hotkey KV 双读<br/>B8 RuntimeBuilder 暂读旧全局"]
+    end
+
+    subgraph OLDS["遗留侧"]
+        MEM["旧全局内存副本<br/>Config::verge() / IClashTemp"]
+        RD6["未迁移读者(Config::* 153 处)"]
+        WR6["未迁移写点(约 28% 为写,feat.rs 等)"]
+    end
+
+    ACT6 -->|"独占落盘"| TY
+    ACT6 -->|"① 正向 mirror:commit 后写回内存"| B7N
+    B7N --> MEM
+    MEM --> RD6
+    WR6 -->|"旧闭包直改内存"| MEM
+    WR6 -->|"② 反向 reseed:run_legacy_*_mutation(B2)"| NC6
+    NC6 -->|"snapshot_legacy() → call(Replace, None)"| ACT6
+    OTHER -.- MEM
+    OTHER -.- NC6
+
+    classDef newC fill:#e8f5e9,stroke:#2e7d32;
+    classDef brC fill:#fff8e1,stroke:#f9a825;
+    classDef oldC fill:#ffebee,stroke:#c62828;
+    class NC6,ACT6,TY newC;
+    class B7N,OTHER brC;
+    class MEM,RD6,WR6 oldC;
+```
+
+> 图注:被 reseed 包住的旧写点不再自己 `save_file()`(D7,no-op 化),typed 文件只有 Actor 一个写者。**落盘格式转换不在此图中**——它只发生在 migration V2(actor spawn 之前,铁律 2)。PR-7 删除整个黄色桥层后,①② 两条流消失,只剩「actor 独占落盘 + 无桥 commit」。
+
+---
+
+## 6. 风险与开放问题
+
+| 风险                                                                                            | 缓解                                                                                     |
+| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **executor 行为漂移**(旧 `enhance` 链语义复杂:HANDLE*FIELDS overlay、builtin gate、use*\* 收尾) | T3p.6 golden 对照 fixtures:同输入断言与旧 `enhance()` 产出等价;guide §7.4 已列为最高风险 |
+| **specta 嵌套 tagged enum 的 TS 推导**                                                          | T3.1 逐 variant 命名导出;CI 检查 TS 产物 diff                                            |
+| **前端 `current` 单值化改造量**(多选 UI → Composition 管理)                                     | 前后端同 PR;先做「多选创建 Composition」的最小交互,完整管理界面后续迭代                  |
+| profiles 迁移不可逆                                                                             | T3.2 强制 `.bak` 备份 + 歧义显式失败(不静默丢弃)                                         |
+| IVerge-only 字段静默丢失                                                                        | T2.1 映射表 100% + 覆盖率单测(spec §11)                                                  |
+| 写无超时下 handler 挂起                                                                         | 不变式:写 handler 禁无界 I/O;引入网络时内部自管 timeout(spec §7)                         |
+| SessionState manager 选型未定(Persistent vs Weak)                                               | T2.7 实施时确认;窗口几何高频写建议 Weak(best-effort),需在 spec 勘误                      |
+| 双 AppHandle 全局(`Handle` + `consts`)                                                          | PR-7 一并清除;期间新代码禁用二者                                                         |
+| `.ccg` 任务账本过期(migration V2 实已合并)                                                      | 关闭该任务;删除本地 `refactor/migration-service-v2` 分支                                 |
+
+---
+
+## 7. 与外部方案的差异速查
+
+| 外部方案                           | 本路线图                                                          |
+| ---------------------------------- | ----------------------------------------------------------------- |
+| PR-2 = 单一 StateActor 装五域消息  | PR-2b = 三对等 Actor;profiles 独立 PR-3;runtime 永不为 actor 状态 |
+| PR-2 渐进字段(theme/language 先行) | 纯字段已全量走 actor(#4778);按副作用模型整体迁移 + 字段映射表     |
+| 兼容 = LegacyCompat loader 常驻    | 兼容 = migration V2 一次性(数据)+ bridge/ 双向桥(运行期,PR-7 删)  |
+| PR-3 保留旧 schema conversion      | 零运行期 conversion;clean 模型已合并(#4840)                       |
+| PR-4(RuntimeBuilder)在 PR-3 后     | executor(PR-3-pre②)**先于** PR-3;PR-4 只剩收尾删除                |
+| PR-6 含 LogActor/ServerActor       | Logger→注入 sink(随 PR-5);server 端口常量保留                     |
+| PR-7 删两个全局                    | PR-7 删**全部**桥层 + 四 legacy 类型 + feat.rs 解散               |
+
+---
+
+_本文档由代码库实测(2026-07-04)修订;实施中若与已批准 spec 冲突,以 spec + 本文档勘误流程为准。_

--- a/docs/superpowers/plans/2026-07-04-runtime-pipeline-executor.md
+++ b/docs/superpowers/plans/2026-07-04-runtime-pipeline-executor.md
@@ -1,0 +1,3585 @@
+# Runtime Pipeline Executor Implementation Plan（PR-3-pre②）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 `nyanpasu-config` 内落地纯 runtime pipeline executor：给定已验证 `Profiles` 快照 + 注入 ports，执行 clean-design §7.1–7.5 五种处理顺序与最终阶段，产出 `RuntimeArtifact{final_config, graph, step_logs, applied_fields}`；`backend/tauri/**` 提交面零改动。
+
+**Architecture:** 权威设计 = `docs/superpowers/specs/2026-07-04-runtime-pipeline-executor-design.md`（下称 **spec**，语义决策一律以其为准，本计划只做落地拆分）。先做 snapshot tag 受控扩展（spec §8.2），再自底向上：ports/类型骨架 → Overlay 指令集 → 三 BuiltinStep 纯函数 → 五顺序编排与录制 → golden/失效/parity 测试 → roadmap 勘误回写。行为基线 = 旧 `backend/tauri/src/enhance/`（spec §4.3 十七步实测），故意差异封闭于 spec §13 台账（14 条）。
+
+**Tech Stack:** Rust、serde / serde_json / serde_yaml_ng（含 `Value::apply_merge`，已核实 fork 保留）、indexmap、thiserror、specta、既有 `runtime::{snapshot, value}`。**不新增任何依赖**。
+
+## Global Constraints
+
+- 只改 `backend/nyanpasu-config/src/runtime/**` 与两份文档（Task 9）。`backend/tauri/**`、其它 crate、`Cargo.toml` **零提交改动**。
+- executor 纯度红线（spec §10.2）：`executor/` 内禁止 `tokio`、`std::fs`/`std::net`、`std::time`、随机数、`cfg(target_os = ...)`、用 `HashSet`/`HashMap` **迭代序**决定输出；容器一律 `IndexMap`/`IndexSet`/`Vec`。禁止 `unwrap`/`panic!` 于非测试代码（静态字面量构造用手写无 panic 形式）。
+- 不新增全局单例 / 可变 static（CLAUDE.md §7）。
+- parity 默认；输出差异必须能对到 spec §13 台账条目，否则视为 bug。
+- 每个 task 结束：`cargo test -p nyanpasu-config` 必须绿；Task 1 与 Task 8 额外跑 `cargo test -p nyanpasu-config --features snapshot-persistence`。
+- 每个 task 至少一次提交（信息见各 task Step）。
+
+**与 spec 的三处实施细化**（写代码时以本计划为准，Task 9 一并回写 spec 勘误行）：
+
+1. `OperatorTag::BuiltinTransform.name` 与 `BuiltinTransform{name, source}` 用 `String`（spec §8.2/§6.1 写的 `Arc<str>`）——`OperatorTag`/`SnapshotNodeKey` 派生 `specta::Type`，`String` 免去 `Arc<str>` 的 specta 兼容风险。
+2. `RuntimePipelineError` 增加 `Internal(String)` 变体（spec §9.2 未列）——承接「理论不可达」的 guard 序列化失败，维持零 panic。
+3. 新增两个 spec §5 未列的文件：`executor/value_util.rs`（路径遍历/对象重建纯辅助）与 `executor/tests/support.rs`（`MapContentSource`/`FakeScriptRunner`/Profiles 构造器）。
+
+---
+
+## File Structure
+
+修改（既有）：
+
+- `backend/nyanpasu-config/src/runtime/mod.rs` — 加 `pub mod executor;`
+- `backend/nyanpasu-config/src/runtime/snapshot.rs` — tag 扩展 + 测试适配（Task 1）
+- `backend/nyanpasu-config/src/runtime/invalidation.rs` — `tag_references_any_profile` 两臂改 + 两臂增 + 1 新测试（Task 1）
+
+新建（`backend/nyanpasu-config/src/runtime/executor/`）：
+
+- `mod.rs` — 输入类型、`ExecutionTarget`、`execute()`、`apply_transform`、`parse_config_document`、`LogSink`
+- `ports.rs` — `PortError`、`ProfileContentSource`、`ScriptRunner`、`ScriptRunOutcome`
+- `artifact.rs` — `RuntimeArtifact`、`StepLog`、`StepLogEntry`、`StepLogLevel`
+- `error.rs` — `RuntimePipelineError`
+- `value_util.rs` — `empty_object`/`clean_seed`/`obj_get`/`obj_insert`/`get_at`/`replace_at`/`remove_at`/`deep_merge_value`/`parse_dotted_path`
+- `overlay.rs` — Overlay 指令集（旧 `use_merge` 对位）
+- `scoped.rs` — scoped FileConfig 分支（三 role 复用）
+- `compose.rs` — composition seed + 11 条追加规则
+- `builtin.rs` — 45 字段常量 + Whitelist/Guard/Finalizing（tun/include-all/cache/sort）
+- `tests/{mod,support,overlay,builtin,compose,orders,golden,invalidation,parity}.rs`
+- `tests/fixtures/*.yaml`（Task 6/8 给出全文）
+
+文档（Task 9）：`docs/design/actor-migration-roadmap.md`、`docs/superpowers/specs/2026-07-04-runtime-pipeline-executor-design.md`。
+
+**关键 import 路径**（已核实）：`crate::profile::*`（mod.rs 全量重导出）；guard/tun 类型**无**顶层重导出，必须 `crate::clash::config::overrides::ClashGuardOverrides`、`crate::clash::config::tun_stack::TunStack`。
+
+---
+
+## Task 1: snapshot tag 受控扩展
+
+**Files:**
+
+- Modify: `backend/nyanpasu-config/src/runtime/snapshot.rs`（`OperatorTag`/`SnapshotNodeKey`/`node_key()` + tests）
+- Modify: `backend/nyanpasu-config/src/runtime/invalidation.rs`（`tag_references_any_profile` + 1 新测试）
+
+**Interfaces:**
+
+- Produces（后续 task 依赖的确切形状）:
+  - `OperatorTag::GlobalTransform { selected_profile_id: Option<ProfileId>, transform_profile_id: ProfileId, transform_kind: TransformKind, step_index: u32 }`
+  - `OperatorTag::BuiltinStep { selected_profile_id: Option<ProfileId>, step: BuiltinStepKind }`
+  - `OperatorTag::BareRoot`（单元变体）
+  - `OperatorTag::BuiltinTransform { selected_profile_id: Option<ProfileId>, name: String, step_index: u32 }`
+  - `SnapshotNodeKey::{GlobalTransform{selected_profile_id: Option<ProfileId>, step_index}, Builtin{selected_profile_id: Option<ProfileId>, step}, BareRoot, BuiltinTransform{selected_profile_id: Option<ProfileId>, step_index}}`
+
+- [ ] **Step 1: 写失败测试（snapshot.rs 的 `mod tests` 末尾追加）**
+
+```rust
+    #[test]
+    fn operator_tag_bare_root_and_builtin_transform_round_trip() {
+        round_trip_tag(OperatorTag::BareRoot);
+        round_trip_tag(OperatorTag::BuiltinTransform {
+            selected_profile_id: Some(pid("selected")),
+            name: "verge_hy_alpn".to_string(),
+            step_index: 0,
+        });
+        round_trip_tag(OperatorTag::BuiltinTransform {
+            selected_profile_id: None,
+            name: "config_fixer".to_string(),
+            step_index: 1,
+        });
+
+        // node_key 丢弃展示性 name 字段。
+        let a = OperatorTag::BuiltinTransform {
+            selected_profile_id: None,
+            name: "a".to_string(),
+            step_index: 2,
+        };
+        let b = OperatorTag::BuiltinTransform {
+            selected_profile_id: None,
+            name: "b".to_string(),
+            step_index: 2,
+        };
+        assert_eq!(a.node_key(), b.node_key());
+        assert_eq!(OperatorTag::BareRoot.node_key(), SnapshotNodeKey::BareRoot);
+    }
+
+    #[test]
+    fn operator_tag_optional_selected_is_forward_compatible_with_v2_wire() {
+        // 旧 v2 wire 中 selected_profile_id 是裸字符串；Option 化后必须解码为 Some。
+        let tag: OperatorTag = serde_json::from_value(json!({
+            "kind": "builtin_step",
+            "data": { "selected_profile_id": "sel", "step": "finalizing" }
+        }))
+        .unwrap();
+        assert_eq!(
+            tag,
+            OperatorTag::BuiltinStep {
+                selected_profile_id: Some(pid("sel")),
+                step: BuiltinStepKind::Finalizing,
+            }
+        );
+
+        let tag: OperatorTag = serde_json::from_value(json!({
+            "kind": "global_transform",
+            "data": {
+                "selected_profile_id": "sel",
+                "transform_profile_id": "t",
+                "transform_kind": { "type": "overlay" },
+                "step_index": 0
+            }
+        }))
+        .unwrap();
+        assert!(matches!(
+            tag,
+            OperatorTag::GlobalTransform { selected_profile_id: Some(_), .. }
+        ));
+    }
+```
+
+- [ ] **Step 2: 跑测试确认编译失败**
+
+Run: `cargo test -p nyanpasu-config operator_tag_bare_root`
+Expected: FAIL —— `no variant or associated item named 'BareRoot'`
+
+- [ ] **Step 3: 实现类型变更**
+
+`snapshot.rs` 中 `OperatorTag`（现 79-113 行）改为：
+
+```rust
+pub enum OperatorTag {
+    FileConfigRoot {
+        profile_id: ProfileId,
+        role: ConfigExecutionRole,
+    },
+    /// `base: None` is the clean seed (`proxies: []`).
+    CompositionRoot {
+        profile_id: ProfileId,
+        base: Option<ProfileId>,
+    },
+    ExtendProxiesStep {
+        composition_id: ProfileId,
+        contributor_profile_id: ProfileId,
+        contributor_index: u32,
+    },
+    ScopedTransform {
+        host_profile_id: ProfileId,
+        role: ConfigExecutionRole,
+        transform_profile_id: ProfileId,
+        transform_kind: TransformKind,
+        step_index: u32,
+    },
+    /// `selected_profile_id: None` = bare 模式（current 为空，spec §2 目标 6）。
+    GlobalTransform {
+        selected_profile_id: Option<ProfileId>,
+        transform_profile_id: ProfileId,
+        transform_kind: TransformKind,
+        step_index: u32,
+    },
+    BuiltinStep {
+        selected_profile_id: Option<ProfileId>,
+        step: BuiltinStepKind,
+    },
+    /// current = None 的裸配置管线根（spec §8.2）。
+    BareRoot,
+    /// 内建增强脚本步骤；`name` 为展示性字段，`node_key()` 丢弃。
+    BuiltinTransform {
+        selected_profile_id: Option<ProfileId>,
+        name: String,
+        step_index: u32,
+    },
+}
+```
+
+`node_key()` 追加两臂（既有 `GlobalTransform`/`BuiltinStep` 臂的 `selected_profile_id.clone()` 对 `Option` 原样可用，不动）：
+
+```rust
+            Self::BareRoot => SnapshotNodeKey::BareRoot,
+            Self::BuiltinTransform {
+                selected_profile_id,
+                step_index,
+                ..
+            } => SnapshotNodeKey::BuiltinTransform {
+                selected_profile_id: selected_profile_id.clone(),
+                step_index: *step_index,
+            },
+```
+
+`SnapshotNodeKey`（现 168-193 行）同步：`GlobalTransform.selected_profile_id` 与 `Builtin.selected_profile_id` 改 `Option<ProfileId>`，末尾追加：
+
+```rust
+    BareRoot,
+    BuiltinTransform {
+        selected_profile_id: Option<ProfileId>,
+        step_index: u32,
+    },
+```
+
+- [ ] **Step 4: 适配 snapshot.rs 既有测试构造器**
+
+测试模块内 `global_transform`/`builtin_step` 两个 helper 包 `Some`：
+
+```rust
+    fn global_transform(
+        selected_profile_id: &str,
+        transform_profile_id: &str,
+        transform_kind: TransformKind,
+        step_index: u32,
+    ) -> OperatorTag {
+        OperatorTag::GlobalTransform {
+            selected_profile_id: Some(pid(selected_profile_id)),
+            transform_profile_id: pid(transform_profile_id),
+            transform_kind,
+            step_index,
+        }
+    }
+
+    fn builtin_step(selected_profile_id: &str, step: BuiltinStepKind) -> OperatorTag {
+        OperatorTag::BuiltinStep {
+            selected_profile_id: Some(pid(selected_profile_id)),
+            step,
+        }
+    }
+```
+
+同一测试模块内 `operator_tag_global_transform_round_trips_and_key_drops_transform_identity` 等使用处不需要改（走 helper）。
+
+- [ ] **Step 5: 演示测试改为规范序（spec §8.3 / D4）**
+
+`selected_file_config_processing_order_is_scoped_global_builtin` 整体替换为（Whitelist→Guard→BuiltinTransform→Finalizing）：
+
+```rust
+    #[test]
+    fn selected_file_config_processing_order_is_scoped_global_builtin() {
+        let mut builder = ConfigSnapshotsBuilder::new_root(
+            value(json!({ "step": "file" })),
+            selected_file_root("selected"),
+        );
+        builder
+            .push(
+                scoped_transform(
+                    "selected",
+                    ConfigExecutionRole::Selected,
+                    "scoped",
+                    TransformKind::Overlay,
+                    0,
+                ),
+                value(json!({ "step": "scoped" })),
+            )
+            .unwrap();
+        builder
+            .push(
+                global_transform("selected", "global", TransformKind::Overlay, 0),
+                value(json!({ "step": "global" })),
+            )
+            .unwrap();
+        builder
+            .push(
+                builtin_step("selected", BuiltinStepKind::WhitelistFieldFilter),
+                value(json!({ "step": "whitelist" })),
+            )
+            .unwrap();
+        builder
+            .push(
+                builtin_step("selected", BuiltinStepKind::GuardOverrides),
+                value(json!({ "step": "guard" })),
+            )
+            .unwrap();
+        builder
+            .push(
+                OperatorTag::BuiltinTransform {
+                    selected_profile_id: Some(pid("selected")),
+                    name: "config_fixer".to_string(),
+                    step_index: 0,
+                },
+                value(json!({ "step": "builtin_transform" })),
+            )
+            .unwrap();
+        builder
+            .push(
+                builtin_step("selected", BuiltinStepKind::Finalizing),
+                value(json!({ "step": "final" })),
+            )
+            .unwrap();
+
+        let graph = builder.build().unwrap();
+        assert!(matches!(
+            &graph.nodes[0].tag,
+            OperatorTag::FileConfigRoot {
+                role: ConfigExecutionRole::Selected,
+                ..
+            }
+        ));
+        assert!(matches!(&graph.nodes[1].tag, OperatorTag::ScopedTransform { .. }));
+        assert!(matches!(&graph.nodes[2].tag, OperatorTag::GlobalTransform { .. }));
+        assert!(matches!(
+            &graph.nodes[3].tag,
+            OperatorTag::BuiltinStep {
+                step: BuiltinStepKind::WhitelistFieldFilter,
+                ..
+            }
+        ));
+        assert!(matches!(
+            &graph.nodes[4].tag,
+            OperatorTag::BuiltinStep {
+                step: BuiltinStepKind::GuardOverrides,
+                ..
+            }
+        ));
+        assert!(matches!(&graph.nodes[5].tag, OperatorTag::BuiltinTransform { .. }));
+        assert!(matches!(
+            &graph.nodes[6].tag,
+            OperatorTag::BuiltinStep {
+                step: BuiltinStepKind::Finalizing,
+                ..
+            }
+        ));
+    }
+```
+
+- [ ] **Step 6: invalidation.rs 适配 + 新测试**
+
+`tag_references_any_profile`（现 125-158 行）中两臂替换、两臂新增：
+
+```rust
+        OperatorTag::GlobalTransform {
+            selected_profile_id,
+            transform_profile_id,
+            ..
+        } => {
+            selected_profile_id
+                .as_ref()
+                .is_some_and(|id| profiles.contains(id))
+                || profiles.contains(transform_profile_id)
+        }
+        OperatorTag::BuiltinStep {
+            selected_profile_id, ..
+        } => selected_profile_id
+            .as_ref()
+            .is_some_and(|id| profiles.contains(id)),
+        OperatorTag::BareRoot => false,
+        OperatorTag::BuiltinTransform {
+            selected_profile_id, ..
+        } => selected_profile_id
+            .as_ref()
+            .is_some_and(|id| profiles.contains(id)),
+```
+
+`invalidation.rs` 测试模块追加：
+
+```rust
+    #[test]
+    fn invalidate_marks_builtin_transform_nodes_of_selected() {
+        let current = pid("current");
+        let mut builder = ConfigSnapshotsBuilder::new_root(
+            Arc::new(ConfigValue::try_from(json!({ "a": 1 })).unwrap()),
+            selected_file_root("current"),
+        );
+        builder
+            .push(
+                OperatorTag::BuiltinTransform {
+                    selected_profile_id: Some(current.clone()),
+                    name: "config_fixer".to_string(),
+                    step_index: 0,
+                },
+                Arc::new(ConfigValue::try_from(json!({ "a": 2 })).unwrap()),
+            )
+            .unwrap();
+        let graph = builder.build_stored().unwrap();
+
+        let invalidation = invalidate_profile(
+            &current,
+            ProfileCategory::Config,
+            Some(&current),
+            &ProfileDependencyIndex::default(),
+            Some(&graph),
+        );
+
+        assert!(invalidation.stale_node_keys.contains(
+            &SnapshotNodeKey::BuiltinTransform {
+                selected_profile_id: Some(current.clone()),
+                step_index: 0,
+            }
+        ));
+    }
+```
+
+- [ ] **Step 7: 全量回归**
+
+Run: `cargo test -p nyanpasu-config && cargo test -p nyanpasu-config --features snapshot-persistence`
+Expected: PASS（含既有 archive v2 往返、v1 拒绝、六类失效场景）
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/nyanpasu-config/src/runtime/snapshot.rs backend/nyanpasu-config/src/runtime/invalidation.rs
+git commit -m "refactor(nyanpasu-config): extend snapshot operator tags for executor recording"
+```
+
+---
+
+## Task 2: executor 骨架（ports / artifact / error / 输入类型 / 测试支撑）
+
+**Files:**
+
+- Modify: `backend/nyanpasu-config/src/runtime/mod.rs`
+- Create: `backend/nyanpasu-config/src/runtime/executor/{mod,ports,artifact,error,value_util}.rs`
+- Create: `backend/nyanpasu-config/src/runtime/executor/tests/{mod,support}.rs`
+
+**Interfaces:**
+
+- Consumes: Task 1 的 tag 形状；`crate::profile::*`；`crate::clash::config::overrides::ClashGuardOverrides`；`crate::clash::config::tun_stack::TunStack`
+- Produces（后续全部 task 依赖）:
+  - `execute` **尚不存在**（Task 5 落地）；本 task 只产类型与 ports
+  - `ProfileContentSource::read(&self, &ManagedProfilePath) -> Result<String, PortError>`
+  - `ScriptRunner::{run(&self, ScriptRuntime, &str, &ConfigValue) -> ScriptRunOutcome, eval_item_predicate(&self, &str, &ConfigValue) -> Result<bool, PortError>, eval_item_expr(&self, &str, &ConfigValue) -> Result<ConfigValue, PortError>}`
+  - `RuntimeArtifact { final_config: Arc<ConfigValue>, graph: ConfigSnapshotsGraph, step_logs: Vec<StepLog>, applied_fields: IndexSet<String> }`
+  - `RuntimePipelineInputs<'a> { profiles, target, guard, whitelist_enabled, tun, builtin_transforms }`、`ExecutionTarget::{Selected(ProfileId), Bare}`、`GuardInputs{overrides, ports}`、`ResolvedPortBindings{mixed_port, port, socks_port, external_controller}`、`TunParams{enable, flavor, windows_fake_ip_filter}`、`TunFlavor::{ClashRs, Standard{stack}}`、`BuiltinTransform{name: String, runtime, source: String}`
+  - value_util: `empty_object()`、`clean_seed()`、`obj_get(&ConfigValue, &str) -> Option<&ConfigValue>`、`obj_insert(&ConfigValue, &str, ConfigValue) -> ConfigValue`、`parse_dotted_path(&str) -> Vec<String>`、`get_at(&ConfigValue, &[String]) -> Option<&ConfigValue>`、`replace_at(&ConfigValue, &[String], ConfigValue) -> Option<ConfigValue>`、`remove_at(&ConfigValue, &[String]) -> Option<ConfigValue>`、`deep_merge_value(Option<&ConfigValue>, &ConfigValue) -> ConfigValue`
+  - 测试支撑：`support::{MapContentSource, FakeScriptRunner, RunReply, PredicateReply, ExprReply, managed_file_source, config_file_item, overlay_item, script_item, composition_item, profiles_with}`
+
+- [ ] **Step 1: runtime/mod.rs 挂模块**
+
+```rust
+pub mod executor;
+pub mod invalidation;
+pub mod snapshot;
+pub mod value;
+```
+
+- [ ] **Step 2: `executor/ports.rs`（完整文件）**
+
+```rust
+//! Caller-implemented ports. The executor performs no IO of its own.
+
+use crate::{
+    profile::{ManagedProfilePath, ScriptRuntime},
+    runtime::value::ConfigValue,
+};
+
+use super::artifact::StepLogEntry;
+
+pub type PortError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Reads the text content of a materialized profile file.
+///
+/// Adapters may pre-load every needed path into a map so the whole pipeline
+/// runs without blocking (spec §6.3).
+pub trait ProfileContentSource {
+    fn read(&self, path: &ManagedProfilePath) -> Result<String, PortError>;
+}
+
+/// Mirrors the legacy `ProcessOutput = (Result<Mapping>, Logs)`: logs are
+/// returned even when the script fails (enhance/utils.rs:114-119 parity).
+pub struct ScriptRunOutcome {
+    pub result: Result<ConfigValue, PortError>,
+    pub logs: Vec<StepLogEntry>,
+}
+
+/// Script execution port.
+///
+/// Adapter obligations (spec §6.2):
+/// 1. `run` MUST return an order-stable config — mihomo's dns policy depends
+///    on mapping order (legacy lua runner's `correct_original_mapping_order`).
+/// 2. Temp files, module loaders and thread hops are adapter-internal.
+/// 3. `eval_item_*` carry legacy `use_merge` Lua-only semantics.
+/// 4. Identical inputs must produce identical replies (determinism contract).
+pub trait ScriptRunner {
+    fn run(&self, runtime: ScriptRuntime, source: &str, config: &ConfigValue) -> ScriptRunOutcome;
+
+    /// Overlay `filter__` string filter / `when` predicate.
+    fn eval_item_predicate(&self, expr: &str, item: &ConfigValue) -> Result<bool, PortError>;
+
+    /// Overlay `filter__` `when + expr` replacement value.
+    fn eval_item_expr(&self, expr: &str, item: &ConfigValue) -> Result<ConfigValue, PortError>;
+}
+```
+
+- [ ] **Step 3: `executor/artifact.rs`（完整文件）**
+
+```rust
+//! Executor output model (spec §9).
+
+use std::sync::Arc;
+
+use indexmap::IndexSet;
+use serde::{Deserialize, Serialize};
+
+use crate::runtime::{
+    snapshot::{ConfigSnapshotsGraph, SnapshotNodeKey},
+    value::ConfigValue,
+};
+
+/// 1:1 with the legacy `LogSpan` wire shape (enhance/utils.rs:18-25).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "lowercase")]
+pub enum StepLogLevel {
+    Log,
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+pub struct StepLogEntry {
+    pub level: StepLogLevel,
+    pub message: String,
+}
+
+impl StepLogEntry {
+    pub fn new(level: StepLogLevel, message: impl Into<String>) -> Self {
+        Self {
+            level,
+            message: message.into(),
+        }
+    }
+
+    pub fn warn(message: impl Into<String>) -> Self {
+        Self::new(StepLogLevel::Warn, message)
+    }
+
+    pub fn error(message: impl Into<String>) -> Self {
+        Self::new(StepLogLevel::Error, message)
+    }
+}
+
+/// Logs anchored to a semantic node position; no StepId (spec D8).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+pub struct StepLog {
+    pub key: SnapshotNodeKey,
+    pub entries: Vec<StepLogEntry>,
+}
+
+/// Covers every consumer of the legacy `IRuntime` triple (spec §9.3).
+/// Not `specta::Type` as a whole: `final_config` is projected via `to_json()`
+/// by the tauri DTO layer (spec D14).
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeArtifact {
+    pub final_config: Arc<ConfigValue>,
+    pub graph: ConfigSnapshotsGraph,
+    pub step_logs: Vec<StepLog>,
+    pub applied_fields: IndexSet<String>,
+}
+```
+
+- [ ] **Step 4: `executor/error.rs`（完整文件）**
+
+```rust
+//! Structural failures only; transform-level failures go to step logs (spec D7).
+
+use thiserror::Error;
+
+use crate::{
+    profile::{ManagedProfilePath, ProfileId},
+    runtime::snapshot::SnapshotBuildError,
+};
+
+use super::ports::PortError;
+
+#[derive(Debug, Error)]
+pub enum RuntimePipelineError {
+    #[error("selected profile {0} not found")]
+    SelectedProfileNotFound(ProfileId),
+
+    #[error("selected profile {0} is not a Config")]
+    SelectedProfileNotConfig(ProfileId),
+
+    #[error("composition {composition} member {member} invalid: {reason}")]
+    CompositionMemberInvalid {
+        composition: ProfileId,
+        member: ProfileId,
+        reason: String,
+    },
+
+    #[error("read profile {profile} content at {path}: {source}")]
+    ContentSource {
+        profile: ProfileId,
+        path: ManagedProfilePath,
+        #[source]
+        source: PortError,
+    },
+
+    #[error("parse profile {profile} as config: {message}")]
+    ParseProfile { profile: ProfileId, message: String },
+
+    #[error(transparent)]
+    Snapshot(#[from] SnapshotBuildError),
+
+    /// Theoretically unreachable invariant breaks (e.g. guard serialization).
+    #[error("internal executor invariant: {0}")]
+    Internal(String),
+}
+```
+
+- [ ] **Step 5: `executor/value_util.rs`（完整文件）**
+
+```rust
+//! Pure ConfigValue helpers. Path semantics mirror legacy `find_field`
+//! (enhance/merge.rs:27-48): mapping segment = string key, sequence segment =
+//! parsed index; anything else fails the lookup.
+
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+
+use crate::runtime::value::{ConfigObject, ConfigValue};
+
+pub(super) fn empty_object() -> ConfigValue {
+    ConfigValue::Object(Arc::new(IndexMap::new()))
+}
+
+/// Clean seed for base-less compositions: `{ proxies: [] }` (clean-design §7.4).
+pub(super) fn clean_seed() -> ConfigValue {
+    let mut map: ConfigObject = IndexMap::new();
+    map.insert(
+        Arc::from("proxies"),
+        ConfigValue::Array(Arc::from(Vec::<ConfigValue>::new())),
+    );
+    ConfigValue::Object(Arc::new(map))
+}
+
+pub(super) fn obj_get<'a>(value: &'a ConfigValue, key: &str) -> Option<&'a ConfigValue> {
+    value.as_object_arc().and_then(|map| map.get(key))
+}
+
+/// Top-level insert/overwrite. A non-object root is replaced by a fresh
+/// object, matching legacy Mapping semantics (the working config is a map).
+pub(super) fn obj_insert(value: &ConfigValue, key: &str, entry: ConfigValue) -> ConfigValue {
+    let mut map: ConfigObject = value
+        .as_object_arc()
+        .map(|map| (**map).clone())
+        .unwrap_or_default();
+    map.insert(Arc::from(key), entry);
+    ConfigValue::Object(Arc::new(map))
+}
+
+pub(super) fn parse_dotted_path(path: &str) -> Vec<String> {
+    path.split('.').map(str::to_string).collect()
+}
+
+pub(super) fn get_at<'a>(root: &'a ConfigValue, segments: &[String]) -> Option<&'a ConfigValue> {
+    let mut current = root;
+    for segment in segments {
+        current = match current {
+            ConfigValue::Object(map) => map.get(segment.as_str())?,
+            ConfigValue::Array(items) => items.get(segment.parse::<usize>().ok()?)?,
+            _ => return None,
+        };
+    }
+    Some(current)
+}
+
+/// Copy-on-write replace; `None` when the path does not fully exist.
+pub(super) fn replace_at(
+    root: &ConfigValue,
+    segments: &[String],
+    new_value: ConfigValue,
+) -> Option<ConfigValue> {
+    let Some((head, rest)) = segments.split_first() else {
+        return Some(new_value);
+    };
+    match root {
+        ConfigValue::Object(map) => {
+            let current = map.get(head.as_str())?;
+            let replaced = replace_at(current, rest, new_value)?;
+            let mut next = (**map).clone();
+            next.insert(Arc::from(head.as_str()), replaced);
+            Some(ConfigValue::Object(Arc::new(next)))
+        }
+        ConfigValue::Array(items) => {
+            let index = head.parse::<usize>().ok()?;
+            let current = items.get(index)?;
+            let replaced = replace_at(current, rest, new_value)?;
+            let mut next: Vec<ConfigValue> = items.to_vec();
+            next[index] = replaced;
+            Some(ConfigValue::Array(Arc::from(next)))
+        }
+        _ => None,
+    }
+}
+
+/// Removes the value at the path (map key or sequence index); `None` when the
+/// path does not fully exist.
+pub(super) fn remove_at(root: &ConfigValue, segments: &[String]) -> Option<ConfigValue> {
+    let (head, rest) = segments.split_first()?;
+    match root {
+        ConfigValue::Object(map) => {
+            if rest.is_empty() {
+                if !map.contains_key(head.as_str()) {
+                    return None;
+                }
+                let mut next = (**map).clone();
+                next.shift_remove(head.as_str());
+                return Some(ConfigValue::Object(Arc::new(next)));
+            }
+            let current = map.get(head.as_str())?;
+            let removed = remove_at(current, rest)?;
+            let mut next = (**map).clone();
+            next.insert(Arc::from(head.as_str()), removed);
+            Some(ConfigValue::Object(Arc::new(next)))
+        }
+        ConfigValue::Array(items) => {
+            let index = head.parse::<usize>().ok()?;
+            if rest.is_empty() {
+                if index >= items.len() {
+                    return None;
+                }
+                let mut next: Vec<ConfigValue> = items.to_vec();
+                next.remove(index);
+                return Some(ConfigValue::Array(Arc::from(next)));
+            }
+            let current = items.get(index)?;
+            let removed = remove_at(current, rest)?;
+            let mut next: Vec<ConfigValue> = items.to_vec();
+            next[index] = removed;
+            Some(ConfigValue::Array(Arc::from(next)))
+        }
+        _ => None,
+    }
+}
+
+/// Legacy `override_recursive` value rule (enhance/merge.rs:8-24): object
+/// into object = per-key deep merge preserving unmentioned siblings; anything
+/// else = wholesale replace (sequences included).
+pub(super) fn deep_merge_value(existing: Option<&ConfigValue>, data: &ConfigValue) -> ConfigValue {
+    match (
+        existing.and_then(ConfigValue::as_object_arc),
+        data.as_object_arc(),
+    ) {
+        (Some(current), Some(incoming)) => {
+            let mut merged = (**current).clone();
+            for (key, value) in incoming.iter() {
+                let previous = merged.get(key.as_ref()).cloned();
+                merged.insert(key.clone(), deep_merge_value(previous.as_ref(), value));
+            }
+            ConfigValue::Object(Arc::new(merged))
+        }
+        _ => data.clone(),
+    }
+}
+```
+
+- [ ] **Step 6: `executor/mod.rs`（本 task 版本：类型 + 解析 + LogSink；`execute` 留 Task 5）**
+
+```rust
+//! Pure runtime pipeline executor: the "execution half" of the runtime
+//! snapshot store (spec: docs/superpowers/specs/2026-07-04-runtime-pipeline-executor-design.md).
+
+mod artifact;
+mod builtin;
+mod compose;
+mod error;
+mod overlay;
+mod ports;
+mod scoped;
+mod value_util;
+
+#[cfg(test)]
+mod tests;
+
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+
+pub use artifact::{RuntimeArtifact, StepLog, StepLogEntry, StepLogLevel};
+pub use error::RuntimePipelineError;
+pub use ports::{PortError, ProfileContentSource, ScriptRunOutcome, ScriptRunner};
+
+use crate::{
+    clash::config::{overrides::ClashGuardOverrides, tun_stack::TunStack},
+    profile::{
+        ProfileDefinition, ProfileId, Profiles, ScriptRuntime, TransformDefinition, TransformKind,
+    },
+    runtime::{
+        snapshot::SnapshotNodeKey,
+        value::ConfigValue,
+    },
+};
+
+pub struct RuntimePipelineInputs<'a> {
+    /// Snapshot that already passed `Profiles::validate()` (spec §4.2).
+    pub profiles: &'a Profiles,
+    pub target: ExecutionTarget,
+    pub guard: GuardInputs<'a>,
+    /// `ClashConfig.enable_clash_fields`: gates both whitelist passes.
+    pub whitelist_enabled: bool,
+    pub tun: TunParams,
+    /// Pre-gated and ordered by the caller against `ClashCore` (spec D3).
+    pub builtin_transforms: &'a [BuiltinTransform],
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExecutionTarget {
+    Selected(ProfileId),
+    /// current = None: legacy bare-config path (spec §4.3).
+    Bare,
+}
+
+pub struct GuardInputs<'a> {
+    /// Serialized to kebab-case top-level keys and force-inserted (spec D6).
+    pub overrides: &'a ClashGuardOverrides,
+    /// Ports resolved by the caller — port probing IO never enters here.
+    pub ports: ResolvedPortBindings,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ResolvedPortBindings {
+    pub mixed_port: u16,
+    /// Legacy `port` (HTTP) key; absent when `None`.
+    pub port: Option<u16>,
+    pub socks_port: Option<u16>,
+    /// `host:port`; absent when `None`.
+    pub external_controller: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TunParams {
+    pub enable: bool,
+    pub flavor: TunFlavor,
+    /// Platform conditional as input: caller passes `cfg!(windows)` (spec §7.4).
+    pub windows_fake_ip_filter: bool,
+}
+
+/// Caller derives from (core, tun_stack), including the legacy
+/// Premium+Mixed→Gvisor downgrade (tun.rs:58-60); executor stays core-free.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TunFlavor {
+    ClashRs,
+    Standard { stack: TunStack },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BuiltinTransform {
+    /// Display name recorded in the `BuiltinTransform` tag (e.g. "verge_hy_alpn").
+    pub name: String,
+    pub runtime: ScriptRuntime,
+    pub source: String,
+}
+
+/// YAML text → `<<:` merge-key expansion → ConfigValue (spec D13; parity with
+/// legacy `help::read_merge_mapping`, utils/help.rs:45-57).
+pub(crate) fn parse_config_document(text: &str) -> Result<ConfigValue, String> {
+    let mut value: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(text).map_err(|error| error.to_string())?;
+    value.apply_merge().map_err(|error| error.to_string())?;
+    ConfigValue::try_from(value).map_err(|error| format!("{error:?}"))
+}
+
+/// Accumulates step logs keyed by semantic node position (spec D8).
+#[derive(Default)]
+struct LogSink(IndexMap<SnapshotNodeKey, Vec<StepLogEntry>>);
+
+impl LogSink {
+    fn extend(&mut self, key: SnapshotNodeKey, entries: Vec<StepLogEntry>) {
+        if entries.is_empty() {
+            return;
+        }
+        self.0.entry(key).or_default().extend(entries);
+    }
+
+    fn into_step_logs(self) -> Vec<StepLog> {
+        self.0
+            .into_iter()
+            .map(|(key, entries)| StepLog { key, entries })
+            .collect()
+    }
+}
+
+/// Shared transform application (scoped / composition / global). Lenient by
+/// design: every failure passes the config through and logs (spec D7). The
+/// `TransformKind::Overlay` placeholder on defensive paths is display-only —
+/// `node_key()` drops the kind.
+pub(crate) fn apply_transform(
+    profiles: &Profiles,
+    content: &dyn ProfileContentSource,
+    runner: &dyn ScriptRunner,
+    transform_id: &ProfileId,
+    current: &Arc<ConfigValue>,
+) -> (Arc<ConfigValue>, TransformKind, Vec<StepLogEntry>) {
+    let mut entries = Vec::new();
+
+    let Some(item) = profiles.items.get(transform_id) else {
+        entries.push(StepLogEntry::error(format!(
+            "transform {transform_id} not found, passthrough"
+        )));
+        return (current.clone(), TransformKind::Overlay, entries);
+    };
+    let ProfileDefinition::Transform { transform } = &item.definition else {
+        entries.push(StepLogEntry::error(format!(
+            "profile {transform_id} is not a transform, passthrough"
+        )));
+        return (current.clone(), TransformKind::Overlay, entries);
+    };
+
+    let kind = transform.kind();
+    let path = transform.source().materialized().file.clone();
+    let text = match content.read(&path) {
+        Ok(text) => text,
+        Err(error) => {
+            entries.push(StepLogEntry::error(format!(
+                "read transform {transform_id} source at {path} failed, passthrough: {error}"
+            )));
+            return (current.clone(), kind, entries);
+        }
+    };
+
+    match transform {
+        TransformDefinition::Overlay(_) => match parse_config_document(&text) {
+            Ok(document) => {
+                let next = overlay::apply_overlay(&document, (**current).clone(), runner, &mut entries);
+                (Arc::new(next), kind, entries)
+            }
+            Err(message) => {
+                entries.push(StepLogEntry::error(format!(
+                    "parse overlay {transform_id} failed, passthrough: {message}"
+                )));
+                (current.clone(), kind, entries)
+            }
+        },
+        TransformDefinition::Script(script) => {
+            let outcome = runner.run(script.runtime, &text, current);
+            entries.extend(outcome.logs);
+            match outcome.result {
+                Ok(next) => (Arc::new(next), kind, entries),
+                Err(error) => {
+                    // Parity: enhance/utils.rs:118 — error log + passthrough.
+                    entries.push(StepLogEntry::error(error.to_string()));
+                    (current.clone(), kind, entries)
+                }
+            }
+        }
+    }
+}
+```
+
+本 task 中 `mod builtin; mod compose; mod overlay; mod scoped;` 先以最小占位文件落地（仅注释，无项目符号），Task 3–5 填充：
+
+```rust
+//! Filled by later plan tasks.
+```
+
+- [ ] **Step 7: 测试支撑 `executor/tests/mod.rs` + `executor/tests/support.rs`**
+
+`tests/mod.rs`（随任务推进逐行解注释，本 task 只启用 support）：
+
+```rust
+mod support;
+// mod overlay;        // Task 3
+// mod builtin;        // Task 4
+// mod compose;        // Task 5
+// mod orders;         // Task 5
+// mod golden;         // Task 6
+// mod invalidation;   // Task 7
+// mod parity;         // Task 8
+```
+
+`tests/support.rs`（完整文件）：
+
+```rust
+//! Test doubles and Profiles literal builders. Pure values only (CLAUDE.md §13).
+
+use std::collections::HashMap;
+
+use crate::profile::{
+    ConfigDefinition, CompositionConfig, FileConfig, LocalBinding, ManagedProfilePath,
+    MaterializedFile, OverlayTransform, ProfileDefinition, ProfileId, ProfileItem,
+    ProfileMetadata, ProfileSource, Profiles, ScriptRuntime, ScriptTransform,
+    TransformDefinition,
+};
+use crate::runtime::executor::{
+    PortError, ProfileContentSource, ScriptRunOutcome, ScriptRunner, StepLogEntry,
+};
+use crate::runtime::value::ConfigValue;
+
+pub fn pid(value: &str) -> ProfileId {
+    ProfileId(value.to_owned())
+}
+
+pub struct MapContentSource(pub HashMap<ManagedProfilePath, String>);
+
+impl MapContentSource {
+    pub fn from_pairs(pairs: &[(&str, &str)]) -> Self {
+        Self(
+            pairs
+                .iter()
+                .map(|(path, content)| {
+                    (
+                        ManagedProfilePath::new(*path).expect("test path must be managed"),
+                        (*content).to_string(),
+                    )
+                })
+                .collect(),
+        )
+    }
+}
+
+impl ProfileContentSource for MapContentSource {
+    fn read(&self, path: &ManagedProfilePath) -> Result<String, PortError> {
+        self.0
+            .get(path)
+            .cloned()
+            .ok_or_else(|| format!("no content for {path}").into())
+    }
+}
+
+pub enum RunReply {
+    Replace(serde_json::Value, Vec<StepLogEntry>),
+    Fail(String, Vec<StepLogEntry>),
+}
+
+pub enum PredicateReply {
+    Fixed(bool),
+    ByItem(fn(&ConfigValue) -> bool),
+    Fail(String),
+}
+
+pub enum ExprReply {
+    Fixed(serde_json::Value),
+    Fail(String),
+}
+
+/// Replays scripted outcomes; unknown sources echo the input config, unknown
+/// predicates return `true`, unknown exprs echo the item.
+#[derive(Default)]
+pub struct FakeScriptRunner {
+    pub runs: HashMap<String, RunReply>,
+    pub predicates: HashMap<String, PredicateReply>,
+    pub exprs: HashMap<String, ExprReply>,
+}
+
+impl ScriptRunner for FakeScriptRunner {
+    fn run(&self, _runtime: ScriptRuntime, source: &str, config: &ConfigValue) -> ScriptRunOutcome {
+        match self.runs.get(source) {
+            Some(RunReply::Replace(json, logs)) => ScriptRunOutcome {
+                result: Ok(ConfigValue::try_from(json.clone()).expect("fake run json")),
+                logs: logs.clone(),
+            },
+            Some(RunReply::Fail(message, logs)) => ScriptRunOutcome {
+                result: Err(message.clone().into()),
+                logs: logs.clone(),
+            },
+            None => ScriptRunOutcome {
+                result: Ok(config.clone()),
+                logs: Vec::new(),
+            },
+        }
+    }
+
+    fn eval_item_predicate(&self, expr: &str, item: &ConfigValue) -> Result<bool, PortError> {
+        match self.predicates.get(expr) {
+            Some(PredicateReply::Fixed(value)) => Ok(*value),
+            Some(PredicateReply::ByItem(judge)) => Ok(judge(item)),
+            Some(PredicateReply::Fail(message)) => Err(message.clone().into()),
+            None => Ok(true),
+        }
+    }
+
+    fn eval_item_expr(&self, expr: &str, item: &ConfigValue) -> Result<ConfigValue, PortError> {
+        match self.exprs.get(expr) {
+            Some(ExprReply::Fixed(json)) => {
+                Ok(ConfigValue::try_from(json.clone()).expect("fake expr json"))
+            }
+            Some(ExprReply::Fail(message)) => Err(message.clone().into()),
+            None => Ok(item.clone()),
+        }
+    }
+}
+
+pub fn managed_file_source(file: &str) -> ProfileSource {
+    ProfileSource::Local {
+        binding: LocalBinding::Managed {
+            materialized: MaterializedFile {
+                file: ManagedProfilePath::new(file).expect("test path must be managed"),
+                updated_at: None,
+            },
+        },
+    }
+}
+
+fn metadata(uid: &str) -> ProfileMetadata {
+    ProfileMetadata {
+        name: uid.to_owned(),
+        desc: None,
+    }
+}
+
+pub fn config_file_item(uid: &str, file: &str, transforms: &[&str]) -> ProfileItem {
+    ProfileItem {
+        uid: pid(uid),
+        metadata: metadata(uid),
+        definition: ProfileDefinition::Config {
+            config: ConfigDefinition::File(FileConfig {
+                source: managed_file_source(file),
+                transforms: transforms.iter().map(|t| pid(t)).collect(),
+            }),
+        },
+    }
+}
+
+pub fn composition_item(
+    uid: &str,
+    base: Option<&str>,
+    extend: &[&str],
+    transforms: &[&str],
+) -> ProfileItem {
+    ProfileItem {
+        uid: pid(uid),
+        metadata: metadata(uid),
+        definition: ProfileDefinition::Config {
+            config: ConfigDefinition::Composition(CompositionConfig {
+                base: base.map(pid),
+                extend_proxies_from: extend.iter().map(|m| pid(m)).collect(),
+                transforms: transforms.iter().map(|t| pid(t)).collect(),
+            }),
+        },
+    }
+}
+
+pub fn overlay_item(uid: &str, file: &str) -> ProfileItem {
+    ProfileItem {
+        uid: pid(uid),
+        metadata: metadata(uid),
+        definition: ProfileDefinition::Transform {
+            transform: TransformDefinition::Overlay(OverlayTransform {
+                source: managed_file_source(file),
+            }),
+        },
+    }
+}
+
+pub fn script_item(uid: &str, file: &str, runtime: ScriptRuntime) -> ProfileItem {
+    ProfileItem {
+        uid: pid(uid),
+        metadata: metadata(uid),
+        definition: ProfileDefinition::Transform {
+            transform: TransformDefinition::Script(ScriptTransform {
+                source: managed_file_source(file),
+                runtime,
+            }),
+        },
+    }
+}
+
+pub fn profiles_with(
+    current: Option<&str>,
+    global_transforms: &[&str],
+    valid: &[&str],
+    items: Vec<ProfileItem>,
+) -> Profiles {
+    Profiles {
+        current: current.map(pid),
+        global_transforms: global_transforms.iter().map(|t| pid(t)).collect(),
+        valid: valid.iter().map(|v| (*v).to_string()).collect(),
+        items: items.into_iter().map(|item| (item.uid.clone(), item)).collect(),
+    }
+}
+```
+
+- [ ] **Step 8: 骨架冒烟测试（support.rs 末尾）**
+
+```rust
+#[cfg(test)]
+mod smoke {
+    use super::*;
+
+    #[test]
+    fn map_content_source_reads_and_misses() {
+        let source = MapContentSource::from_pairs(&[("a.yaml", "proxies: []")]);
+        let path = ManagedProfilePath::new("a.yaml").unwrap();
+        assert_eq!(source.read(&path).unwrap(), "proxies: []");
+        let missing = ManagedProfilePath::new("b.yaml").unwrap();
+        assert!(source.read(&missing).is_err());
+    }
+
+    #[test]
+    fn parse_config_document_applies_yaml_merge_keys() {
+        let text = "base: &base\n  a: 1\nmerged:\n  <<: *base\n  b: 2\n";
+        let value = crate::runtime::executor::parse_config_document(text).unwrap();
+        assert_eq!(
+            value.to_json(),
+            serde_json::json!({ "base": { "a": 1 }, "merged": { "a": 1, "b": 2 } })
+        );
+    }
+}
+```
+
+- [ ] **Step 9: 跑测试 + Commit**
+
+Run: `cargo test -p nyanpasu-config executor`
+Expected: PASS（2 个 smoke 测试）
+
+```bash
+git add backend/nyanpasu-config/src/runtime/mod.rs backend/nyanpasu-config/src/runtime/executor/
+git commit -m "feat(nyanpasu-config): scaffold runtime pipeline executor ports and artifact types"
+```
+
+---
+
+## Task 3: Overlay 指令集（旧 `use_merge` 对位）
+
+**Files:**
+
+- Rewrite: `backend/nyanpasu-config/src/runtime/executor/overlay.rs`
+- Create: `backend/nyanpasu-config/src/runtime/executor/tests/overlay.rs`（并解注释 `tests/mod.rs` 的 `mod overlay;`）
+
+**Interfaces:**
+
+- Consumes: `value_util::*`、`ScriptRunner::{eval_item_predicate, eval_item_expr}`、`StepLogEntry`
+- Produces: `pub(super) fn apply_overlay(overlay: &ConfigValue, config: ConfigValue, runner: &dyn ScriptRunner, logs: &mut Vec<StepLogEntry>) -> ConfigValue`
+
+语义权威 = spec §7.3 表 + 旧 `enhance/merge.rs`。**永不失败**：一切异常路径 = WARN/ERROR 日志 + 该键跳过。指令键整体小写化（含路径），裸键保留大小写（怪癖原样保留，spec D10）。`when`/`expr` 错误路径按下面代码实现后，须逐分支对照 `merge.rs` 源码确认（spec 开放问题 #1）；若发现出入，以旧代码为准修正实现与测试并在 PR 描述记录。
+
+- [ ] **Step 1: 写失败测试 `tests/overlay.rs`（完整文件）**
+
+```rust
+use serde_json::json;
+
+use super::support::{ExprReply, FakeScriptRunner, PredicateReply};
+use crate::runtime::executor::overlay::apply_overlay;
+use crate::runtime::executor::StepLogLevel;
+use crate::runtime::value::ConfigValue;
+
+fn value(json: serde_json::Value) -> ConfigValue {
+    ConfigValue::try_from(json).unwrap()
+}
+
+fn apply(overlay: serde_json::Value, config: serde_json::Value) -> (serde_json::Value, Vec<(StepLogLevel, String)>) {
+    apply_with(overlay, config, &FakeScriptRunner::default())
+}
+
+fn apply_with(
+    overlay: serde_json::Value,
+    config: serde_json::Value,
+    runner: &FakeScriptRunner,
+) -> (serde_json::Value, Vec<(StepLogLevel, String)>) {
+    let mut logs = Vec::new();
+    let result = apply_overlay(&value(overlay), value(config), runner, &mut logs);
+    (
+        result.to_json(),
+        logs.into_iter().map(|entry| (entry.level, entry.message)).collect(),
+    )
+}
+
+#[test]
+fn prepend_and_append_splice_sequences() {
+    let (result, logs) = apply(
+        json!({ "prepend-rules": ["r0"], "append__rules": ["r9"] }),
+        json!({ "rules": ["r1", "r2"] }),
+    );
+    assert_eq!(result, json!({ "rules": ["r0", "r1", "r2", "r9"] }));
+    assert!(logs.is_empty());
+}
+
+#[test]
+fn prepend_missing_or_non_sequence_field_warns_and_skips() {
+    let (result, logs) = apply(json!({ "prepend__rules": ["r0"] }), json!({ "a": 1 }));
+    assert_eq!(result, json!({ "a": 1 }));
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].0, StepLogLevel::Warn);
+
+    let (result, logs) = apply(json!({ "append__a": ["x"] }), json!({ "a": 1 }));
+    assert_eq!(result, json!({ "a": 1 }));
+    assert_eq!(logs.len(), 1);
+}
+
+#[test]
+fn override_replaces_nested_paths_including_sequence_index() {
+    // 对位旧 test_override（merge.rs:436-476）。
+    let (result, logs) = apply(
+        json!({ "override__a.f.0": "wow", "override__b": 7 }),
+        json!({ "a": { "f": [123, 456] }, "b": 1 }),
+    );
+    assert_eq!(result, json!({ "a": { "f": ["wow", 456] }, "b": 7 }));
+    assert!(logs.is_empty());
+}
+
+#[test]
+fn override_missing_path_warns_and_does_not_create() {
+    let (result, logs) = apply(json!({ "override__x.y": 1 }), json!({ "a": 1 }));
+    assert_eq!(result, json!({ "a": 1 }));
+    assert_eq!(logs.len(), 1);
+}
+
+#[test]
+fn bare_key_deep_merges_maps_and_replaces_sequences() {
+    // 对位旧 test_override_recursive（merge.rs:1031-1071）：
+    // 映射深合并保留兄弟键；序列整体替换；缺失键插入。
+    let (result, logs) = apply(
+        json!({ "a": { "b": { "c": 2 } }, "f": ["wow"], "new": true }),
+        json!({ "a": { "b": { "c": 1, "keep": 9 }, "sib": 3 }, "f": [123, 456] }),
+    );
+    assert_eq!(
+        result,
+        json!({
+            "a": { "b": { "c": 2, "keep": 9 }, "sib": 3 },
+            "f": ["wow"],
+            "new": true
+        })
+    );
+    assert!(logs.is_empty());
+}
+
+#[test]
+fn directive_keys_are_lowercased_but_bare_keys_preserve_case() {
+    // 怪癖原样保留（spec §13 前注、merge.rs:248 vs :310-312）：
+    // 指令路径被小写化 → 找不到混合大小写字段 → WARN 跳过；裸键保留大小写。
+    let (result, logs) = apply(
+        json!({ "APPEND__Rules.Sub": ["x"], "BareKey": 1 }),
+        json!({ "Rules": { "Sub": ["a"] } }),
+    );
+    assert_eq!(result, json!({ "Rules": { "Sub": ["a"] }, "BareKey": 1 }));
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].0, StepLogLevel::Warn);
+}
+
+#[test]
+fn filter_string_predicate_retains_and_removes_on_error() {
+    let mut runner = FakeScriptRunner::default();
+    runner.predicates.insert(
+        "keep_big".to_string(),
+        PredicateReply::ByItem(|item| {
+            item.to_json().get("n").and_then(|n| n.as_i64()).unwrap_or(0) > 1
+        }),
+    );
+    runner
+        .predicates
+        .insert("boom".to_string(), PredicateReply::Fail("lua error".to_string()));
+
+    let (result, logs) = apply_with(
+        json!({ "filter__proxies": "keep_big" }),
+        json!({ "proxies": [{ "n": 1 }, { "n": 2 }] }),
+        &runner,
+    );
+    assert_eq!(result, json!({ "proxies": [{ "n": 2 }] }));
+    assert!(logs.is_empty());
+
+    // 求值错误 = 项被移除 + WARN（parity）。
+    let (result, logs) = apply_with(
+        json!({ "filter__proxies": "boom" }),
+        json!({ "proxies": [{ "n": 1 }] }),
+        &runner,
+    );
+    assert_eq!(result, json!({ "proxies": [] }));
+    assert_eq!(logs.len(), 1);
+}
+
+#[test]
+fn filter_when_variants_expr_override_merge_remove() {
+    let mut runner = FakeScriptRunner::default();
+    runner
+        .predicates
+        .insert("hit".to_string(), PredicateReply::Fixed(true));
+    runner
+        .predicates
+        .insert("miss".to_string(), PredicateReply::Fixed(false));
+    runner
+        .exprs
+        .insert("rewrite".to_string(), ExprReply::Fixed(json!({ "n": 99 })));
+
+    // when + expr
+    let (result, _) = apply_with(
+        json!({ "filter__items": { "when": "hit", "expr": "rewrite" } }),
+        json!({ "items": [{ "n": 1 }] }),
+        &runner,
+    );
+    assert_eq!(result, json!({ "items": [{ "n": 99 }] }));
+
+    // when(miss) → 原样
+    let (result, _) = apply_with(
+        json!({ "filter__items": { "when": "miss", "expr": "rewrite" } }),
+        json!({ "items": [{ "n": 1 }] }),
+        &runner,
+    );
+    assert_eq!(result, json!({ "items": [{ "n": 1 }] }));
+
+    // when + override（字面替换，不经求值）
+    let (result, _) = apply_with(
+        json!({ "filter__items": { "when": "hit", "override": { "fixed": true } } }),
+        json!({ "items": [{ "n": 1 }] }),
+        &runner,
+    );
+    assert_eq!(result, json!({ "items": [{ "fixed": true }] }));
+
+    // when + merge（存在键深合并、缺失键插入）
+    let (result, _) = apply_with(
+        json!({ "filter__items": { "when": "hit", "merge": { "a": { "b": 2 }, "add": 1 } } }),
+        json!({ "items": [{ "a": { "b": 1, "keep": 3 } }] }),
+        &runner,
+    );
+    assert_eq!(result, json!({ "items": [{ "a": { "b": 2, "keep": 3 }, "add": 1 }] }));
+
+    // when + remove（点路径含末尾序列索引 / 映射键）
+    let (result, _) = apply_with(
+        json!({ "filter__items": { "when": "hit", "remove": ["good.should_remove", "test.1"] } }),
+        json!({ "items": [{ "good": { "should_remove": 1, "keep": 2 }, "test": [10, 20, 30] }] }),
+        &runner,
+    );
+    assert_eq!(
+        result,
+        json!({ "items": [{ "good": { "keep": 2 }, "test": [10, 30] }] })
+    );
+}
+
+#[test]
+fn filter_sequence_composes_and_invalid_filter_warns() {
+    let mut runner = FakeScriptRunner::default();
+    runner.predicates.insert(
+        "gt1".to_string(),
+        PredicateReply::ByItem(|item| item.to_json().as_i64().unwrap_or(0) > 1),
+    );
+    runner.predicates.insert(
+        "lt3".to_string(),
+        PredicateReply::ByItem(|item| item.to_json().as_i64().unwrap_or(9) < 3),
+    );
+
+    let (result, _) = apply_with(
+        json!({ "filter__nums": ["gt1", "lt3"] }),
+        json!({ "nums": [1, 2, 3] }),
+        &runner,
+    );
+    assert_eq!(result, json!({ "nums": [2] }));
+
+    let (result, logs) = apply(json!({ "filter__nums": 42 }), json!({ "nums": [1] }));
+    assert_eq!(result, json!({ "nums": [1] }));
+    assert_eq!(logs.len(), 1);
+}
+
+#[test]
+fn overlay_non_mapping_document_warns_and_passes_through() {
+    let (result, logs) = apply(json!(["not", "a", "map"]), json!({ "a": 1 }));
+    assert_eq!(result, json!({ "a": 1 }));
+    assert_eq!(logs.len(), 1);
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cargo test -p nyanpasu-config executor::tests::overlay`
+Expected: FAIL —— `apply_overlay` 不存在（占位文件）
+
+- [ ] **Step 3: 实现 `overlay.rs`（完整文件）**
+
+```rust
+//! Overlay (= legacy Merge chain item) directive semantics.
+//! Authority: spec §7.3 table; legacy source enhance/merge.rs. Never fails:
+//! every abnormal path logs and skips that key (merge.rs:242-318 parity).
+
+use std::sync::Arc;
+
+use crate::runtime::value::ConfigValue;
+
+use super::{
+    artifact::StepLogEntry,
+    ports::ScriptRunner,
+    value_util::{deep_merge_value, get_at, parse_dotted_path, remove_at, replace_at},
+};
+
+pub(super) fn apply_overlay(
+    overlay: &ConfigValue,
+    mut config: ConfigValue,
+    runner: &dyn ScriptRunner,
+    logs: &mut Vec<StepLogEntry>,
+) -> ConfigValue {
+    let Some(entries) = overlay.as_object_arc() else {
+        logs.push(StepLogEntry::warn("overlay document is not a mapping, skipped"));
+        return config;
+    };
+
+    // IndexMap iteration = document order (parity with Mapping iteration).
+    for (key, value) in entries.iter() {
+        // Legacy quirk kept verbatim (merge.rs:248): directive matching and
+        // the remainder path are lowercased; bare keys preserve case.
+        let lowered = key.to_ascii_lowercase();
+        if let Some(field) = strip_any(&lowered, &["prepend__", "prepend-"]) {
+            config = splice_sequence(config, field, value, true, logs);
+        } else if let Some(field) = strip_any(&lowered, &["append__", "append-"]) {
+            config = splice_sequence(config, field, value, false, logs);
+        } else if let Some(field) = lowered.strip_prefix("override__") {
+            config = override_path(config, field, value, logs);
+        } else if let Some(field) = lowered.strip_prefix("filter__") {
+            config = filter_path(config, field, value, runner, logs);
+        } else {
+            config = bare_key_merge(config, key, value);
+        }
+    }
+    config
+}
+
+fn strip_any<'a>(key: &'a str, prefixes: &[&str]) -> Option<&'a str> {
+    prefixes.iter().find_map(|prefix| key.strip_prefix(prefix))
+}
+
+fn splice_sequence(
+    config: ConfigValue,
+    field: &str,
+    value: &ConfigValue,
+    prepend: bool,
+    logs: &mut Vec<StepLogEntry>,
+) -> ConfigValue {
+    let Some(to_merge) = value.as_array_arc() else {
+        logs.push(StepLogEntry::warn(format!(
+            "merge value for `{field}` is not a sequence, skipped"
+        )));
+        return config;
+    };
+    let segments = parse_dotted_path(field);
+    let Some(target) = get_at(&config, &segments) else {
+        logs.push(StepLogEntry::warn(format!("field `{field}` not found, skipped")));
+        return config;
+    };
+    let Some(existing) = target.as_array_arc() else {
+        logs.push(StepLogEntry::warn(format!(
+            "field `{field}` is not a sequence, skipped"
+        )));
+        return config;
+    };
+
+    let items: Vec<ConfigValue> = if prepend {
+        to_merge.iter().cloned().chain(existing.iter().cloned()).collect()
+    } else {
+        existing.iter().cloned().chain(to_merge.iter().cloned()).collect()
+    };
+    replace_at(&config, &segments, ConfigValue::Array(Arc::from(items))).unwrap_or(config)
+}
+
+fn override_path(
+    config: ConfigValue,
+    field: &str,
+    value: &ConfigValue,
+    logs: &mut Vec<StepLogEntry>,
+) -> ConfigValue {
+    let segments = parse_dotted_path(field);
+    match replace_at(&config, &segments, value.clone()) {
+        Some(next) => next,
+        None => {
+            // Legacy: override does NOT create missing paths (merge.rs:292-304).
+            logs.push(StepLogEntry::warn(format!("field `{field}` not found, skipped")));
+            config
+        }
+    }
+}
+
+/// Bare key: deep-merge for maps, wholesale replace otherwise, insert when
+/// absent (merge.rs:8-24, 310-312). Original key case preserved.
+fn bare_key_merge(config: ConfigValue, key: &Arc<str>, data: &ConfigValue) -> ConfigValue {
+    let existing = config
+        .as_object_arc()
+        .and_then(|map| map.get(key.as_ref()))
+        .cloned();
+    let merged = deep_merge_value(existing.as_ref(), data);
+    super::value_util::obj_insert(&config, key.as_ref(), merged)
+}
+
+fn filter_path(
+    config: ConfigValue,
+    field: &str,
+    filter: &ConfigValue,
+    runner: &dyn ScriptRunner,
+    logs: &mut Vec<StepLogEntry>,
+) -> ConfigValue {
+    let segments = parse_dotted_path(field);
+    let Some(target) = get_at(&config, &segments) else {
+        logs.push(StepLogEntry::warn(format!("field `{field}` not found, skipped")));
+        return config;
+    };
+    let Some(existing) = target.as_array_arc() else {
+        logs.push(StepLogEntry::warn(format!(
+            "field `{field}` is not a sequence, skipped"
+        )));
+        return config;
+    };
+
+    let filtered = apply_filter(existing.to_vec(), filter, runner, logs);
+    replace_at(&config, &segments, ConfigValue::Array(Arc::from(filtered))).unwrap_or(config)
+}
+
+fn apply_filter(
+    items: Vec<ConfigValue>,
+    filter: &ConfigValue,
+    runner: &dyn ScriptRunner,
+    logs: &mut Vec<StepLogEntry>,
+) -> Vec<ConfigValue> {
+    match filter {
+        // Sequence of filters: composable multi-pass (merge.rs do_filter).
+        ConfigValue::Array(filters) => filters
+            .iter()
+            .fold(items, |acc, sub| apply_filter(acc, sub, runner, logs)),
+        // String: Lua boolean predicate; eval error removes the item (parity).
+        ConfigValue::String(expr) => items
+            .into_iter()
+            .filter(|item| match runner.eval_item_predicate(expr, item) {
+                Ok(keep) => keep,
+                Err(error) => {
+                    logs.push(StepLogEntry::warn(format!(
+                        "filter expr failed, item removed: {error}"
+                    )));
+                    false
+                }
+            })
+            .collect(),
+        ConfigValue::Object(actions) => {
+            let Some(ConfigValue::String(when)) = actions.get("when") else {
+                logs.push(StepLogEntry::warn("invalid filter: missing `when`"));
+                return items;
+            };
+            items
+                .into_iter()
+                .map(|item| {
+                    let hit = match runner.eval_item_predicate(when, &item) {
+                        Ok(hit) => hit,
+                        Err(error) => {
+                            logs.push(StepLogEntry::warn(format!(
+                                "filter `when` failed, treated as false: {error}"
+                            )));
+                            false
+                        }
+                    };
+                    if !hit {
+                        return item;
+                    }
+                    if let Some(ConfigValue::String(expr)) = actions.get("expr") {
+                        return match runner.eval_item_expr(expr, &item) {
+                            Ok(next) => next,
+                            Err(error) => {
+                                logs.push(StepLogEntry::warn(format!(
+                                    "filter `expr` failed, item kept: {error}"
+                                )));
+                                item
+                            }
+                        };
+                    }
+                    if let Some(replacement) = actions.get("override") {
+                        return replacement.clone();
+                    }
+                    if let Some(merge) = actions.get("merge") {
+                        return deep_merge_value(Some(&item), merge);
+                    }
+                    if let Some(ConfigValue::Array(paths)) = actions.get("remove") {
+                        return remove_from_item(item, paths, logs);
+                    }
+                    logs.push(StepLogEntry::warn("invalid filter: no action"));
+                    item
+                })
+                .collect()
+        }
+        _ => {
+            logs.push(StepLogEntry::warn("invalid filter value, skipped"));
+            items
+        }
+    }
+}
+
+fn remove_from_item(
+    item: ConfigValue,
+    paths: &Arc<[ConfigValue]>,
+    logs: &mut Vec<StepLogEntry>,
+) -> ConfigValue {
+    let mut current = item;
+    for path in paths.iter() {
+        match path {
+            ConfigValue::String(dotted) => {
+                let segments = parse_dotted_path(dotted);
+                match remove_at(&current, &segments) {
+                    Some(next) => current = next,
+                    None => logs.push(StepLogEntry::warn(format!(
+                        "remove path `{dotted}` not found, skipped"
+                    ))),
+                }
+            }
+            ConfigValue::Number(index) => {
+                let removed = index
+                    .as_u64()
+                    .map(|index| index.to_string())
+                    .and_then(|segment| remove_at(&current, &[segment]));
+                match removed {
+                    Some(next) => current = next,
+                    None => logs.push(StepLogEntry::warn("remove index invalid, skipped")),
+                }
+            }
+            _ => logs.push(StepLogEntry::warn("invalid remove entry, skipped")),
+        }
+    }
+    current
+}
+```
+
+同时把 `tests/mod.rs` 的 `mod overlay;` 解注释。
+
+- [ ] **Step 4: 对照 `merge.rs` 复核错误分支（spec 开放问题 #1）**
+
+打开 `backend/tauri/src/enhance/merge.rs` 通读 `do_filter`（99-238 行）与 `run_expr`（62-97 行），逐分支核对：字符串谓词错误→移除、`when` 错误→按假、`expr` 错误→保留原项。若与上面实现不符，改实现与测试对齐旧代码，并把最终行为回填 spec §7.3 表（Task 9 一并提交）。
+
+- [ ] **Step 5: 跑测试 + Commit**
+
+Run: `cargo test -p nyanpasu-config executor::tests::overlay`
+Expected: PASS（10 个测试）
+
+```bash
+git add backend/nyanpasu-config/src/runtime/executor/
+git commit -m "feat(nyanpasu-config): implement overlay transform directive semantics"
+```
+
+---
+
+## Task 4: 三 BuiltinStep 纯函数（whitelist / guard / finalizing）
+
+**Files:**
+
+- Rewrite: `backend/nyanpasu-config/src/runtime/executor/builtin.rs`
+- Create: `backend/nyanpasu-config/src/runtime/executor/tests/builtin.rs`（解注释 `mod builtin;`）
+
+**Interfaces:**
+
+- Consumes: `value_util::{obj_get, obj_insert}`、`GuardInputs`/`TunParams`/`TunFlavor`（mod.rs）、`RuntimePipelineError::Internal`
+- Produces:
+  - `pub(super) const HANDLE_FIELDS: [&str; 9]` / `DEFAULT_FIELDS: [&str; 5]` / `OTHERS_FIELDS: [&str; 31]`
+  - `pub(super) fn known_fields() -> impl Iterator<Item = &'static str>`（45 键，DEFAULT++HANDLE++OTHERS 序）
+  - `pub(super) fn stage1_fields(valid: &[String]) -> Vec<String>`
+  - `pub(super) fn whitelist_filter(config: &ConfigValue, allow: &[String], enabled: bool) -> ConfigValue`
+  - `pub(super) fn apply_guard(config: &ConfigValue, guard: &GuardInputs<'_>) -> Result<ConfigValue, RuntimePipelineError>`
+  - `pub(super) fn finalize(config: &ConfigValue, tun: &TunParams, whitelist_enabled: bool) -> ConfigValue`
+
+- [ ] **Step 1: 写失败测试 `tests/builtin.rs`（完整文件）**
+
+```rust
+use serde_json::json;
+
+use crate::clash::config::{overrides::ClashGuardOverrides, tun_stack::TunStack};
+use crate::runtime::executor::builtin::{
+    apply_guard, finalize, known_fields, stage1_fields, whitelist_filter,
+};
+use crate::runtime::executor::{GuardInputs, ResolvedPortBindings, TunFlavor, TunParams};
+use crate::runtime::value::ConfigValue;
+
+fn value(json: serde_json::Value) -> ConfigValue {
+    ConfigValue::try_from(json).unwrap()
+}
+
+/// 固定 secret 的守卫输入（默认构造的 secret 是随机 uuid，测试必须反序列化固定值）。
+pub fn fixed_overrides() -> ClashGuardOverrides {
+    serde_yaml_ng::from_str(
+        "log-level: info\nallow-lan: false\nmode: rule\nsecret: golden-secret\nunified-delay: true\ntcp-concurrent: true\nipv6: false\n",
+    )
+    .unwrap()
+}
+
+fn tun_off() -> TunParams {
+    TunParams {
+        enable: false,
+        flavor: TunFlavor::Standard { stack: TunStack::Gvisor },
+        windows_fake_ip_filter: false,
+    }
+}
+
+#[test]
+fn known_fields_are_exactly_45() {
+    assert_eq!(known_fields().count(), 45);
+    assert!(known_fields().any(|f| f == "proxies"));
+    assert!(known_fields().any(|f| f == "external-controller"));
+    assert!(known_fields().any(|f| f == "global-client-fingerprint"));
+}
+
+#[test]
+fn stage1_fields_take_valid_intersect_others_plus_default_and_never_handle() {
+    // field.rs:67-77 对位：valid∩OTHERS(小写) ++ DEFAULT；HANDLE 永不在内。
+    let fields = stage1_fields(&[
+        "DNS".to_string(),              // ∈ OTHERS（大小写不敏感）
+        "not-a-clash-field".to_string(), // 静默丢弃
+        "mode".to_string(),             // ∈ HANDLE → 不进 stage-1
+    ]);
+    assert!(fields.contains(&"dns".to_string()));
+    assert!(fields.contains(&"proxies".to_string()));
+    assert!(!fields.contains(&"not-a-clash-field".to_string()));
+    assert!(!fields.contains(&"mode".to_string()));
+}
+
+#[test]
+fn whitelist_filter_keeps_only_allowed_and_is_noop_when_disabled() {
+    let config = value(json!({ "proxies": [], "mode": "rule", "custom": 1 }));
+    let allow = vec!["proxies".to_string()];
+    assert_eq!(
+        whitelist_filter(&config, &allow, true).to_json(),
+        json!({ "proxies": [] })
+    );
+    assert_eq!(whitelist_filter(&config, &allow, false), config);
+}
+
+#[test]
+fn guard_inserts_override_keys_and_resolved_ports() {
+    let overrides = fixed_overrides();
+    let guard = GuardInputs {
+        overrides: &overrides,
+        ports: ResolvedPortBindings {
+            mixed_port: 7890,
+            port: None,
+            socks_port: Some(7891),
+            external_controller: Some("127.0.0.1:9090".to_string()),
+        },
+    };
+    let result = apply_guard(&value(json!({ "mode": "from-profile", "rules": [] })), &guard)
+        .unwrap()
+        .to_json();
+
+    // typed overrides 覆盖 profile 值（绕过白名单，无条件插入）。
+    assert_eq!(result["mode"], json!("rule"));
+    assert_eq!(result["log-level"], json!("info"));
+    assert_eq!(result["allow-lan"], json!(false));
+    assert_eq!(result["ipv6"], json!(false));
+    assert_eq!(result["secret"], json!("golden-secret"));
+    assert_eq!(result["unified-delay"], json!(true));
+    assert_eq!(result["tcp-concurrent"], json!(true));
+    // 预解析端口。
+    assert_eq!(result["mixed-port"], json!(7890));
+    assert_eq!(result["socks-port"], json!(7891));
+    assert_eq!(result["external-controller"], json!("127.0.0.1:9090"));
+    assert!(result.get("port").is_none()); // None → 不插键
+    // 非守卫键不动。
+    assert_eq!(result["rules"], json!([]));
+}
+
+#[test]
+fn tun_disabled_without_tun_key_is_untouched() {
+    let config = value(json!({ "proxies": [] }));
+    let result = finalize(&config, &tun_off(), false).to_json();
+    assert!(result.get("tun").is_none());
+}
+
+#[test]
+fn tun_disabled_with_existing_tun_key_forces_enable_false() {
+    let config = value(json!({ "tun": { "enable": true, "stack": "system" } }));
+    let result = finalize(&config, &tun_off(), false).to_json();
+    assert_eq!(result["tun"]["enable"], json!(false));
+    assert_eq!(result["tun"]["stack"], json!("system")); // 既有键不动
+    assert!(result.get("dns").is_none()); // 关闭时不做 dns 收尾
+}
+
+#[test]
+fn tun_enabled_standard_appends_defaults_and_dns() {
+    let params = TunParams {
+        enable: true,
+        flavor: TunFlavor::Standard { stack: TunStack::Gvisor },
+        windows_fake_ip_filter: true,
+    };
+    let config = value(json!({ "tun": { "stack": "system" }, "dns": { "nameserver": ["1.1.1.1"] } }));
+    let result = finalize(&config, &params, false).to_json();
+
+    assert_eq!(result["tun"]["enable"], json!(true));
+    assert_eq!(result["tun"]["stack"], json!("system")); // append 不覆盖用户值
+    assert_eq!(result["tun"]["dns-hijack"], json!(["any:53"]));
+    assert_eq!(result["tun"]["auto-route"], json!(true));
+    assert_eq!(result["tun"]["auto-detect-interface"], json!(true));
+    // dns 收尾：enable 覆盖写；nameserver 用户值保留；缺省键补齐。
+    assert_eq!(result["dns"]["enable"], json!(true));
+    assert_eq!(result["dns"]["nameserver"], json!(["1.1.1.1"]));
+    assert_eq!(result["dns"]["enhanced-mode"], json!("fake-ip"));
+    assert_eq!(result["dns"]["fake-ip-range"], json!("198.18.0.1/16"));
+    assert_eq!(result["dns"]["fallback"], json!([]));
+    assert_eq!(
+        result["dns"]["fake-ip-filter"],
+        json!(["dns.msftncsi.com", "www.msftncsi.com", "www.msftconnecttest.com"])
+    );
+}
+
+#[test]
+fn tun_enabled_clash_rs_uses_device_branch_and_no_windows_filter() {
+    let params = TunParams {
+        enable: true,
+        flavor: TunFlavor::ClashRs,
+        windows_fake_ip_filter: false,
+    };
+    let result = finalize(&value(json!({})), &params, false).to_json();
+    assert_eq!(result["tun"]["enable"], json!(true));
+    assert_eq!(result["tun"]["device-id"], json!("dev://utun1989"));
+    assert_eq!(result["tun"]["auto-route"], json!(true));
+    assert!(result["tun"].get("stack").is_none());
+    assert!(result["tun"].get("dns-hijack").is_none());
+    assert!(result["dns"].get("fake-ip-filter").is_none());
+}
+
+#[test]
+fn finalize_applies_include_all_cache_sort_and_stage2_filter() {
+    // include-all（mod.rs:163-248 对位）+ cache + sort + stage-2 过滤。
+    let config = value(json!({
+        "custom-unknown": 1,
+        "proxies": [ { "name": "Proxy1" }, { "name": "Proxy2" } ],
+        "proxy-providers": { "provider1": {} },
+        "proxy-groups": [
+            { "name": "GLOBAL", "type": "select", "include-all": true, "proxies": ["DIRECT"] },
+            { "name": "Plain", "type": "select", "proxies": ["DIRECT"] }
+        ],
+        "mode": "rule"
+    }));
+
+    // whitelist_enabled = true：stage-2 过滤删掉 custom-unknown。
+    let result = finalize(&config, &tun_off(), true).to_json();
+    assert!(result.get("custom-unknown").is_none());
+    let groups = result["proxy-groups"].as_array().unwrap();
+    let global = groups.iter().find(|g| g["name"] == "GLOBAL").unwrap();
+    assert!(global.get("include-all").is_none());
+    let proxies: Vec<&str> = global["proxies"].as_array().unwrap().iter().map(|p| p.as_str().unwrap()).collect();
+    assert_eq!(proxies, vec!["Proxy1", "Proxy2", "provider1", "DIRECT"]);
+    // cache：无 profile 键 → 插入缺省。
+    assert_eq!(result["profile"], json!({ "store-selected": true, "store-fake-ip": false }));
+    // sort：mode(HANDLE) 在 profile(OTHERS) 前，proxies(DEFAULT) 最后段。
+    let keys: Vec<&str> = result.as_object().unwrap().keys().map(String::as_str).collect();
+    let pos = |k: &str| keys.iter().position(|x| *x == k).unwrap();
+    assert!(pos("mode") < pos("profile"));
+    assert!(pos("profile") < pos("proxies"));
+
+    // whitelist_enabled = false：未知键保留且按原相对序追尾（差异 #2）。
+    let kept = finalize(&config, &tun_off(), false).to_json();
+    assert_eq!(kept["custom-unknown"], json!(1));
+    let keys: Vec<&str> = kept.as_object().unwrap().keys().map(String::as_str).collect();
+    assert_eq!(*keys.last().unwrap(), "custom-unknown");
+}
+
+#[test]
+fn cache_does_not_merge_into_existing_profile_key() {
+    let config = value(json!({ "profile": { "do-not-override": true } }));
+    let result = finalize(&config, &tun_off(), false).to_json();
+    assert_eq!(result["profile"], json!({ "do-not-override": true }));
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cargo test -p nyanpasu-config executor::tests::builtin`
+Expected: FAIL —— `builtin` 占位无符号
+
+- [ ] **Step 3: 实现 `builtin.rs`（完整文件）**
+
+```rust
+//! WhitelistFieldFilter / GuardOverrides / Finalizing (spec §7.4).
+//! Constants transplanted verbatim from enhance/field.rs:4-56.
+
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+
+use crate::runtime::value::{ConfigObject, ConfigValue};
+
+use super::{
+    error::RuntimePipelineError,
+    value_util::{obj_get, obj_insert},
+    GuardInputs, TunFlavor, TunParams,
+};
+
+pub(super) const HANDLE_FIELDS: [&str; 9] = [
+    "mode",
+    "port",
+    "socks-port",
+    "mixed-port",
+    "allow-lan",
+    "log-level",
+    "ipv6",
+    "secret",
+    "external-controller",
+];
+
+pub(super) const DEFAULT_FIELDS: [&str; 5] = [
+    "proxies",
+    "proxy-groups",
+    "proxy-providers",
+    "rules",
+    "rule-providers",
+];
+
+pub(super) const OTHERS_FIELDS: [&str; 31] = [
+    "dns",
+    "tun",
+    "ebpf",
+    "hosts",
+    "script",
+    "profile",
+    "payload",
+    "tunnels",
+    "auto-redir",
+    "experimental",
+    "interface-name",
+    "routing-mark",
+    "redir-port",
+    "tproxy-port",
+    "iptables",
+    "external-ui",
+    "bind-address",
+    "authentication",
+    "tls",
+    "sniffer",
+    "geox-url",
+    "listeners",
+    "sub-rules",
+    "geodata-mode",
+    "unified-delay",
+    "tcp-concurrent",
+    "enable-process",
+    "find-process-mode",
+    "skip-auth-prefixes",
+    "external-controller-tls",
+    "global-client-fingerprint",
+];
+
+/// 45-key full whitelist, DEFAULT ++ HANDLE ++ OTHERS (field.rs:58-65 order).
+pub(super) fn known_fields() -> impl Iterator<Item = &'static str> {
+    DEFAULT_FIELDS
+        .into_iter()
+        .chain(HANDLE_FIELDS)
+        .chain(OTHERS_FIELDS)
+}
+
+/// Stage-1 list: (valid ∩ OTHERS, lowercased) ++ DEFAULT; HANDLE never
+/// included — guarded fields must not come from profile output (field.rs:67-77).
+pub(super) fn stage1_fields(valid: &[String]) -> Vec<String> {
+    let mut fields: Vec<String> = valid
+        .iter()
+        .map(|field| field.to_ascii_lowercase())
+        .filter(|field| OTHERS_FIELDS.contains(&field.as_str()))
+        .collect();
+    fields.extend(DEFAULT_FIELDS.iter().map(|field| (*field).to_string()));
+    fields
+}
+
+pub(super) fn whitelist_filter(config: &ConfigValue, allow: &[String], enabled: bool) -> ConfigValue {
+    if !enabled {
+        return config.clone();
+    }
+    let Some(map) = config.as_object_arc() else {
+        return config.clone();
+    };
+    let filtered: ConfigObject = map
+        .iter()
+        .filter(|(key, _)| allow.iter().any(|allowed| allowed.as_str() == key.as_ref()))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+    ConfigValue::Object(Arc::new(filtered))
+}
+
+/// Legacy HANDLE overwrite (enhance/mod.rs:110-116): typed overrides + caller
+/// resolved ports force-inserted at top level, bypassing stage-1 whitelist.
+pub(super) fn apply_guard(
+    config: &ConfigValue,
+    guard: &GuardInputs<'_>,
+) -> Result<ConfigValue, RuntimePipelineError> {
+    let raw = serde_json::to_value(guard.overrides)
+        .map_err(|error| RuntimePipelineError::Internal(format!("encode guard overrides: {error}")))?;
+    let entries = ConfigValue::try_from(raw)
+        .map_err(|error| RuntimePipelineError::Internal(format!("convert guard overrides: {error:?}")))?;
+
+    let mut next = config.clone();
+    if let Some(map) = entries.as_object_arc() {
+        for (key, value) in map.iter() {
+            next = obj_insert(&next, key.as_ref(), value.clone());
+        }
+    }
+
+    next = obj_insert(
+        &next,
+        "mixed-port",
+        ConfigValue::Number(serde_json::Number::from(guard.ports.mixed_port)),
+    );
+    if let Some(port) = guard.ports.port {
+        next = obj_insert(&next, "port", ConfigValue::Number(serde_json::Number::from(port)));
+    }
+    if let Some(port) = guard.ports.socks_port {
+        next = obj_insert(
+            &next,
+            "socks-port",
+            ConfigValue::Number(serde_json::Number::from(port)),
+        );
+    }
+    if let Some(controller) = &guard.ports.external_controller {
+        next = obj_insert(
+            &next,
+            "external-controller",
+            ConfigValue::String(Arc::from(controller.as_str())),
+        );
+    }
+    Ok(next)
+}
+
+/// Finalizing composite node (spec §7.4): stage-2 filter → tun → include-all
+/// → cache → sort. One recorded node; changed_fields shows the net effect.
+pub(super) fn finalize(config: &ConfigValue, tun: &TunParams, whitelist_enabled: bool) -> ConfigValue {
+    let full: Vec<String> = known_fields().map(str::to_string).collect();
+    let mut next = whitelist_filter(config, &full, whitelist_enabled);
+    next = apply_tun(&next, tun);
+    next = apply_include_all(&next);
+    next = apply_cache(&next);
+    apply_sort(&next)
+}
+
+fn object_of(value: Option<&ConfigValue>) -> ConfigObject {
+    value
+        .and_then(ConfigValue::as_object_arc)
+        .map(|map| (**map).clone())
+        .unwrap_or_default()
+}
+
+fn append_default(map: &mut ConfigObject, key: &str, value: ConfigValue) {
+    if !map.contains_key(key) {
+        map.insert(Arc::from(key), value);
+    }
+}
+
+fn string_value(text: &str) -> ConfigValue {
+    ConfigValue::String(Arc::from(text))
+}
+
+fn string_list(items: &[&str]) -> ConfigValue {
+    ConfigValue::Array(Arc::from(
+        items.iter().map(|item| string_value(item)).collect::<Vec<_>>(),
+    ))
+}
+
+/// enhance/tun.rs:26-109 对位；`revise!` = 覆盖写、`append!` = 缺键补。
+fn apply_tun(config: &ConfigValue, params: &TunParams) -> ConfigValue {
+    let existing = obj_get(config, "tun");
+    if !params.enable && existing.is_none() {
+        return config.clone();
+    }
+
+    let mut tun = object_of(existing);
+    tun.insert(Arc::from("enable"), ConfigValue::Bool(params.enable));
+    if params.enable {
+        match params.flavor {
+            TunFlavor::ClashRs => {
+                append_default(&mut tun, "device-id", string_value("dev://utun1989"));
+                append_default(&mut tun, "auto-route", ConfigValue::Bool(true));
+            }
+            TunFlavor::Standard { stack } => {
+                append_default(&mut tun, "stack", string_value(stack.as_ref()));
+                append_default(&mut tun, "dns-hijack", string_list(&["any:53"]));
+                append_default(&mut tun, "auto-route", ConfigValue::Bool(true));
+                append_default(&mut tun, "auto-detect-interface", ConfigValue::Bool(true));
+            }
+        }
+    }
+
+    let mut next = obj_insert(config, "tun", ConfigValue::Object(Arc::new(tun)));
+    if params.enable {
+        next = apply_tun_dns(&next, params.windows_fake_ip_filter);
+    }
+    next
+}
+
+fn apply_tun_dns(config: &ConfigValue, windows_fake_ip_filter: bool) -> ConfigValue {
+    let mut dns = object_of(obj_get(config, "dns"));
+    dns.insert(Arc::from("enable"), ConfigValue::Bool(true));
+    append_default(&mut dns, "enhanced-mode", string_value("fake-ip"));
+    append_default(&mut dns, "fake-ip-range", string_value("198.18.0.1/16"));
+    append_default(
+        &mut dns,
+        "nameserver",
+        string_list(&["114.114.114.114", "223.5.5.5", "8.8.8.8"]),
+    );
+    append_default(
+        &mut dns,
+        "fallback",
+        ConfigValue::Array(Arc::from(Vec::<ConfigValue>::new())),
+    );
+    if windows_fake_ip_filter {
+        append_default(
+            &mut dns,
+            "fake-ip-filter",
+            string_list(&["dns.msftncsi.com", "www.msftncsi.com", "www.msftconnecttest.com"]),
+        );
+    }
+    obj_insert(config, "dns", ConfigValue::Object(Arc::new(dns)))
+}
+
+/// enhance/mod.rs:163-248 对位。
+fn apply_include_all(config: &ConfigValue) -> ConfigValue {
+    let mut names: Vec<String> = Vec::new();
+    if let Some(proxies) = obj_get(config, "proxies").and_then(ConfigValue::as_array_arc) {
+        for proxy in proxies.iter() {
+            if let Some(ConfigValue::String(name)) =
+                proxy.as_object_arc().and_then(|map| map.get("name"))
+            {
+                names.push(name.to_string());
+            }
+        }
+    }
+    if let Some(providers) = obj_get(config, "proxy-providers").and_then(ConfigValue::as_object_arc) {
+        names.extend(providers.keys().map(|key| key.to_string()));
+    }
+
+    let Some(groups) = obj_get(config, "proxy-groups").and_then(ConfigValue::as_array_arc) else {
+        return config.clone();
+    };
+    let rebuilt: Vec<ConfigValue> = groups
+        .iter()
+        .map(|group| {
+            let Some(map) = group.as_object_arc() else {
+                return group.clone();
+            };
+            let include_all = matches!(map.get("include-all"), Some(ConfigValue::Bool(true)));
+            if !include_all || !map.contains_key("name") {
+                return group.clone();
+            }
+            let existing: Vec<String> = map
+                .get("proxies")
+                .and_then(ConfigValue::as_array_arc)
+                .map(|seq| {
+                    seq.iter()
+                        .filter_map(|value| match value {
+                            ConfigValue::String(name) => Some(name.to_string()),
+                            _ => None,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let mut proxies: Vec<ConfigValue> =
+                names.iter().map(|name| string_value(name)).collect();
+            proxies.extend(
+                existing
+                    .iter()
+                    .filter(|name| !names.contains(name))
+                    .map(|name| string_value(name)),
+            );
+
+            let mut next = (**map).clone();
+            next.insert(Arc::from("proxies"), ConfigValue::Array(Arc::from(proxies)));
+            next.shift_remove("include-all");
+            ConfigValue::Object(Arc::new(next))
+        })
+        .collect();
+    obj_insert(config, "proxy-groups", ConfigValue::Array(Arc::from(rebuilt)))
+}
+
+/// enhance/mod.rs:250-261 对位：已有 `profile` 键不合并。
+fn apply_cache(config: &ConfigValue) -> ConfigValue {
+    if obj_get(config, "profile").is_some() {
+        return config.clone();
+    }
+    let mut profile: ConfigObject = IndexMap::new();
+    profile.insert(Arc::from("store-selected"), ConfigValue::Bool(true));
+    profile.insert(Arc::from("store-fake-ip"), ConfigValue::Bool(false));
+    obj_insert(config, "profile", ConfigValue::Object(Arc::new(profile)))
+}
+
+/// field.rs:115-147 对位：已知键固定 HANDLE++OTHERS++DEFAULT 序；未知键保持
+/// 原相对序追尾（修复旧 HashSet 乱序，spec §13 #2）。
+fn apply_sort(config: &ConfigValue) -> ConfigValue {
+    let Some(map) = config.as_object_arc() else {
+        return config.clone();
+    };
+    let mut next: ConfigObject = IndexMap::new();
+    for key in HANDLE_FIELDS.into_iter().chain(OTHERS_FIELDS).chain(DEFAULT_FIELDS) {
+        if let Some(value) = map.get(key) {
+            next.insert(Arc::from(key), value.clone());
+        }
+    }
+    for (key, value) in map.iter() {
+        if !next.contains_key(key.as_ref()) {
+            next.insert(key.clone(), value.clone());
+        }
+    }
+    ConfigValue::Object(Arc::new(next))
+}
+```
+
+解注释 `tests/mod.rs` 的 `mod builtin;`。
+
+- [ ] **Step 4: 跑测试 + Commit**
+
+Run: `cargo test -p nyanpasu-config executor::tests::builtin`
+Expected: PASS（11 个测试）
+
+```bash
+git add backend/nyanpasu-config/src/runtime/executor/
+git commit -m "feat(nyanpasu-config): implement builtin whitelist/guard/finalizing steps"
+```
+
+---
+
+## Task 5: 五顺序编排与录制（scoped / compose / execute）
+
+**Files:**
+
+- Rewrite: `backend/nyanpasu-config/src/runtime/executor/{scoped,compose}.rs`
+- Modify: `backend/nyanpasu-config/src/runtime/executor/mod.rs`（追加 `execute`）
+- Create: `backend/nyanpasu-config/src/runtime/executor/tests/{compose,orders}.rs`（解注释）
+
+**Interfaces:**
+
+- Consumes: Task 2/3/4 全部；`ConfigSnapshotsBuilder`、`OperatorTag`、`ConfigExecutionRole`、`BuiltinStepKind`
+- Produces:
+  - `pub fn execute(inputs: &RuntimePipelineInputs<'_>, content: &dyn ProfileContentSource, runner: &dyn ScriptRunner) -> Result<RuntimeArtifact, RuntimePipelineError>`
+  - `scoped::ScopedBuild { builder: ConfigSnapshotsBuilder, value: Arc<ConfigValue> }`
+  - `scoped::build_scoped_file(profiles, content, runner, logs, profile_id, role) -> Result<ScopedBuild, RuntimePipelineError>`
+  - `compose::run_composition(profiles, content, runner, logs, composition_id, composition) -> Result<(ConfigSnapshotsBuilder, Arc<ConfigValue>), RuntimePipelineError>`
+  - `compose::append_proxies(working, member_value, member_id, logs) -> ConfigValue`（`pub(super)`，供 11 条规则单测）
+
+- [ ] **Step 1: 写失败测试 `tests/orders.rs`（完整文件）**
+
+```rust
+use serde_json::json;
+
+use super::support::*;
+use crate::clash::config::tun_stack::TunStack;
+use crate::runtime::executor::{
+    execute, BuiltinTransform, ExecutionTarget, GuardInputs, ResolvedPortBindings,
+    RuntimePipelineError, RuntimePipelineInputs, StepLogLevel, TunFlavor, TunParams,
+};
+use crate::runtime::snapshot::{BuiltinStepKind, ConfigExecutionRole, OperatorTag};
+use crate::profile::{Profiles, ScriptRuntime};
+
+pub fn base_inputs<'a>(
+    profiles: &'a Profiles,
+    target: ExecutionTarget,
+    overrides: &'a crate::clash::config::overrides::ClashGuardOverrides,
+    builtin_transforms: &'a [BuiltinTransform],
+) -> RuntimePipelineInputs<'a> {
+    RuntimePipelineInputs {
+        profiles,
+        target,
+        guard: GuardInputs {
+            overrides,
+            ports: ResolvedPortBindings {
+                mixed_port: 7890,
+                port: None,
+                socks_port: None,
+                external_controller: None,
+            },
+        },
+        whitelist_enabled: true,
+        tun: TunParams {
+            enable: false,
+            flavor: TunFlavor::Standard { stack: TunStack::Gvisor },
+            windows_fake_ip_filter: false,
+        },
+        builtin_transforms,
+    }
+}
+
+fn overrides() -> crate::clash::config::overrides::ClashGuardOverrides {
+    super::builtin::fixed_overrides()
+}
+
+#[test]
+fn selected_file_config_records_canonical_mainline() {
+    // §7.1：root → scoped → global → whitelist → guard → builtin-transform → finalizing
+    let profiles = profiles_with(
+        Some("sub-a"),
+        &["global-fix"],
+        &["dns"],
+        vec![
+            config_file_item("sub-a", "sub-a.yaml", &["normalize"]),
+            overlay_item("normalize", "normalize.yaml"),
+            overlay_item("global-fix", "global-fix.yaml"),
+        ],
+    );
+    let content = MapContentSource::from_pairs(&[
+        ("sub-a.yaml", "proxies:\n  - name: a1\nrules: [r1]\ndns: { enable: true }\n"),
+        ("normalize.yaml", "append__rules: [r-scoped]\n"),
+        ("global-fix.yaml", "append__rules: [r-global]\n"),
+    ]);
+    let ov = overrides();
+    let builtins = vec![BuiltinTransform {
+        name: "config_fixer".to_string(),
+        runtime: ScriptRuntime::JavaScript,
+        source: "builtin-src".to_string(),
+    }];
+    let inputs = base_inputs(&profiles, ExecutionTarget::Selected(pid("sub-a")), &ov, &builtins);
+
+    let artifact = execute(&inputs, &content, &FakeScriptRunner::default()).unwrap();
+
+    let tags: Vec<_> = artifact.graph.nodes.iter().map(|node| &node.tag).collect();
+    assert!(matches!(tags[0], OperatorTag::FileConfigRoot { role: ConfigExecutionRole::Selected, .. }));
+    assert!(matches!(tags[1], OperatorTag::ScopedTransform { step_index: 0, .. }));
+    assert!(matches!(tags[2], OperatorTag::GlobalTransform { step_index: 0, .. }));
+    assert!(matches!(tags[3], OperatorTag::BuiltinStep { step: BuiltinStepKind::WhitelistFieldFilter, .. }));
+    assert!(matches!(tags[4], OperatorTag::BuiltinStep { step: BuiltinStepKind::GuardOverrides, .. }));
+    assert!(matches!(tags[5], OperatorTag::BuiltinTransform { step_index: 0, .. }));
+    assert!(matches!(tags[6], OperatorTag::BuiltinStep { step: BuiltinStepKind::Finalizing, .. }));
+    assert_eq!(artifact.graph.nodes.len(), 7);
+
+    // 语义断言：scoped + global 追加都生效，guard 覆盖 mode。
+    let config = artifact.final_config.to_json();
+    assert_eq!(config["rules"], json!(["r1", "r-scoped", "r-global"]));
+    assert_eq!(config["mode"], json!("rule"));
+    assert_eq!(config["mixed-port"], json!(7890));
+
+    // applied_fields：全局变换后采样(proxies/rules/dns)，确定序。
+    let applied: Vec<&str> = artifact.applied_fields.iter().map(String::as_str).collect();
+    assert_eq!(applied, vec!["proxies", "rules", "dns"]);
+}
+
+#[test]
+fn composition_with_base_matches_recording_contract() {
+    // §7.3 + spec §8.1：base/成员分支独立嫁接，extend 主线推进。
+    let profiles = profiles_with(
+        Some("all"),
+        &[],
+        &[],
+        vec![
+            config_file_item("base", "base.yaml", &[]),
+            config_file_item("member", "member.yaml", &[]),
+            composition_item("all", Some("base"), &["member"], &[]),
+        ],
+    );
+    let content = MapContentSource::from_pairs(&[
+        ("base.yaml", "proxies:\n  - name: b1\nrules: [r1]\n"),
+        ("member.yaml", "proxies:\n  - name: m1\nextra: dropped\n"),
+    ]);
+    let ov = overrides();
+    let inputs = base_inputs(&profiles, ExecutionTarget::Selected(pid("all")), &ov, &[]);
+
+    let artifact = execute(&inputs, &content, &FakeScriptRunner::default()).unwrap();
+    let config = artifact.final_config.to_json();
+
+    // 11 条规则：只提取 proxies、按序追加、不合并其他字段、不去重。
+    let names: Vec<&str> = config["proxies"].as_array().unwrap().iter()
+        .map(|p| p["name"].as_str().unwrap()).collect();
+    assert_eq!(names, vec!["b1", "m1"]);
+    assert_eq!(config["rules"], json!(["r1"]));
+    assert!(config.get("extra").is_none());
+
+    // 图形状（对齐 snapshot.rs composition 测试期望形态）。
+    let nodes = &artifact.graph.nodes;
+    let root = artifact.graph.root_id as usize;
+    assert!(matches!(&nodes[root].tag, OperatorTag::CompositionRoot { base: Some(_), .. }));
+    let root_children = nodes[root].next.as_deref().unwrap();
+    assert_eq!(root_children.len(), 3); // base 分支根、member 分支根、extend 步
+    let base_branch = root_children[0] as usize;
+    assert!(matches!(
+        &nodes[base_branch].tag,
+        OperatorTag::FileConfigRoot { role: ConfigExecutionRole::CompositionBase { .. }, .. }
+    ));
+    let member_branch = root_children[1] as usize;
+    assert!(matches!(
+        &nodes[member_branch].tag,
+        OperatorTag::FileConfigRoot { role: ConfigExecutionRole::CompositionContributor { .. }, .. }
+    ));
+    let extend = root_children[2] as usize;
+    assert!(matches!(&nodes[extend].tag, OperatorTag::ExtendProxiesStep { contributor_index: 0, .. }));
+}
+
+#[test]
+fn composition_without_base_starts_from_clean_seed() {
+    // §7.4：clean seed = {proxies: []}，不隐式注入其他字段。
+    let profiles = profiles_with(
+        Some("clean"),
+        &[],
+        &[],
+        vec![
+            config_file_item("member", "member.yaml", &[]),
+            composition_item("clean", None, &["member"], &[]),
+        ],
+    );
+    let content = MapContentSource::from_pairs(&[("member.yaml", "proxies:\n  - name: m1\n")]);
+    let ov = overrides();
+    let inputs = base_inputs(&profiles, ExecutionTarget::Selected(pid("clean")), &ov, &[]);
+
+    let artifact = execute(&inputs, &content, &FakeScriptRunner::default()).unwrap();
+
+    let root = artifact.graph.root_id as usize;
+    assert!(matches!(
+        &artifact.graph.nodes[root].tag,
+        OperatorTag::CompositionRoot { base: None, .. }
+    ));
+    assert_eq!(artifact.graph.nodes[root].snapshot.config, json!({ "proxies": [] }));
+    let names: Vec<&str> = artifact.final_config.to_json()["proxies"].as_array().unwrap()
+        .iter().map(|p| p["name"].as_str().unwrap()).collect();
+    assert_eq!(names, vec!["m1"]);
+}
+
+#[test]
+fn bare_target_reuses_shared_tail_with_none_selected() {
+    // §7.1 场景⑤：BareRoot → global(选中=None) → 尾部四步；产出可用裸配置。
+    let profiles = profiles_with(None, &["global-fix"], &[], vec![overlay_item("global-fix", "g.yaml")]);
+    let content = MapContentSource::from_pairs(&[("g.yaml", "injected: { a: 1 }\n")]);
+    let ov = overrides();
+    let inputs = base_inputs(&profiles, ExecutionTarget::Bare, &ov, &[]);
+
+    let artifact = execute(&inputs, &content, &FakeScriptRunner::default()).unwrap();
+
+    let tags: Vec<_> = artifact.graph.nodes.iter().map(|node| &node.tag).collect();
+    assert!(matches!(tags[0], OperatorTag::BareRoot));
+    assert!(matches!(tags[1], OperatorTag::GlobalTransform { selected_profile_id: None, .. }));
+    assert!(matches!(tags[2], OperatorTag::BuiltinStep { selected_profile_id: None, step: BuiltinStepKind::WhitelistFieldFilter }));
+
+    let config = artifact.final_config.to_json();
+    assert_eq!(config["mode"], json!("rule"));            // guard 生效
+    assert_eq!(config["mixed-port"], json!(7890));
+    assert!(config.get("injected").is_none());            // whitelist 过滤了非法注入
+    assert_eq!(config["profile"]["store-selected"], json!(true)); // cache 生效
+}
+
+#[test]
+fn script_transform_failure_is_lenient_with_anchored_error_log() {
+    let profiles = profiles_with(
+        Some("sub-a"),
+        &[],
+        &[],
+        vec![
+            config_file_item("sub-a", "sub-a.yaml", &["boom"]),
+            script_item("boom", "boom.js", ScriptRuntime::JavaScript),
+        ],
+    );
+    let content = MapContentSource::from_pairs(&[
+        ("sub-a.yaml", "proxies: []\n"),
+        ("boom.js", "explode"),
+    ]);
+    let mut runner = FakeScriptRunner::default();
+    runner.runs.insert(
+        "explode".to_string(),
+        RunReply::Fail("script exploded".to_string(), vec![]),
+    );
+    let ov = overrides();
+    let inputs = base_inputs(&profiles, ExecutionTarget::Selected(pid("sub-a")), &ov, &[]);
+
+    let artifact = execute(&inputs, &content, &runner).unwrap();
+
+    // 透传：scoped 节点值 == root 值。
+    assert_eq!(
+        artifact.graph.nodes[1].snapshot.config,
+        artifact.graph.nodes[0].snapshot.config
+    );
+    // error 日志锚定在该 ScopedTransform 节点键上。
+    let scoped_key = artifact.graph.nodes[1].key.clone();
+    let log = artifact.step_logs.iter().find(|log| log.key == scoped_key).unwrap();
+    assert!(log.entries.iter().any(|entry| entry.level == StepLogLevel::Error));
+}
+
+#[test]
+fn missing_selected_content_is_strict_error() {
+    let profiles = profiles_with(Some("sub-a"), &[], &[], vec![config_file_item("sub-a", "missing.yaml", &[])]);
+    let content = MapContentSource::from_pairs(&[]);
+    let ov = overrides();
+    let inputs = base_inputs(&profiles, ExecutionTarget::Selected(pid("sub-a")), &ov, &[]);
+
+    let error = execute(&inputs, &content, &FakeScriptRunner::default()).unwrap_err();
+    assert!(matches!(error, RuntimePipelineError::ContentSource { .. }));
+}
+
+#[test]
+fn applied_fields_keep_prefilter_known_keys_and_drop_unknown_even_unfiltered() {
+    // D9：采样点在全局变换后；∩45 无条件（enable_filter=false 时 config 保留
+    // 未知键但 applied_fields 不列——旧 mod.rs:155-157 怪癖保留）。
+    let profiles = profiles_with(
+        Some("sub-a"),
+        &[],
+        &[],
+        vec![config_file_item("sub-a", "sub-a.yaml", &[])],
+    );
+    let content = MapContentSource::from_pairs(&[
+        ("sub-a.yaml", "mode: from-profile\ncustom-unknown: 1\nproxies: []\n"),
+    ]);
+    let ov = overrides();
+    let mut inputs = base_inputs(&profiles, ExecutionTarget::Selected(pid("sub-a")), &ov, &[]);
+    inputs.whitelist_enabled = false;
+
+    let artifact = execute(&inputs, &content, &FakeScriptRunner::default()).unwrap();
+
+    // mode ∈ HANDLE ⊂ 45 → 计入(即使 stage-1 会滤掉它——采样在过滤前)；
+    // custom-unknown ∉ 45 → 不计入，但 config 里保留(whitelist 关闭)。
+    assert!(artifact.applied_fields.contains("mode"));
+    assert!(artifact.applied_fields.contains("proxies"));
+    assert!(!artifact.applied_fields.contains("custom-unknown"));
+    assert_eq!(artifact.final_config.to_json()["custom-unknown"], json!(1));
+}
+```
+
+- [ ] **Step 2: 写失败测试 `tests/compose.rs`（完整文件，11 条规则单元级）**
+
+```rust
+use serde_json::json;
+
+use super::support::pid;
+use crate::runtime::executor::compose::append_proxies;
+use crate::runtime::executor::StepLogLevel;
+use crate::runtime::value::ConfigValue;
+
+fn value(json: serde_json::Value) -> ConfigValue {
+    ConfigValue::try_from(json).unwrap()
+}
+
+#[test]
+fn append_extracts_only_proxies_in_order_without_dedup() {
+    // 规则 5/7/8/9/10：按序追加、只取 proxies、不并其他字段、不去重。
+    let mut logs = Vec::new();
+    let working = value(json!({ "proxies": [{ "name": "a" }], "rules": ["r1"] }));
+    let member = value(json!({ "proxies": [{ "name": "a" }, { "name": "b" }], "rules": ["r2"] }));
+    let result = append_proxies(&working, &member, &pid("m"), &mut logs).to_json();
+    assert_eq!(
+        result,
+        json!({ "proxies": [{ "name": "a" }, { "name": "a" }, { "name": "b" }], "rules": ["r1"] })
+    );
+    assert!(logs.is_empty());
+}
+
+#[test]
+fn member_without_proxies_warns_and_contributes_nothing() {
+    // D11（旧 merge_profiles 此处 panic，差异 #3）。
+    let mut logs = Vec::new();
+    let working = value(json!({ "proxies": [] }));
+    let member = value(json!({ "rules": [] }));
+    let result = append_proxies(&working, &member, &pid("m"), &mut logs).to_json();
+    assert_eq!(result, json!({ "proxies": [] }));
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].level, StepLogLevel::Warn);
+}
+
+#[test]
+fn working_without_proxies_creates_list_then_appends() {
+    let mut logs = Vec::new();
+    let working = value(json!({ "rules": [] }));
+    let member = value(json!({ "proxies": [{ "name": "m" }] }));
+    let result = append_proxies(&working, &member, &pid("m"), &mut logs).to_json();
+    assert_eq!(result, json!({ "rules": [], "proxies": [{ "name": "m" }] }));
+}
+
+#[test]
+fn non_sequence_working_proxies_warns_and_skips() {
+    let mut logs = Vec::new();
+    let working = value(json!({ "proxies": 3 }));
+    let member = value(json!({ "proxies": [{ "name": "m" }] }));
+    let result = append_proxies(&working, &member, &pid("m"), &mut logs).to_json();
+    assert_eq!(result, json!({ "proxies": 3 }));
+    assert_eq!(logs.len(), 1);
+}
+```
+
+- [ ] **Step 3: 跑测试确认失败**
+
+Run: `cargo test -p nyanpasu-config executor::tests::orders executor::tests::compose`
+Expected: FAIL —— `execute`/`append_proxies` 不存在
+
+- [ ] **Step 4: 实现 `scoped.rs`（完整文件）**
+
+```rust
+//! Scoped FileConfig branch: parse + own transforms; reused for the selected
+//! file, composition base and contributors (clean-design §7.1/§7.2).
+
+use std::sync::Arc;
+
+use crate::{
+    profile::{ConfigDefinition, ProfileDefinition, ProfileId, Profiles},
+    runtime::snapshot::{ConfigExecutionRole, ConfigSnapshotsBuilder, OperatorTag},
+};
+
+use super::{
+    apply_transform, parse_config_document, LogSink,
+    error::RuntimePipelineError,
+    ports::{ProfileContentSource, ScriptRunner},
+};
+use crate::runtime::value::ConfigValue;
+
+pub(super) struct ScopedBuild {
+    pub builder: ConfigSnapshotsBuilder,
+    pub value: Arc<ConfigValue>,
+}
+
+pub(super) fn build_scoped_file(
+    profiles: &Profiles,
+    content: &dyn ProfileContentSource,
+    runner: &dyn ScriptRunner,
+    logs: &mut LogSink,
+    profile_id: &ProfileId,
+    role: ConfigExecutionRole,
+) -> Result<ScopedBuild, RuntimePipelineError> {
+    let member_error = |reason: &str| match &role {
+        ConfigExecutionRole::Selected => RuntimePipelineError::SelectedProfileNotConfig(profile_id.clone()),
+        ConfigExecutionRole::CompositionBase { composition_id }
+        | ConfigExecutionRole::CompositionContributor { composition_id, .. } => {
+            RuntimePipelineError::CompositionMemberInvalid {
+                composition: composition_id.clone(),
+                member: profile_id.clone(),
+                reason: reason.to_string(),
+            }
+        }
+    };
+
+    let item = profiles.items.get(profile_id).ok_or_else(|| match &role {
+        ConfigExecutionRole::Selected => RuntimePipelineError::SelectedProfileNotFound(profile_id.clone()),
+        _ => member_error("member not found"),
+    })?;
+    let ProfileDefinition::Config {
+        config: ConfigDefinition::File(file),
+    } = &item.definition
+    else {
+        return Err(member_error("not a direct FileConfig"));
+    };
+
+    let path = file.source.materialized().file.clone();
+    let text = content
+        .read(&path)
+        .map_err(|source| RuntimePipelineError::ContentSource {
+            profile: profile_id.clone(),
+            path: path.clone(),
+            source,
+        })?;
+    let raw = parse_config_document(&text).map_err(|message| RuntimePipelineError::ParseProfile {
+        profile: profile_id.clone(),
+        message,
+    })?;
+
+    let mut value = Arc::new(raw);
+    let mut builder = ConfigSnapshotsBuilder::new_root(
+        value.clone(),
+        OperatorTag::FileConfigRoot {
+            profile_id: profile_id.clone(),
+            role: role.clone(),
+        },
+    );
+
+    for (index, transform_id) in file.transforms.iter().enumerate() {
+        let (next, kind, entries) = apply_transform(profiles, content, runner, transform_id, &value);
+        let tag = OperatorTag::ScopedTransform {
+            host_profile_id: profile_id.clone(),
+            role: role.clone(),
+            transform_profile_id: transform_id.clone(),
+            transform_kind: kind,
+            step_index: index as u32,
+        };
+        logs.extend(tag.node_key(), entries);
+        builder.push(tag, next.clone())?;
+        value = next;
+    }
+
+    Ok(ScopedBuild { builder, value })
+}
+```
+
+（注意：`scoped.rs` 的 `use super::{...}` 列表**不含** `value_util`——该文件用不到它。）
+
+- [ ] **Step 5: 实现 `compose.rs`（完整文件）**
+
+```rust
+//! Composition seed + extend_proxies_from (clean-design §7.3–7.5, 11 rules).
+
+use std::sync::Arc;
+
+use crate::{
+    profile::{CompositionConfig, ProfileId, Profiles},
+    runtime::snapshot::{ConfigExecutionRole, ConfigSnapshotsBuilder, OperatorTag},
+    runtime::value::ConfigValue,
+};
+
+use super::{
+    apply_transform, LogSink,
+    artifact::StepLogEntry,
+    error::RuntimePipelineError,
+    ports::{ProfileContentSource, ScriptRunner},
+    scoped::build_scoped_file,
+    value_util::{clean_seed, obj_get, obj_insert},
+};
+
+pub(super) fn run_composition(
+    profiles: &Profiles,
+    content: &dyn ProfileContentSource,
+    runner: &dyn ScriptRunner,
+    logs: &mut LogSink,
+    composition_id: &ProfileId,
+    composition: &CompositionConfig,
+) -> Result<(ConfigSnapshotsBuilder, Arc<ConfigValue>), RuntimePipelineError> {
+    // 规则 1/2：Some(base) → scoped base 起步；None → clean seed。
+    let (mut builder, mut working) = match &composition.base {
+        Some(base_id) => {
+            let base = build_scoped_file(
+                profiles,
+                content,
+                runner,
+                logs,
+                base_id,
+                ConfigExecutionRole::CompositionBase {
+                    composition_id: composition_id.clone(),
+                },
+            )?;
+            let working = base.value.clone();
+            let mut builder = ConfigSnapshotsBuilder::new_root(
+                working.clone(),
+                OperatorTag::CompositionRoot {
+                    profile_id: composition_id.clone(),
+                    base: Some(base_id.clone()),
+                },
+            );
+            builder.attach_independent_branch(builder.root_node_id(), base.builder)?;
+            (builder, working)
+        }
+        None => {
+            let seed = Arc::new(clean_seed());
+            let builder = ConfigSnapshotsBuilder::new_root(
+                seed.clone(),
+                OperatorTag::CompositionRoot {
+                    profile_id: composition_id.clone(),
+                    base: None,
+                },
+            );
+            (builder, seed)
+        }
+    };
+
+    // 规则 5/6：按声明序；成员先完成 scoped 解析与自身 transforms。
+    for (index, member_id) in composition.extend_proxies_from.iter().enumerate() {
+        let contributor_index = index as u32;
+        let member = build_scoped_file(
+            profiles,
+            content,
+            runner,
+            logs,
+            member_id,
+            ConfigExecutionRole::CompositionContributor {
+                composition_id: composition_id.clone(),
+                contributor_index,
+            },
+        )?;
+        builder.attach_independent_branch(builder.current_node_id(), member.builder)?;
+
+        let tag = OperatorTag::ExtendProxiesStep {
+            composition_id: composition_id.clone(),
+            contributor_profile_id: member_id.clone(),
+            contributor_index,
+        };
+        let mut entries = Vec::new();
+        working = Arc::new(append_proxies(&working, &member.value, member_id, &mut entries));
+        logs.extend(tag.node_key(), entries);
+        builder.push(tag, working.clone())?;
+    }
+
+    // composition 自身 transforms：host=composition、role=Selected（composition
+    // 只能被选中，不能作为成员——validate 保证）。
+    for (index, transform_id) in composition.transforms.iter().enumerate() {
+        let (next, kind, entries) = apply_transform(profiles, content, runner, transform_id, &working);
+        let tag = OperatorTag::ScopedTransform {
+            host_profile_id: composition_id.clone(),
+            role: ConfigExecutionRole::Selected,
+            transform_profile_id: transform_id.clone(),
+            transform_kind: kind,
+            step_index: index as u32,
+        };
+        logs.extend(tag.node_key(), entries);
+        builder.push(tag, next.clone())?;
+        working = next;
+    }
+
+    Ok((builder, working))
+}
+
+/// 规则 3/4/7/8/9/10 + D11 宽容化（缺 proxies → WARN + 空；工作配置缺键 →
+/// 建列表；非序列 → WARN + 跳过，保留用户数据）。
+pub(super) fn append_proxies(
+    working: &ConfigValue,
+    member: &ConfigValue,
+    member_id: &ProfileId,
+    logs: &mut Vec<StepLogEntry>,
+) -> ConfigValue {
+    let extracted: Vec<ConfigValue> = match obj_get(member, "proxies") {
+        Some(value) => match value.as_array_arc() {
+            Some(items) => items.to_vec(),
+            None => {
+                logs.push(StepLogEntry::warn(format!(
+                    "member {member_id} `proxies` is not a sequence, contributed nothing"
+                )));
+                Vec::new()
+            }
+        },
+        None => {
+            logs.push(StepLogEntry::warn(format!(
+                "member {member_id} has no `proxies`, contributed nothing"
+            )));
+            Vec::new()
+        }
+    };
+
+    match obj_get(working, "proxies") {
+        Some(value) => match value.as_array_arc() {
+            Some(items) => {
+                let mut next = items.to_vec();
+                next.extend(extracted);
+                obj_insert(working, "proxies", ConfigValue::Array(Arc::from(next)))
+            }
+            None => {
+                logs.push(StepLogEntry::warn(
+                    "working config `proxies` is not a sequence, append skipped",
+                ));
+                working.clone()
+            }
+        },
+        None => obj_insert(working, "proxies", ConfigValue::Array(Arc::from(extracted))),
+    }
+}
+```
+
+- [ ] **Step 6: `mod.rs` 追加 `execute`（在 `apply_transform` 之后）**
+
+```rust
+use indexmap::IndexSet;
+use crate::runtime::snapshot::{
+    BuiltinStepKind, ConfigExecutionRole, ConfigSnapshotsBuilder, OperatorTag,
+};
+
+/// Executes the full pipeline for one target (spec §7.1 table + shared tail).
+/// Strict on structural failures, lenient on transform failures (spec D7).
+pub fn execute(
+    inputs: &RuntimePipelineInputs<'_>,
+    content: &dyn ProfileContentSource,
+    runner: &dyn ScriptRunner,
+) -> Result<RuntimeArtifact, RuntimePipelineError> {
+    let mut logs = LogSink::default();
+
+    let (mut builder, mut working, selected) = match &inputs.target {
+        ExecutionTarget::Bare => {
+            let empty = Arc::new(value_util::empty_object());
+            (
+                ConfigSnapshotsBuilder::new_root(empty.clone(), OperatorTag::BareRoot),
+                empty,
+                None,
+            )
+        }
+        ExecutionTarget::Selected(id) => {
+            let item = inputs
+                .profiles
+                .items
+                .get(id)
+                .ok_or_else(|| RuntimePipelineError::SelectedProfileNotFound(id.clone()))?;
+            let ProfileDefinition::Config { config } = &item.definition else {
+                return Err(RuntimePipelineError::SelectedProfileNotConfig(id.clone()));
+            };
+            match config {
+                crate::profile::ConfigDefinition::File(_) => {
+                    let scoped = scoped::build_scoped_file(
+                        inputs.profiles,
+                        content,
+                        runner,
+                        &mut logs,
+                        id,
+                        ConfigExecutionRole::Selected,
+                    )?;
+                    (scoped.builder, scoped.value, Some(id.clone()))
+                }
+                crate::profile::ConfigDefinition::Composition(composition) => {
+                    let (builder, value) = compose::run_composition(
+                        inputs.profiles,
+                        content,
+                        runner,
+                        &mut logs,
+                        id,
+                        composition,
+                    )?;
+                    (builder, value, Some(id.clone()))
+                }
+            }
+        }
+    };
+
+    // 共享尾部（spec §7.1）：global → 采样 → whitelist → guard → builtin×N → finalizing
+    for (index, transform_id) in inputs.profiles.global_transforms.iter().enumerate() {
+        let (next, kind, entries) =
+            apply_transform(inputs.profiles, content, runner, transform_id, &working);
+        let tag = OperatorTag::GlobalTransform {
+            selected_profile_id: selected.clone(),
+            transform_profile_id: transform_id.clone(),
+            transform_kind: kind,
+            step_index: index as u32,
+        };
+        logs.extend(tag.node_key(), entries);
+        builder.push(tag, next.clone())?;
+        working = next;
+    }
+
+    // applied_fields 采样（spec D9）：此刻顶层键，小写，保持插入序。
+    let mut applied_fields: IndexSet<String> = working
+        .as_object_arc()
+        .map(|map| map.keys().map(|key| key.to_ascii_lowercase()).collect())
+        .unwrap_or_default();
+
+    let stage1 = builtin::stage1_fields(&inputs.profiles.valid);
+    working = Arc::new(builtin::whitelist_filter(&working, &stage1, inputs.whitelist_enabled));
+    builder.push(
+        OperatorTag::BuiltinStep {
+            selected_profile_id: selected.clone(),
+            step: BuiltinStepKind::WhitelistFieldFilter,
+        },
+        working.clone(),
+    )?;
+
+    working = Arc::new(builtin::apply_guard(&working, &inputs.guard)?);
+    builder.push(
+        OperatorTag::BuiltinStep {
+            selected_profile_id: selected.clone(),
+            step: BuiltinStepKind::GuardOverrides,
+        },
+        working.clone(),
+    )?;
+
+    for (index, builtin_transform) in inputs.builtin_transforms.iter().enumerate() {
+        let outcome = runner.run(builtin_transform.runtime, &builtin_transform.source, &working);
+        let tag = OperatorTag::BuiltinTransform {
+            selected_profile_id: selected.clone(),
+            name: builtin_transform.name.clone(),
+            step_index: index as u32,
+        };
+        let mut entries = outcome.logs;
+        let next = match outcome.result {
+            Ok(value) => Arc::new(value),
+            Err(error) => {
+                // Parity: builtin errors are swallowed with a log (mod.rs:136-141),
+                // now retained instead of discarded (spec §13 #7).
+                entries.push(StepLogEntry::error(error.to_string()));
+                working.clone()
+            }
+        };
+        logs.extend(tag.node_key(), entries);
+        builder.push(tag, next.clone())?;
+        working = next;
+    }
+
+    working = Arc::new(builtin::finalize(&working, &inputs.tun, inputs.whitelist_enabled));
+    builder.push(
+        OperatorTag::BuiltinStep {
+            selected_profile_id: selected.clone(),
+            step: BuiltinStepKind::Finalizing,
+        },
+        working.clone(),
+    )?;
+
+    // 旧 mod.rs:155-157 对位：∩45 无条件；IndexSet 保序（差异 #1）。
+    applied_fields.retain(|key| builtin::known_fields().any(|field| field == key));
+
+    let graph = builder.build()?;
+    Ok(RuntimeArtifact {
+        final_config: working,
+        graph,
+        step_logs: logs.into_step_logs(),
+        applied_fields,
+    })
+}
+```
+
+同时删除 `scoped.rs` 末尾的 `let _ = value_util::empty_object;` 行，解注释 `tests/mod.rs` 的 `mod compose;`/`mod orders;`。
+
+- [ ] **Step 7: 全量跑测试 + Commit**
+
+Run: `cargo test -p nyanpasu-config`
+Expected: PASS（orders 7 + compose 4 + 既有全部）
+
+```bash
+git add backend/nyanpasu-config/src/runtime/executor/
+git commit -m "feat(nyanpasu-config): implement five-order pipeline orchestration and recording"
+```
+
+---
+
+## Task 6: 五顺序 golden + 确定性
+
+**Files:**
+
+- Create: `backend/nyanpasu-config/src/runtime/executor/tests/golden.rs`（解注释）
+- Create: `backend/nyanpasu-config/src/runtime/executor/tests/fixtures/{sub_a.yaml,sub_b.yaml,build_groups.yaml,global_fix.yaml}`
+
+**Interfaces:**
+
+- Consumes: `execute` + support 构造器（Task 5 形状）
+
+- [ ] **Step 1: fixtures（四个文件，全文）**
+
+`fixtures/sub_a.yaml`:
+
+```yaml
+proxies:
+  - name: a1
+    type: ss
+    server: a.example.com
+    port: 443
+rules:
+  - MATCH,DIRECT
+dns:
+  enable: true
+```
+
+`fixtures/sub_b.yaml`:
+
+```yaml
+proxies:
+  - name: b1
+    type: vmess
+    server: b.example.com
+    port: 8080
+custom-field: dropped-by-scope
+```
+
+`fixtures/build_groups.yaml`:
+
+```yaml
+proxy-groups:
+  - name: Auto
+    type: select
+    proxies:
+      - a1
+      - b1
+```
+
+`fixtures/global_fix.yaml`:
+
+```yaml
+append__rules:
+  - 'DOMAIN,example.com,DIRECT'
+```
+
+- [ ] **Step 2: `tests/golden.rs`（完整文件）**
+
+```rust
+//! Five-order golden coverage against clean-design §6.1-shaped inputs, plus
+//! the determinism invariant (spec §10.2).
+
+use serde_json::json;
+
+use super::support::*;
+use super::orders::base_inputs;
+use crate::runtime::executor::{execute, ExecutionTarget};
+
+const SUB_A: &str = include_str!("fixtures/sub_a.yaml");
+const SUB_B: &str = include_str!("fixtures/sub_b.yaml");
+const BUILD_GROUPS: &str = include_str!("fixtures/build_groups.yaml");
+const GLOBAL_FIX: &str = include_str!("fixtures/global_fix.yaml");
+
+fn content() -> MapContentSource {
+    MapContentSource::from_pairs(&[
+        ("sub-a.yaml", SUB_A),
+        ("sub-b.yaml", SUB_B),
+        ("build-groups.yaml", BUILD_GROUPS),
+        ("global-fix.yaml", GLOBAL_FIX),
+    ])
+}
+
+/// §6.1 缩影：两个订阅、一个 base 组合、一个 clean-seed 组合、
+/// overlay transforms + global transform。
+fn golden_profiles() -> crate::profile::Profiles {
+    profiles_with(
+        Some("clean-subscriptions"),
+        &["global-fix"],
+        &["dns", "unified-delay", "tcp-concurrent"],
+        vec![
+            config_file_item("subscription-a", "sub-a.yaml", &[]),
+            config_file_item("subscription-b", "sub-b.yaml", &[]),
+            composition_item("all-subscriptions", Some("subscription-a"), &["subscription-b"], &[]),
+            composition_item("clean-subscriptions", None, &["subscription-a", "subscription-b"], &["build-groups"]),
+            overlay_item("build-groups", "build-groups.yaml"),
+            overlay_item("global-fix", "global-fix.yaml"),
+        ],
+    )
+}
+
+#[test]
+fn golden_clean_seed_composition_full_config() {
+    let profiles = golden_profiles();
+    let overrides = super::builtin::fixed_overrides();
+    let inputs = base_inputs(
+        &profiles,
+        ExecutionTarget::Selected(pid("clean-subscriptions")),
+        &overrides,
+        &[],
+    );
+
+    let artifact = execute(&inputs, &content(), &FakeScriptRunner::default()).unwrap();
+    let config = artifact.final_config.to_json();
+
+    // 完整 golden：固定 secret 下逐键断言。注意两处语义要点：
+    // ① clean seed 无 `rules` 键 → global-fix 的 `append__rules` 按旧语义
+    //    「目标不存在 → WARN 跳过」，最终配置**没有** rules 键（不隐式创建）；
+    // ② ResolvedPortBindings 的 port/socks_port/external_controller 均为
+    //    None → 对应键**不插入**（guard 只插 mixed-port）。
+    assert_eq!(
+        config,
+        json!({
+            "mode": "rule",
+            "mixed-port": 7890,
+            "allow-lan": false,
+            "log-level": "info",
+            "ipv6": false,
+            "secret": "golden-secret",
+            "profile": { "store-selected": true, "store-fake-ip": false },
+            "unified-delay": true,
+            "tcp-concurrent": true,
+            "proxies": [
+                { "name": "a1", "type": "ss", "server": "a.example.com", "port": 443 },
+                { "name": "b1", "type": "vmess", "server": "b.example.com", "port": 8080 }
+            ],
+            "proxy-groups": [
+                { "name": "Auto", "type": "select", "proxies": ["a1", "b1"] }
+            ]
+        })
+    );
+
+    // append 在缺失字段上跳过时必须留下 WARN（锚定在 GlobalTransform 节点）。
+    assert!(artifact.step_logs.iter().any(|log| {
+        log.entries.iter().any(|entry| entry.message.contains("rules"))
+    }));
+}
+
+#[test]
+fn golden_base_composition_inherits_base_fields() {
+    let profiles = golden_profiles();
+    let overrides = super::builtin::fixed_overrides();
+    let inputs = base_inputs(
+        &profiles,
+        ExecutionTarget::Selected(pid("all-subscriptions")),
+        &overrides,
+        &[],
+    );
+
+    let artifact = execute(&inputs, &content(), &FakeScriptRunner::default()).unwrap();
+    let config = artifact.final_config.to_json();
+
+    // base 的完整字段(dns/rules)继承；成员只贡献 proxies；global 追加 rules。
+    assert_eq!(config["dns"], json!({ "enable": true }));
+    assert_eq!(config["rules"], json!(["MATCH,DIRECT", "DOMAIN,example.com,DIRECT"]));
+    let names: Vec<&str> = config["proxies"].as_array().unwrap().iter()
+        .map(|p| p["name"].as_str().unwrap()).collect();
+    assert_eq!(names, vec!["a1", "b1"]);
+    // 成员 scoped 之外的字段不合并（规则 9）。
+    assert!(config.get("custom-field").is_none());
+}
+
+#[test]
+fn determinism_same_inputs_same_artifact() {
+    let profiles = golden_profiles();
+    let overrides = super::builtin::fixed_overrides();
+    let inputs = base_inputs(
+        &profiles,
+        ExecutionTarget::Selected(pid("clean-subscriptions")),
+        &overrides,
+        &[],
+    );
+
+    let first = execute(&inputs, &content(), &FakeScriptRunner::default()).unwrap();
+    let second = execute(&inputs, &content(), &FakeScriptRunner::default()).unwrap();
+    assert_eq!(first, second); // graph 节点 id、键、日志序全等
+}
+```
+
+**注意**：`golden_clean_seed_composition_full_config` 里的期望 JSON 是**按 spec §7.4 语义手推的**；首跑若与实现有出入，先判定是实现 bug 还是手推错误——语义仲裁顺序 = 旧 `enhance()` 行为（spec §4.3）→ spec §13 台账 → 修正断言。产物里若出现 `socks-port`/`port`/`external-controller` 或 `rules` 键，都是实现 bug（前者 = guard 对 `None` 插了键，后者 = `append__` 隐式创建了字段）。
+
+- [ ] **Step 3: 跑测试、修正 golden、Commit**
+
+Run: `cargo test -p nyanpasu-config executor::tests::golden`
+Expected: PASS（3 个测试；`socks-port` 键不存在于产物）
+
+```bash
+git add backend/nyanpasu-config/src/runtime/executor/tests/
+git commit -m "test(nyanpasu-config): add five-order golden and determinism coverage"
+```
+
+---
+
+## Task 7: 失效 → FullCurrent → 重建闭环
+
+**Files:**
+
+- Create: `backend/nyanpasu-config/src/runtime/executor/tests/invalidation.rs`（解注释）
+
+- [ ] **Step 1: 测试（完整文件）**
+
+```rust
+//! Invalidation → FullCurrent → re-execute loop (spec §11) with node-key
+//! anchor stability across rebuilds.
+
+use indexmap::IndexSet;
+
+use super::support::*;
+use super::orders::base_inputs;
+use crate::profile::{ProfileCategory, ProfileDependencyIndex};
+use crate::runtime::executor::{execute, ExecutionTarget, RuntimeArtifact};
+use crate::runtime::invalidation::{invalidate_profile, SnapshotRebuild};
+use crate::runtime::snapshot::SnapshotNodeKey;
+
+#[test]
+fn contributor_change_triggers_full_rebuild_with_stable_anchors() {
+    let profiles = profiles_with(
+        Some("clean"),
+        &[],
+        &[],
+        vec![
+            config_file_item("member", "member.yaml", &[]),
+            composition_item("clean", None, &["member"], &[]),
+        ],
+    );
+    let overrides = super::builtin::fixed_overrides();
+    let inputs = base_inputs(&profiles, ExecutionTarget::Selected(pid("clean")), &overrides, &[]);
+
+    // 首次构建。
+    let before = execute(
+        &inputs,
+        &MapContentSource::from_pairs(&[("member.yaml", "proxies:\n  - name: old\n")]),
+        &FakeScriptRunner::default(),
+    )
+    .unwrap();
+
+    // member 内容变更 → 失效判定（artifact 只携带物化图，stale_node_keys 的
+    // 精确锚定需要调用方保留 stored 图——PR-3 事项；这里走 None 路径覆盖
+    // rebuild 判定本身）。
+    let index = ProfileDependencyIndex::build(&profiles);
+    let invalidation = invalidate_profile(
+        &pid("member"),
+        ProfileCategory::Config,
+        Some(&pid("clean")),
+        &index,
+        None,
+    );
+    assert_eq!(invalidation.rebuild, SnapshotRebuild::FullCurrent);
+    assert!(invalidation.affected_configs.contains(&pid("clean")));
+
+    // FullCurrent → 重跑 executor（新内容）。
+    let after = execute(
+        &inputs,
+        &MapContentSource::from_pairs(&[("member.yaml", "proxies:\n  - name: new\n")]),
+        &FakeScriptRunner::default(),
+    )
+    .unwrap();
+
+    let names: Vec<&str> = after.final_config.to_json()["proxies"].as_array().unwrap()
+        .iter().map(|p| p["name"].as_str().unwrap()).collect();
+    assert_eq!(names, vec!["new"]);
+
+    // 锚点稳定：重建前后的语义位置键集合一致（UI 可对齐）。
+    let keys = |artifact: &RuntimeArtifact| -> IndexSet<SnapshotNodeKey> {
+        artifact.graph.nodes.iter().map(|node| node.key.clone()).collect()
+    };
+    assert_eq!(keys(&before), keys(&after));
+    // 但配置内容确实变了。
+    assert_ne!(
+        before.final_config.to_json()["proxies"],
+        after.final_config.to_json()["proxies"]
+    );
+}
+```
+
+- [ ] **Step 2: 跑测试 + Commit**
+
+Run: `cargo test -p nyanpasu-config executor::tests::invalidation`
+Expected: PASS
+
+```bash
+git add backend/nyanpasu-config/src/runtime/executor/tests/
+git commit -m "test(nyanpasu-config): add invalidation rebuild integration coverage"
+```
+
+---
+
+## Task 8: 旧 `enhance()` parity fixtures（无脚本路径）
+
+**Files:**
+
+- Create: `backend/nyanpasu-config/src/runtime/executor/tests/parity.rs`（解注释）
+- Create: `backend/nyanpasu-config/src/runtime/executor/tests/fixtures/parity_{single,merged,bare}_expected.yaml`
+
+**约束**：期望值由旧管线纯函数**离线**生成——临时 harness 不入库，`backend/tauri` 提交面零改动（spec T8）。fixtures 场景刻意避开 §13 会显形的差异（成员都有 `proxies`、whitelist 开、tun 关、无脚本、secret 固定），**唯一不可避开的是差异 #5**：typed `ClashGuardOverrides` 恒插 `unified-delay`/`tcp-concurrent`，而旧 HANDLE 覆盖不含这两键——parity 比较前双边剥除这两键（`normalized()`），其余键逐字节等价。
+
+- [ ] **Step 1: 临时 harness 生成期望值（不提交）**
+
+在 `backend/tauri/src/enhance/mod.rs` 的 `mod tests` 里**临时**粘贴（生成后 `git checkout -- backend/tauri` 还原）：
+
+```rust
+    /// TEMP capture harness — DO NOT COMMIT.
+    /// 按 spec §4.3 顺序用旧纯函数复现无脚本管线，打印期望 YAML。
+    #[test]
+    fn parity_capture() {
+        // 该 tests 模块已有 `use super::*;`，enhance/mod.rs 顶部的私有 glob
+        // import（field::* / tun::* / utils::merge_profiles / IndexMap / Mapping）
+        // 对子模块可见，无需新增 use。
+        let parse = |text: &str| -> Mapping { serde_yaml::from_str(text).unwrap() };
+        let guard: Mapping = parse(
+            "mode: rule\nlog-level: info\nallow-lan: false\nipv6: false\nsecret: golden-secret\nmixed-port: 7890\nunified-delay: true\ntcp-concurrent: true\n",
+        );
+        let sub_a = parse(include_str!("../../../nyanpasu-config/src/runtime/executor/tests/fixtures/sub_a.yaml"));
+        let sub_b = parse(include_str!("../../../nyanpasu-config/src/runtime/executor/tests/fixtures/sub_b.yaml"));
+
+        let run = |profiles: IndexMap<String, Mapping>| -> Mapping {
+            let valid = use_valid_fields(&["dns".into(), "unified-delay".into(), "tcp-concurrent".into()]);
+            let mut config = merge_profiles(profiles);
+            config = use_whitelist_fields_filter(config, &valid, true);
+            guard.iter()
+                .filter(|(k, _)| HANDLE_FIELDS.contains(&k.as_str().unwrap_or_default()))
+                .for_each(|(k, v)| { config.insert(k.clone(), v.clone()); });
+            let clash_fields = use_clash_fields();
+            config = use_whitelist_fields_filter(config, &clash_fields, true);
+            config = use_tun(config, false);
+            config = use_include_all_proxy_groups(config);
+            config = use_cache(config);
+            use_sort(config, true)
+        };
+
+        let mut single = IndexMap::new();
+        single.insert("a".to_string(), sub_a.clone());
+        println!("== single ==\n{}", serde_yaml::to_string(&run(single)).unwrap());
+
+        let mut merged = IndexMap::new();
+        merged.insert("a".to_string(), sub_a);
+        merged.insert("b".to_string(), sub_b);
+        println!("== merged ==\n{}", serde_yaml::to_string(&run(merged)).unwrap());
+
+        println!("== bare ==\n{}", serde_yaml::to_string(&run(IndexMap::new())).unwrap());
+    }
+```
+
+Run: `cargo test -p clash-nyanpasu --lib parity_capture -- --nocapture`
+Expected: 打印三段 YAML。把三段分别存入 `parity_single_expected.yaml` / `parity_merged_expected.yaml` / `parity_bare_expected.yaml`（nyanpasu-config fixtures 目录），然后：
+
+```bash
+git checkout -- backend/tauri
+git status --short   # 确认 backend/tauri 无残留改动
+```
+
+若 harness 因私有可见性编译失败（`field`/`utils` 模块项不是 pub），在 harness 内联相应逻辑副本（常量与函数体照抄 field.rs——它们本来就是本 crate 已移植的 45 常量与过滤/排序函数），不改动任何 tauri 源码可见性。
+
+- [ ] **Step 2: `tests/parity.rs`（完整文件）**
+
+```rust
+//! Byte-equivalence against legacy enhance() on script-free paths (spec T8).
+//! Scenarios deliberately avoid §13 divergences; script-involved end-to-end
+//! parity is handed off to PR-3 (real boa/mlua only exist in tauri).
+
+use serde_json::Value;
+
+use super::support::*;
+use super::orders::base_inputs;
+use crate::runtime::executor::{execute, ExecutionTarget};
+
+const EXPECTED_SINGLE: &str = include_str!("fixtures/parity_single_expected.yaml");
+const EXPECTED_MERGED: &str = include_str!("fixtures/parity_merged_expected.yaml");
+const EXPECTED_BARE: &str = include_str!("fixtures/parity_bare_expected.yaml");
+
+fn expected(yaml: &str) -> Value {
+    let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(yaml).unwrap();
+    normalized(serde_json::to_value(value).unwrap())
+}
+
+/// spec §13 #5：typed guard 恒插 unified-delay/tcp-concurrent，旧 HANDLE 覆盖
+/// 不含这两键——parity 比较前双边剥除，其余键逐字节等价。
+fn normalized(mut value: Value) -> Value {
+    if let Value::Object(map) = &mut value {
+        map.remove("unified-delay");
+        map.remove("tcp-concurrent");
+    }
+    value
+}
+
+fn content() -> MapContentSource {
+    MapContentSource::from_pairs(&[
+        ("sub-a.yaml", include_str!("fixtures/sub_a.yaml")),
+        ("sub-b.yaml", include_str!("fixtures/sub_b.yaml")),
+    ])
+}
+
+#[test]
+fn parity_single_file_config() {
+    let profiles = profiles_with(
+        Some("a"),
+        &[],
+        &["dns", "unified-delay", "tcp-concurrent"],
+        vec![config_file_item("a", "sub-a.yaml", &[])],
+    );
+    let overrides = super::builtin::fixed_overrides();
+    let inputs = base_inputs(&profiles, ExecutionTarget::Selected(pid("a")), &overrides, &[]);
+    let artifact = execute(&inputs, &content(), &FakeScriptRunner::default()).unwrap();
+    assert_eq!(normalized(artifact.final_config.to_json()), expected(EXPECTED_SINGLE));
+}
+
+#[test]
+fn parity_merged_equals_base_composition() {
+    // 旧 current: [a, b] ≡ 新 Composition{base: a, extend: [b]}（迁移映射语义）。
+    let profiles = profiles_with(
+        Some("all"),
+        &[],
+        &["dns", "unified-delay", "tcp-concurrent"],
+        vec![
+            config_file_item("a", "sub-a.yaml", &[]),
+            config_file_item("b", "sub-b.yaml", &[]),
+            composition_item("all", Some("a"), &["b"], &[]),
+        ],
+    );
+    let overrides = super::builtin::fixed_overrides();
+    let inputs = base_inputs(&profiles, ExecutionTarget::Selected(pid("all")), &overrides, &[]);
+    let artifact = execute(&inputs, &content(), &FakeScriptRunner::default()).unwrap();
+    assert_eq!(normalized(artifact.final_config.to_json()), expected(EXPECTED_MERGED));
+}
+
+#[test]
+fn parity_bare_mode() {
+    let profiles = profiles_with(None, &[], &["dns", "unified-delay", "tcp-concurrent"], vec![]);
+    let overrides = super::builtin::fixed_overrides();
+    let inputs = base_inputs(&profiles, ExecutionTarget::Bare, &overrides, &[]);
+    let artifact = execute(&inputs, &content(), &FakeScriptRunner::default()).unwrap();
+    assert_eq!(normalized(artifact.final_config.to_json()), expected(EXPECTED_BARE));
+}
+```
+
+- [ ] **Step 3: 跑测试；失配三分法**
+
+Run: `cargo test -p nyanpasu-config executor::tests::parity`
+Expected: PASS。若 FAIL，对每个失配键三分归因：① 实现 bug → 修实现；② 属 spec §13 台账差异（说明场景没选干净）→ 调整 fixture 场景避开；③ 台账外真实语义差异 → **停下**，把差异补进 spec §13 或修实现，二选一并在 PR 描述记录。
+
+- [ ] **Step 4: 全量回归 + Commit**
+
+Run: `cargo test -p nyanpasu-config && cargo test -p nyanpasu-config --features snapshot-persistence && git status --short`
+Expected: 全绿；`backend/tauri` 无未提交改动
+
+```bash
+git add backend/nyanpasu-config/src/runtime/executor/tests/
+git commit -m "test(nyanpasu-config): add legacy enhance parity fixtures"
+```
+
+---
+
+## Task 9: 文档回写（roadmap 勘误 + spec 状态）
+
+**Files:**
+
+- Modify: `docs/design/actor-migration-roadmap.md`（§4.4 末尾追加勘误块）
+- Modify: `docs/superpowers/specs/2026-07-04-runtime-pipeline-executor-design.md`（状态行 + §19 落实标注）
+
+- [ ] **Step 1: roadmap §4.4 表格后追加**
+
+在 `| T3p.6 | 测试:五顺序 golden 测试(对照 clean-design §6.1 YAML 示例)、与失效机制的集成(\`invalidate_profile\` → FullCurrent 重建)、**与旧 \`enhance()\` 行为对照 fixtures**(同输入产出等价配置,防语义漂移——tauri 迁移指南 §7.4 列为最高风险) | \`cargo test -p nyanpasu-config\` 全绿 |` 行之后追加：
+
+```markdown
+> **勘误(2026-07-04,executor 设计定稿,详见 `docs/superpowers/specs/2026-07-04-runtime-pipeline-executor-design.md` §19):**
+> ① T3p.1 的 `ScriptRunner` 单 `run` 方法不够——Overlay `filter__` 内嵌 per-item Lua,需另加 `eval_item_predicate`/`eval_item_expr` 两方法;
+> ② T3p.2 「六变体」实为**八变体**:新增 `BareRoot` 与 `BuiltinTransform`,且 `GlobalTransform`/`BuiltinStep` 的 `selected_profile_id` Option 化(bare 模式);
+> ③ T3p.5 所称 `get_runtime_exists_keys` 实名 `get_runtime_exists`(`ipc.rs:433-436`);
+> ④ T3p.3 Finalizing 已裁定:stage-2 45 键过滤 + tun + include-all + cache + sort 全入 executor,advice 除外;
+> ⑤ 补遗:bare 模式(`current=None`)是 executor 显式目标——旧 `enhance()` 无激活配置仍产出裸配置,启动路径依赖之。
+```
+
+- [ ] **Step 2: spec 状态行更新**
+
+`- **状态**: 设计稿（待批准；批准后按 writing-plans 拆实施计划）` 改为：
+
+```markdown
+- **状态**: 已批准；实施计划：`docs/superpowers/plans/2026-07-04-runtime-pipeline-executor.md`
+```
+
+并在 spec 文末追加实施勘误小节（若 Task 3 Step 4 的 `merge.rs` 复核产生 §7.3 表修正，一并写入）：
+
+```markdown
+## 20. 实施勘误（随实施计划落地）
+
+1. `BuiltinTransform.name/source` 与 `OperatorTag::BuiltinTransform.name` 实施为 `String`（原 §6.1/§8.2 写 `Arc<str>`；specta 派生兼容性优先）。
+2. `RuntimePipelineError` 增加 `Internal(String)` 变体承接理论不可达的 guard 序列化失败（原 §9.2 未列）。
+3. 新增实施文件：`executor/value_util.rs`、`executor/tests/support.rs`（原 §5 树未列）。
+```
+
+- [ ] **Step 3: 最终全量验证 + Commit**
+
+Run:
+
+```bash
+cargo test -p nyanpasu-config
+cargo test -p nyanpasu-config --features snapshot-persistence
+grep -rn "tokio\|std::fs\|std::net\|std::time\|target_os" backend/nyanpasu-config/src/runtime/executor/ --include="*.rs" | grep -v tests/
+git status --short
+```
+
+Expected: 测试全绿；grep 零命中（成功判据 #7）；工作区仅剩本计划各 task 的已提交内容，`backend/tauri` 干净。
+
+```bash
+git add docs/design/actor-migration-roadmap.md docs/superpowers/specs/2026-07-04-runtime-pipeline-executor-design.md
+git commit -m "docs: record runtime executor roadmap errata and spec status"
+```
+
+---
+
+## Self-Review 备忘（执行完所有 task 后过一遍）
+
+1. **spec 覆盖**：§7.1 五场景 + bare ↔ orders/golden 测试；§7.2 11 条规则 ↔ compose 测试；§7.3 指令集 ↔ overlay 测试；§7.4 三步 ↔ builtin 测试；§8.1 录制契约 ↔ orders 图形状断言；§9 artifact ↔ 类型 + applied_fields 测试；§10 错误矩阵 ↔ lenient/strict 测试；§11 ↔ invalidation 测试；§13 台账 ↔ parity 三分法；§14 T1–T9 ↔ 本计划 Task 1–9。
+2. **成功判据对账**（spec §16 九条）：#7 纯度 grep 在 Task 9 Step 3；#9 `backend/tauri` 零改动在 Task 8 Step 4 复核。
+3. **类型一致性抽查**：`ScriptRunOutcome.result`（非 tuple）、`ResolvedPortBindings.port: Option<u16>` 不插键、`SnapshotNodeKey::BuiltinTransform{selected_profile_id, step_index}`（无 name）三处最易写岔。

--- a/docs/superpowers/specs/2026-06-27-three-stateactors-nyanpasu-config-design.md
+++ b/docs/superpowers/specs/2026-06-27-three-stateactors-nyanpasu-config-design.md
@@ -1,0 +1,389 @@
+# 三 StateActor 迁移到 nyanpasu-config 设计文档
+
+- **日期**: 2026-06-27
+- **状态**: 已批准设计，待写实施计划
+- **作者**: Jonson Petard（brainstorming with Claude）
+- **关联**: 紧随 `migration 子系统 V2 + PathResolver`（PathResolver 已合并）
+
+---
+
+## 1. 摘要
+
+将现有基于旧 `IVerge` 全局单例的单一 `StateActor`，迁移为持有 `nyanpasu-config` crate 三个配置域类型的**三个独立对等 ractor Actor**：
+
+| 域                           | nyanpasu-config 类型 | Actor               | Client               |
+| ---------------------------- | -------------------- | ------------------- | -------------------- |
+| Application                  | `NyanpasuAppConfig`  | `ApplicationActor`  | `ApplicationClient`  |
+| Session（窗口/会话恢复状态） | `PersistentState`    | `SessionStateActor` | `SessionStateClient` |
+| Clash                        | `ClashConfig`        | `ClashConfigActor`  | `ClashConfigClient`  |
+
+本 spec 是**基础设施 + 迁移策略**：建三 Actor、接入 `NyanpasuClient`、定义读写超时策略、产出旧调用网络分析文档。147 处旧全局调用通过文档化的 `TODO(actor-migration)` 双向桥保持可用，实际切换分阶段后续 PR。
+
+遵循仓库 `CLAUDE.md`：无新全局单例、显式 DI、Actor 拥有可变状态、Tauri 隔离在适配器后、facade 不退化为 service locator、可迁移的破坏性改动优先于隐藏兼容层。
+
+---
+
+## 2. 目标 / 非目标
+
+### 目标
+
+- 三个独立对等 Actor，各自拥有一个 nyanpasu-config 域类型，串行化命令。
+- 三个 typed client，由 `NyanpasuClient` facade 持有并暴露稳定 async 方法。
+- 读写分离的 RPC 超时策略（写无超时、读可超时）。
+- 过渡期双向桥：Actor 为 source of truth，旧全局保持一致且可读。
+- 一份独立的「旧 IVerge 全局调用网络」分析文档，含字段映射表（覆盖率 100%）。
+- 必要图表：模块/组件图 + 读/写/reseed 三张时序图。
+- 设计为「可抽取边界」，为未来 `nyanpasu-client` crate 解耦预留。
+
+### 非目标（明确范围外，分阶段后续）
+
+- 实际切换全部 147 处旧调用、删除 `Config::verge()/clash()/...` 旧全局。
+- 真正创建 `nyanpasu-client` crate（本轮只做 Tauri-free 边界，不移动 crate）。
+- `profiles`、`runtime` 两个域的 Actor 化（维持现状）。
+- 重写 `PersistentStateManager`、`PathResolver`、migration 子系统本身。
+
+---
+
+## 3. 锁定的架构决策
+
+| #   | 决策项         | 结论                                                                                             |
+| --- | -------------- | ------------------------------------------------------------------------------------------------ |
+| D1  | 范围           | 基础设施 + 迁移策略；旧全局桥接，切换分阶段后续                                                  |
+| D2  | 拓扑           | 三个独立对等 Actor + 三个 typed client（无父监督 actor，无跨 actor 同步环）                      |
+| D3  | 过渡共存       | 双向桥：commit 后镜像写回旧全局 + 热点旧写点 reseed；各 Actor 只镜像自己字段                     |
+| D4  | 持久化 DI      | 复用泛型 `PersistentStateManager<T>`，路径改注入 `PathResolver`（不再 `dirs::`）                 |
+| D5  | 窗口域命名     | `SessionStateActor` / `SessionStateClient`（不改 nyanpasu-config 的 `PersistentState` 类型）     |
+| D6  | crate 边界     | 本 spec 只做可抽取边界（`state/`+`client/` Tauri-free）；旧全局桥接实现隔离在 tauri 侧 `bridge/` |
+| D7  | 落盘归属       | Actor 独占文件写；被 reseed 包住的旧写点 `save_file()` 改 no-op 并标 TODO                        |
+| D8  | 一次性数据迁移 | 交给 migration V2 + PathResolver（窗口字段搬迁、clash overrides 提取），必须在 spawn 前完成      |
+| D9  | 跨域编排       | 在 `NyanpasuClient` facade 上层顺序编排，禁止 Actor 直接调用另一个 Actor                         |
+
+---
+
+## 4. 现状（迁移起点）
+
+### 4.1 nyanpasu-config（纯类型 crate）
+
+- `NyanpasuAppConfig` — `nyanpasu-config/src/application/mod.rs:67`，38 字段，`#[derive(Patch)]` → `NyanpasuAppConfigPatch`。
+- `PersistentState` — `nyanpasu-config/src/state/mod.rs:14`，含 `window_state: BTreeMap<WindowLabel, WindowState>`，→ `PersistentStatePatch`。
+- `ClashConfig` — `nyanpasu-config/src/clash/config/mod.rs:27`，overrides + 端口策略，→ `ClashConfigPatch`。
+- 三者均 `serde_yaml_ng` + `specta::Type` + `struct-patch`（`skip_serializing_none` / `double_option`）。**尚未接入 PathResolver**。
+
+### 4.2 现有 Actor（仅一个真正管配置）
+
+- `StateActor` — `backend/tauri/src/state/verge.rs:46`，拥有旧 `IVerge`（全 Optional 包装类型，`backend/tauri/src/config/nyanpasu/mod.rs:193`）。
+- `StateActorState { manager: PersistentStateManager<IVerge>, mirror: VergeMirror }`，消息 `GetVerge/PatchVerge/ReplaceVerge`（均 `RpcReplyPort`）。
+- `StateClient` — `backend/tauri/src/client/state.rs`，**读写统一 5s 超时**（`STATE_RPC_TIMEOUT`，line 16）。
+- `VergeMirror` 钩子：commit 后写回 `Config::verge()` 旧全局（现有双向桥雏形，将扩到三域）。
+- Clash / 窗口状态目前**无 Actor**：`Config::clash()` 是裸 `IClashTemp(Mapping)`；窗口几何内嵌在 `IVerge.window_size_state`。
+
+### 4.3 facade 与 composition root
+
+- `NyanpasuClient` — `backend/tauri/src/client/mod.rs:19`，当前仅持有 `StateClient` + ui sink。
+- composition root：`backend/tauri/src/setup.rs` → `client::setup()`；`PathResolver`（`backend/tauri/src/utils/path.rs:39`）目前**仅 migration 子系统使用**，未提升到 composition root。
+
+### 4.4 旧 IVerge 全局调用网络（分析文档原材料，已测绘）
+
+147 处 / 27 文件：`Config::verge()` 84（57%）· `Config::clash()` 30（20%）· `Config::profiles()` 23（16%）· `Config::runtime()` 10（7%）。
+热点模块：`feat.rs`、`ipc.rs`、`core/clash/core.rs`、`utils/resolve.rs`、`core/sysopt.rs`、`core/tray/`。约 28% 为写操作（`draft→patch→apply` 链）。
+
+---
+
+## 5. 目标模块结构
+
+```text
+backend/tauri/src/
+├── state/                         # [可抽取边界 → 未来 nyanpasu-client crate；Tauri-free]
+│   ├── application.rs             # ApplicationActor   (owns NyanpasuAppConfig)
+│   ├── session_state.rs           # SessionStateActor  (owns PersistentState)
+│   ├── clash_config.rs            # ClashConfigActor   (owns ClashConfig)
+│   └── mirror.rs                  # Tauri-free trait 定义：*LegacyBridge（正反两向钩子）
+├── client/                        # [可抽取边界；Tauri-free]
+│   ├── application.rs             # ApplicationClient
+│   ├── session_state.rs           # SessionStateClient
+│   ├── clash_config.rs            # ClashConfigClient
+│   └── mod.rs                     # NyanpasuClient（facade，持三 client + 注入三 bridge）
+└── bridge/                        # [留在 tauri] 触碰 IVerge/IClashTemp/Config 的具体桥接实现
+    ├── verge.rs                   # NyanpasuAppConfig ⇄ IVerge（应用字段）
+    ├── window.rs                  # PersistentState   ⇄ IVerge.window_size_state
+    └── clash.rs                   # ClashConfig       ⇄ IClashTemp（overrides 子集）
+```
+
+**边界规则**：`state/` 与 `client/` 只依赖 `nyanpasu-config` + `nyanpasu-core` + `ractor`，**禁止 import `tauri::*` 或 `crate::config::Config`**；一切旧全局耦合走注入的 `*LegacyBridge` trait，具体实现在 `bridge/`。未来抽 crate = 机械搬移 `state/`+`client/`。
+
+---
+
+## 6. 三个 Actor（同构）
+
+每个 Actor 沿用现有 `Get/Patch/Replace` 三元组。以 Application 为例（其余同构，替换类型）：
+
+```rust
+// state/application.rs —— Tauri-free
+enum ApplicationMessage {
+    Get(RpcReplyPort<Result<Arc<NyanpasuAppConfig>>>),                 // 读
+    Patch  { patch: NyanpasuAppConfigPatch,                            // 写（struct-patch）
+             reply: RpcReplyPort<Result<Arc<NyanpasuAppConfig>>> },
+    Replace{ state: NyanpasuAppConfig,                                 // 可信全量替换（reseed 用）
+             reply: RpcReplyPort<Result<Arc<NyanpasuAppConfig>>> },
+}
+
+struct ApplicationState {
+    manager: PersistentStateManager<NyanpasuAppConfig>,   // D4：路径来自注入的 PathResolver
+    bridge:  Arc<dyn VergeLegacyBridge>,                  // D3：commit 后镜像钩子
+}
+
+struct ApplicationArgs {        // DI 边界：spawn 时注入全部依赖
+    paths:   PathResolver,
+    bridge:  Arc<dyn VergeLegacyBridge>,
+    initial: NyanpasuAppConfig,
+}
+```
+
+- **快照**返回 `Arc<T>`：读廉价、无锁共享。
+- **State 持有可变状态于 actor 内部**，不经 `Arc<Mutex<_>>` 外泄（CLAUDE.md §8）。
+- `SessionStateActor` 同构持有 `PersistentStateManager<PersistentState>` + `WindowLegacyBridge`；`ClashConfigActor` 持有 `PersistentStateManager<ClashConfig>` + `ClashLegacyBridge`。
+
+---
+
+## 7. RPC 超时策略（读写分离）
+
+| 操作                   | RPC 调用                                  | 超时                        | 理由                   |
+| ---------------------- | ----------------------------------------- | --------------------------- | ---------------------- |
+| 读 `Get`               | `actor_ref.call(Get, Some(READ_TIMEOUT))` | **有**（每域常量，默认 5s） | 读卡住可降级/报错      |
+| 写 `Patch` / `Replace` | `actor_ref.call(Patch, None)`             | **无**                      | 底层事务必须成功或失败 |
+
+**写无超时的配套不变式（强制）**：写消息 handler 内**禁止无界外部 I/O**。落盘由 `PersistentStateManager` 原子写有界完成；镜像写回是内存操作；该路径**无网络**。若未来写路径引入可能挂起的操作（如网络请求），**超时责任在 handler/listener 内部自管**，绝不上抛到 RPC 层 —— 即「写若耗时过长，是 listener 没做 timeout 处理」，而非靠 RPC 超时兜底。
+
+---
+
+## 8. 双向桥（过渡期共存）
+
+### 8.1 Mirror trait（Tauri-free 定义，tauri 侧实现）
+
+```rust
+// state/mirror.rs —— Actor 只依赖此 trait，绝不 import IVerge
+pub trait VergeLegacyBridge: Send + Sync + 'static {
+    fn mirror(&self, snap: &NyanpasuAppConfig) -> anyhow::Result<()>;  // 正向：写回 Config::verge() 内存
+    fn snapshot_legacy(&self) -> anyhow::Result<NyanpasuAppConfig>;     // 反向：旧全局 → 新类型（reseed）
+}
+// 同理 WindowLegacyBridge（PersistentState ⇄ IVerge.window_size_state）
+//      ClashLegacyBridge （ClashConfig   ⇄ IClashTemp overrides 子集）
+```
+
+`bridge/` 中实现（标 `TODO(actor-migration)`），各 Actor **只镜像自己字段**：App 写 verge 应用字段、Session 只写 `window_size_state`、Clash 只写 overrides 键 → 解决「App 与 Session 同写 `Config::verge()`」的字段归属。
+
+### 8.2 两条数据流
+
+- **正向镜像**：`Patch/Replace` → `PersistentStateManager` 原子落盘 → `bridge.mirror(&snap)` 写回旧全局内存副本，供未迁移的旧读者。
+- **反向 reseed**（处理 ~28% 旧直写）：facade `run_legacy_verge_mutation(f)` → 跑旧闭包改旧全局 → `bridge.snapshot_legacy()` 转新类型 → `client.replace(state)` 覆盖 Actor → Actor 落盘 + 幂等再镜像。被包住的旧写点不再自己 `save_file()`（D7）；未包的零散写点暂忍并标 TODO。
+
+---
+
+## 9. 一次性落盘数据迁移（交给 migration V2）
+
+genuinely-new 的跨文件搬迁，归 migration 子系统 V2 + PathResolver（非 Actor 懒加载）：
+
+- `window_size_state` 从 `verge.yaml` **搬到** SessionState 文件；并确保 `NyanpasuAppConfig` 反序列化忽略/剥离该旧键。
+- Clash overrides 从裸 `IClashTemp` Mapping **提取**成 typed `ClashConfig` 文件。
+
+**顺序约束**：migration V2 在三个 Actor spawn **之前**跑完。Actor 初始加载只读自己的 typed 文件（缺失则默认或一次性从旧全局导入）。
+
+---
+
+## 10. NyanpasuClient facade + composition root
+
+### 10.1 facade API（稳定 async 方法，示例）
+
+```rust
+client.get_app_config().await?;        client.patch_app_config(patch).await?;
+client.get_clash_config().await?;      client.patch_clash_config(patch).await?;
+client.get_session_state().await?;     client.patch_session_state(patch).await?;
+client.run_legacy_verge_mutation(f).await?;   // 过渡期 reseed 入口
+```
+
+- 跨域操作在 facade 上层**顺序编排**两次 client 调用（D9，无跨 actor 同步环）。
+- 仍是 facade 不是 service locator：**无** `resolve::<T>()` / `get_actor_ref` / `actor_registry`。
+
+### 10.2 composition root 新流程（`client::setup` / `setup.rs`）
+
+```text
+1. 构造 PathResolver（从 migration 子系统提升到 composition root，单实例共享）  → verify: 单实例
+2. 运行 migration V2 一次性落盘迁移（窗口搬迁 / clash 提取）                  → verify: 在 spawn 之前
+3. spawn 三个 Actor（Args{ PathResolver 派生路径, bridge.mirror 钩子, 初始值 }）
+4. 构造三个 client（各持 ActorRef）
+5. 构造 NyanpasuClient（持三 client + 注入三 bridge 对象）
+6. app.manage(NyanpasuClient)
+```
+
+---
+
+## 11. 字段映射要求（防静默丢失）
+
+`IVerge`（~40 字段）与 `NyanpasuAppConfig`（38）并非全等，存在 IVerge-only 字段。Actor 独占文件写后，未映射字段会被**静默丢弃**。
+
+**强制**：分析文档须含一张字段映射表，每个 `IVerge` 字段 →〔App | Session | Clash | 显式丢弃〕，**覆盖率 100%**，并据此驱动 `bridge/` 双向转换与 migration 搬迁。该映射有对应的覆盖率单测。
+
+---
+
+## 12. 图表
+
+### 12.1 模块 / 组件图
+
+```mermaid
+flowchart TB
+  subgraph cmds["Tauri 命令 / UI 适配"]
+    C1["ipc.rs / feat.rs"]
+  end
+  subgraph extractable["可抽取边界（未来 nyanpasu-client crate，Tauri-free）"]
+    NC["NyanpasuClient facade"]
+    AC["ApplicationClient"]
+    SC["SessionStateClient"]
+    CC["ClashConfigClient"]
+    AA["ApplicationActor"]
+    SA["SessionStateActor"]
+    CA["ClashConfigActor"]
+    MT["mirror traits<br/>VergeLegacyBridge / WindowLegacyBridge / ClashLegacyBridge"]
+  end
+  subgraph tauribridge["tauri 侧 bridge 实现"]
+    BV["bridge/verge.rs"]
+    BW["bridge/window.rs"]
+    BC["bridge/clash.rs"]
+  end
+  subgraph legacy["旧全局"]
+    LV["Config::verge → IVerge"]
+    LC["Config::clash → IClashTemp"]
+  end
+  subgraph infra["基础设施"]
+    PSM["PersistentStateManager&lt;T&gt;（nyanpasu-core）"]
+    PR["PathResolver"]
+    CFG["nyanpasu-config 类型"]
+  end
+  C1 --> NC
+  NC --> AC & SC & CC
+  AC --> AA
+  SC --> SA
+  CC --> CA
+  AA & SA & CA --> PSM
+  PSM --> PR
+  AA & SA & CA -. uses .-> CFG
+  AA & SA & CA -. mirror 钩子 .-> MT
+  MT -. impl .-> BV & BW & BC
+  BV --> LV
+  BW --> LV
+  BC --> LC
+```
+
+### 12.2 读时序（有超时）
+
+```mermaid
+sequenceDiagram
+  participant Cmd as Tauri 命令
+  participant NC as NyanpasuClient
+  participant Cl as ApplicationClient
+  participant A as ApplicationActor
+  Cmd->>NC: get_app_config()
+  NC->>Cl: get()
+  Cl->>A: call(Get, Some(READ_TIMEOUT))
+  A-->>Cl: Ok(Arc<NyanpasuAppConfig>)
+  Cl-->>NC: Arc<T>
+  NC-->>Cmd: config
+  Note over Cl,A: 读可超时：卡住返回 Timeout，调用方降级
+```
+
+### 12.3 写时序（无超时）
+
+```mermaid
+sequenceDiagram
+  participant Cmd as Tauri 命令
+  participant NC as NyanpasuClient
+  participant Cl as ApplicationClient
+  participant A as ApplicationActor
+  participant M as PersistentStateManager
+  participant B as VergeLegacyBridge（tauri）
+  Cmd->>NC: patch_app_config(patch)
+  NC->>Cl: patch(patch)
+  Cl->>A: call(Patch, None)
+  A->>A: validate(patch)
+  A->>M: upsert(next)（原子落盘）
+  M-->>A: Ok
+  A->>B: mirror(&next)（写回 Config::verge 内存）
+  B-->>A: Ok
+  A-->>Cl: Ok(Arc<T>)
+  Note over Cl,A: 写无 RPC 超时：事务必须成功/失败；handler 内禁止无界 I/O
+```
+
+### 12.4 旧写 reseed 时序
+
+```mermaid
+sequenceDiagram
+  participant L as 旧写点（feat.rs 等）
+  participant NC as NyanpasuClient
+  participant B as VergeLegacyBridge
+  participant Cl as ApplicationClient
+  participant A as ApplicationActor
+  L->>NC: run_legacy_verge_mutation(f)
+  NC->>NC: f()（改 Config::verge 旧全局）
+  NC->>B: snapshot_legacy()
+  B-->>NC: NyanpasuAppConfig（来自旧全局）
+  NC->>Cl: replace(state)
+  Cl->>A: call(Replace, None)
+  A->>A: commit + mirror（幂等）
+  A-->>Cl: Ok
+```
+
+---
+
+## 13. 交付物与实施顺序
+
+1. **`docs/architecture/legacy-iverge-call-network.md`（实施第 1 任务，先分析后实现）**：147 处调用清单（按 accessor/域/热点分组）+ IVerge 字段映射表（→App|Session|Clash|丢弃，覆盖率 100%）+ 分阶段切换批次建议。
+2. `nyanpasu-config` 接入 PathResolver（如需）。
+3. migration V2 增量：窗口搬迁 + clash overrides 提取。
+4. `state/mirror.rs` trait + `bridge/` 三实现（双向 + reseed）。
+5. 三 Actor（`application.rs` / `session_state.rs` / `clash_config.rs`）。
+6. 三 client + `NyanpasuClient` facade 新方法。
+7. composition root 改造（PathResolver 提升 + 顺序约束 + spawn 三 Actor）。
+8. 替换旧 `StateActor`/`StateClient`，热点旧写点用 `run_legacy_*_mutation` 包住。
+9. 测试 + 文档。
+
+---
+
+## 14. 测试策略
+
+- **每 Actor**：mock `*LegacyBridge` + temp-dir `PersistentStateManager` spawn；断言 `Get/Patch/Replace`；断言写路径 `call(_, None)` 能完成；断言读路径在 actor 卡住时 `Some(timeout)` 返回错误（测试钩子，**不 sleep**）。
+- **纯转换**：`bridge/` 双向 round-trip（`IVerge ⇄ NyanpasuAppConfig` 等）+ 字段映射覆盖率测试。
+- **同步**：用 `RpcReplyPort` ack，不用 sleep（CLAUDE.md §13）。
+- **mockable trait**：`*LegacyBridge` 兼容 `mockall::automock`。
+
+---
+
+## 15. 成功判据（可验证）
+
+1. 三 Actor 经 composition root 编译 + spawn；`NyanpasuClient` 暴露 typed 方法，无 service-locator API。
+2. 写 = `call(_, None)`、读 = `call(_, Some(_))` —— 有断言覆盖。
+3. Actor commit 后旧全局仍可读且一致（bridge 测试通过）。
+4. 字段映射表覆盖 100% IVerge 字段，无静默丢弃（覆盖率单测）。
+5. 旧 IVerge 调用网络分析文档产出。
+6. `cargo build` + `cargo test` 绿；现有行为冒烟保持。
+7. `state/`+`client/` 不含 `tauri::*` / `crate::config::Config` import（可抽取边界成立）。
+
+---
+
+## 16. 风险与缓解
+
+| 风险                                         | 缓解                                                          |
+| -------------------------------------------- | ------------------------------------------------------------- |
+| IVerge-only 字段静默丢失                     | 字段映射表 100% 覆盖 + 覆盖率单测（§11）                      |
+| verge.yaml 双写（Actor vs 旧 `save_file()`） | D7：Actor 独占文件写；桥接点旧 save no-op                     |
+| 未包的旧直写导致 Actor 快照变脏              | 热点写点 reseed；其余标 TODO 并在分析文档列入切换批次         |
+| migration 与 spawn 顺序错乱                  | composition root 顺序约束（§10.2）+ 测试                      |
+| 写无超时下 handler 真挂起                    | 不变式：写 handler 禁止无界 I/O；引入时内部自管 timeout（§7） |
+| `nyanpasu-client` 边界被意外破坏             | 成功判据 #7：import 静态检查                                  |
+
+---
+
+## 17. 假设
+
+- `profiles` / `runtime` 维持现状，不在本轮三 Actor 内。
+- `NyanpasuAppConfig` 能与现有 `verge.yaml` 字段往返（除 `window_size_state` 外迁），由字段映射表逐项确认。
+- migration V2 + PathResolver 接口稳定，足以承载本轮一次性落盘搬迁。
+- 读超时默认 5s（沿用现 `STATE_RPC_TIMEOUT`），每域常量可独立调整。

--- a/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/design.md
+++ b/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/design.md
@@ -1,0 +1,631 @@
+# PR-3(R-3) — profiles 域切换(tauri, BC)设计文档
+
+- **日期**: 2026-07-04
+- **状态**: 设计草案(待批准)
+- **作者**: Jonson Petard(design with Claude)
+- **基准**: 分支 `refactor/runtime-snapshot-store-v2` @ `d0b3cf6ac`(= main `b5b168627` + snapshot store v2)
+- **路线图定位**: `docs/design/actor-migration-roadmap.md` §4.5(PR-3)
+- **关联文档**:
+  - `docs/design/profile-composition-clean-design.md` — profiles 域模型(已实施,#4840;下文以「design §N」引用)
+  - `docs/design/profile-patch-interface.md` — 分层 patch 接口 + 事务流程(已实施)
+  - `docs/design/profile-tauri-migration-guide.md` — 逐命令迁移指南(下文以「guide §N」引用)
+  - `docs/design/profile-snapshot-store-migration.md` — snapshot store v2(PR-3-pre①)
+  - `docs/superpowers/specs/2026-06-27-three-stateactors-nyanpasu-config-design.md` — PR-2b 蓝图(超时策略/边界规则沿用)
+
+---
+
+## 1. 摘要
+
+将 tauri 的 profiles 域**一次性 BC 切换**到 `nyanpasu-config` 新域模型,不留新旧双轨:
+
+1. **数据迁移**: migration V2 `profiles` 模块新增 revision 3,legacy `profiles.yaml` → clean schema(Value 层,强制 `.bak` 备份,歧义显式失败);
+2. **状态归属**: 新建 `ProfilesActor` + `ProfilesClient`,拥有 `PersistentStateManager<Profiles>`,全部 mutation 走「clone→mutate→validate→原子持久化→commit→重建依赖索引→reconcile」事务;
+3. **文件与订阅**: `ProfileFileService`(ports + 适配器)承接物化文件读写删与订阅下载;`RemoteUpdateScheduler` + External Symlink/Mirror watcher 作为 actor 子任务,取代 `ProfilesJobGuard`;
+4. **IPC 全量 BC 重写**: 13 条 profile 命令 → 16 条新命令(`patch_profiles_config` 拆 2、`patch_profile` 拆 3),specta/TS 绑定与前端 UI 同 PR 适配;
+5. **runtime 生成切换**: `enhance()` 替换为 `RuntimeBuilder`(纯 service)+ runtime pipeline executor(PR-3-pre② 产物);产物本 PR 仍写 `Config::runtime()`(全删留给 PR-4,控制半径);
+6. **清算**: 删除 `backend/tauri/src/config/profile/**` 全目录、`Config::profiles()` accessor、`ProfilesBuilder`/`ProfileBuilder`、`ProfilesJobGuard`。
+
+遵循 roadmap §1 三条铁律:运行期共存只在桥层(本 PR 仅新增台账 B8 一处)、数据兼容只走 migration V2、前端 BC 与后端同 PR 落地。
+
+---
+
+## 2. 目标 / 非目标
+
+### 目标
+
+- profiles 域状态由 `ProfilesActor` 独占拥有,`profiles.yaml` 由其独占写。
+- 全部 13 条 profile IPC 命令迁移为 thin adapter,经 `NyanpasuClient` typed 方法调用。
+- 引用保护删除(design §17)、分层 patch(design §15)、单值 `current` + `CompositionConfig`(design §14.3)语义全部落地。
+- 订阅定时刷新与外部文件监听纳入 actor 事务后 reconcile(design §9/§10),消灭 `ProfilesJobGuard`。
+- `enhance()` 消费 legacy `Profiles` 的路径彻底移除;运行配置由 executor 从新域快照派生。
+- 前端 profiles 页在新 TS 绑定下全功能可用(`current` 单值化,多选交互改为最小 Composition 创建)。
+- 编译期保证 legacy profiles 类型零残留。
+
+### 非目标(明确范围外)
+
+- 删除 `Config::runtime()` / `IRuntime` / `generate_file()`(→ PR-4)。
+- `CoreManager` actor 化(→ PR-5);本 PR 经 `Config::runtime()` + `CoreManager::global().update_config()` 消费产物,标 TODO。
+- verge/clash/session 三域切换(→ PR-2b 及其后续批次)。
+- 前端 Composition 完整管理界面(本 PR 只做「多选创建 Composition」最小交互,完整界面后续迭代)。
+- runtime pipeline executor 本体(→ PR-3-pre②,本 PR 的硬前置,见 §3 D7 与 §17 假设)。
+- snapshot 持久化归档启用(`snapshot-persistence` feature 维持默认关闭)。
+
+---
+
+## 3. 锁定的架构决策
+
+| #   | 决策项          | 结论                                                                                                                                                                                                                |
+| --- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | 切换策略        | **一次性 BC 切换,不留双轨**:前端 TS/UI 同 PR 适配;不留 `*_v1` 命令别名(确实阻塞时按铁律 3 标 `TODO(actor-migration)` 并给删除条件——推翻 guide §7.2 的「先留别名」建议)                                              |
+| D2  | 拓扑            | `ProfilesActor` 独立对等 actor(不并入三 StateActor,修正 C1);禁止跨 actor 同步环;跨域编排在 `NyanpasuClient` facade 上层顺序进行(沿用 PR-2b D9)                                                                      |
+| D3  | 数据兼容        | 只走 migration V2 `profiles` revision 3(Value 层),在 migrate 子进程内、actor spawn **之前**完成;强制写 `profiles.yaml.bak`;任何歧义显式失败(带 uid + 字段路径),不静默丢弃                                           |
+| D4  | 持久化          | `PersistentStateManager<Profiles>`(nyanpasu-core);索引文件路径 = `PathResolver::profiles_path()`,物化文件目录 = `PathResolver::app_profiles_dir()`;不使用 `dirs::`                                                  |
+| D5  | 事务模型        | patch-interface §6 七步事务:clone→mutate→`validate()`→计算 scheduler/watcher diff→原子持久化→commit 内存→重建 `ProfileDependencyIndex` + reconcile;**commit 后副作用失败 = 降级结果,不回滚已持久化状态**            |
+| D6  | 删除策略        | 引用保护(design §17):被 `current`/`base`/`extend_proxies_from`/`transforms`/`global_transforms` 引用者拒删,返回 `ProfileInUse{引用者}`;不再有旧「删 current 后自动激活第一个」行为                                  |
+| D7  | runtime 生成    | `enhance()` → `RuntimeBuilder`(纯 service,组装 executor 输入)+ pipeline executor(PR-3-pre② 产物,**硬前置**,修正 C5);产物 `RuntimeArtifact` 本 PR 仍写入 `Config::runtime()` draft 并落 `clash-config.yaml`          |
+| D8  | 订阅调度归属    | `RemoteUpdateScheduler` + External watcher 首选实现为 **ProfilesActor 子任务**(spawn 于 actor `post_start`,随 actor 生命周期);若实施中复杂度失控可升级为独立 actor(开放点 O1),两种形态对外协议不变                  |
+| D9  | RPC 超时        | 沿用 PR-2b §7 读写分离:读 `call(Get, Some(PROFILES_READ_TIMEOUT))`(域内常量,默认 5s)、写 `call(_, None)`;**写 handler 禁无界 I/O**——订阅下载绝不在写 handler 内进行,由子任务下载完成后经内部消息提交(见 §8/图 13.4) |
+| D10 | Tauri-free 边界 | `state/profiles.rs` + `client/profiles.rs` 禁止 import `tauri::*` / `crate::config::Config`;文件系统、HTTP、脚本运行走消费方拥有的窄 ports(§7);`view_profile` 的「打开文件」UI 行为留在 IPC 层                      |
+| D11 | specta 导出     | 嵌套 tagged enum(`ProfileDefinition`/`ConfigDefinition`/`TransformDefinition`/`ProfileSource`)**逐 variant 单独命名导出**,规避 specta 2.x 递归内联限制;CI 检查 TS 产物 diff                                         |
+| D12 | PR-2b 时序      | 非硬依赖:`RuntimeBuilder` 的 `ClashGuardOverrides`/tun 等取数点,PR-2b 已合则走 `ClashConfigClient`/`ApplicationClient`,否则暂读旧全局并标 `TODO(actor-migration)`(台账 B8,PR-2b 合并后即删)                         |
+| D13 | uid 生成        | `ProfileId` 由服务端(actor 事务内)生成,碰撞安全;前端不再自造 uid                                                                                                                                                    |
+
+---
+
+## 4. 现状(迁移起点,实测锚点)
+
+### 4.1 legacy profiles 面
+
+- **类型**: `backend/tauri/src/config/profile/`(`profiles.rs:21` legacy `Profiles`,`ProfilesBuilder` 由 `derive_builder` 生成;`item/` 四变体、`builder.rs`、`item_type.rs`)。
+- **全局访问**: `Config::profiles()`(`config/core.rs:42`),全仓 23 处 / 5 文件。
+- **IPC 13 条**(`ipc.rs`): `get_profiles:102`、`enhance_profiles:128`、`import_profile:136`、`create_profile:175`、`reorder_profile:242`、`reorder_profiles_by_list:250`、`update_profile:258`、`delete_profile:265`、`patch_profiles_config:288`、`patch_profile:299`、`view_profile:345`、`read_profile_file:365`、`save_profile_file:382`。
+- **facade 现状**: `NyanpasuClient::patch_profiles_config`(`client/mod.rs:80`)为 ACL 模式——内部仍委托 `Config::profiles()` draft + `CoreManager::global().update_config()`。
+- **运行配置生成**: `enhance()`(`enhance/mod.rs:22`)直读 `Config::clash():24` / `Config::verge():27` / `Config::profiles():39`;builtin 脚本门控 `enhance/chain.rs:145`;`ChainTypeWrapper::try_from` `chain.rs:62`;产物经 `Config::generate()`(`config/core.rs:88`)写 runtime draft,`generate_file`(`:70`)落 `clash-config.yaml`。
+- **定时订阅**: `ProfilesJob`/`ProfilesJobGuard`(`core/tasks/jobs/profiles.rs:49,55`),cron diff 式 `refresh()`(`:118`)。
+- **手动时间戳**: `feat::update_profile`(`feat.rs:441` 附近)对 Local/Merge/Script 手工 patch `updated`。
+
+### 4.2 新域模型(已合并,#4840)
+
+`backend/nyanpasu-config/src/profile/` 全套齐备:`profiles.rs:12`(`Profiles`,`validate():128`、`sanitize_top_level():86`)、`definition.rs`、`source.rs`(`RemoteProfileOptions:106` + Patch)、`metadata.rs:6`(+ Patch)、`patch.rs`(分层 mutator + list-ops)、`dependency.rs:10`(`ProfileDependencyIndex`)、`path.rs`(`ManagedProfilePath`)、`id.rs`(`ProfileId`)。测试 7 组(round_trip/validation/sanitize/mutators/两 patch/dependency)。
+
+### 4.3 runtime 模块(数据半已合,执行半待 PR-3-pre②)
+
+- snapshot store v2(当前分支): `ConfigSnapshotsBuilder`(`runtime/snapshot.rs:354`)、`invalidate_profile`(`runtime/invalidation.rs:38`)、`SnapshotRebuild::FullCurrent`(`:21`)。
+- **executor 尚不存在**——五种处理顺序(design §7.1–7.5)、三个 BuiltinStep 真实逻辑、`ProfileContentSource`/`ScriptRunner` ports、`RuntimeArtifact` 输出均为 PR-3-pre② 交付物,是本 PR 的硬前置。
+
+### 4.4 migration V2(已合并,#4824)
+
+- `core/migration/registry.rs:4` 注册 `profiles`/`app_config`/`storage` 三模块;`MigrationStep` trait(`mod.rs:83`,含 `revision`/`run`/`rollback`)。
+- `modules/profiles.rs` 已有 revision 1(`profiles/null_value`,`:47`)、revision 2(`profiles/script_newtype`,`:114`)——**本 PR 新增 revision 3**。
+- 端到端 fixture 测试样板: `runner.rs:367`(1.6.1→2.0)。
+
+### 4.5 前端消费点(代表锚点)
+
+- 生成绑定: `frontend/interface/src/ipc/bindings.ts:118`(`patch_profiles_config`)。
+- hook: `frontend/interface/src/ipc/use-profile.ts:167`。
+- `current` 多值消费: `frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/active-button.tsx:21`(`data?.current?.find(...)`)。
+
+---
+
+## 5. 目标模块结构
+
+```text
+backend/tauri/src/
+├── state/
+│   ├── profiles.rs               # ProfilesActor(owns PersistentStateManager<Profiles>
+│   │                             #   + ProfileDependencyIndex + scheduler/watcher 子任务句柄)
+│   │                             # 消费方拥有的 ports: ProfileFsPort / SubscriptionFetcher / RebuildNotifier
+│   └── ...                       # (PR-2b 三 actor,与本 PR 无文件重叠)
+├── client/
+│   ├── profiles.rs               # ProfilesClient(typed,读 Some(5s) / 写 None)
+│   └── mod.rs                    # NyanpasuClient 新增 profiles 域方法 + rebuild_running_config()
+├── service/
+│   └── profile_file.rs           # ProfileFileService:ProfileFsPort + SubscriptionFetcher 具体实现
+│                                 # (fs 原子写 / 符号链接检查 / YAML 规范化 / reqwest 下载)
+├── enhance/                      # 重写为 RuntimeBuilder 适配层:
+│   ├── mod.rs                    #   RuntimeBuilder(纯 service,组装 executor 输入,调 executor)
+│   ├── content_source.rs         #   ProfileContentSource 适配器(读物化文件,PathResolver 派生)
+│   └── script/                   #   ScriptRunner 适配器(收编现有 boa/lua runner)
+└── core/migration/modules/
+    └── profiles.rs               # + revision 3: legacy schema → clean schema
+
+删除:
+├── config/profile/**             # legacy 四变体 + builder + item_type + profiles
+├── core/tasks/jobs/profiles.rs   # ProfilesJobGuard(职责移交 RemoteUpdateScheduler)
+└── Config::profiles() accessor / ManagedState<Profiles> / client/mod.rs:80 旧 patch_profiles_config
+```
+
+**边界规则**(沿用 PR-2b §5): `state/profiles.rs` + `client/profiles.rs` 只依赖 `nyanpasu-config` + `nyanpasu-core` + `ractor` + ports;`ProfileFileService` 与 `enhance/` 适配器允许 fs/网络,但同样不依赖 `tauri::*`;`view_profile` 打开文件的 `AppHandle` 用法留在 `ipc.rs`。
+
+---
+
+## 6. ProfilesActor 设计
+
+### 6.1 消息协议
+
+```rust
+// state/profiles.rs —— Tauri-free
+pub enum ProfilesMessage {
+    // ── 读(call(_, Some(PROFILES_READ_TIMEOUT))) ──
+    Get(RpcReplyPort<Result<Arc<Profiles>, ProfilesError>>),
+
+    // ── 写(call(_, None);全部走 §6.3 事务) ──
+    Add        { item: NewProfileRequest, initial_file: Option<String>,
+                 reply: RpcReplyPort<Result<CommitReport, ProfilesError>> },
+    Delete     { uid: ProfileId, reply: RpcReplyPort<Result<CommitReport, ProfilesError>> },
+    Reorder    { op: ReorderOp,  reply: RpcReplyPort<Result<CommitReport, ProfilesError>> },
+    PatchMetadata      { uid: ProfileId, patch: ProfileMetadataPatch,      reply: ... },
+    PatchRemoteOptions { uid: ProfileId, patch: RemoteProfileOptionsPatch, reply: ... },
+    ReplaceDefinition  { uid: ProfileId, definition: ProfileDefinition,    reply: ... },
+    SetCurrent         { current: Option<ProfileId>,                       reply: ... },
+    SetGlobalTransforms{ ids: Vec<ProfileId>,                              reply: ... },
+    Replace            { profiles: Profiles,                               reply: ... }, // 可信全量替换
+
+    // ── 长任务触发(reply 挂起,下载在子任务内完成后经内部消息回填) ──
+    RefreshRemote { uid: ProfileId, patch: Option<RemoteProfileOptionsPatch>,
+                    reply: RpcReplyPort<Result<CommitReport, ProfilesError>> },
+
+    // ── 内部消息(不出现在 client API) ──
+    CommitRefreshed     { uid: ProfileId, outcome: RefreshOutcome },
+    ExternalFileChanged { uid: ProfileId },
+}
+
+pub enum ReorderOp { Move { active: ProfileId, over: ProfileId }, ByList(Vec<ProfileId>) }
+
+pub struct CommitReport {
+    pub snapshot: Arc<Profiles>,
+    pub affects_current: bool,     // 依赖索引判定:current 传递闭包是否被本次提交触及
+}
+```
+
+### 6.2 State 与 Args(DI 边界)
+
+```rust
+pub struct ProfilesActorState {
+    manager:  PersistentStateManager<Profiles>,   // D4:路径来自注入的 PathResolver
+    index:    ProfileDependencyIndex,             // 派生数据,每次 commit 后全量重建(design §16)
+    fs:       Arc<dyn ProfileFsPort>,             // 物化文件读/写/删/原子替换/链接检查
+    fetcher:  Arc<dyn SubscriptionFetcher>,       // 订阅下载(网络超时自管)
+    notifier: Arc<dyn RebuildNotifier>,           // 后台提交(定时/watcher)触发的重建通知
+    scheduler: RemoteUpdateScheduler,             // 子任务:定时表 + watcher 句柄(D8)
+    pending_refresh: HashMap<ProfileId, RpcReplyPort<...>>, // RefreshRemote 挂起的 reply
+}
+
+pub struct ProfilesActorArgs {
+    pub paths:    PathResolver,
+    pub fs:       Arc<dyn ProfileFsPort>,
+    pub fetcher:  Arc<dyn SubscriptionFetcher>,
+    pub notifier: Arc<dyn RebuildNotifier>,
+    pub initial:  Profiles,        // migrate 子进程完成 revision 3 后加载
+}
+```
+
+- 快照返回 `Arc<Profiles>`,读廉价无锁。
+- `post_start`: 全量重建依赖索引 → scheduler 首次 reconcile(为每个 Remote 文件型 Profile upsert `profile-update:{uid}`,为每个 External binding 建 watcher)。
+- **单一写者**: `profiles.yaml` 与全部托管物化文件的写入只发生在 actor 消息处理内或其派生子任务(经内部消息串行提交),天然取代旧 `Arc<RwLock<ProfilesJob>>`。
+
+### 6.3 写事务(每条写消息同构)
+
+```text
+clone 当前 Profiles
+→ 应用修改(patch.rs 分层 mutator:apply_metadata_patch / set_definition / set_current / list-ops …)
+→ validate()(design §13.2;失败 → Err(ValidationFailed),内存/磁盘均不变)
+→ 计算 scheduler/watcher diff(Remote 集合、External 集合前后对比)
+→ manager 原子持久化 profiles.yaml
+→ 提交内存快照
+→ 重建 ProfileDependencyIndex
+→ reconcile(upsert/remove 定时任务、建/拆 watcher;文件副作用:Add 写初始文件、Delete 清物化文件)
+→ 回 CommitReport{snapshot, affects_current}
+```
+
+commit 之后的 reconcile / 文件清理失败**不回滚**已持久化状态,以降级错误(或 `CommitReport` 内 warning 字段,实施时定)上报(D5)。
+
+### 6.4 运行配置重建的触发路径(避免跨 actor 环)
+
+- **IPC 驱动的写**: actor 只返回 `CommitReport.affects_current`;由 `NyanpasuClient` facade 在调用侧判断并顺序调用 `rebuild_running_config()`(PR-2b D9 的 facade 编排,actor 不反向调用 facade)。
+- **后台驱动的提交**(定时刷新、External watcher): actor 在 commit 后经注入的 `RebuildNotifier`(fire-and-forget 窄 port,composition root 把它接到 facade 的重建入口)发出通知。actor 自身不知道 facade 存在。
+
+---
+
+## 7. Ports 与 ProfileFileService
+
+消费方(`state/profiles.rs`)拥有 trait 定义,`service/profile_file.rs` 提供具体实现;全部兼容 `mockall::automock`:
+
+```rust
+#[cfg_attr(test, mockall::automock)]
+pub trait ProfileFsPort: Send + Sync + 'static {
+    fn read(&self, path: &ManagedProfilePath) -> anyhow::Result<String>;
+    fn write_atomic(&self, path: &ManagedProfilePath, content: &str) -> anyhow::Result<()>;
+    fn remove(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
+    /// Remote 更新器写入前防御:目标不得是意外符号链接(design §9 末段)
+    fn ensure_not_symlink(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
+    fn ensure_symlink(&self, path: &ManagedProfilePath, target: &ExternalProfilePath) -> anyhow::Result<()>;
+}
+
+#[cfg_attr(test, mockall::automock)]
+pub trait SubscriptionFetcher: Send + Sync + 'static {
+    /// 网络超时在实现内部自管(D9);返回内容 + 从响应头解析的 SubscriptionInfo
+    async fn fetch(&self, url: &Url, options: &RemoteProfileOptions)
+        -> anyhow::Result<FetchedSubscription>;
+}
+
+#[cfg_attr(test, mockall::automock)]
+pub trait RebuildNotifier: Send + Sync + 'static {
+    fn request_rebuild(&self);   // fire-and-forget;去抖由接收侧负责
+}
+```
+
+`RemoteUpdateScheduler`(actor 子任务,D8)职责:
+
+- 维护 `profile-update:{uid}` 定时表(间隔 = `update_interval_minutes`),到期向 actor `cast(RefreshRemote 内部触发)`;
+- 维护 External Symlink/Mirror watcher(design §10):Symlink 监听 target 真实路径、变化即失效;Mirror 监听 target、变化后临时文件 + 校验 + 原子替换镜像副本;
+- reconcile 幂等:每次 commit 后按 diff 增删任务/监听(design §9,测试 design §18 第 22 条)。
+
+下载-提交分离(D9 关键):`RefreshRemote` handler 不做网络 I/O——把 reply 存入 `pending_refresh`,spawn 下载任务;任务完成后 `cast(CommitRefreshed)`,actor 在该消息内走 §6.3 事务(更新 `MaterializedFile.updated_at` / `SubscriptionInfo`)并结清挂起的 reply。下载失败同样经 `CommitRefreshed` 回错,不留悬挂 reply。
+
+---
+
+## 8. RuntimeBuilder(enhance 替换)
+
+`RuntimeBuilder` 是纯 service:自身无状态、无全局读,所有输入显式传参;executor(PR-3-pre②)在 `nyanpasu-config` 内保持无 IO。
+
+```rust
+pub struct RuntimeBuildInput {
+    pub profiles: Arc<Profiles>,                       // ProfilesClient 快照
+    pub guard_overrides: ClashGuardOverrides,          // D12:ClashConfigActor 或旧全局(TODO, B8)
+    pub finalize_params: FinalizeParams,               // tun / clash_fields / valid 等(来源同上)
+    pub builtins: Vec<BuiltinTransform>,               // chain.rs:145 按 ClashCore bitflags 组装后传入
+}
+// RuntimeBuilder::build(input, content_source, script_runner) -> Result<RuntimeArtifact>
+```
+
+- `ProfileContentSource` 适配器按 `ManagedProfilePath` 读物化文件(`enhance/content_source.rs`);`ScriptRunner` 适配器收编现 `enhance/script/{js,lua,runner}.rs` 的 boa/lua 运行器。
+- executor 按 design §7.1–7.5 五种顺序执行,经 `ConfigSnapshotsBuilder` 记录快照图,输出 `RuntimeArtifact { final_config, graph, step_logs, applied_fields }`——覆盖旧 `IRuntime{config, exists_keys, postprocessing_output}` 的全部消费(含前端 `get_postprocessing_output`)。
+- **本 PR 的产物落点(D7)**: `Config::generate()`(`config/core.rs:88`)改为调用 `RuntimeBuilder`,产物仍写 `Config::runtime()` draft 并 `generate_file()` 落 `clash-config.yaml`,随后 `CoreManager::global().update_config()`。这两处旧全局消费各标:
+
+```rust
+// TODO(actor-migration): temporary bridge to Config::runtime()/CoreManager.
+// Reason: runtime derivation cleanup is PR-4, core lifecycle is PR-5.
+// Remove when: PR-4 lands RuntimeArtifact in SimpleStateManager; PR-5 lands CoreActor.
+```
+
+---
+
+## 9. IPC 全量 BC 切换(13 → 16 条)
+
+全部命令改为 thin adapter:解析 DTO → 调 `NyanpasuClient` → 映射域错误。`uid: String` 在边界解析为 `ProfileId`。
+
+| 旧命令(锚点)                       | 新命令                                                                                          | facade 方法                                                                     | BC 要点                                                                                                                                               |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get_profiles`(`ipc.rs:102`)       | `get_profiles`                                                                                  | `get_profiles()`                                                                | 返回新 `Profiles`;TS 类型全换(§11)                                                                                                                    |
+| `enhance_profiles`(`:128`)         | `enhance_profiles`                                                                              | `rebuild_running_config()`                                                      | 不再直调 `CoreManager::global()`                                                                                                                      |
+| `import_profile`(`:136`)           | `import_profile`                                                                                | `add_profile(...)` (+ 条件 `activate_profile`)                                  | `RemoteProfileOptionsBuilder` → `RemoteProfileOptionsPatch`;自动激活条件 `current == None`                                                            |
+| `create_profile`(`:175`)           | `create_profile`                                                                                | `add_profile(NewProfileRequest, file_data)`                                     | `ProfileBuilder` 四变体废弃;自动激活条件 = `ProfileDefinition::Config(_)`(含 Composition);uid 服务端生成(D13)                                         |
+| `reorder_profile`(`:242`)          | `reorder_profile`                                                                               | `reorder_profile(active, over)`                                                 | `ReorderOp::Move`                                                                                                                                     |
+| `reorder_profiles_by_list`(`:250`) | `reorder_profiles_by_list`                                                                      | `reorder_profiles_by_list(Vec<ProfileId>)`                                      | `ReorderOp::ByList`                                                                                                                                   |
+| `update_profile`(`:258`)           | `update_profile`                                                                                | `refresh_profile(uid, patch)`                                                   | Remote:下载→校验→原子替换,`updated_at`/`subscription` 由更新器写入;非 Remote 文件型返回错误(旧「手工 patch updated」取消);`feat::update_profile` 删除 |
+| `delete_profile`(`:265`)           | `delete_profile`                                                                                | `delete_profile(uid)`                                                           | **引用保护**(D6);文件清理按 binding 类型(图 13.5)                                                                                                     |
+| `patch_profiles_config`(`:288`)    | **拆** `activate_profile` + `set_global_transforms`                                             | `activate_profile(Option<ProfileId>)` / `set_global_transforms(Vec<ProfileId>)` | `ProfilesBuilder` 废弃;`current` 单值;global_transforms 只收 Transform,违规 → `ValidationFailed`                                                      |
+| `patch_profile`(`:299`)            | **拆** `patch_profile_metadata` + `patch_remote_profile_options` + `replace_profile_definition` | 同名三方法                                                                      | 分层 patch(design §15):metadata/options 稀疏 patch(`double_option` 三态),variant 切换走 definition 原子替换;variant 不匹配不再静默忽略 → 错误         |
+| `view_profile`(`:345`)             | `view_profile`                                                                                  | `get_profile_materialized_path(uid)`                                            | 返回绝对路径由 IPC 层 `help::open_file`;Composition → `ProfileHasNoFile`                                                                              |
+| `read_profile_file`(`:365`)        | `read_profile_file`                                                                             | `read_profile_file(uid)`                                                        | 分支按 `definition`(Config::File 规范化 / Overlay 原文 / Script 原文);Composition → `ProfileHasNoFile`                                                |
+| `save_profile_file`(`:382`)        | `save_profile_file`                                                                             | `save_profile_file(uid, data)`                                                  | 仅 Local/Managed 可写;Remote(更新器独占)/External(外部编辑器负责)/Composition 拒绝                                                                    |
+
+**域错误集**(IPC 边界映射为命令错误): `ProfileNotFound`、`ProfileInUse { referrers }`、`ProfileHasNoFile`、`ValidationFailed(Vec<ProfileValidationError>)`、`NotARemoteProfile`、`FileNotWritable { reason }`、`RefreshFailed { source }`。
+
+---
+
+## 10. migration V2 — `profiles` revision 3
+
+注册于 `core/migration/modules/profiles.rs`(现 revision 1/2 之后),Value 层操作,规则 = guide §6 / design §14:
+
+| 规则          | 内容                                                                                                                                                                                                                          |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 类型映射      | `local→Config/File(Local/Managed)`、`remote→Config/File(Remote)`、`merge→Transform/Overlay`、`script→Transform/Script`                                                                                                        |
+| 字段移动      | 顶层 `chain→global_transforms`;`local/remote.chain→File.transforms`;`script_type→Script.runtime`;`file+updated→MaterializedFile{file, updated_at}`;`remote.url/option/extra→ProfileSource::Remote{url, option, subscription}` |
+| 兼容细节      | `extra.expire: 0 → None`;`update_interval → update_interval_minutes`;旧 `file` 为 HTTP(S) URL → 按旧 type 定新定义、URL 入 `source.url`、生成 `ManagedProfilePath`(design §14.2)                                              |
+| multi-current | 缺失/`[]`→`None`;`[a]`→`Some(a)`;`[a,b,c]`→新建 `CompositionConfig{base:Some(a), extend:[b,c]}`(碰撞安全 uid,名 "Combined Profile"),`current` 指向之;顺序原样保留;成员无法映射为 FileConfig → **显式失败**                    |
+| 安全          | 迁移前写 `profiles.yaml.bak`;任何歧义返回 `MigrationError{uid, field_path}` 中止(D3);幂等可重入(revision 账本判定)                                                                                                            |
+| 收尾          | 反序列化为新 `Profiles` → `validate()` + 路径/URL/interval 校验 → 原子写回(design §14.4)                                                                                                                                      |
+
+时序保证:migrate 子进程(`lib.rs:120` 既有机制)在主进程 spawn `ProfilesActor` 之前完成 revision 3;actor 初始加载只读新 schema,新类型永不解析旧 wire 格式(铁律 2)。
+
+---
+
+## 11. specta/TS 绑定与前端改造(同 PR,BC)
+
+| 旧 TS                              | 新 TS                                                                                            | 变更                                    |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------- |
+| `Profiles.current: string[]`       | `current: string \| null`                                                                        | 多值 → 单值                             |
+| `Profiles.chain: string[]`         | `global_transforms: string[]`                                                                    | 重命名 + 只收 Transform                 |
+| `Profiles.items: Profile[]`        | `items: ProfileItem[]`(uid 为字段,序列化仍为数组)                                                | 内存 IndexMap;重复 uid 反序列化报错     |
+| `Profile` 四变体 union             | `ProfileItem{uid, metadata, definition}` + 逐 variant 命名导出(D11)                              | 完全重构                                |
+| `ProfileBuilder`/`ProfilesBuilder` | `NewProfileRequest` / `ProfileMetadataPatch` / `RemoteProfileOptionsPatch` / `ProfileDefinition` | 按操作拆分;`ProfilesBuilder` 破坏性删除 |
+
+前端改造(最小集):
+
+1. `bindings.ts` 重新生成(命令集 13→16);`use-profile.ts:167` 等 hook 改调新命令;
+2. `current` 单值化:`active-button.tsx:21` 一类 `current.find(...)` → `current === uid`;
+3. 多选激活交互 → 「选中多个 File Config 时提示创建 Composition」的最小流程(完整 Composition 管理界面为后续迭代,非目标);
+4. profile 编辑对话框按 definition 分支渲染(metadata / remote options / definition 替换三类操作分开提交)。
+
+---
+
+## 12. 组件图
+
+```mermaid
+flowchart TB
+  subgraph fe["前端"]
+    UI["profiles 页 / use-profile.ts<br/>(current 单值化, 新绑定)"]
+  end
+  subgraph cmds["Tauri 命令层(thin adapter)"]
+    IPC["ipc.rs:16 条 profile 命令(BC 重写)"]
+  end
+  subgraph extractable["可抽取边界(Tauri-free)"]
+    NC["NyanpasuClient facade<br/>+ rebuild_running_config()"]
+    PC["ProfilesClient"]
+    PA["ProfilesActor<br/>PersistentStateManager&lt;Profiles&gt;<br/>+ ProfileDependencyIndex"]
+    SCH["RemoteUpdateScheduler<br/>+ External watcher(actor 子任务)"]
+    RB["RuntimeBuilder(纯 service)"]
+  end
+  subgraph ports["ports(消费方拥有的 trait)"]
+    FSP["ProfileFsPort"]
+    SF["SubscriptionFetcher"]
+    RN["RebuildNotifier"]
+    PCS["ProfileContentSource"]
+    SR["ScriptRunner"]
+  end
+  subgraph svc["适配器实现"]
+    PFS["service/profile_file.rs<br/>ProfileFileService(fs + reqwest)"]
+    ECS["enhance/content_source.rs"]
+    ESR["enhance/script/(boa / lua)"]
+  end
+  subgraph cfg["nyanpasu-config(纯)"]
+    DM["profile 域模型<br/>validate / sanitize / patch / 依赖索引"]
+    EX["runtime pipeline executor<br/>(PR-3-pre②, 硬前置)"]
+  end
+  subgraph legacy["遗留消费(本 PR 保留, 标 TODO → PR-4/5 删)"]
+    RT["Config::runtime() + clash-config.yaml"]
+    CM["CoreManager::global().update_config()"]
+  end
+  UI --> IPC --> NC
+  NC --> PC --> PA
+  PA --> SCH
+  PA -. uses .-> DM
+  PA --> FSP & RN
+  SCH --> SF & FSP
+  NC --> RB
+  RB --> EX
+  RB --> PCS
+  EX -. 回调 .-> SR
+  FSP -. impl .-> PFS
+  SF  -. impl .-> PFS
+  PCS -. impl .-> ECS
+  SR  -. impl .-> ESR
+  RB --> RT --> CM
+  RN -. 接线到 .-> NC
+```
+
+---
+
+## 13. 时序图与流程图
+
+### 13.1 写事务时序(以 `replace_profile_definition` 为例,IPC 驱动)
+
+```mermaid
+sequenceDiagram
+  participant FE as 前端
+  participant IPC as ipc.rs
+  participant NC as NyanpasuClient
+  participant PC as ProfilesClient
+  participant A as ProfilesActor
+  participant M as PersistentStateManager
+  participant S as Scheduler/Watcher
+  FE->>IPC: replace_profile_definition(uid, definition)
+  IPC->>NC: replace_profile_definition(uid, definition)
+  NC->>PC: replace_definition(uid, definition)
+  PC->>A: call(ReplaceDefinition, None) — 写无超时
+  A->>A: clone Profiles → item.set_definition(...)(原子替换,无中间态)
+  A->>A: validate()
+  alt 验证失败
+    A-->>PC: Err(ValidationFailed) — 内存/磁盘均不变
+  else 验证通过
+    A->>A: 计算 scheduler/watcher diff
+    A->>M: 原子持久化 profiles.yaml
+    M-->>A: Ok
+    A->>A: 提交内存 + 重建 ProfileDependencyIndex
+    A->>S: reconcile(upsert/remove 定时任务与 watcher)
+    Note over A,S: reconcile 失败 = 降级上报, 不回滚(D5)
+    A-->>PC: Ok(CommitReport{snapshot, affects_current})
+  end
+  PC-->>NC: CommitReport
+  alt affects_current == true
+    NC->>NC: rebuild_running_config()(见 13.2)
+  end
+  NC-->>IPC: Ok
+  IPC-->>FE: Ok
+```
+
+### 13.2 激活 profile → 重建运行配置时序
+
+```mermaid
+sequenceDiagram
+  participant FE as 前端
+  participant IPC as ipc.rs
+  participant NC as NyanpasuClient
+  participant PC as ProfilesClient
+  participant A as ProfilesActor
+  participant RB as RuntimeBuilder
+  participant EX as executor(nyanpasu-config)
+  participant RT as Config::runtime()(legacy, TODO→PR-4)
+  participant CM as CoreManager(legacy, TODO→PR-5)
+  FE->>IPC: activate_profile(uid)
+  IPC->>NC: activate_profile(Some(uid))
+  NC->>PC: set_current(Some(uid))
+  PC->>A: call(SetCurrent, None)
+  A->>A: 事务:uid 必须存在且为 Config(File|Composition)
+  A-->>PC: Ok(CommitReport{affects_current: true})
+  NC->>PC: get() — call(Get, Some(5s))
+  PC-->>NC: Arc<Profiles> 快照
+  NC->>NC: 组装 RuntimeBuildInput(guard_overrides/tun/valid/builtins;<br/>PR-2b 未合则读旧全局, TODO 台账 B8)
+  NC->>RB: build(input, content_source, script_runner)
+  RB->>EX: 执行管线(design §7.1–7.5 五种顺序,<br/>GuardOverrides→WhitelistFieldFilter→Finalizing)
+  EX-->>RB: RuntimeArtifact{final_config, graph, step_logs}
+  RB-->>NC: RuntimeArtifact
+  NC->>RT: 写 runtime draft + generate_file(clash-config.yaml)
+  NC->>CM: update_config()
+  CM-->>NC: Ok / 降级错误(不回滚 profiles 提交)
+  NC-->>IPC: Ok
+  IPC-->>FE: 事件:refresh_clash
+```
+
+### 13.3 Remote 订阅定时更新时序(后台驱动,下载-提交分离)
+
+```mermaid
+sequenceDiagram
+  participant SCH as RemoteUpdateScheduler(actor 子任务)
+  participant A as ProfilesActor
+  participant DL as 下载任务(spawn)
+  participant SF as SubscriptionFetcher
+  participant FS as ProfileFsPort
+  participant RN as RebuildNotifier
+  participant NC as NyanpasuClient
+  Note over SCH: profile-update:{uid} 到期
+  SCH->>A: cast(RefreshRemote{uid})
+  A->>A: 快照校验:uid 为 Remote 文件型
+  A->>DL: spawn(url, options, path) — handler 不做网络 I/O(D9)
+  DL->>SF: fetch(url, options) — 网络超时自管
+  SF-->>DL: 内容 + subscription 响应头
+  DL->>FS: 按目标类型校验内容 → ensure_not_symlink → 临时文件 → 原子替换物化文件
+  DL->>A: cast(CommitRefreshed{uid, outcome})
+  A->>A: 事务提交:MaterializedFile.updated_at / SubscriptionInfo
+  A->>A: invalidate_profile(uid) × 依赖索引 → affects_current?
+  alt affects_current == true
+    A->>RN: request_rebuild()(fire-and-forget)
+    RN->>NC: rebuild_running_config()(composition root 接线)
+  end
+  Note over A: 用户手动 update_profile 走同一链路:<br/>RefreshRemote 携带 reply, 挂起于 pending_refresh,<br/>CommitRefreshed 时结清(成功或失败)
+```
+
+### 13.4 启动数据迁移流程图(migration V2 revision 3)
+
+```mermaid
+flowchart TD
+  A["应用启动:migrate 子进程(lib.rs:120 既有机制)"] --> B["migration runner:profiles 模块 detect_baseline"]
+  B --> C{"revision < 3?"}
+  C -- 否 --> Z["跳过(幂等重入)"]
+  C -- 是 --> D["读 profiles.yaml 为 Value<br/>+ 写 profiles.yaml.bak 备份"]
+  D --> E["Value 层 schema 转换(§10 规则):<br/>type 映射 / chain→transforms / multi-current→Composition /<br/>URL-file→Remote / expire:0→None / update_interval 重命名"]
+  E --> F{"歧义或无法映射?"}
+  F -- 是 --> G["显式失败:MigrationError{uid, 字段路径}<br/>中止启动, .bak 保留"]
+  F -- 否 --> H["反序列化为新 Profiles<br/>→ validate() + 路径/URL/interval 校验"]
+  H -- 验证失败 --> G
+  H -- 通过 --> I["原子写回 profiles.yaml, revision=3 落账"]
+  I --> J["主进程:spawn ProfilesActor(初始加载只认新 schema)"]
+  Z --> J
+  J --> K["post_start:重建依赖索引<br/>+ scheduler/watcher 首次 reconcile"]
+```
+
+### 13.5 delete_profile 引用保护流程图
+
+```mermaid
+flowchart TD
+  S["delete_profile(uid)"] --> C1{"uid 存在?"}
+  C1 -- 否 --> E1["Err(ProfileNotFound)"]
+  C1 -- 是 --> C2{"被引用?<br/>current / Composition.base /<br/>extend_proxies_from / transforms /<br/>global_transforms(依赖索引查询)"}
+  C2 -- 是 --> E2["Err(ProfileInUse{referrers})<br/>不自动改 current, 不静默移除引用(design §17)"]
+  C2 -- 否 --> T["事务:clone → 移除 item → validate → 原子持久化 → commit"]
+  T --> F{"物化文件清理(commit 后副作用)"}
+  F -- "Managed / Remote" --> D1["删除物化文件"]
+  F -- "External Symlink" --> D2["只删应用管理的链接,<br/>不删外部 target(design §10.1)"]
+  F -- "External Mirror" --> D3["删除镜像副本,<br/>不删外部 target(design §10.2)"]
+  F -- "Composition(无文件)" --> D4["无文件操作"]
+  D1 --> P
+  D2 --> P
+  D3 --> P
+  D4 --> P["重建依赖索引 → reconcile 调度/watcher"]
+  P --> R["Ok(CommitReport)<br/>清理失败 = 降级上报, 不回滚(D5)"]
+```
+
+---
+
+## 14. 可执行任务序列(交付顺序)
+
+对应 roadmap §4.5 T3.1–T3.9,补充验证判据;顺序原则 = guide §7.1「最小增量、可独立验证」:
+
+| #    | 任务                                                                                                                                                            | 关键落点                                            | 验证                                                                                                           |
+| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| T3.1 | tauri 引入 `nyanpasu-config` 依赖;specta 导出新类型(逐 variant 命名导出,D11)                                                                                    | `backend/tauri/Cargo.toml`、`lib.rs` specta builder | 编译通过;TS 产物生成且 CI diff 检查在位                                                                        |
+| T3.2 | migration V2 `profiles` revision 3(§10 全规则;`.bak` + 歧义显式失败)                                                                                            | `core/migration/modules/profiles.rs`、fixtures      | fixtures 覆盖 guide §6 全规则 + design §18 第 24–27 条;幂等重入;仿 `runner.rs:367` 端到端                      |
+| T3.3 | `ProfilesActor` + `ProfilesClient`(§6 全协议;事务/索引/reconcile)                                                                                               | `state/profiles.rs`、`client/profiles.rs`           | mock ports + tempdir spawn;断言写 `call(_,None)`、读 `call(_,Some)`;引用保护/重排/validate 失败不落盘;不 sleep |
+| T3.4 | `ProfileFileService`(`ProfileFsPort`/`SubscriptionFetcher` 实现;原子替换 + 符号链接防御)                                                                        | `service/profile_file.rs`                           | 单测:原子写、`ensure_not_symlink` 拒绝、YAML 规范化                                                            |
+| T3.5 | `RemoteUpdateScheduler` + External watcher(D8;下载-提交分离)                                                                                                    | `state/profiles.rs` 子任务                          | reconcile diff 测试(design §18 第 22 条);watcher 失效传导(第 23 条);挂起 reply 必结清                          |
+| T3.6 | IPC 全量 BC 切换(§9 表)+ facade 方法 + 前端 TS/UI 适配(§11)                                                                                                     | `ipc.rs`、`client/mod.rs`、`frontend/`              | IPC 集成测试;前端 profiles 页冒烟(增删改查/激活/排序/编辑文件)                                                 |
+| T3.7 | `enhance()` → `RuntimeBuilder` + executor 接线(§8;产物仍写 `Config::runtime()`,标 TODO B8)                                                                      | `enhance/` 重写                                     | 与旧 `enhance()` golden 对照 fixtures(同输入等价产物);`enhance_profiles` 行为不变                              |
+| T3.8 | 删除 legacy:`config/profile/**`、`ManagedState<Profiles>`、`Config::profiles()`、`ProfilesBuilder`/`ProfileBuilder`、`ProfilesJobGuard`、`feat::update_profile` | 全仓                                                | 编译零引用;`grep -r "Config::profiles()"` 零命中                                                               |
+| T3.9 | 全量测试 + 文档(roadmap 状态行、台账 B8 登记)                                                                                                                   | —                                                   | `cargo build` + `cargo test` 绿;前端 `pnpm build` 绿                                                           |
+
+依赖关系:T3.2 与 T3.3–T3.5 可并行;T3.6 依赖 T3.3;T3.7 依赖 PR-3-pre② 合并;T3.8 必须最后(编译期清算)。
+
+---
+
+## 15. 测试策略
+
+- **migration**: fixtures 覆盖 §10 每条规则,含真实旧格式样本(多 current、URL-file、expire:0、update_interval 别名、chain 双层);`.bak` 生成断言;歧义样本必须失败且错误含 uid + 字段路径;重入幂等。
+- **actor**: mock `ProfileFsPort`/`SubscriptionFetcher`/`RebuildNotifier` + tempdir `PersistentStateManager` spawn;逐消息断言(含 `ValidationFailed` 不落盘、`ProfileInUse` 拒删、`CommitReport.affects_current` 正确性);同步用 `RpcReplyPort` ack,**不 sleep**(CLAUDE.md §13)。
+- **scheduler/watcher**: reconcile 支持新增/修改/Local↔Remote 切换/删除(design §18 第 22 条);Symlink/Mirror 变化使依赖 Composition 失效(第 23 条);下载失败路径结清 reply。
+- **RuntimeBuilder golden 对照**(最高风险项,guide §7.4): 旧 `enhance()` 行为 fixtures——单 current、multi-current(经 migration 转 Composition)、scoped chain、global chain、builtin 门控、HANDLE_FIELDS overlay、whitelist 过滤——断言新旧产物等价。
+- **IPC 集成**: 16 条命令 happy path + 域错误映射(`ProfileHasNoFile`/`ProfileInUse`/`ValidationFailed`)。
+- **前端**: 生成绑定编译通过;profiles 页 e2e 冒烟(导入/创建/激活/重排/编辑/删除/更新订阅)。
+
+---
+
+## 16. 成功判据(可验证)
+
+1. `grep -rn "Config::profiles()" backend/tauri/src` 零命中;`config/profile/` 目录不存在;`ProfilesJobGuard`/`ProfilesBuilder`/`ProfileBuilder` 编译期零引用。
+2. 旧 `profiles.yaml` 样本 → migrate 子进程 → 新 schema(`.bak` 在位)→ 应用启动 → 生成运行配置 → 核心可运行。
+3. 16 条 IPC 命令全部 thin adapter;`state/profiles.rs` + `client/profiles.rs` 无 `tauri::*` / `crate::config::Config` import。
+4. 写 = `call(_, None)`、读 = `call(_, Some(_))` 有断言覆盖;写 handler 无网络 I/O(下载-提交分离有测试)。
+5. 引用保护、`ProfileHasNoFile`、validate-拒绝脏落盘均有测试。
+6. RuntimeBuilder golden 对照全绿(与旧 `enhance()` 产物等价)。
+7. 本 PR 新增的旧全局消费点仅 §8 所列两处(+ D12 取数点),全部带 `TODO(actor-migration)` 注释,台账 B8 登记。
+8. `cargo build` + `cargo test` + 前端构建绿;profiles 页全功能冒烟通过。
+
+---
+
+## 17. 风险与缓解
+
+| 风险                                                                                          | 缓解                                                                                  |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **executor 行为漂移**(旧 enhance 链语义复杂:HANDLE*FIELDS overlay、builtin 门控、use*\* 收尾) | T3.7 golden 对照 fixtures;PR-3-pre② 自带对照测试(T3p.6),本 PR 复用为回归              |
+| **specta 嵌套 tagged enum TS 推导失败**                                                       | D11 逐 variant 命名导出;T3.1 先行落地并 CI 检查 TS diff,失败则最早暴露                |
+| **前端 `current` 单值化改造量**                                                               | 最小交互先行(多选→建 Composition 提示);完整管理界面明确移出范围                       |
+| **profiles 迁移不可逆**                                                                       | 强制 `.bak` + 歧义显式失败;migration 失败中止启动,用户数据不损                        |
+| **写无超时下 handler 挂起**                                                                   | 不变式:写 handler 禁无界 I/O;订阅下载在子任务内自管超时(D9);挂起 reply 有结清测试     |
+| **PR 半径失控**(runtime/core 一并动)                                                          | D7 明确:产物仍写 `Config::runtime()`,`CoreManager` 保持全局调用,只标 TODO;PR-4/5 分担 |
+| **scheduler 与用户操作竞态**(刷新中删除 profile 等)                                           | 全部提交串行于 actor;`CommitRefreshed` 时 uid 已删则丢弃结果并结清 reply              |
+| **PR-2b 未合时的取数点**                                                                      | D12/台账 B8:暂读旧全局 + TODO,PR-2b 合并后一处替换                                    |
+
+---
+
+## 18. 假设与开放问题
+
+### 假设
+
+- PR-3-pre②(runtime pipeline executor)已合并,`ProfileContentSource`/`ScriptRunner` ports 与 `RuntimeArtifact` 形态与 roadmap §4.4 一致。
+- profiles 域模型(#4840)冻结;实施若需模型变更走 spec 勘误。
+- migration V2 step/registry 接口稳定(`mod.rs:83` trait 不变)。
+- PR-2b 可能未合并;D12 的桥接点是唯一时序敏感处。
+
+### 开放问题(实施时确认)
+
+| #   | 问题                                                                                                   | 倾向                                                                      |
+| --- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| O1  | scheduler/watcher 形态:actor 子任务 vs 独立 actor                                                      | 子任务(D8);对外协议不变,可无痛升级                                        |
+| O2  | `valid`/`enable_clash_fields` 的归属:executor `WhitelistFieldFilter` 吃掉多少、tauri finalize 保留多少 | 以 PR-3-pre② T3p.3 的「确定性、无 IO」准绳为准;本 PR 只传参不决策         |
+| O3  | `import_profile` 下载首个订阅内容的执行位置(add 前在 IPC/facade 侧下载,还是 add 后走 RefreshRemote)    | add 后走 `RefreshRemote` 复用同一条下载-提交链路,失败时保留 item 并报降级 |
+| O4  | `CommitReport` 是否携带 reconcile 降级 warning 列表                                                    | 携带(前端 toast 提示),实施时定字段形态                                    |
+
+---
+
+_本文档基于代码库实测锚点(2026-07-04)撰写;实施中若与 clean-design/patch-interface/roadmap 冲突,以 design 文档 + roadmap 勘误流程为准。_

--- a/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+++ b/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
@@ -1,0 +1,428 @@
+# PR-3(R-3) — profiles 域切换 任务拆解(task.md)
+
+- **关联设计**: [`./design.md`](./design.md)(下文「design §N」均指该文件章节)
+- **拆解目标**: 每个任务 = 一个可独立 plan、独立执行、独立过审的 commit 组(1–3 个 conventional commit);任务卡自带 scope、接口契约与验证判据,供后续用 `superpowers:writing-plans` 逐卡展开为 bite-sized plan(执行时配合 `superpowers:subagent-driven-development` 或 `executing-plans`)。
+- **分支策略**: 单一 feature 分支(建议 `refactor/pr3-profiles-domain-switch`),任务按依赖序落 commit;T07–T10 为**原子切换组**(见 §4),必须同 PR 合并。
+
+---
+
+## 0. 全局约束(每张任务卡隐含,plan 时逐条带入)
+
+1. CLAUDE.md 铁律:无新 `::global()` / 静态可变服务;依赖显式注入;Tauri 隔离在适配器后。
+2. `state/profiles.rs` + `client/profiles.rs` **禁止** import `tauri::*` / `crate::config::Config`(design D10)。
+3. RPC 超时:读 `call(_, Some(PROFILES_READ_TIMEOUT))`(5s 域内常量)、写 `call(_, None)`;写 handler 禁无界 I/O(design D9)。
+4. 全部 mutation 走七步事务:clone→mutate→`validate()`→scheduler diff→原子持久化→commit→重建索引+reconcile;commit 后副作用失败 = 降级不回滚(design D5)。
+5. 本 PR 允许的旧全局消费点仅:`Config::runtime()` 写产物、`CoreManager::global().update_config()`、D12 取数点——全部标 `TODO(actor-migration)` 注释(格式见 design §8),台账 B8。
+6. 测试不 sleep,同步用 `RpcReplyPort` ack;ports 兼容 `mockall::automock`。
+7. 硬前置:**PR-3-pre②(runtime pipeline executor)已合并**;PR-3-pre①(snapshot store v2,当前分支)已合并。未满足时 T06 及其下游全部阻塞。
+8. 中间态规则:每个 commit 必须 `cargo build` + `cargo test` 绿;「应用端到端可运行」只在原子切换组边界(T07 之前 / T10 之后)保证。
+
+---
+
+## 1. 任务依赖图
+
+```mermaid
+flowchart LR
+  subgraph pre["硬前置(非本 PR)"]
+    P2["PR-3-pre② executor"]
+  end
+  subgraph parallel["可并行 lane"]
+    T01["T01 specta 接入<br/>与类型导出"]
+    T02["T02 migration V2<br/>profiles revision 3"]
+    T03["T03 ports +<br/>ProfileFileService"]
+    T06["T06 RuntimeBuilder<br/>(add-only, 不切换)"]
+  end
+  subgraph actor["actor lane"]
+    T04["T04 ProfilesActor<br/>+ ProfilesClient 核心事务"]
+    T05["T05 RefreshRemote +<br/>Scheduler + watcher"]
+  end
+  subgraph flagday["原子切换组(同 PR, 串行)"]
+    T07["T07 composition root<br/>+ facade 接线"]
+    T08["T08 IPC BC 切换<br/>(13→16 条)"]
+    T09["T09 前端适配"]
+    T10["T10 legacy 清算"]
+  end
+  T11["T11 端到端验证<br/>+ 文档收尾"]
+  P2 --> T06
+  T01 --> T06
+  T03 --> T04 --> T05
+  T02 --> T07
+  T04 --> T07
+  T05 --> T07
+  T06 --> T07
+  T01 --> T08
+  T07 --> T08 --> T09 --> T10 --> T11
+```
+
+**并行性**: T01 / T02 / T03 三者零文件重叠,可同时开工;T06 依赖 P2+T01;T04→T05 串行(同文件);切换组 T07–T10 严格串行。
+
+---
+
+## 2. 任务总表
+
+| #   | 任务                                | scope(一句话)                                                   | 建议 commit                                                                | 依赖            | design 锚点      |
+| --- | ----------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------- | --------------- | ---------------- |
+| T01 | specta 接入与类型导出               | tauri 依赖 nyanpasu-config,新类型逐 variant 导出 TS             | `feat(tauri): export nyanpasu-config profile types via specta`             | —               | §3 D11, §11      |
+| T02 | migration profiles revision 3       | legacy profiles.yaml → clean schema(Value 层)                   | `feat(migration): add profiles revision 3 legacy-to-clean schema step`     | —               | §10, 图 13.4     |
+| T03 | ports + ProfileFileService          | 三个窄 trait + fs/http 具体实现                                 | `feat(tauri): add profile fs/subscription ports and file service`          | —               | §7               |
+| T04 | ProfilesActor + ProfilesClient      | 事务化状态归属 + 全部同步写消息                                 | `feat(tauri): add ProfilesActor with transactional profile state`          | T03             | §6, 图 13.1/13.5 |
+| T05 | RefreshRemote + scheduler + watcher | 下载-提交分离、定时 reconcile、External 监听                    | `feat(tauri): add remote update scheduler and external watchers`           | T04             | §7, 图 13.3      |
+| T06 | RuntimeBuilder(add-only)            | executor 输入组装 + golden 对照,不动调用点                      | `feat(tauri): add RuntimeBuilder over runtime pipeline executor`           | P2, T01         | §8, 图 13.2      |
+| T07 | composition root + facade 接线      | spawn actor、facade 方法、rebuild 链路切换                      | `feat(tauri): wire ProfilesActor and RuntimeBuilder into composition root` | T02,T04,T05,T06 | §5, §6.4         |
+| T08 | IPC BC 切换                         | 13 条旧命令 → 16 条 thin adapter                                | `feat(tauri)!: rewrite profile IPC commands against NyanpasuClient`        | T01, T07        | §9               |
+| T09 | 前端适配                            | 新绑定 + current 单值化 + 最小 Composition 交互                 | `feat(frontend)!: adapt profiles UI to single current and new bindings`    | T08             | §11              |
+| T10 | legacy 清算                         | 删 config/profile/\*\*、Config::profiles()、ProfilesJobGuard 等 | `refactor(tauri)!: remove legacy profiles types and accessors`             | T09             | §14 T3.8, §16    |
+| T11 | 端到端验证 + 文档收尾               | e2e 冒烟、roadmap 状态行、台账 B8 登记                          | `docs: update actor migration roadmap for PR-3`                            | T10             | §15, §16         |
+
+---
+
+## 3. 任务卡
+
+### T01 — specta 接入与类型导出
+
+**目标**: tauri crate 依赖 `nyanpasu-config`,新 profile 域类型可生成 TS 绑定;旧代码零行为变化(add-only)。
+
+**Files**:
+
+- Modify: `backend/tauri/Cargo.toml`(加 `nyanpasu-config` workspace 依赖)
+- Modify: `backend/tauri/src/lib.rs`(specta builder 注册新类型)
+- Generated: `frontend/interface/src/ipc/bindings.ts`(仅新增类型,命令未变)
+
+**Interfaces — Produces**(T08/T09 依赖):
+
+- TS 侧命名类型:`Profiles`、`ProfileItem`、`ProfileDefinition` 及其逐 variant 命名导出(`FileConfig`/`CompositionConfig`/`OverlayTransform`/`ScriptTransform`/`ProfileSourceLocal`/`ProfileSourceRemote`…,具体命名 plan 时定,原则 = design D11:嵌套 tagged enum 不内联递归)
+- `ProfileMetadataPatch` / `RemoteProfileOptionsPatch` 的 TS 形态(`double_option` 三态字段)
+
+**验证**:
+
+- `cargo build -p clash-nyanpasu` 绿;TS 绑定生成命令成功且产物含全部命名类型
+- CI TS diff 检查在位(绑定产物入库,diff 即 fail)
+- 风险探针:specta 2.x 对嵌套 tagged enum 的推导问题**在本任务暴露**(design §17 风险 2)——若推导失败,方案调整只影响本卡
+
+**单独 plan 时读**: design §11、D11;`backend/nyanpasu-config/src/profile/` 各类型的 serde/specta 属性。
+
+---
+
+### T02 — migration V2 `profiles` revision 3
+
+**目标**: 注册 revision 3 step,把 legacy `profiles.yaml` 在 Value 层转换为 clean schema;`.bak` 备份;歧义显式失败;幂等重入。
+
+**Files**:
+
+- Modify: `backend/tauri/src/core/migration/modules/profiles.rs`(现 revision 1 `:47` / revision 2 `:114` 之后新增)
+- Create: 迁移 fixtures(旧格式样本 YAML,建议随测试内联或 `tests/fixtures/`)
+
+**规则清单**(全部来自 design §10,plan 时逐条转为测试):
+
+- 类型映射四则;字段移动五组(`chain→global_transforms`、`local/remote.chain→File.transforms`、`script_type→runtime`、`file+updated→MaterializedFile`、`url/option/extra→ProfileSource::Remote`)
+- `extra.expire:0→None`;`update_interval→update_interval_minutes`;URL-file→Remote(design §14.2)
+- multi-current:`[]→None`、`[a]→Some(a)`、`[a,b,c]→CompositionConfig{base:Some(a),extend:[b,c]}` + 碰撞安全 uid,顺序原样;成员无法映射 → **显式失败**(`MigrationError{uid, field_path}`)
+- 收尾:反序列化为新 `Profiles` → `validate()` → 原子写回
+
+**Interfaces — Produces**: revision 3 落账后,`profiles.yaml` 为新 schema(T07 spawn 前提);`MigrationStep` 实现遵循 `core/migration/mod.rs:83` trait(含 `rollback`)。
+
+**验证**:
+
+- fixtures 覆盖 design §10 全规则 + clean-design §18 第 24–27 条;幂等重入测试;`.bak` 生成断言
+- 仿 `runner.rs:367` 的端到端样板(1.6.1 全量旧样本 → revision 3 → 新 schema 可 validate)
+- `cargo test -p clash-nyanpasu migration` 绿
+
+**单独 plan 时读**: design §10;guide §6;clean-design §14;`core/migration/{mod.rs, registry.rs, runner.rs:367, modules/profiles.rs}`。
+
+---
+
+### T03 — ports + ProfileFileService
+
+**目标**: 定义消费方拥有的三个窄 trait 并提供具体实现;纯增量,无调用方。
+
+**Files**:
+
+- Create: `backend/tauri/src/state/profiles/ports.rs`(或 `state/profiles.rs` 内 mod;plan 时定,保持 Tauri-free)
+- Create: `backend/tauri/src/service/profile_file.rs`(`ProfileFileService`)
+- Modify: `backend/tauri/src/service/mod.rs` / `lib.rs`(模块声明)
+
+**Interfaces — Produces**(T04/T05/T07 依赖,签名以此为准):
+
+```rust
+#[cfg_attr(test, mockall::automock)]
+pub trait ProfileFsPort: Send + Sync + 'static {
+    fn read(&self, path: &ManagedProfilePath) -> anyhow::Result<String>;
+    fn write_atomic(&self, path: &ManagedProfilePath, content: &str) -> anyhow::Result<()>;
+    fn remove(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
+    fn ensure_not_symlink(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
+    fn ensure_symlink(&self, path: &ManagedProfilePath, target: &ExternalProfilePath) -> anyhow::Result<()>;
+}
+#[cfg_attr(test, mockall::automock)]
+pub trait SubscriptionFetcher: Send + Sync + 'static {
+    async fn fetch(&self, url: &Url, options: &RemoteProfileOptions) -> anyhow::Result<FetchedSubscription>;
+}
+#[cfg_attr(test, mockall::automock)]
+pub trait RebuildNotifier: Send + Sync + 'static {
+    fn request_rebuild(&self);
+}
+pub struct FetchedSubscription { pub content: String, pub subscription: SubscriptionInfo }
+// ProfileFileService::new(paths: PathResolver, http: reqwest::Client) — 同时 impl ProfileFsPort + SubscriptionFetcher
+```
+
+**验证**:
+
+- 单测(tempdir):原子写、`ensure_not_symlink` 对符号链接拒绝、YAML 规范化读、`fetch` 网络超时自管(mock http 或 feature-gate)
+- `state/profiles/` 无 `tauri::*` / `crate::config` import(grep 断言)
+
+**单独 plan 时读**: design §7、D9、D10;`utils/path.rs:40,94,99`(PathResolver);clean-design §9 末段(符号链接防御)。
+
+---
+
+### T04 — ProfilesActor + ProfilesClient(核心事务)
+
+**目标**: profiles 状态归属 actor;全部**同步写消息**落地(Add/Delete/Reorder/PatchMetadata/PatchRemoteOptions/ReplaceDefinition/SetCurrent/SetGlobalTransforms/Replace)+ Get 读;七步事务 + 依赖索引 + `CommitReport`。**不含** RefreshRemote/scheduler/watcher(→T05,缩小审查半径)。
+
+**Files**:
+
+- Create: `backend/tauri/src/state/profiles.rs`(actor;若 T03 用了子目录则为 `state/profiles/mod.rs` + `actor.rs`)
+- Create: `backend/tauri/src/client/profiles.rs`(`ProfilesClient`)
+- Modify: `backend/tauri/src/state/mod.rs`、`client/mod.rs`(仅模块声明,facade 方法留给 T07)
+
+**Interfaces — Consumes**: T03 三 trait + `PersistentStateManager<Profiles>`(`nyanpasu-core/src/state/manager/persistent_state.rs:128`)+ `nyanpasu-config` patch.rs 分层 mutator + `ProfileDependencyIndex`(`dependency.rs:10`)。
+
+**Interfaces — Produces**(T05/T07/T08 依赖):
+
+```rust
+pub struct ProfilesClient { /* ActorRef 私有 */ }
+impl ProfilesClient {
+    pub async fn get(&self) -> Result<Arc<Profiles>, ProfilesError>;                    // call(_, Some(PROFILES_READ_TIMEOUT))
+    pub async fn add(&self, req: NewProfileRequest, initial_file: Option<String>) -> Result<CommitReport, ProfilesError>;
+    pub async fn delete(&self, uid: ProfileId) -> Result<CommitReport, ProfilesError>;  // 引用保护
+    pub async fn reorder(&self, op: ReorderOp) -> Result<CommitReport, ProfilesError>;
+    pub async fn patch_metadata(&self, uid: ProfileId, patch: ProfileMetadataPatch) -> Result<CommitReport, ProfilesError>;
+    pub async fn patch_remote_options(&self, uid: ProfileId, patch: RemoteProfileOptionsPatch) -> Result<CommitReport, ProfilesError>;
+    pub async fn replace_definition(&self, uid: ProfileId, definition: ProfileDefinition) -> Result<CommitReport, ProfilesError>;
+    pub async fn set_current(&self, current: Option<ProfileId>) -> Result<CommitReport, ProfilesError>;
+    pub async fn set_global_transforms(&self, ids: Vec<ProfileId>) -> Result<CommitReport, ProfilesError>;
+    pub async fn replace(&self, profiles: Profiles) -> Result<CommitReport, ProfilesError>;
+}
+pub struct CommitReport { pub snapshot: Arc<Profiles>, pub affects_current: bool }
+pub struct NewProfileRequest { pub metadata: ProfileMetadata, pub definition: ProfileDefinition }  // uid 服务端生成(D13)
+pub enum ReorderOp { Move { active: ProfileId, over: ProfileId }, ByList(Vec<ProfileId>) }
+pub enum ProfilesError { ProfileNotFound, ProfileInUse { referrers: Vec<ProfileId> }, ProfileHasNoFile,
+                         ValidationFailed(Vec<ProfileValidationError>), NotARemoteProfile,
+                         FileNotWritable { reason: String }, RefreshFailed { message: String }, Rpc(String) }
+pub const PROFILES_READ_TIMEOUT: Duration = Duration::from_secs(5);
+pub struct ProfilesActorArgs { pub paths: PathResolver, pub fs: Arc<dyn ProfileFsPort>,
+                               pub fetcher: Arc<dyn SubscriptionFetcher>, pub notifier: Arc<dyn RebuildNotifier>,
+                               pub initial: Profiles }
+```
+
+**验证**(mock ports + tempdir manager spawn,不 sleep):
+
+- 每条消息 happy path;`ValidationFailed` 不落盘不改内存;`Delete` 五类引用全部拒绝(`ProfileInUse.referrers` 正确);`affects_current` 判定(改 current 传递闭包内/外各一例)
+- 写路径 `call(_, None)`、读路径 `call(_, Some)` 有断言;Add 写初始文件、Delete 按 binding 清理(Managed 删 / Symlink 只删链接 / Mirror 删副本 / Composition 无操作)
+- `cargo test -p clash-nyanpasu profiles` 绿
+
+**单独 plan 时读**: design §6 全部、图 13.1/13.5;patch-interface §4–6;clean-design §13/§16/§17;PR-2b spec §6–7(actor 同构样板);现 `state/verge.rs`(消息/manager 用法参考)。
+
+---
+
+### T05 — RefreshRemote + RemoteUpdateScheduler + External watcher
+
+**目标**: 订阅刷新与外部文件同步纳入 actor:下载-提交分离(`RefreshRemote` 挂起 reply → 子任务下载 → `CommitRefreshed` 串行提交)、定时表 reconcile、Symlink/Mirror watcher、后台提交经 `RebuildNotifier` 通知。
+
+**Files**:
+
+- Modify: `backend/tauri/src/state/profiles.rs`(新增消息 `RefreshRemote`/`CommitRefreshed`/`ExternalFileChanged`、`pending_refresh` 表、`post_start` 首次 reconcile、scheduler 子任务)
+- Create(如拆文件): `backend/tauri/src/state/profiles/scheduler.rs`
+- Modify: `backend/tauri/src/client/profiles.rs`(+`refresh(uid, Option<RemoteProfileOptionsPatch>) -> Result<CommitReport, ProfilesError>`)
+
+**Interfaces — Consumes**: T04 全部 + T03 `SubscriptionFetcher`/`ProfileFsPort`/`RebuildNotifier`。
+**Interfaces — Produces**: `ProfilesClient::refresh(...)`(T07/T08 的 `update_profile` 链路);scheduler/watcher 对外不可见(actor 内部)。
+
+**行为要点**(plan 时逐条转测试):
+
+- handler 内零网络 I/O;下载任务超时自管(options 派生);失败路径必结清挂起 reply
+- reconcile 幂等:新增/修改/Local↔Remote 切换/删除四类 diff(clean-design §18 第 22 条)
+- watcher:Symlink 监听 target 真实路径、Mirror 变化→临时文件→校验→原子替换(design §7;clean-design §10)
+- `CommitRefreshed` 时 uid 已被删除 → 丢弃结果、结清 reply(design §17 竞态行)
+- 后台提交且 `affects_current` → `notifier.request_rebuild()` 恰好一次
+
+**验证**: mock fetcher 注入可控延迟/失败;watcher 用 tempdir 真实文件事件或注入触发;全程无 sleep(用消息 ack/通道)。
+
+**单独 plan 时读**: design §7、图 13.3、D8/D9、§18 O1/O3;clean-design §9/§10;现 `core/tasks/jobs/profiles.rs:49-139`(被取代者的 cron diff 语义参考)。
+
+---
+
+### T06 — RuntimeBuilder(add-only,不切换调用点)
+
+**目标**: 新建 `RuntimeBuilder` 纯 service + 两个 executor 适配器;golden 对照测试证明与旧 `enhance()` 产物等价。**本卡不改 `Config::generate()`、不删旧 enhance 逻辑**——行为切换在 T07,保证本卡纯增量、可独立回滚。
+
+**Files**:
+
+- Create: `backend/tauri/src/enhance/runtime_builder.rs`(`RuntimeBuilder` + `RuntimeBuildInput`/`FinalizeParams`)
+- Create: `backend/tauri/src/enhance/content_source.rs`(`FsProfileContentSource: ProfileContentSource`,按 `ManagedProfilePath` 读物化文件)
+- Modify: `backend/tauri/src/enhance/script/`(为现 boa/lua runner 加 `ScriptRunner` trait impl 包装,不动原逻辑)
+- Create: golden fixtures(旧行为样本:单 current、multi-current→Composition、scoped chain、global chain、builtin 门控、HANDLE_FIELDS overlay、whitelist 过滤)
+
+**Interfaces — Consumes**: PR-3-pre② 交付的 `ProfileContentSource`/`ScriptRunner` ports 与 executor 入口、`RuntimeArtifact`;`enhance/chain.rs:145` builtin 门控表(组装为 `Vec<BuiltinTransform>` 传参)。
+**Interfaces — Produces**(T07 依赖):
+
+```rust
+pub struct RuntimeBuildInput { pub profiles: Arc<Profiles>, pub guard_overrides: ClashGuardOverrides,
+                               pub finalize_params: FinalizeParams, pub builtins: Vec<BuiltinTransform> }
+impl RuntimeBuilder {
+    pub fn build(input: RuntimeBuildInput, content: &dyn ProfileContentSource, scripts: &dyn ScriptRunner)
+        -> Result<RuntimeArtifact>;
+}
+```
+
+**验证**:
+
+- golden 对照:同输入下 `RuntimeBuilder::build` 产物与旧 `enhance()` 等价(design §15「最高风险项」;PR-3-pre② T3p.6 fixtures 复用为回归)
+- `RuntimeArtifact.step_logs` 能还原旧 `postprocessing_output` 消费需求
+- 纯度断言:`runtime_builder.rs` 无 `Config::` / `tauri::` import(D12 取数不在本卡——输入全部显式传参)
+
+**单独 plan 时读**: design §8、图 13.2、D7/D12;roadmap §4.4(executor 交付形态);`enhance/mod.rs:22-104`、`enhance/chain.rs:59-160`(旧语义源)。
+
+---
+
+### T07 — composition root + facade 接线(⚠️ 切换组起点)
+
+**目标**: spawn `ProfilesActor` 进 composition root;`NyanpasuClient` 暴露全部 profiles 域方法 + `rebuild_running_config()`;`Config::generate()` 改调 RuntimeBuilder;`RebuildNotifier` 接线。**自本卡起应用进入 BC 中间态**(旧 IPC 仍在但底层已切换,见 §4)。
+
+**Files**:
+
+- Modify: `backend/tauri/src/setup.rs` / `client/mod.rs`(spawn 顺序:migration 子进程已完成 → 构造 ProfileFileService → spawn ProfilesActor → 构造 ProfilesClient → facade;`RebuildNotifier` 具体实现接到 facade 重建入口,注意用 `Weak`/channel 避免循环持有)
+- Modify: `backend/tauri/src/config/core.rs:88`(`generate()` 改调 RuntimeBuilder;产物仍写 runtime draft + `generate_file`,两处标 `TODO(actor-migration)` B8)
+- Modify: `backend/tauri/src/client/mod.rs`(新 facade 方法;旧 `patch_profiles_config:80` 本卡保留——删除在 T10)
+
+**Interfaces — Produces**(T08 依赖,方法名以此为准):
+
+```rust
+impl NyanpasuClient {
+    pub async fn get_profiles(&self) -> Result<Arc<Profiles>>;
+    pub async fn add_profile(&self, req: NewProfileRequest, initial_file: Option<String>) -> Result<()>;
+    pub async fn delete_profile(&self, uid: ProfileId) -> Result<()>;
+    pub async fn reorder_profile(&self, active: ProfileId, over: ProfileId) -> Result<()>;
+    pub async fn reorder_profiles_by_list(&self, list: Vec<ProfileId>) -> Result<()>;
+    pub async fn refresh_profile(&self, uid: ProfileId, patch: Option<RemoteProfileOptionsPatch>) -> Result<()>;
+    pub async fn patch_profile_metadata(&self, uid: ProfileId, patch: ProfileMetadataPatch) -> Result<()>;
+    pub async fn patch_remote_profile_options(&self, uid: ProfileId, patch: RemoteProfileOptionsPatch) -> Result<()>;
+    pub async fn replace_profile_definition(&self, uid: ProfileId, definition: ProfileDefinition) -> Result<()>;
+    pub async fn activate_profile(&self, uid: Option<ProfileId>) -> Result<()>;
+    pub async fn set_global_transforms(&self, ids: Vec<ProfileId>) -> Result<()>;
+    pub async fn get_profile_materialized_path(&self, uid: ProfileId) -> Result<PathBuf>;   // Composition → ProfileHasNoFile
+    pub async fn read_profile_file(&self, uid: ProfileId) -> Result<String>;
+    pub async fn save_profile_file(&self, uid: ProfileId, data: String) -> Result<()>;      // 仅 Local/Managed
+    pub async fn rebuild_running_config(&self) -> Result<()>;   // 快照→RuntimeBuilder→runtime draft→CoreManager(TODO B8)
+}
+```
+
+写方法内部统一模式:`CommitReport.affects_current == true` → 顺序调用 `rebuild_running_config()`(facade 编排,design §6.4)。
+
+**验证**:
+
+- 启动冒烟(顺序断言:migration 先于 spawn);`rebuild_running_config` 集成测试(mock 或真实 executor)
+- 台账检查:本卡新增 TODO 注释恰好覆盖 design §8 所列两处 + D12 取数点
+
+**单独 plan 时读**: design §5/§6.4/§8、图 13.2;PR-2b spec §10.2(composition root 顺序样板);`setup.rs`/`lib.rs:120,362-398` 现状。
+
+---
+
+### T08 — IPC BC 切换(13 → 16 条)
+
+**目标**: `ipc.rs` 全部 profile 命令重写为 thin adapter;新增/拆分命令注册进 specta builder 与 handler 列表;域错误 → 命令错误映射。
+
+**Files**:
+
+- Modify: `backend/tauri/src/ipc.rs:102-382`(13 条命令按 design §9 表逐条替换;`patch_profiles_config`/`patch_profile` 删除,5 条新命令加入)
+- Modify: `backend/tauri/src/lib.rs`(command 注册表 + specta 导出)
+- Modify: `backend/tauri/src/feat.rs:441` 附近(`feat::update_profile` 调用点改走 facade;函数本体删除在 T10)
+- Generated: `frontend/interface/src/ipc/bindings.ts`(命令面变化——**自本 commit 起前端类型检查红,直至 T09**,见 §4)
+
+**Interfaces — Consumes**: T07 全部 facade 方法。
+**Interfaces — Produces**: 16 条命令名(前端 T09 依赖):`get_profiles / enhance_profiles / import_profile / create_profile / reorder_profile / reorder_profiles_by_list / update_profile / delete_profile / activate_profile / set_global_transforms / patch_profile_metadata / patch_remote_profile_options / replace_profile_definition / view_profile / read_profile_file / save_profile_file`。
+
+**验证**:
+
+- 每条命令 = 解析 DTO → facade → 错误映射,**零业务编排**(CLAUDE.md §12 形状检查)
+- IPC 集成测试:happy path + `ProfileInUse`/`ProfileHasNoFile`/`ValidationFailed` 映射
+- `grep -n "Config::profiles()" backend/tauri/src/ipc.rs` 零命中
+
+**单独 plan 时读**: design §9 全表(每行含 BC 要点);guide §5(逐命令现状签名)。
+
+---
+
+### T09 — 前端适配
+
+**目标**: 前端在新绑定下恢复类型检查绿 + profiles 页全功能;`current` 单值化;多选激活改为最小 Composition 创建交互。
+
+**Files**(代表锚点,plan 时全量盘点):
+
+- Regenerate: `frontend/interface/src/ipc/bindings.ts`
+- Modify: `frontend/interface/src/ipc/use-profile.ts:167` 及同文件相关 hook(命令改名/拆分)
+- Modify: `frontend/nyanpasu/src/pages/(main)/main/profiles/` 下 `current` 消费点(如 `active-button.tsx:21` 的 `current?.find(...)` → `current === uid`)
+- Modify: profile 编辑对话框(metadata / remote options / definition 三类操作分开提交)
+- Create: 「多选 File Config → 创建 Composition」最小交互(design §11 第 3 条;完整管理界面为非目标)
+
+**Interfaces — Consumes**: T08 的 16 条命令 + T01 的 TS 类型。
+
+**验证**:
+
+- 前端类型检查 + 构建绿;profiles 页手动冒烟:导入/创建/激活/重排/编辑文件/删除(含被引用删除的错误 toast)/更新订阅
+- 全仓 `patch_profiles_config` / `chain` 字段引用零残留(grep 前端源码)
+
+**单独 plan 时读**: design §11;guide §7.2/§7.3(TS 破坏性变更表);现 profiles 页组件树。
+
+---
+
+### T10 — legacy 清算(切换组终点)
+
+**目标**: 编译期保证 legacy profiles 面零残留。
+
+**Files**:
+
+- Delete: `backend/tauri/src/config/profile/**` 全目录
+- Delete: `backend/tauri/src/core/tasks/jobs/profiles.rs`(`ProfilesJob`/`ProfilesJobGuard`)及其注册点
+- Modify: `backend/tauri/src/config/core.rs:42`(删 `Config::profiles()` accessor + `ManagedState<Profiles>` 字段)
+- Modify: `backend/tauri/src/client/mod.rs:80`(删旧 `patch_profiles_config` 方法)
+- Modify: `backend/tauri/src/feat.rs`(删 `feat::update_profile` 本体)
+- Modify: `backend/tauri/src/enhance/mod.rs`(删旧 `enhance()` 函数与 legacy chain 解析;`chain.rs` 中仅被旧路径使用的部分一并清理,builtin 表保留给 T06 适配器)
+
+**验证**(design §16 判据 1):
+
+- `grep -rn "Config::profiles()" backend/tauri/src` 零命中
+- `grep -rn "config::profile::" backend/tauri/src` 零命中(新代码只 import `nyanpasu_config::profile::`)
+- `ProfilesBuilder` / `ProfileBuilder` / `ProfilesJobGuard` 编译期零引用
+- `cargo build` + `cargo test` 全绿
+
+**单独 plan 时读**: design §14 T3.8、§16;T08/T09 完成后的实际残留清单(plan 时以 grep 现场盘点为准,不硬编码本卡文件列表)。
+
+---
+
+### T11 — 端到端验证 + 文档收尾
+
+**目标**: 全链路验证 + 迁移账本更新,PR 提交就绪。
+
+**内容**:
+
+1. e2e 冒烟(design §16 判据 2):真实旧 `profiles.yaml` 样本 → migrate 子进程 → `.bak` 在位 → 应用启动 → 激活 profile → `clash-config.yaml` 生成 → 核心可运行;
+2. 前端全功能冒烟复核(判据 8);
+3. TODO 台账核对(判据 7):`grep -rn "TODO(actor-migration)" backend/tauri/src` 输出与 design §8/D12 清单一致;
+4. 文档:`docs/design/actor-migration-roadmap.md` §2.1 状态行更新(PR-3 → 已实施)、§5 台账 B8 登记状态;guide 状态行标注「已实施」。
+
+**验证**: `cargo build && cargo test` + 前端构建全绿;判据 1–8 逐条勾选留痕(PR 描述引用)。
+
+---
+
+## 4. 原子切换组说明(T07–T10)
+
+- **T07 之前**: 每个任务 add-only 或纯 migration step,应用行为不变,任意顺序可独立合入 commit。
+- **T07–T10 之间为 BC 中间态**:
+  - T07 落地后,运行配置生成链路已切换,但旧 IPC 命令仍消费 legacy 类型——**若此时真实运行且 profiles.yaml 已被 revision 3 迁移,旧命令失读**。因此本组期间只要求「编译 + 测试绿」,不要求应用端到端可运行;
+  - T08 落地后前端类型检查红,直至 T09 完成——这是铁律 3(前端 BC 同 PR)的预期形态;
+  - **本组四卡必须在同一 PR 内连续完成后再请求 review/merge**,不得单独合入 main。
+- **T10 之后**: 应用恢复端到端可运行,进入 T11 验证。
+
+## 5. 执行建议
+
+1. **逐卡出 plan**: 每张卡以「本卡 + design.md 对应章节 + 卡内 Interfaces 契约」为输入,用 `superpowers:writing-plans` 展开为 bite-sized plan(TDD、每步一动作、含完整代码);卡与卡之间只通过 Interfaces 契约耦合,plan 之间不需要互读。
+2. **推荐排程**: 先并行 T01/T02/T03(+ T06 若 PR-3-pre② 已合),再 T04→T05,最后一口气完成切换组 T07–T10 + T11。
+3. **契约变更规则**: 实施中若需改动任务卡 Produces 签名,先改本文件对应卡(及下游 Consumes),再改代码——本文件是跨卡契约的唯一权威。

--- a/docs/superpowers/specs/2026-07-04-runtime-pipeline-executor-design.md
+++ b/docs/superpowers/specs/2026-07-04-runtime-pipeline-executor-design.md
@@ -1,0 +1,800 @@
+# PR-3-pre② — Runtime Pipeline Executor 设计（纯执行半，nyanpasu-config）
+
+- **日期**: 2026-07-04
+- **状态**: 设计稿（待批准；批准后按 writing-plans 拆实施计划）
+- **作者**: Jonson Petard（design task with Claude）
+- **上游依据**: `docs/design/actor-migration-roadmap.md` §4.4（T3p.1–T3p.6，修正 C5：executor 是 PR-3 的硬前置）
+- **规范语义来源**: `docs/design/profile-composition-clean-design.md` §6.1 / §7.1–7.5 / §18
+- **基底**: 分支 `refactor/runtime-snapshot-store-v2` @ `d0b3cf6ac`（PR-3-pre① snapshot store v2）
+- **行为对照基线**: `backend/tauri/src/enhance/`（实测测绘 2026-07-04，逐条 `file:line`）
+
+---
+
+## 1. 摘要
+
+`nyanpasu-config` 的 runtime 模块目前只有「数据结构半」：`ConfigSnapshotsBuilder` 自述是 "Pure recorder for the pipeline executor"（`runtime/snapshot.rs:351-353`），`BuiltinStepKind` 只是 tag（`snapshot.rs:70-76`），**没有任何代码读 profile 内容、应用 Overlay、跑 JS/Lua、合并 proxies、过滤 whitelist**。本设计补上「执行半」：
+
+> 给定 `Profiles` 快照 + 文件内容（经 port 注入）+ Clash 域守卫参数，**纯地、确定地**执行 clean-design §7.1–7.5 的五种处理顺序与最终阶段，产出 `RuntimeArtifact { final_config, graph, step_logs, applied_fields }`。
+
+执行器是 **pure service**（CLAUDE.md §8）：无 IO、无 Tauri、无 actor、无全局；文件读取与脚本执行经两个 crate 内 trait port（`ProfileContentSource` / `ScriptRunner`）由调用方注入。它是 PR-3（profiles 域切换）的硬前置——profiles.yaml 一旦迁到新 schema，旧 `enhance()`（直读 legacy `Profiles`，`enhance/mod.rs:38-76`）立即失读。
+
+**范围内的唯一 tauri 无关缝隙**：为记录内建增强脚本与 bare 模式，`OperatorTag`/`SnapshotNodeKey` 需要一次受控扩展（§8.2，wire 前向兼容，缓存契约兜底）。
+
+---
+
+## 2. 目标 / 非目标
+
+### 目标
+
+1. 五种处理顺序（§7.1–7.5）的完整纯实现，逐步经 `ConfigSnapshotsBuilder::push / attach_independent_branch` 录制。
+2. `extend_proxies_from` 11 条追加规则的逐条落实（clean-design §7.5）。
+3. 三个 BuiltinStep 的真实逻辑：`WhitelistFieldFilter` / `GuardOverrides` / `Finalizing`，语义与旧 `enhance()` 等价（对照台账 §13）。
+4. 内建增强脚本建模为**调用方组装的有序参数列表**，executor 不含任何 `ClashCore` 判断。
+5. 输出 `RuntimeArtifact`，完整覆盖旧 `IRuntime { config, exists_keys, postprocessing_output }` 三元组的消费需求（`config/runtime.rs:19-26`）。
+6. bare 模式（`current = None`）：复刻旧「无激活配置仍产出可用运行配置」的行为（旧路径实测见 §4.3）。
+7. 与失效机制集成：`invalidate_profile` → `SnapshotRebuild::FullCurrent` → 重跑 executor，`SnapshotNodeKey` 锚点跨重建稳定。
+8. 确定性不变式：相同输入 + 相同 port 应答 ⇒ 逐字节相同的 artifact（消除旧实现两处 `HashSet` 顺序不确定性，§13 #1/#2）。
+
+### 非目标（明确范围外）
+
+- tauri 侧接线：`RuntimeBuilder` 装配、boa/lua runner 适配、`enhance()` 替换、IPC 改造 —— 全部归 PR-3（roadmap T3.7）。
+- `Config::runtime()` / `IRuntime` 删除、artifact 存放点 —— 归 PR-4。
+- Pipeline IR、StepId、GUI preview/diff、Script 静态分析（clean-design §3 既有推迟项）。
+- 增量子树重建（失效策略已锁定整图 `FullCurrent`，`runtime/invalidation.rs:14-22`）。
+- `advice`（`enhance/advice.rs` 的 `chain_advice`）：纯分析 + Tauri 对话框副作用，不属于配置生成，留在 tauri 侧对 `final_config` 调用（§9.3）。
+- 脚本引擎本体（boa/mlua 不进 `nyanpasu-config` 依赖）。
+
+---
+
+## 3. 锁定的架构决策
+
+| #   | 决策项           | 结论                                                                                                                                                                                                                                                                                                                                             |
+| --- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| D1  | 形态             | pure service：同步、顺序、无 IO/时钟/随机；文件与脚本经 port 注入                                                                                                                                                                                                                                                                                |
+| D2  | ports            | `ProfileContentSource`（按 `ManagedProfilePath` 读文本）+ `ScriptRunner`（整配置变换 `run` + Overlay `filter__` 所需的两个 item 级 Lua 求值方法，§6.2；roadmap T3p.1 勘误：仅 `run` 不够，实测 `use_merge` 内嵌 per-item Lua，`enhance/merge.rs:62-97`）                                                                                         |
+| D3  | 内建脚本         | `&[BuiltinTransform { name, runtime, source }]` 由调用方按 `ClashCore` bitflags 预门控、按序传入（旧门控表 `enhance/chain.rs:170-175`）；executor 零核类型知识                                                                                                                                                                                   |
+| D4  | 最终阶段节点划分 | 4 类节点：`WhitelistFieldFilter`（旧 stage-1 过滤）→ `GuardOverrides`（旧 HANDLE 覆盖）→ `BuiltinTransform`×N（旧内建脚本）→ `Finalizing`（旧 stage-2 过滤 + tun + include-all + cache + sort 复合单节点）。顺序依据旧实测 `enhance/mod.rs:107→110→121→146-150`；snapshot.rs 演示测试中的 Guard→Whitelist 顺序为非规范演示，随本 PR 修正（§8.3） |
+| D5  | tag 扩展         | 新增 `OperatorTag::BareRoot` 与 `OperatorTag::BuiltinTransform`；`GlobalTransform` / `BuiltinStep` / `BuiltinTransform` 的 `selected_profile_id` 改为 `Option<ProfileId>`（bare 模式复用同一条尾部管线）。`SnapshotNodeKey` 同步。wire 前向兼容 + 缓存严格解码契约兜底（§8.2）                                                                   |
+| D6  | guard 输入       | typed：`&ClashGuardOverrides`（serde 序列化取 kebab-case 键）+ `ResolvedPortBindings`（端口/external-controller 由**调用方**预解析——`PortStrategy::pick_and_try_port` 带 socket 探测 IO，绝不进 executor）                                                                                                                                       |
+| D7  | 错误策略         | 双层：**结构性失败 strict**（选中/base/contributor 的 Config 文件读取或解析失败 → typed error，调用方保留上一份 artifact 降级）；**变换级失败 lenient**（Overlay/Script/内建脚本失败 → 该节点值透传 + error 日志锚定于节点，管线继续；复刻旧 `process_chain` 语义，`enhance/utils.rs:114-119`）                                                  |
+| D8  | 日志             | `StepLogEntry { level: Log\|Info\|Warn\|Error, message }`（serde lowercase，1:1 对齐旧 `LogSpan`/`Logs`，`enhance/utils.rs:18-38`）；按 `SnapshotNodeKey` 锚定为 `Vec<StepLog>`，不引入 StepId                                                                                                                                                   |
+| D9  | applied_fields   | = 全局变换后节点的顶层键（小写、保持插入序）∩ 45 已知字段集，`IndexSet<String>`；覆盖旧 `exists_keys` 语义（含「无条件相交」怪癖），修复其 `HashSet` 乱序（`enhance/mod.rs:155-157`）                                                                                                                                                            |
+| D10 | Overlay 语义     | 全量复刻旧 `use_merge` 指令集（`prepend__/append__/override__/filter__` + 裸键深合并），含「指令键小写化、裸键保留大小写」的不对称怪癖（`merge.rs:248,310-312`），parity 优先、修复留待后续独立提案                                                                                                                                              |
+| D11 | 组合宽容化       | `extend_proxies_from` 成员缺 `proxies` 键 → 记 WARN + 视为空列表；工作配置缺 `proxies` → 建空列表再追加。旧 `merge_profiles` 在此**直接 panic**（`enhance/utils.rs:83-84` 双 `unwrap`），故意差异 #3                                                                                                                                             |
+| D12 | 并发             | 不并发。旧 scoped chains 经 `join_all` 并发只是性能优化（结果按 `IndexMap` 序收集，语义顺序无关）；纯执行器按声明序串行，输出等价。调用方可整体 `spawn_blocking`（§10.3）                                                                                                                                                                        |
+| D13 | 解析契约         | Config/Overlay 文件：YAML 文本 → `serde_yaml_ng::Value` → **应用 `<<:` merge key** → `ConfigValue::try_from`（拒绝非字符串键与 YAML tag）。复刻旧 `read_merge_mapping`（`utils/help.rs:45-57`）；strict 差异见 §13 #8                                                                                                                            |
+| D14 | artifact 序列化  | `RuntimeArtifact` 不整体 derive `specta::Type`（`ConfigValue` 无 specta）；graph/step_logs/applied_fields 各自可序列化，`final_config` 经 `to_json()` 投影，DTO 组装归 PR-3/PR-4                                                                                                                                                                 |
+
+---
+
+## 4. 现状（迁移起点，全部实测）
+
+### 4.1 nyanpasu-config runtime 模块（执行半缺失）
+
+- `ConfigSnapshotsBuilder`：`new_root(root_value, tag)` / `push(tag, value) -> NodeId`（主线追加并推进游标）/ `attach_independent_branch(parent_id, branch)`（嫁接独立分支，分支根强制 `Independent` + `Full` keyframe，主线游标不动）/ `build_stored()` / `build()`（`snapshot.rs:354-485`）。
+- `OperatorTag` 六变体：`FileConfigRoot{profile_id, role}` / `CompositionRoot{profile_id, base}` / `ExtendProxiesStep{composition_id, contributor_profile_id, contributor_index}` / `ScopedTransform{host, role, transform, kind, step_index}` / `GlobalTransform{selected, transform, kind, step_index}` / `BuiltinStep{selected, step}`（`snapshot.rs:79-113`）；`node_key()` 纯派生语义位置键 `SnapshotNodeKey`（丢弃展示性字段，跨重建稳定，`snapshot.rs:115-162`）。
+- `ConfigExecutionRole`：`Selected` / `CompositionBase{composition_id}` / `CompositionContributor{composition_id, contributor_index}`（`snapshot.rs:55-67`）。
+- 五种处理顺序的**录制形态已由测试锁定**（builder 模拟，非执行）：`snapshot.rs:1444-1741`——本设计的录制契约（§8.1）与其逐一对齐。
+- 失效：`invalidate_profile(changed, category, current, index, graph) -> SnapshotInvalidation{affected_configs, stale_node_keys, rebuild: None|FullCurrent}`（`invalidation.rs:38-78`），沿 base/extend 两表传递闭包。
+- 值模型 `ConfigValue`：结构共享（容器 `Arc` 包裹，路径更新只克隆 spine）、保序、custom serde；`try_from(serde_json/serde_yaml_ng::Value)`、`to_json()`、`set_path/remove_path`（`runtime/value/mod.rs:14-52`、`value/path.rs`）。
+- 持久化 feature `snapshot-persistence` 默认关闭；archive v2 严格解码，**任何解码失败 = cache miss 重建**（契约注释 `snapshot.rs:945-959`）。
+
+### 4.2 profile / clash 域输入面（#4840 已合并）
+
+- `Profiles { current: Option<ProfileId>, global_transforms: Vec<ProfileId>, valid: Vec<String>, items: IndexMap<ProfileId, ProfileItem> }`（`profile/profiles.rs:12-30`；`valid` 默认 `["dns","unified-delay","tcp-concurrent"]`，`:423-429`）。
+- `ConfigDefinition::File(FileConfig{source, transforms})` / `Composition(CompositionConfig{base: Option<ProfileId>, extend_proxies_from, transforms})`（`profile/definition.rs:15-51`）；`TransformDefinition::Overlay(OverlayTransform{source})` / `Script(ScriptTransform{source, runtime: JavaScript|Lua})`（`:54-96`）。
+- **三种来源统一物化**：`ProfileSource::materialized() -> &MaterializedFile{ file: ManagedProfilePath, .. }`（`profile/source.rs:34-47,93-104`）——executor 只经 `ManagedProfilePath` 读内容，不区分 Local/Remote/Symlink/Mirror。
+- `Profiles::validate()` 已保证：current 是 Config、transforms 全是 Transform、composition 成员是直接 FileConfig、无自引用/重复 contributor 等（`profiles.rs:128`, 错误集 `:223-293`）。executor 以「已验证快照」为前置，仍防御性返回 typed error 而非 panic。
+- Clash 域：`ClashConfig { overrides: ClashGuardOverrides, enable_tun_mode, enable_clash_fields, external_controller, mixed_port, socks_port, http_port, tun_stack, .. }`（`clash/config/mod.rs:27-59`）。`ClashGuardOverrides` 私有字段 `{log_level, allow_lan, mode, secret, unified_delay*, tcp_concurrent*, ipv6}`（kebab-case 序列化，`clash/config/overrides/mod.rs:57-67`；`*` 为 `default-meta` 门控）。**端口是策略类型，解析带 socket 探测 IO**（`clash_strategy/port.rs:58-65`）→ D6。
+- App 域仅两个相关输入：`core: ClashCore`（bitflags 五变体，`application/clash_core.rs:24-35`）与 `enable_builtin_enhanced: bool`（`application/mod.rs:129`）——两者只被**调用方**用于组装 `BuiltinTransform` 列表（D3）。
+
+### 4.3 旧 `enhance()` 实测流程（行为对照基线）
+
+`backend/tauri/src/enhance/mod.rs:22-160`，唯一调用点 `Config::generate()`（`config/core.rs:89`）：
+
+```text
+ 1. clash_config = IClashTemp.0 克隆                          (mod.rs:24)
+ 2. verge 读 4 项: clash_core / enable_tun / enable_builtin
+    / enable_filter(enable_clash_fields)                      (mod.rs:26-35)
+ 3. profiles 读: current 集 + scoped chains + global chain
+    + valid; 文件同步 IO + rayon 并行读                        (mod.rs:38-76)
+ 4. valid = use_valid_fields(valid)
+          = (valid∩OTHERS, 小写) ++ DEFAULT                    (field.rs:67-77)
+ 5. scoped chains 并发执行(join_all), 链内严格串行              (mod.rs:83-88)
+ 6. merge_profiles: 首个全量, 其余仅追加 proxies(缺键 panic!)   (utils.rs:72-89)
+ 7. global chain 串行                                          (mod.rs:102)
+ 8. exists_keys = use_keys(config)  ← 过滤前快照, 小写保序      (mod.rs:106)
+ 9. 【stage-1 过滤】whitelist(valid), enable_filter 门控        (mod.rs:107)
+10. 【守卫覆盖】HANDLE_FIELDS 9 键从 clash_config 无条件插入,
+    绕过 stage-1 白名单                                        (mod.rs:110-116)
+11. clash_fields = 45 全集(DEFAULT++HANDLE++OTHERS)            (mod.rs:118)
+12. 【内建脚本】enable_builtin 门控, 按核 bitflags 过滤, 串行,
+    错误吞掉+透传, 日志被丢弃((res, _))                        (mod.rs:121-144)
+13. 【stage-2 过滤】whitelist(clash_fields 45), 同门控          (mod.rs:146)
+14. use_tun → use_include_all_proxy_groups → use_cache
+    → use_sort                                                (mod.rs:147-150)
+15. advice::chain_advice(&config) → 仅产日志(含对话框副作用)     (mod.rs:152)
+16. exists_keys ∩= clash_fields — 无条件、经 HashSet 乱序       (mod.rs:155-157)
+17. 返回 (config, exists_keys, PostProcessingOutput)
+```
+
+关键常量（`enhance/field.rs:4-56`，共 45 键）：
+
+- `HANDLE_FIELDS`（9）：`mode, port, socks-port, mixed-port, allow-lan, log-level, ipv6, secret, external-controller`
+- `DEFAULT_FIELDS`（5）：`proxies, proxy-groups, proxy-providers, rules, rule-providers`
+- `OTHERS_FIELDS`（31）：`dns, tun, ebpf, hosts, script, profile, payload, tunnels, auto-redir, experimental, interface-name, routing-mark, redir-port, tproxy-port, iptables, external-ui, bind-address, authentication, tls, sniffer, geox-url, listeners, sub-rules, geodata-mode, unified-delay, tcp-concurrent, enable-process, find-process-mode, skip-auth-prefixes, external-controller-tls, global-client-fingerprint`
+
+链条目语义（`enhance/utils.rs:92-127`）：Merge（`use_merge` 永不失败，只产 WARN，`merge.rs:242-318`）；Script 失败 → `logs.error` + 配置**透传**。链引用解析失败（文件缺失等）→ 条目**静默丢弃**（`utils.rs:11-16` 双 `filter_map`）。
+
+**bare 路径实测**（`current` 为空）：`current_mappings` 空 → `merge_profiles` fold 零次 → 空 Mapping → global chain 照跑 → 守卫 9 键插入 → 内建 → tun/cache/sort ⇒ 产出可用裸配置。启动时 `Config::init_config()` 无条件 `generate()`（`config/core.rs:52`），此路径真实存在，必须保留。
+
+`use_tun` 键级语义（`enhance/tun.rs:26-109`）：见 §7.4 Finalizing 表。`use_sort`：已知键按 `HANDLE++OTHERS++DEFAULT` 固定序重排；`enable_filter == false` 时未知键经 `HashSet::difference` **乱序**追尾（`field.rs:115-147`）。
+
+### 4.4 输出消费面（artifact 必须覆盖）
+
+- `IRuntime { config: Option<Mapping>, exists_keys: Vec<String>, postprocessing_output }`（`config/runtime.rs:19-26`）；写入点唯一：`Config::generate()`（`core.rs:87-98`）；落盘 `generate_file` → `clash-config.yaml`（`core.rs:70-85`）。
+- IPC 四条（`ipc.rs:400-443`，注册 `lib.rs:213-216`）：`get_runtime_config`（JSON）/ `get_runtime_yaml` / `get_runtime_exists`（注意：**不是** `get_runtime_exists_keys`，roadmap T3p.5 笔误）/ `get_postprocessing_output`。
+- `PostProcessingOutput { scopes: IndexMap<ProfileUid, IndexMap<ProfileUid, Logs>>, global: IndexMap<ProfileUid, Logs>, advice: Logs }`（`enhance/chain.rs:21-31`），`Logs = Vec<(LogSpan, String)>`，`LogSpan ∈ {Log, Info, Warn, Error}`（serde lowercase，`utils.rs:18-38`）。
+- `enhance()` 的 7 个间接触发点与 4 个 `generate_file` 调用点（PR-3/PR-4 切换清单，见 roadmap）。
+
+---
+
+## 5. 目标模块结构
+
+```text
+backend/nyanpasu-config/src/runtime/
+├── mod.rs                    # + pub mod executor;
+├── snapshot.rs               # 受控扩展: BareRoot / BuiltinTransform 变体、
+│                             #   selected_profile_id: Option 化（§8.2）
+├── invalidation.rs           # 仅适配 tag 变更（两个 match 臂），策略不动
+├── value/                    # 不动
+└── executor/
+    ├── mod.rs                # RuntimePipelineInputs / ExecutionTarget /
+    │                         #   execute() 入口 + 五顺序编排 + 共享尾部
+    ├── ports.rs              # ProfileContentSource / ScriptRunner /
+    │                         #   ScriptRunOutcome / PortError
+    ├── scoped.rs             # scoped FileConfig 分支构建
+    │                         #   （parse + 自身 transforms；三种 role 复用）
+    ├── compose.rs            # composition seed + proxies 提取/追加（11 条规则）
+    ├── overlay.rs            # Overlay 指令集全量语义（旧 use_merge 对位）
+    ├── builtin.rs            # Whitelist / Guard / Finalizing 三步实现
+    │                         #   + 45 字段常量 + tun/include-all/cache/sort
+    ├── artifact.rs           # RuntimeArtifact / StepLog / StepLogEntry / StepLogLevel
+    ├── error.rs              # RuntimePipelineError
+    └── tests/                # 仿 profile/tests 形态
+        ├── mod.rs
+        ├── orders.rs         # 五顺序 golden（§6.1 YAML 示例）
+        ├── overlay.rs        # 指令集表驱动
+        ├── builtin.rs        # 三步 + tun 矩阵
+        ├── compose.rs        # 11 条规则逐条
+        ├── invalidation.rs   # 失效→FullCurrent→重建集成
+        ├── parity.rs         # 旧 enhance() 对照 fixtures（无脚本路径）
+        └── fixtures/*.yaml   # include_str! 引入
+```
+
+**边界规则**：`executor/` 只依赖 `crate::{profile, clash::config, runtime::{snapshot, value}}` + `serde/serde_json/serde_yaml_ng/indexmap/thiserror/tracing`。禁止：`tokio`、文件/网络 IO、`std::time`、随机数、`port_scanner`、boa/mlua。CI 验证同成功判据 #7。
+
+---
+
+## 6. 输入模型（ports + 参数，完整签名）
+
+### 6.1 输入结构
+
+```rust
+// executor/mod.rs
+pub struct RuntimePipelineInputs<'a> {
+    /// 已通过 Profiles::validate() 的快照。
+    pub profiles: &'a Profiles,
+    pub target: ExecutionTarget,
+    pub guard: GuardInputs<'a>,
+    /// ClashConfig.enable_clash_fields —— 门控两段白名单过滤与 sort 的已知键约束。
+    pub whitelist_enabled: bool,
+    pub tun: TunParams,
+    /// 调用方已按 ClashCore bitflags 门控并排序（D3）。
+    pub builtin_transforms: &'a [BuiltinTransform],
+}
+
+pub enum ExecutionTarget {
+    /// Profiles.current 已解析出的选中 Config。
+    Selected(ProfileId),
+    /// current = None：复刻旧「裸配置」路径（§4.3）。
+    Bare,
+}
+
+pub struct GuardInputs<'a> {
+    /// 序列化后取 kebab-case 顶层键值对整体插入（D6）。
+    pub overrides: &'a ClashGuardOverrides,
+    /// 调用方预解析（端口探测 IO 不进 executor）。
+    pub ports: ResolvedPortBindings,
+}
+
+/// 与旧 HANDLE_FIELDS 中 4 个端口类键对位（§7.4 映射表）。
+pub struct ResolvedPortBindings {
+    pub mixed_port: u16,
+    pub port: Option<u16>,        // HTTP 端口（旧键 "port"）
+    pub socks_port: Option<u16>,
+    pub external_controller: Option<String>,  // "host:port"
+}
+
+pub struct TunParams {
+    pub enable: bool,
+    pub flavor: TunFlavor,
+    /// 平台条件作为输入（调用方传 cfg!(windows)），executor 跨平台确定（§7.4）。
+    pub windows_fake_ip_filter: bool,
+}
+
+/// 调用方从 (core, ClashConfig.tun_stack) 派生，含 Premium+Mixed→Gvisor 降级
+/// （旧 tun.rs:58-60 的核知识留在调用方，executor 零核类型）。
+pub enum TunFlavor {
+    ClashRs,                       // device-id/auto-route 分支（tun.rs:44-50）
+    Standard { stack: TunStack },  // stack/dns-hijack/auto-route/auto-detect-interface 分支
+}
+
+pub struct BuiltinTransform {
+    pub name: Arc<str>,            // 如 "verge_hy_alpn"，进 tag 与日志锚点
+    pub runtime: ScriptRuntime,
+    pub source: Arc<str>,
+}
+```
+
+不单列 `valid` 参数：白名单步骤直接读 `profiles.valid`（域内数据不重复注入）。
+
+### 6.2 Ports
+
+```rust
+// executor/ports.rs
+pub type PortError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// 按物化路径读文本。调用方可用「预读内容 map」实现，使 executor 全程零阻塞。
+pub trait ProfileContentSource {
+    fn read(&self, path: &ManagedProfilePath) -> Result<String, PortError>;
+}
+
+/// 镜像旧 ProcessOutput = (Result<Mapping>, Logs)：失败也返回日志（parity，D8）。
+pub struct ScriptRunOutcome {
+    pub result: Result<ConfigValue, PortError>,
+    pub logs: Vec<StepLogEntry>,
+}
+
+pub trait ScriptRunner {
+    /// 整配置变换（Script transform / 内建脚本）。对位旧 process_honey。
+    fn run(&self, runtime: ScriptRuntime, source: &str, config: &ConfigValue) -> ScriptRunOutcome;
+
+    /// Overlay `filter__` 的 item 级 Lua 谓词（旧 run_expr 布尔用法 / `when`）。
+    fn eval_item_predicate(&self, expr: &str, item: &ConfigValue) -> Result<bool, PortError>;
+
+    /// Overlay `filter__` 的 `when + expr` 变体：以 item 为输入求值出替换值。
+    fn eval_item_expr(&self, expr: &str, item: &ConfigValue) -> Result<ConfigValue, PortError>;
+}
+```
+
+**port 契约（写入 rustdoc，PR-3 适配器义务）**：
+
+1. `run` 必须**保序返回**（旧 Lua runner 的 `correct_original_mapping_order` 是正确性步骤——mihomo dns policy 依赖字典序，`script/lua.rs:55-105`；boa 路径经 JSON 往返天然保序）。
+2. `run` 的临时文件、模块加载器（https import、`nyan:` 内建包）、`spawn_blocking` 等全部是适配器内部事务（`script/js.rs:202-277`）；executor 对其不可见。
+3. 两个 `eval_*` 方法今日仅 Lua 语义（旧 `use_merge` 硬编码 Lua，`merge.rs:63`），签名不带 runtime 参数；未来扩展再议。
+4. 同一输入必须给出同一应答（确定性责任划界，§10.2）。
+
+### 6.3 tauri 侧适配草图（PR-3 上下文，非本 PR 交付）
+
+- `ProfileContentSource` ⇒ 预读 map：`RuntimeBuilder` 先异步收集所有需要的 `ManagedProfilePath`（selected/base/contributors + 全部被引用 transforms），`tokio::fs` 批量读入 `HashMap<ManagedProfilePath, String>`，再进 `spawn_blocking` 同步执行整条管线。
+- `ScriptRunner` ⇒ 适配现有 `RunnerManager`/boa/mlua（`enhance/script/`），`eval_*` 适配 `run_expr`。
+
+---
+
+## 7. 管线语义
+
+### 7.1 顺序分派（clean-design §7.1–7.5 → 执行）
+
+| 场景                     | 触发条件                                        | 管线                                                                                                                                        |
+| ------------------------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| ① FileConfig-as-current  | `target=Selected(id)`，`ConfigDefinition::File` | 读文件→解析→scoped transforms→**共享尾部**                                                                                                  |
+| ② FileConfig-as-member   | 被 ③/④ 递归调用（base 或 contributor）          | 读文件→解析→scoped transforms→返回 scoped result；**不跑** global/尾部（§7.2 铁律）                                                         |
+| ③ Composition with base  | `Composition{base: Some(b)}`                    | ② 构建 b（role=CompositionBase）→以其 scoped result 为工作配置→逐 contributor：② 构建→提取 proxies→追加→composition transforms→**共享尾部** |
+| ④ Composition clean-seed | `Composition{base: None}`                       | 工作配置 = `{proxies: []}`（最小 seed，不隐式注入其他字段）→同 ③ 的 contributor/transforms→**共享尾部**                                     |
+| ⑤ Bare                   | `target=Bare`                                   | 工作配置 = `{}`→**共享尾部**（global transforms 照跑，复刻旧路径 §4.3）                                                                     |
+
+**共享尾部**（唯一一次，只作用于最终被选中的工作配置）：
+
+```text
+global_transforms（逐条）
+→ applied_fields 采样（此刻顶层键，小写，保序）
+→ WhitelistFieldFilter（stage-1: (valid∩OTHERS 小写) ∪ DEFAULT；whitelist_enabled 门控）
+→ GuardOverrides（overrides 序列化键值 + ResolvedPortBindings 无条件插入）
+→ BuiltinTransform × N（lenient）
+→ Finalizing（stage-2 45 键过滤〔同门控〕→ tun → include-all → cache → sort）
+→ applied_fields ∩= 45 已知集（无条件，parity）
+```
+
+### 7.2 `extend_proxies_from` 11 条规则 → 实现对位
+
+| 规则（clean-design §7.5）                       | 实现                                                                                      |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 1/2 base Some→scoped base 起步；None→clean seed | `compose.rs`：工作配置初值                                                                |
+| 3/4 保留工作配置全部字段与已有 proxies          | 只 append，不触碰其他键                                                                   |
+| 5 按声明序处理成员                              | `for (idx, id) in extend_proxies_from.iter().enumerate()`                                 |
+| 6 成员先完成解析 + 自身 transforms              | 复用 `scoped.rs`（role=CompositionContributor{idx}）                                      |
+| 7 只提取 `proxies`                              | `member.get("proxies")`；缺键/非数组 → WARN + 空列表（D11）                               |
+| 8 依次追加                                      | `working.proxies.extend(member_proxies)`；工作配置缺 `proxies` 键 → 建 `[]` 再追加（D11） |
+| 9 不合并其他字段                                | 无其他键操作                                                                              |
+| 10 不去重/不覆盖/不重命名                       | 原样 extend                                                                               |
+| 11 重复节点交给下游 Clash 校验                  | executor 不做去重                                                                         |
+
+### 7.3 Transform 应用语义
+
+**Script**（`TransformDefinition::Script`）：`ContentSource.read(source.materialized().file)` → `ScriptRunner::run(runtime, source_text, current)`。`result: Ok` → 采用新配置；`Err` → error 日志 + 透传（D7）。transform 源文件读取失败同为 lenient（error 日志 + 透传节点；旧行为是**静默不进链**，改进见 §13 #6）。
+
+**Overlay**（`TransformDefinition::Overlay`，= 旧 Merge 链条目，`enhance/merge.rs` 全量对位）：
+
+| 指令                       | 语义（全部路径支持 `.` 嵌套 + 数字段索引，`merge.rs:27-48`）                                                                                                                                                                                               |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `prepend__x` / `prepend-x` | 目标须存在且为序列：`splice(0..0)`；否则 WARN 跳过                                                                                                                                                                                                         |
+| `append__x` / `append-x`   | 同上但 `extend` 尾插                                                                                                                                                                                                                                       |
+| `override__x`              | 路径存在→整体替换；**不存在不创建**，WARN                                                                                                                                                                                                                  |
+| `filter__x`                | 目标须存在且为序列。过滤值：字符串→Lua 谓词逐项 `retain`（求值错误 = 移除该项，parity）；序列→递归多过滤器；映射 `when`+`expr`→真值项替换为 `eval_item_expr` 结果；`when`+`override`→字面替换;`when`+`merge`→逐键深合并；`when`+`remove`→按点路径/索引删除 |
+| 裸键                       | `override_recursive`：既有值为映射→逐键深合并（保留未提及兄弟键）；标量/**序列**→整体替换；缺失→插入                                                                                                                                                       |
+| 大小写                     | 指令键整体小写化（含路径段），裸键保留原大小写——不对称怪癖**原样保留**（D10）                                                                                                                                                                              |
+| 失败模型                   | 永不中断：一切异常路径 = WARN 日志 + 该键跳过（`merge.rs:242-318`）                                                                                                                                                                                        |
+
+`when`/`expr` 求值错误路径以 `merge.rs` 逐行为准在实施时锁定（golden 测试固化），本表为当前最佳读解（开放问题 #1）。
+
+### 7.4 三个 BuiltinStep 的真实逻辑（`builtin.rs`）
+
+**WhitelistFieldFilter**（旧 stage-1，`field.rs:67-95`）：
+
+- 列表 = `(profiles.valid 逐项小写 ∩ OTHERS_FIELDS) ∪ DEFAULT_FIELDS`；`HANDLE_FIELDS` 永不在内（守卫字段不许来自 profile 输出——这是白名单在 Guard **之前**的原因，D4）。
+- `whitelist_enabled == false` → 整步 no-op（节点仍录制，changed_fields 为空）。
+
+**GuardOverrides**（旧 mod.rs:110-116 的 HANDLE 覆盖）：
+
+| 旧 HANDLE 键（9）                                   | 新来源                                                                                                     |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `mode, log-level, allow-lan, ipv6, secret`          | `ClashGuardOverrides` 序列化键                                                                             |
+| `mixed-port, port, socks-port, external-controller` | `ResolvedPortBindings`（`port`/`socks-port`/`external-controller` 为 `None` 时不插键）                     |
+| —（新增）`unified-delay, tcp-concurrent`            | `ClashGuardOverrides`（`default-meta` 门控）——**故意差异 #5**：域类型接管这两个 app 拥有的开关，无条件强制 |
+
+插入 = 顶层键无条件覆盖（绕过 stage-1 白名单，parity）。
+
+**Finalizing**（复合单节点，旧 mod.rs:146-150）：
+
+1. stage-2 过滤：45 全集，`whitelist_enabled` 门控。
+2. `tun`（`tun.rs:26-109` 对位）：`!enable && 无 tun 键` → 不动；否则 `tun.enable = enable`（覆盖写）；enable 时按 `TunFlavor` 追加缺省键（仅缺键补，`append!` 语义）——`ClashRs`: `device-id:"dev://utun1989", auto-route:true`；`Standard{stack}`: `stack:<str>, dns-hijack:["any:53"], auto-route:true, auto-detect-interface:true`——再作 dns 收尾：`dns.enable=true`（覆盖写）+ 缺键补 `enhanced-mode:"fake-ip"`、`fake-ip-range:"198.18.0.1/16"`、`nameserver:[114.114.114.114,223.5.5.5,8.8.8.8]`、`fallback:[]`，`windows_fake_ip_filter` 时补 `fake-ip-filter:[dns.msftncsi.com,www.msftncsi.com,www.msftconnecttest.com]`。
+3. include-all（`mod.rs:163-248` 对位）：收集 `proxies[].name` + `proxy-providers` 键；对 `include-all: true` 的 proxy-group 重写 `proxies` 为「全部收集名 + 原有未重复项」并删 `include-all` 键。
+4. cache（`mod.rs:250-261` 对位）：缺 `profile` 键则插 `{store-selected: true, store-fake-ip: false}`；已存在不合并。
+5. sort（`field.rs:115-147` 对位）：已知键按 `HANDLE++OTHERS++DEFAULT` 固定序重排；未知键（仅 `!whitelist_enabled` 时存在）**保持原相对序**追尾（修复旧 HashSet 乱序，故意差异 #2）。
+
+### 7.5 决策流程图（顺序分派 + 共享尾部）
+
+```mermaid
+flowchart TD
+  A["execute(inputs)"] --> B{"target"}
+  B -->|"Bare"| E0["工作配置 = {}<br/>root: BareRoot"]
+  B -->|"Selected(id)"| C{"items[id].definition"}
+  C -->|"Config::File"| D1["§7.1 读文件+解析<br/>root: FileConfigRoot(Selected)"]
+  D1 --> D1t["scoped transforms 逐条<br/>push: ScopedTransform"]
+  C -->|"Config::Composition"| E{"base?"}
+  E -->|"Some(b)"| F1["§7.2 构建 b 分支<br/>role=CompositionBase"]
+  F1 --> F2["工作配置 = b 的 scoped result<br/>root: CompositionRoot{base:Some}"]
+  E -->|"None"| G["工作配置 = {proxies: []}<br/>root: CompositionRoot{base:None}"]
+  F2 --> H["逐 contributor:<br/>§7.2 构建成员分支(独立嫁接)<br/>提取 proxies → 追加<br/>push: ExtendProxiesStep"]
+  G --> H
+  H --> I["composition transforms 逐条<br/>push: ScopedTransform(host=composition)"]
+  D1t --> J
+  I --> J["global_transforms 逐条<br/>push: GlobalTransform"]
+  E0 --> J
+  J --> K["applied_fields 采样"]
+  K --> L["push: BuiltinStep::WhitelistFieldFilter<br/>(stage-1: valid∩OTHERS ∪ DEFAULT)"]
+  L --> M["push: BuiltinStep::GuardOverrides<br/>(overrides + resolved ports)"]
+  M --> N["逐内建脚本(lenient)<br/>push: BuiltinTransform"]
+  N --> O["push: BuiltinStep::Finalizing<br/>(45键过滤→tun→include-all→cache→sort)"]
+  O --> P["applied_fields ∩= 45 已知集"]
+  P --> Q["builder.build() → RuntimeArtifact"]
+```
+
+（§7.2 成员子流程：`ContentSource.read` → 解析 → 自身 transforms 逐条 `push: ScopedTransform(role=member)` → 返回分支 builder + 末值；**绝不**执行 global/尾部。）
+
+---
+
+## 8. 快照图录制契约
+
+### 8.1 逐步录制规则（与 `snapshot.rs:1444-1741` 既有 builder 模拟测试对齐）
+
+| 管线时刻                                 | builder 调用                                                                                              | tag                                                                                                  | baseline                    |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------- |
+| 选中 FileConfig 解析完                   | `new_root(raw, ..)`                                                                                       | `FileConfigRoot{id, Selected}`                                                                       | Independent（根强制）       |
+| bare 起步                                | `new_root({}, ..)`                                                                                        | `BareRoot`（新）                                                                                     | Independent                 |
+| composition 起步                         | `new_root(seed_or_base_result, ..)`                                                                       | `CompositionRoot{id, base}`                                                                          | Independent                 |
+| base 分支                                | 子 builder 整体 `attach_independent_branch(root, ..)`                                                     | 分支内 `FileConfigRoot{b, CompositionBase}` + `ScopedTransform`                                      | 分支根强制 Independent+Full |
+| 第 i 个 contributor 分支                 | `attach_independent_branch(当前主线节点, ..)` → 随后 `push(ExtendProxiesStep{comp, member, i}, 追加后值)` | 同上（role=Contributor{i}）                                                                          | 同上                        |
+| 每条 scoped/composition/global transform | `push(tag, 变换后值)`；lenient 失败时值 = 透传前值                                                        | `ScopedTransform{host, role, transform, kind, i}` / `GlobalTransform{selected?, transform, kind, i}` | Parent                      |
+| 白名单/守卫/收尾                         | `push`                                                                                                    | `BuiltinStep{selected?, step}`                                                                       | Parent                      |
+| 每个内建脚本                             | `push`                                                                                                    | `BuiltinTransform{selected?, name, i}`（新）                                                         | Parent                      |
+
+不变式：主线 = 单链；分支只经 `attach_independent_branch` 嫁接（`current` 游标不动，`snapshot.rs:424-427`）；同一 `SnapshotNodeKey` 在一张图中唯一（尾部四类步各至多一次 + 内建脚本以 `step_index` 区分）。
+
+### 8.2 `OperatorTag` / `SnapshotNodeKey` 受控扩展（D5）
+
+```rust
+// runtime/snapshot.rs 变更
+pub enum OperatorTag {
+    // ... 既有六变体，其中两个字段 Option 化：
+    GlobalTransform { selected_profile_id: Option<ProfileId>, /* 余下不变 */ },
+    BuiltinStep     { selected_profile_id: Option<ProfileId>, step: BuiltinStepKind },
+    // 新增：
+    /// current = None 的裸配置管线根。
+    BareRoot,
+    /// 内建增强脚本步骤（旧 BuiltinChain{name} 在 v2 重做中被移除，此处按新模型补回）。
+    BuiltinTransform {
+        selected_profile_id: Option<ProfileId>,
+        name: Arc<str>,        // 展示性；node_key() 丢弃
+        step_index: u32,
+    },
+}
+// SnapshotNodeKey 同步新增 BareRoot / BuiltinTransform{selected_profile_id, step_index}
+// 并对 GlobalTransform/Builtin 两键做同样 Option 化。
+```
+
+理由与备选：
+
+- 内建脚本必须有节点——step*logs 锚定（旧实现丢日志是缺陷，`mod.rs:133` 的 `(res, *)`）+ 未来 UI 图展示。**备选 A**（塞进 `BuiltinStepKind`）破坏其 `Copy`/位置键语义，涟漪更大；**备选 B**（伪 `ProfileId`复用`GlobalTransform`）污染失效扫描的 profile 引用语义（`invalidation.rs:125-158`）——均否决。
+- bare 模式四类尾部节点与 `GlobalTransform` 都携带 `selected_profile_id`，`Option` 化是唯一不复制管线的方案（备选「PR-3 侧复制最终阶段」= 逻辑漂移温床，否决）。
+- **wire 影响**：新增变体不影响旧档解码；`ProfileId → Option<ProfileId>` 在 serde 下前向兼容（旧值直接落 `Some`）；即便有边角失配，archive v2 严格解码 + 「解码失败 = cache miss 重建」契约兜底（`snapshot.rs:945-959`），且 feature 默认关闭、crate 尚无消费者。**不 bump `SNAPSHOT_ARCHIVE_VERSION`**。
+- 连带适配：`node_key()` 两臂 + 两新臂；`invalidation.rs::tag_references_any_profile` 的 `GlobalTransform`/`BuiltinStep` 臂改 `Option` 判定并补两新臂（`BareRoot` 不引用任何 profile；`BuiltinTransform` 仅引用 `selected`）。
+
+### 8.3 既有演示测试勘误
+
+`snapshot.rs:1444-1523`（`selected_file_config_processing_order_is_scoped_global_builtin`）演示序为 Guard→Whitelist→Finalizing，与本设计的规范序（Whitelist→Guard→内建→Finalizing，依据旧实测 §4.3 第 9/10/12/13 步）不符。该测试是 builder 机械演示、非语义规范；随本 PR 把演示序改为规范序，避免误导后续读者（改动仅测试内 tag 顺序，属于本次变更的直接收尾）。
+
+---
+
+## 9. 输出模型
+
+### 9.1 类型
+
+```rust
+// executor/artifact.rs
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "lowercase")]
+pub enum StepLogLevel { Log, Info, Warn, Error }   // 1:1 旧 LogSpan（utils.rs:18-25）
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+pub struct StepLogEntry { pub level: StepLogLevel, pub message: String }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
+pub struct StepLog { pub key: SnapshotNodeKey, pub entries: Vec<StepLogEntry> }
+
+pub struct RuntimeArtifact {
+    pub final_config: Arc<ConfigValue>,        // 主线末节点值；serde 经 to_json() 投影（D14）
+    pub graph: ConfigSnapshotsGraph,           // 已物化，UI/前端可直接消费
+    pub step_logs: Vec<StepLog>,               // 仅含非空条目节点，按录制序
+    pub applied_fields: IndexSet<String>,      // D9
+}
+```
+
+### 9.2 错误
+
+```rust
+// executor/error.rs —— 仅结构性失败（D7）；变换级失败进 step_logs 不进 Err
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimePipelineError {
+    #[error("selected profile {0} not found")]
+    SelectedProfileNotFound(ProfileId),
+    #[error("selected profile {0} is not a Config")]
+    SelectedProfileNotConfig(ProfileId),
+    #[error("composition {composition} member {member} invalid: {reason}")]
+    CompositionMemberInvalid { composition: ProfileId, member: ProfileId, reason: String },
+    #[error("read profile {profile} content at {path}: {source}")]
+    ContentSource { profile: ProfileId, path: ManagedProfilePath, #[source] source: PortError },
+    #[error("parse profile {profile} as config: {message}")]
+    ParseProfile { profile: ProfileId, message: String },   // YAML 解析 / merge-key / ConfigValue 转换
+    #[error(transparent)]
+    Snapshot(#[from] SnapshotBuildError),
+}
+```
+
+strict 面 = 选中/base/contributor 的 **Config 文件**读取与解析；transform 源文件与脚本执行 = lenient。`Snapshot(..)` 属实现级不变式破坏（理论不可达，防御保留）。
+
+### 9.3 旧消费面覆盖映射（PR-3/PR-4 接线表）
+
+| 旧消费                                                                                | 来源                         | 新来源                                                                                                                   |
+| ------------------------------------------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `IRuntime.config` / `get_runtime_config` / `get_runtime_yaml` / `generate_file` 落盘  | `Mapping`                    | `artifact.final_config.to_json()` / YAML 序列化                                                                          |
+| `IRuntime.exists_keys` / `get_runtime_exists`                                         | `Vec<String>`（乱序）        | `artifact.applied_fields`（确定序）                                                                                      |
+| `PostProcessingOutput.scopes[profile][chain_uid]`                                     | scoped 链日志                | `step_logs` 中 `SnapshotNodeKey::ScopedTransform{host_profile_id, ..}` 分组（按 tag 的 `transform_profile_id` 取链 uid） |
+| `PostProcessingOutput.global[chain_uid]`                                              | 全局链日志                   | `SnapshotNodeKey::GlobalTransform` 节点分组                                                                              |
+| 内建脚本日志                                                                          | **旧被丢弃**（`mod.rs:133`） | `SnapshotNodeKey::BuiltinTransform` 节点（新能力）                                                                       |
+| `PostProcessingOutput.advice`                                                         | `chain_advice(&config)`      | 不入 executor；tauri 侧对 `final_config` 调用（非目标）                                                                  |
+| `IRuntime::patch_config`（allow-lan/ipv6/log-level/mode 四键热补，`runtime.rs:6-17`） | 直改 runtime 全局            | PR-4：四键并入 `GuardInputs.overrides` 重建（roadmap §4.6 ④）                                                            |
+
+---
+
+## 10. 错误策略、确定性与纯度
+
+### 10.1 失败矩阵
+
+| 失败点                             | 策略                           | 旧行为                             | 依据                                                           |
+| ---------------------------------- | ------------------------------ | ---------------------------------- | -------------------------------------------------------------- |
+| 选中 Config 文件读/解析失败        | **strict** `Err`               | 静默跳过→退化成裸配置              | 调用方保留上一份 artifact 降级，比静默换配置更可诊断（§13 #4） |
+| base / contributor 文件读/解析失败 | **strict** `Err`               | `merge_profiles` panic 或静默缺席  | 显式组合不许静默丢节点（§13 #3）                               |
+| Overlay/Script 源文件读失败        | lenient：节点透传 + error 日志 | 链条目静默消失（`utils.rs:11-16`） | 图上可见失败（§13 #6）                                         |
+| Script 执行失败                    | lenient：透传 + error 日志     | 同（`utils.rs:114-119`）           | parity                                                         |
+| Overlay 指令异常                   | lenient：该键 WARN 跳过        | 同（`merge.rs`）                   | parity                                                         |
+| 内建脚本失败                       | lenient：透传 + error 日志     | 同但日志被丢（`mod.rs:136-141`）   | parity + 日志保留                                              |
+| 成员缺 `proxies`                   | lenient：WARN + 空列表         | **panic**（`utils.rs:83-84`）      | D11                                                            |
+| 图录制失败                         | strict（不变式破坏）           | N/A                                | 防御                                                           |
+
+### 10.2 确定性不变式（强制，有测试）
+
+- executor 内禁止：时钟、随机、环境读取、平台 `cfg`（平台差异一律参数化，如 `windows_fake_ip_filter`）、`HashSet`/`HashMap` **迭代**决定输出顺序（容器一律 `IndexMap`/`IndexSet`/`Vec`）。
+- 契约：`inputs` 相等 + ports 应答逐调用相等 ⇒ `RuntimeArtifact` 完全相等（含 graph 节点 id、键、日志序）。
+- port 侧不纯（JS 的 https import、缓存,`boa_utils/module/combine.rs:35-64`）是既有产品行为，属适配器责任域；契约以「相同应答」为界（风险表 R5）。
+
+### 10.3 阻塞模型
+
+executor 全同步。`ScriptRunner::run` 在 tauri 适配器内部封装 boa 的 `spawn_blocking` 需要时，推荐**整条 `execute()` 包进一个 `spawn_blocking`**（§6.3），避免逐脚本跨线程往返。
+
+---
+
+## 11. 失效集成（重建闭环）
+
+调用方（PR-3 的 ProfilesActor commit 钩子 / `rebuild_running_config`）：
+
+1. profile 事务提交 → `ProfileDependencyIndex::build(&profiles)`。
+2. `invalidate_profile(&changed, category, current.as_ref(), &index, Some(&stored_graph))`。
+3. `rebuild == FullCurrent` → 重新装配 inputs → `execute()` → 原子替换 artifact；`stale_node_keys` 交 UI 做锚点淡出。
+4. `rebuild == None` → 不动（图仍新鲜）。
+
+executor 自身不持图、不判断失效——它是被 `FullCurrent` 触发的无状态重建函数。`SnapshotNodeKey` 的跨重建稳定性（`snapshot.rs:163-165`）保证 UI 锚点在 3 后仍对得上，有专项测试（§15 T7）。
+
+---
+
+## 12. 图表
+
+### 12.1 组件 / 端口图
+
+```mermaid
+flowchart TB
+  subgraph caller["调用方（PR-3: tauri RuntimeBuilder / 测试: fakes）"]
+    IN["RuntimePipelineInputs<br/>profiles快照 · target · guard(typed+已解析端口)<br/>whitelist_enabled · tun · builtin_transforms"]
+    CSA["ContentSource 适配器<br/>（预读 map / tokio::fs）"]
+    SRA["ScriptRunner 适配器<br/>（boa / mlua / run_expr）"]
+  end
+  subgraph exec["nyanpasu-config :: runtime::executor（纯）"]
+    EN["mod.rs execute()"]
+    SC["scoped.rs<br/>FileConfig 分支"]
+    CO["compose.rs<br/>seed + 11 条追加规则"]
+    OV["overlay.rs<br/>指令集"]
+    BI["builtin.rs<br/>Whitelist/Guard/Finalizing<br/>45 字段常量"]
+    PT["ports.rs<br/>trait 边界"]
+  end
+  subgraph store["runtime::snapshot（既有 + §8.2 扩展）"]
+    BL["ConfigSnapshotsBuilder<br/>push / attach_independent_branch"]
+    IV["invalidation<br/>invalidate_profile → FullCurrent"]
+  end
+  OUT["RuntimeArtifact<br/>final_config · graph · step_logs · applied_fields"]
+  IN --> EN
+  EN --> SC & CO & BI
+  SC & CO --> OV
+  OV -. "filter__ 求值" .-> PT
+  SC -. "读文件 / run 脚本" .-> PT
+  BI -. "内建脚本 run" .-> PT
+  PT -. impl .-> CSA & SRA
+  EN --> BL
+  BL --> OUT
+  IV -. "FullCurrent 触发重跑" .-> EN
+```
+
+### 12.2 时序图 ①：选中 FileConfig 全程（§7.1）
+
+```mermaid
+sequenceDiagram
+  participant C as 调用方
+  participant E as executor
+  participant CS as ProfileContentSource
+  participant SR as ScriptRunner
+  participant B as SnapshotsBuilder
+  C->>E: execute(inputs{target: Selected(file_cfg)})
+  E->>CS: read(selected.materialized.file)
+  CS-->>E: yaml 文本
+  E->>E: 解析(+YAML merge-key)→ConfigValue
+  E->>B: new_root(raw, FileConfigRoot{Selected})
+  loop 每条 scoped transform
+    alt Overlay
+      E->>CS: read(overlay 源)
+      E->>E: 指令集应用
+      opt filter__ 指令
+        E->>SR: eval_item_predicate / eval_item_expr
+        SR-->>E: bool / 替换值
+      end
+    else Script
+      E->>CS: read(script 源)
+      E->>SR: run(runtime, source, cur)
+      SR-->>E: ScriptRunOutcome{result, logs}
+    end
+    E->>B: push(ScopedTransform{i}, 新值或透传)
+  end
+  loop 每条 global transform
+    E->>B: push(GlobalTransform{i}, ...)
+  end
+  E->>E: applied_fields 采样
+  E->>B: push(BuiltinStep::WhitelistFieldFilter)
+  E->>B: push(BuiltinStep::GuardOverrides)
+  loop 每个 builtin_transforms[j]
+    E->>SR: run(bt.runtime, bt.source, cur)
+    SR-->>E: outcome（失败=透传+error 日志）
+    E->>B: push(BuiltinTransform{j})
+  end
+  E->>B: push(BuiltinStep::Finalizing)
+  E->>B: build()
+  B-->>E: ConfigSnapshotsGraph
+  E-->>C: Ok(RuntimeArtifact)
+```
+
+### 12.3 时序图 ②：Composition with base（§7.3，分支嫁接细节）
+
+```mermaid
+sequenceDiagram
+  participant E as executor
+  participant CS as ContentSource
+  participant SR as ScriptRunner
+  participant BB as 分支 Builder（成员）
+  participant B as 主线 Builder
+  Note over E: base 分支（role=CompositionBase）
+  E->>CS: read(base 文件)
+  E->>BB: new_root(raw_base, FileConfigRoot{CompositionBase})
+  E->>SR: base 自身 transforms（同 §12.2 循环）
+  E->>BB: push(ScopedTransform ...)
+  Note over E: base scoped result = V_base
+  E->>B: new_root(V_base, CompositionRoot{base:Some})
+  E->>B: attach_independent_branch(root, base 分支)
+  loop 第 i 个 contributor
+    E->>CS: read(member_i)
+    E->>BB: 成员分支（role=Contributor{i}, 仅 scoped）
+    E->>B: attach_independent_branch(当前主线节点, 成员分支)
+    E->>E: 提取 proxies（缺→WARN+[]）→ 追加到工作配置
+    E->>B: push(ExtendProxiesStep{comp, member_i, i}, 追加后值)
+  end
+  E->>B: push(ScopedTransform{host=comp} × composition.transforms)
+  Note over E,B: 之后进入共享尾部（同 §12.2 global→…→Finalizing）
+```
+
+（clean-seed 变体 §7.4：`new_root({proxies: []}, CompositionRoot{base: None})`，无 base 分支，其余同上。）
+
+### 12.4 时序图 ③：失效 → FullCurrent → 重建（§11）
+
+```mermaid
+sequenceDiagram
+  participant P as 调用方（profile 事务提交后）
+  participant IV as invalidate_profile
+  participant E as executor
+  participant UI as UI（锚点）
+  P->>P: ProfileDependencyIndex::build(profiles')
+  P->>IV: invalidate_profile(changed, cat, current, index, Some(graph))
+  IV-->>P: {affected_configs, stale_node_keys, rebuild}
+  alt rebuild == FullCurrent
+    P->>P: 重装 inputs（新 profiles 快照 + 预读内容）
+    P->>E: execute(inputs)
+    E-->>P: RuntimeArtifact'
+    P->>P: 原子替换 artifact（旧图整体丢弃）
+    P->>UI: stale_node_keys + 新 graph（SnapshotNodeKey 稳定锚定）
+  else rebuild == None
+    P->>P: 保留现 artifact
+  end
+```
+
+### 12.5 上下文图：PR-3 消费拓扑（非本 PR 交付，定位用）
+
+```mermaid
+flowchart LR
+  PA["ProfilesActor<br/>(PR-3)"] -->|"commit 后快照"| RB["RuntimeBuilder（pure service, tauri）<br/>装配 inputs：<br/>· ClashConfigActor/ApplicationActor 取数<br/>（PR-2b 未合则旧全局+TODO 桥）<br/>· ClashCore 门控内建列表<br/>· 端口预解析 · 预读内容 map"]
+  RB -->|"spawn_blocking"| EX["runtime::executor::execute()"]
+  EX --> AR["RuntimeArtifact"]
+  AR --> Y["clash-config.yaml 落盘（产物）"]
+  AR --> CA["CoreActor / CoreManager<br/>UpdateConfig"]
+  AR --> IPC["get_runtime_config / yaml /<br/>exists / postprocessing_output"]
+  AR --> ADV["chain_advice(final_config)<br/>（tauri 侧，advice 补齐）"]
+```
+
+---
+
+## 13. 与旧 `enhance()` 的故意差异台账
+
+parity 是默认；**只有**下表条目允许输出不同，golden/parity 测试按此表放行：
+
+| #   | 差异                                | 旧行为（证据）                                   | 新行为                                                      | 理由                                                                      |
+| --- | ----------------------------------- | ------------------------------------------------ | ----------------------------------------------------------- | ------------------------------------------------------------------------- |
+| 1   | `exists_keys`/`applied_fields` 顺序 | `HashSet` 乱序（`mod.rs:155-157`）               | `IndexSet` 首见序                                           | 确定性（D9）                                                              |
+| 2   | sort 后未知键顺序                   | `HashSet::difference` 乱序（`field.rs:130-144`） | 原相对序                                                    | 确定性                                                                    |
+| 3   | 组合成员缺 `proxies`                | **panic**（`utils.rs:83-84`）                    | WARN + 空列表                                               | D11；崩溃不是语义                                                         |
+| 4   | 选中/成员 Config 文件坏             | 静默跳过 → 退化配置                              | strict `Err`，调用方保上一份 artifact                       | 可诊断降级                                                                |
+| 5   | `unified-delay`/`tcp-concurrent`    | 仅经 profile+valid 白名单路径                    | 进 GuardOverrides 无条件强制（meta 门控）                   | 域类型接管 app 拥有开关（D6）                                             |
+| 6   | transform 源文件缺失                | 链条目静默消失（`utils.rs:11-16`）               | 节点在图、透传 + error 日志                                 | 可见性                                                                    |
+| 7   | 内建脚本日志                        | 丢弃（`mod.rs:133`）                             | `BuiltinTransform` 节点锚定保留                             | 新能力                                                                    |
+| 8   | YAML tag / 非字符串键               | `Mapping` 容忍                                   | `ConfigValue` 解析 strict `Err`（`value/convert.rs:10-17`） | 值模型契约；风险 R4 缓解                                                  |
+| 9   | bare 模式 global transforms 的 tag  | 无图概念                                         | `GlobalTransform{selected: None}`（行为照跑）               | D5                                                                        |
+| 10  | scoped 链执行                       | 跨 profile 并发（`join_all`）                    | 串行                                                        | 输出等价，纯化（D12）                                                     |
+| 11  | `use_lowercase`                     | 死代码未被调用（`field.rs:97-113`）              | 不移植                                                      | 实测无调用点                                                              |
+| 12  | advice                              | 管线内产出（含对话框副作用）                     | 不入 executor，tauri 补                                     | 非目标                                                                    |
+| 13  | tun 期间二次读 verge                | `tun.rs:41` 重读全局                             | 参数一次注入                                                | 纯化，同快照内语义一致                                                    |
+| 14  | 守卫键缺省                          | 旧 guard 文件**缺**某 HANDLE 键 → 运行配置无该键 | typed `ClashGuardOverrides` 恒有默认值 → 恒插入             | migration V2 提取（roadmap T2.4）保证实际值延续；typed 域不表达「键缺失」 |
+
+（Overlay 指令键小写化不对称、`filter__` 错误移除项、`override__` 不创建路径、cache 不合并已有 `profile` 键、stage-1 排除 HANDLE 等怪癖 **原样保留**，不在差异表——它们是 parity 的一部分。）
+
+---
+
+## 14. 交付物与实施顺序
+
+对位 roadmap T3p.1–T3p.6；每项独立可验收，建议按序（T2 依赖 T1 的类型，T4–T6 依赖 T2/T3）：
+
+| #   | 任务                                                                                                                                                                                                                                                                    | 落点                                                             | 验证                                                                                                                                                          |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | **tag 扩展**：`BareRoot`/`BuiltinTransform` 变体 + `GlobalTransform`/`BuiltinStep` 的 `selected` Option 化；`node_key()`/`SnapshotNodeKey`/`invalidation.rs` 两臂适配；§8.3 演示测试改规范序                                                                            | `runtime/snapshot.rs`、`runtime/invalidation.rs`                 | 全部既有 serde 往返/失效测试绿 + 新变体往返测试 + 旧 v2 档解码仍过（`snapshot-persistence` 测试）                                                             |
+| T2  | **ports + 类型骨架**（T3p.1/T3p.5）：`ports.rs`/`artifact.rs`/`error.rs`/`inputs`；`MapContentSource`、`FakeScriptRunner`（`#[cfg(test)]`，脚本按预置应答表回放）                                                                                                       | `executor/{ports,artifact,error}.rs`、`executor/mod.rs` 类型部分 | 编译 + fake 注入单测                                                                                                                                          |
+| T3  | **Overlay 指令集**（T3p.2 一部分）：`overlay.rs` 全指令 + 怪癖 + WARN 模型；`filter__` 经 `eval_*` port                                                                                                                                                                 | `executor/overlay.rs`                                            | 表驱动测试逐指令（含大小写不对称、嵌套路径、数字索引、`when+expr/override/merge/remove` 五变体、错误路径对照 `merge.rs` 逐行）                                |
+| T4  | **scoped 分支 + 组合**（T3p.2）：`scoped.rs`（解析契约 D13 + 三 role）+ `compose.rs`（11 条规则 + D11 宽容化）+ 五顺序编排与录制契约（§8.1）                                                                                                                            | `executor/{scoped,compose}.rs`、`mod.rs` 编排                    | 11 条规则逐条单测 + 图形状断言（对齐 `snapshot.rs:1545-1655` 形态：root.next=[base 分支, member0 分支, extend0]…）                                            |
+| T5  | **三 BuiltinStep + 内建脚本步**（T3p.3/T3p.4）：`builtin.rs` 45 常量 + 四步实现 + tun 矩阵 + bare 尾部复用                                                                                                                                                              | `executor/builtin.rs`                                            | 白名单两段语义、guard 键映射表（§7.4）、tun 全矩阵（enable×flavor×windows 标志）、include-all/cache/sort 移植测试（含 `mod.rs:263-367` 两个旧测试的对位迁移） |
+| T6  | **五顺序 golden**（T3p.6 前半）：clean-design §6.1 YAML 示例做 fixtures，跑 ①–⑤ 全场景断言 final_config + graph + step_logs                                                                                                                                             | `executor/tests/{orders,fixtures}`                               | golden 全绿；确定性测试（跑两遍 artifact 全等）                                                                                                               |
+| T7  | **失效集成 + 锚点稳定**（T3p.6 中）：改 contributor 内容 → `FullCurrent` → 重建 → 断言新值 + `SnapshotNodeKey` 集与旧图可对齐                                                                                                                                           | `executor/tests/invalidation.rs`                                 | 集成测试绿                                                                                                                                                    |
+| T8  | **旧行为 parity fixtures**（T3p.6 后半）：无脚本路径（overlay/组合/守卫/收尾）的输入-期望对；期望值一次性用旧 `enhance()` 经**临时本地 harness 离线生成（harness 不入库，`backend/tauri` 提交面零改动）**，仅 fixtures YAML 提交到 nyanpasu-config 侧；含 bare 模式对照 | `executor/tests/parity.rs` + fixtures                            | 差异仅落在 §13 台账内；**含脚本的端到端 parity 显式移交 PR-3**（真实 boa/mlua 只在 tauri 侧存在）——在 PR-3 任务清单挂钩 T3.7                                  |
+| T9  | 文档收尾：roadmap §4.4 勘误（§16 清单）+ 本 spec 状态行更新                                                                                                                                                                                                             | `docs/design/actor-migration-roadmap.md`、本文件                 | git diff review                                                                                                                                               |
+
+统一验证：`cargo test -p nyanpasu-config` 全绿；`cargo test -p nyanpasu-config --features snapshot-persistence` 全绿。
+
+---
+
+## 15. 测试策略
+
+- **纯值测试为主**：一切输入显式构造（`Profiles` 字面量 + `MapContentSource` + `FakeScriptRunner` 应答表），无 tempdir、无 sleep、无 tokio（CLAUDE.md §13）。
+- **fake ScriptRunner**：`run` 按 `(runtime, source)` 查表返回预置 `ScriptRunOutcome`（含失败样例）；`eval_*` 同理。真实引擎 parity 归 PR-3。
+- **golden**（T6）：§6.1 完整示例（remote a/b、composition `all-subscriptions`、clean-seed `clean-subscriptions`、overlay/script transforms、global-fix）驱动五顺序。
+- **图形状**：录制契约逐场景断言 `stored.nodes[..].next` 拓扑与 baseline（对齐既有 builder 模拟测试的期望形态）。
+- **确定性**：同 inputs 双跑全等（含 graph 与日志序）。
+- **失效闭环**（T7）+ **parity**（T8）如上。
+- 覆盖 clean-design §18 第 17–21 条（顺序类）与第 25 条（clean-seed 场景）在 executor 侧的对应义务。
+
+## 16. 成功判据（可验证）
+
+1. 五种处理顺序 + bare 模式全部经 `execute()` 产出 artifact，golden 测试锁定。
+2. 11 条追加规则逐条有测试；组合宽容化（D11）有失败样例测试。
+3. 三 BuiltinStep + 内建脚本步语义与 §7.4 表逐键一致；tun 矩阵全绿。
+4. `RuntimeArtifact` 四字段覆盖 §9.3 映射表全部旧消费（映射表进 rustdoc）。
+5. 录制契约成立：每图单根单链主线、分支独立嫁接、`SnapshotNodeKey` 图内唯一且跨重建稳定（专项测试）。
+6. 失效闭环集成测试绿（`FullCurrent` → 重建 → 锚点对齐）。
+7. 纯度静态检查：`executor/` 无 `tokio`/`std::fs`/`std::net`/`std::time`/`rand`/`cfg(target_os` 引用（grep 断言即可）；无新增全局。
+8. parity fixtures 差异 ⊆ §13 台账；台账外差异 = 测试失败。
+9. `cargo test -p nyanpasu-config`（含 `--features snapshot-persistence`）全绿；`backend/tauri` **零改动**（本 PR 与 PR-2b 零文件重叠，可并行）。
+
+## 17. 风险与缓解
+
+| #   | 风险                                                                              | 缓解                                                                          |
+| --- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| R1  | **executor 行为漂移**（guide §7.4 列为最高风险）：白名单两段/守卫绕过/怪癖众多    | §4.3 十七步实测基线 + §13 封闭差异台账 + T8 parity fixtures；台账外差异即红   |
+| R2  | Overlay `filter__` 错误路径读解偏差                                               | T3 实施时对照 `merge.rs` 逐行锁定，golden 固化（开放问题 #1）                 |
+| R3  | tag wire 变更破坏旧缓存                                                           | 前向兼容分析（§8.2）+ 严格解码=重建契约 + feature 默认关 + 零消费者现状       |
+| R4  | 存量 profile 含 YAML tag/非字符串键 → strict 解析失败                             | 差异 #8 显式化；PR-3 迁移期对真实用户样本跑冒烟；错误信息带 profile id + 原因 |
+| R5  | JS 脚本网络 import 使「相同输入≠相同输出」                                        | 确定性契约以 port 应答为界（§10.2）；适配器缓存行为归 PR-3 文档               |
+| R6  | ClashRsAlpha 不吃 `clash_rs_comp` 的旧门控疑似 bug（`chain.rs:174` 仅 `ClashRs`） | executor 无关（列表调用方组装）；作为疑点移交 PR-3 决策：复刻或修复           |
+| R7  | bare 模式 tag Option 化涟漪超预期                                                 | T1 独立成任务先行落地，全量既有测试回归后再动 executor                        |
+
+## 18. 假设与开放问题
+
+**假设**
+
+1. `serde_yaml_ng::Value` 提供 `apply_merge`（对位旧 `<<:` 处理）；若无，等价 merge-key 解析实现进 `scoped.rs` 解析步（T4 首件事核实）。
+2. executor 输入的 `Profiles` 已 `validate()`；违约走防御性 typed error，不 panic。
+3. PR-2b 与本 PR 并行不冲突（零文件重叠，roadmap §4.1 已确认）。
+4. 前端对 `exists`/日志的消费按集合/分组语义处理，顺序变化（差异 #1/#2）无 UI 影响。
+
+**开放问题**
+
+1. `filter__` 的 `when`/`expr` 求值错误的逐分支行为 —— T3 对照源码锁定后回填 §7.3 表。
+2. 45 字段常量是否随 mihomo 新字段扩充（如 `tun` 新键）——本轮 verbatim 移植，扩充另开小 PR（常量单点维护在 `builtin.rs`）。
+3. `StepLogLevel` 是否需要 `Other(String)` 兜底 —— 旧 `LogSpan` 封闭四级，暂不需要；PR-3 若接第三方 runner 再议。
+
+## 19. roadmap 勘误清单（随 T9 回写 `actor-migration-roadmap.md` §4.4）
+
+1. T3p.1 的 `ScriptRunner` 单方法签名不够：Overlay `filter__` 需要 item 级求值方法 ×2（本 spec §6.2）。
+2. T3p.2 「tag 用新六变体」→ 实为**八变体**（+`BareRoot`、+`BuiltinTransform`，两字段 Option 化，§8.2）。
+3. T3p.5 提及的 `get_runtime_exists_keys` 实名为 `get_runtime_exists`（`ipc.rs:433-436`）。
+4. T3p.3 的 Finalizing 决策已裁定：stage-2 过滤 + tun + include-all + cache + sort 全部入 executor（皆确定无 IO）；advice 除外（§2 非目标）。
+5. 补充遗漏工作项：bare 模式（`current=None`）是 executor 显式目标（§2 目标 6）。


### PR DESCRIPTION
## Summary

Adds design and planning documents for the **actor-migration v2** effort. Docs only — no source changes.

These follow the repo's existing `docs/design/` and `docs/superpowers/specs/` conventions and provide the authoritative roadmap and per-PR blueprints for the next migration steps.

## Documents

| File | What it is |
|---|---|
| `docs/design/actor-migration-roadmap.md` | Corrected v2 migration roadmap (PR-1~PR-7 split) with `file:line` evidence; supersedes the external review doc as the single source of truth. |
| `docs/superpowers/specs/2026-06-27-three-stateactors-nyanpasu-config-design.md` | Approved blueprint (PR-2b) for splitting `StateActor` into three peer config-domain actors backed by `nyanpasu-config`. |
| `docs/superpowers/specs/2026-07-04-runtime-pipeline-executor-design.md` | Pure runtime pipeline executor design (PR-3-pre②) — the "execution half" of `nyanpasu-config`'s runtime module. |
| `docs/superpowers/plans/2026-07-04-runtime-pipeline-executor.md` | Task-by-task implementation plan for the executor above. |
| `docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/design.md` + `task.md` | PR-3 profiles domain switch (tauri, breaking change) — design and task breakdown. |

## Notes

- **Docs only**: no code, no dependency, no config changes.
- Baseline referenced by these docs is `refactor/runtime-snapshot-store-v2 @ d0b3cf6ac`, which has since landed in `main` via #4868.
- Branched off `main`; intended to merge independently of any in-flight implementation branch.
