### PR TITLE
fix(migration): preserve typed clash config during migration

### DIFF
--- a/backend/tauri/src/bridge/clash.rs
+++ b/backend/tauri/src/bridge/clash.rs
@@ -8,7 +8,7 @@ use nyanpasu_config::clash::config::{
         BreakConnectionStrategy, PortStrategy, PortStrategyKind, ProxyChangeBreakMode,
     },
 };
-use serde_yaml::Mapping;
+use serde_yaml::{Mapping, Value};
 use std::net::SocketAddr;
 
 pub struct LegacyClashBridge;
@@ -34,8 +34,9 @@ pub(crate) fn clash_config_from_legacy(
     legacy_verge: &IVerge,
     legacy_clash: &Mapping,
 ) -> anyhow::Result<ClashConfig> {
+    let legacy_clash = normalize_legacy_clash_overrides(legacy_clash);
     let mut next = ClashConfig {
-        overrides: super::yaml_convert(legacy_clash)?,
+        overrides: super::yaml_convert(&legacy_clash)?,
         ..ClashConfig::default()
     };
 
@@ -54,7 +55,7 @@ pub(crate) fn clash_config_from_legacy(
 
     let mixed_port = legacy_verge
         .verge_mixed_port
-        .unwrap_or_else(|| IClashTemp::guard_mixed_port(legacy_clash));
+        .unwrap_or_else(|| IClashTemp::guard_mixed_port(&legacy_clash));
     next.mixed_port = if legacy_verge.enable_random_port.unwrap_or(false) {
         PortStrategy {
             kind: PortStrategyKind::Random,
@@ -64,7 +65,7 @@ pub(crate) fn clash_config_from_legacy(
         PortStrategy::new_allow_fallback(mixed_port)
     };
 
-    if let Some(controller) = external_controller_from_legacy_clash(legacy_clash) {
+    if let Some(controller) = external_controller_from_legacy_clash(&legacy_clash) {
         next.external_controller.host = controller.ip();
         next.external_controller.port.start_port = controller.port();
     }
@@ -77,6 +78,16 @@ pub(crate) fn clash_config_from_legacy(
     next.break_connection = break_connection_from_legacy(legacy_verge);
 
     Ok(next)
+}
+
+fn normalize_legacy_clash_overrides(legacy_clash: &Mapping) -> Mapping {
+    let mut merged = IClashTemp::template().0;
+    for (key, value) in legacy_clash {
+        if !matches!(value, Value::Null) {
+            merged.insert(key.clone(), value.clone());
+        }
+    }
+    merged
 }
 
 fn external_controller_from_legacy_clash(legacy_clash: &Mapping) -> Option<SocketAddr> {

--- a/backend/tauri/src/config/core.rs
+++ b/backend/tauri/src/config/core.rs
@@ -9,6 +9,7 @@ use nyanpasu_utils::runtime::block_on;
 use once_cell::sync::OnceCell;
 use std::{env::temp_dir, path::PathBuf};
 
+pub const RUNTIME_CONFIG_DIR: &str = "runtime";
 pub const RUNTIME_CONFIG: &str = "clash-config.yaml";
 pub const CHECK_CONFIG: &str = "clash-config-check.yaml";
 
@@ -53,9 +54,12 @@ impl Config {
         if let Err(err) = Self::generate_file(ConfigType::Run) {
             log::error!(target: "app", "{err:?}");
 
-            let runtime_path = dirs::app_config_dir()?.join(RUNTIME_CONFIG);
+            let runtime_path = Self::runtime_config_path()?;
             // 如果不存在就将默认的clash文件拿过来
             if !runtime_path.exists() {
+                if let Some(parent) = runtime_path.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
                 help::save_yaml(
                     &runtime_path,
                     &Config::clash().latest().0,
@@ -69,9 +73,12 @@ impl Config {
     /// 将配置丢到对应的文件中
     pub fn generate_file(typ: ConfigType) -> Result<PathBuf> {
         let path = match typ {
-            ConfigType::Run => dirs::app_config_dir()?.join(RUNTIME_CONFIG),
+            ConfigType::Run => Self::runtime_config_path()?,
             ConfigType::Check => temp_dir().join(CHECK_CONFIG),
         };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
 
         let runtime = Config::runtime();
         let runtime = runtime.latest();
@@ -95,6 +102,12 @@ impl Config {
         };
 
         Ok(())
+    }
+
+    fn runtime_config_path() -> Result<PathBuf> {
+        Ok(dirs::app_config_dir()?
+            .join(RUNTIME_CONFIG_DIR)
+            .join(RUNTIME_CONFIG))
     }
 }
 

--- a/backend/tauri/src/core/migration/modules/typed_config.rs
+++ b/backend/tauri/src/core/migration/modules/typed_config.rs
@@ -8,9 +8,8 @@ use anyhow::{Context as _, bail};
 use once_cell::sync::Lazy;
 use semver::Version;
 use serde::{Serialize, de::DeserializeOwned};
-use serde_yaml::Mapping;
-use std::path::{Path, PathBuf};
-use struct_patch::Patch;
+use serde_yaml::{Mapping, Value};
+use std::path::Path;
 
 pub static MIGRATOR: TypedConfigMigrator = TypedConfigMigrator;
 
@@ -89,45 +88,154 @@ enum TypedFileState {
     None,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SharedClashFileState {
+    Missing,
+    Typed,
+    LegacyRuntime,
+    Unrecognized,
+}
+
 fn typed_file_state(ctx: &Ctx) -> anyhow::Result<TypedFileState> {
-    let paths = typed_paths(ctx);
-    let mut existing = Vec::new();
-    let mut missing = Vec::new();
+    let application_exists = typed_path_exists(&ctx.application_config_path())?;
+    let session_exists = typed_path_exists(&ctx.session_state_path())?;
+    let clash_state = classify_shared_clash_file(ctx)?;
 
-    for (name, path) in &paths {
-        if path
-            .try_exists()
-            .with_context(|| format!("failed to inspect typed config file {}", path.display()))?
-        {
-            existing.push(*name);
-        } else {
-            missing.push(*name);
-        }
+    if !application_exists && !session_exists {
+        return match clash_state {
+            SharedClashFileState::Missing => Ok(TypedFileState::None),
+            SharedClashFileState::LegacyRuntime => Ok(TypedFileState::None),
+            SharedClashFileState::Typed => partial_typed_file_state(
+                vec!["clash-config.yaml"],
+                vec!["application.yaml", "session-state.yaml"],
+            ),
+            SharedClashFileState::Unrecognized => bail!(
+                "unrecognized typed config migration state: existing {} is neither \
+                 a valid typed clash config nor a recognized legacy runtime config; restore or \
+                 remove it before retrying",
+                ctx.clash_config_path().display()
+            ),
+        };
     }
 
-    if existing.is_empty() {
-        return Ok(TypedFileState::None);
-    }
-
-    if missing.is_empty() {
+    if application_exists && session_exists && clash_state == SharedClashFileState::Typed {
         validate_existing_typed_files(ctx)?;
         return Ok(TypedFileState::All);
     }
 
+    if clash_state == SharedClashFileState::Unrecognized {
+        bail!(
+            "unrecognized typed config migration state: existing {} is neither \
+             a valid typed clash config nor a recognized legacy runtime config; restore or \
+             remove it before retrying",
+            ctx.clash_config_path().display()
+        );
+    }
+
+    let mut existing = Vec::new();
+    let mut missing = Vec::new();
+    push_file_state(
+        &mut existing,
+        &mut missing,
+        application_exists,
+        "application.yaml",
+    );
+    push_file_state(
+        &mut existing,
+        &mut missing,
+        session_exists,
+        "session-state.yaml",
+    );
+    match clash_state {
+        SharedClashFileState::Typed => existing.push("clash-config.yaml"),
+        SharedClashFileState::Missing | SharedClashFileState::LegacyRuntime => {
+            missing.push("clash-config.yaml")
+        }
+        SharedClashFileState::Unrecognized => unreachable!("handled above"),
+    }
+
+    partial_typed_file_state(existing, missing)
+}
+
+fn typed_path_exists(path: &Path) -> anyhow::Result<bool> {
+    path.try_exists()
+        .with_context(|| format!("failed to inspect typed config file {}", path.display()))
+}
+
+fn classify_shared_clash_file(ctx: &Ctx) -> anyhow::Result<SharedClashFileState> {
+    let path = ctx.clash_config_path();
+    if !typed_path_exists(&path)? {
+        return Ok(SharedClashFileState::Missing);
+    }
+
+    if read_yaml::<nyanpasu_config::clash::config::ClashConfig>(&path).is_ok() {
+        return Ok(SharedClashFileState::Typed);
+    }
+
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let value: Value = serde_yaml::from_str(&raw)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+
+    if looks_like_legacy_runtime_clash_mapping(&value) {
+        return Ok(SharedClashFileState::LegacyRuntime);
+    }
+
+    Ok(SharedClashFileState::Unrecognized)
+}
+
+fn looks_like_legacy_runtime_clash_mapping(value: &Value) -> bool {
+    let Some(map) = value.as_mapping() else {
+        return false;
+    };
+
+    [
+        "mixed-port",
+        "port",
+        "socks-port",
+        "redir-port",
+        "tproxy-port",
+        "external-controller",
+        "allow-lan",
+        "log-level",
+        "mode",
+        "ipv6",
+        "dns",
+        "tun",
+        "listeners",
+        "proxies",
+        "proxy-groups",
+        "rules",
+        "proxy-providers",
+        "rule-providers",
+    ]
+    .iter()
+    .any(|key| map.contains_key(&Value::String((*key).to_string())))
+}
+
+fn push_file_state(
+    existing: &mut Vec<&'static str>,
+    missing: &mut Vec<&'static str>,
+    exists: bool,
+    name: &'static str,
+) {
+    if exists {
+        existing.push(name);
+    } else {
+        missing.push(name);
+    }
+}
+
+fn partial_typed_file_state(
+    existing: Vec<&'static str>,
+    missing: Vec<&'static str>,
+) -> anyhow::Result<TypedFileState> {
     bail!(
         "partial typed config migration state: existing [{}], missing [{}]; \
          restore or remove the typed config files before retrying",
         existing.join(", "),
         missing.join(", ")
     );
-}
-
-fn typed_paths(ctx: &Ctx) -> [(&'static str, PathBuf); 3] {
-    [
-        ("application.yaml", ctx.application_config_path()),
-        ("session-state.yaml", ctx.session_state_path()),
-        ("clash-config.yaml", ctx.clash_config_path()),
-    ]
 }
 
 fn validate_existing_typed_files(ctx: &Ctx) -> anyhow::Result<()> {
@@ -261,6 +369,73 @@ mod tests {
         legacy.insert("mode".into(), "global".into());
         legacy.insert("ipv6".into(), true.into());
         write_yaml(path, &legacy);
+    }
+
+    #[test]
+    fn legacy_runtime_clash_config_alone_detects_baseline_zero() {
+        let (ctx, _temp) = test_ctx();
+        write_legacy_clash(&ctx.clash_config_path());
+
+        assert_eq!(MIGRATOR.detect_baseline(&ctx).unwrap(), 0);
+    }
+
+    #[test]
+    fn split_legacy_config_accepts_legacy_runtime_clash_config_alone() {
+        let (mut ctx, _temp) = test_ctx();
+        write_legacy_clash(&ctx.clash_config_path());
+        write_yaml(&ctx.nyanpasu_config_path(), &IVerge::template());
+
+        SPLIT_LEGACY_CONFIG.run(&mut ctx).unwrap();
+
+        let _: NyanpasuAppConfig = read_typed(&ctx.application_config_path());
+        let _: PersistentState = read_typed(&ctx.session_state_path());
+        let _: ClashConfig = read_typed(&ctx.clash_config_path());
+    }
+
+    #[test]
+    fn typed_clash_config_alone_still_fails_as_partial_typed_state() {
+        let (mut ctx, _temp) = test_ctx();
+        write_yaml(&ctx.clash_config_path(), &ClashConfig::default());
+
+        let err = SPLIT_LEGACY_CONFIG.run(&mut ctx).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("partial typed config migration state"),
+            "{err:#}"
+        );
+        assert!(err.to_string().contains("existing [clash-config.yaml]"));
+    }
+
+    #[test]
+    fn all_existing_valid_typed_files_detect_current_baseline() {
+        let (ctx, _temp) = test_ctx();
+        write_yaml(
+            &ctx.application_config_path(),
+            &NyanpasuAppConfig::default(),
+        );
+        write_yaml(&ctx.session_state_path(), &PersistentState::default());
+        write_yaml(&ctx.clash_config_path(), &ClashConfig::default());
+
+        assert_eq!(MIGRATOR.detect_baseline(&ctx).unwrap(), current_revision());
+    }
+
+    #[test]
+    fn unrecognized_clash_config_alone_fails_without_overwrite() {
+        let (ctx, _temp) = test_ctx();
+        std::fs::write(ctx.clash_config_path(), "unexpected: true\n").unwrap();
+
+        let err = MIGRATOR.detect_baseline(&ctx).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("unrecognized typed config migration state"),
+            "{err:#}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(ctx.clash_config_path()).unwrap(),
+            "unexpected: true\n"
+        );
     }
 
     #[test]

--- a/backend/tauri/src/core/migration/modules/typed_config.rs
+++ b/backend/tauri/src/core/migration/modules/typed_config.rs
@@ -610,4 +610,28 @@ mod tests {
         assert_eq!(clash.external_controller.host.to_string(), "127.0.0.1");
         assert_eq!(clash.external_controller.port.start_port, 19090);
     }
+
+    #[test]
+    fn legacy_clash_null_overrides_keep_defaults() {
+        let (mut ctx, _temp) = test_ctx();
+        write_yaml(&ctx.nyanpasu_config_path(), &IVerge::template());
+        std::fs::write(
+            ctx.clash_guard_overrides_path(),
+            "mode:\nlog-level:\nallow-lan:\nipv6:\n",
+        )
+        .unwrap();
+
+        SPLIT_LEGACY_CONFIG.run(&mut ctx).unwrap();
+
+        let clash: ClashConfig = read_typed(&ctx.clash_config_path());
+        let overrides = serde_yaml::to_value(&clash.overrides).unwrap();
+        let overrides = overrides.as_mapping().unwrap();
+        assert_eq!(overrides.get("mode"), Some(&Value::String("rule".into())));
+        assert_eq!(
+            overrides.get("log-level"),
+            Some(&Value::String("info".into()))
+        );
+        assert_eq!(overrides.get("allow-lan"), Some(&Value::Bool(false)));
+        assert_eq!(overrides.get("ipv6"), Some(&Value::Bool(false)));
+    }
 }

--- a/backend/tauri/src/core/migration/runner.rs
+++ b/backend/tauri/src/core/migration/runner.rs
@@ -190,7 +190,7 @@ fn introduced_in_reached(introduced_in: &Version, target: &Version) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::migration::store::ModuleState;
+    use crate::core::migration::store::{ModuleState, STORE_FILE_NAME};
     use anyhow::bail;
     use once_cell::sync::Lazy;
 
@@ -446,6 +446,78 @@ mod tests {
             application.hotkeys.is_empty(),
             "hotkeys are KV-owned after storage/hotkeys_to_kv and must not be re-seeded into typed application config"
         );
+        let _: nyanpasu_config::state::PersistentState = serde_yaml::from_str(
+            &std::fs::read_to_string(config_dir.join("session-state.yaml")).unwrap(),
+        )
+        .unwrap();
+        let _: nyanpasu_config::clash::config::ClashConfig = serde_yaml::from_str(
+            &std::fs::read_to_string(config_dir.join("clash-config.yaml")).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn existing_store_without_typed_config_accepts_legacy_runtime_clash_baseline() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_dir = temp.path().join("config");
+        let data_dir = temp.path().join("data");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let mut store = MigrationStore::default();
+        store.modules.insert(
+            "profiles".to_string(),
+            ModuleState {
+                applied_revision: 2,
+                baseline_revision: 2,
+            },
+        );
+        store.modules.insert(
+            "app_config".to_string(),
+            ModuleState {
+                applied_revision: 3,
+                baseline_revision: 3,
+            },
+        );
+        store.modules.insert(
+            "storage".to_string(),
+            ModuleState {
+                applied_revision: 1,
+                baseline_revision: 1,
+            },
+        );
+        store
+            .flush_atomic(&config_dir.join(STORE_FILE_NAME))
+            .unwrap();
+        std::fs::write(
+            config_dir.join("clash-config.yaml"),
+            "mixed-port: 7890\nproxies: []\nproxy-groups: []\nrules: []\n",
+        )
+        .unwrap();
+
+        let ctx = Ctx::new(config_dir.clone(), data_dir);
+        let mut runner =
+            Runner::with_context(Version::parse("2.0.0").unwrap(), false, ctx).unwrap();
+
+        assert_eq!(
+            runner.store.module_state("typed_config").applied_revision,
+            0
+        );
+        assert_eq!(
+            runner.store.module_state("typed_config").baseline_revision,
+            0
+        );
+
+        runner.run_pending().unwrap();
+
+        assert_eq!(
+            runner.store.module_state("typed_config").applied_revision,
+            1
+        );
+        let _: nyanpasu_config::application::NyanpasuAppConfig = serde_yaml::from_str(
+            &std::fs::read_to_string(config_dir.join("application.yaml")).unwrap(),
+        )
+        .unwrap();
         let _: nyanpasu_config::state::PersistentState = serde_yaml::from_str(
             &std::fs::read_to_string(config_dir.join("session-state.yaml")).unwrap(),
         )


### PR DESCRIPTION
## Summary

- classify an existing legacy runtime `clash-config.yaml` separately from real typed config state during `typed_config` baseline detection
- allow stores that predate the `typed_config` module to initialize at revision 0 and run `typed_config/split_legacy_config`
- ignore null legacy Clash override values while converting to typed `ClashGuardOverrides`, preserving defaults for enum/bool fields
- move generated runtime Clash output to `runtime/clash-config.yaml` so startup/core updates no longer overwrite typed `clash-config.yaml`

## Validation

- `cargo test --manifest-path backend/tauri/Cargo.toml "client::clash_config" --lib`
- `cargo test --manifest-path backend/tauri/Cargo.toml typed_config --lib`
- `cargo test --manifest-path backend/tauri/Cargo.toml "core::migration" --lib`

## Notes

This keeps typed `config_dir/clash-config.yaml` owned by the typed Clash config migration/state path, while the Clash core runtime artifact is generated under `config_dir/runtime/clash-config.yaml`.
