### PR TITLE
feat(tauri): add profiles domain layer (ports, file service, actor, refresh scheduler)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1836,6 +1836,7 @@ dependencies = [
  "md-5",
  "mime",
  "mlua",
+ "mockall",
  "nanoid",
  "nix 0.31.3",
  "notify",
@@ -2865,6 +2866,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3581,6 +3588,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fragile"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -5799,6 +5815,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7744,6 +7786,32 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "presser"
@@ -10664,6 +10732,12 @@ checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "termwiz"

--- a/backend/tauri/Cargo.toml
+++ b/backend/tauri/Cargo.toml
@@ -35,7 +35,7 @@ nyanpasu-utils = { workspace = true }
 nyanpasu-egui = { path = "../nyanpasu-egui" }
 
 # Common Utilities
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 tokio-util = { version = "0.7", features = ["full"] }
 oneshot = "0.2"
 futures = "0.3"

--- a/backend/tauri/Cargo.toml
+++ b/backend/tauri/Cargo.toml
@@ -271,6 +271,9 @@ windows-sys = { version = "0.61", features = [
 windows-core = "0.61"
 webview2-com = "0.38"
 
+[dev-dependencies]
+mockall = "0.13"
+
 [features]
 default = ["custom-protocol", "default-meta"]
 nightly = ["devtools", "deadlock-detection"]

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -2,6 +2,7 @@ mod application;
 mod clash_config;
 mod error;
 mod event_sink;
+pub mod profiles;
 mod session_state;
 
 use self::{

--- a/backend/tauri/src/client/profiles.rs
+++ b/backend/tauri/src/client/profiles.rs
@@ -876,6 +876,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "relies on real OS file events; flaky on loaded CI runners - run manually"]
     async fn external_watcher_smoke_mirror_real_file_event() {
         let config_dir = tempdir().unwrap();
         let data_dir = tempdir().unwrap();
@@ -1165,10 +1166,17 @@ mod tests {
             .reorder(ReorderOp::ByList(vec![ProfileId("cfg1".into())]))
             .await
             .unwrap_err();
-        assert!(matches!(
-            err,
-            ProfilesError::ValidationFailed(_) | ProfilesError::ProfileNotFound(_)
-        ));
+        assert!(matches!(err, ProfilesError::InvalidReorderList { .. }));
+
+        let err = client
+            .reorder(ReorderOp::ByList(vec![
+                ProfileId("cfg1".into()),
+                ProfileId("cfg1".into()),
+                ProfileId("ovl1".into()),
+            ]))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ProfilesError::InvalidReorderList { .. }));
     }
 
     #[tokio::test]
@@ -1230,10 +1238,291 @@ mod tests {
 
         let err = client.delete(ProfileId("ovl1".into())).await.unwrap_err();
         match err {
-            ProfilesError::ProfileInUse { referrers } => {
+            ProfilesError::ProfileInUse {
+                referrers,
+                current,
+                global_transforms,
+            } => {
                 assert_eq!(referrers, vec![ProfileId("cfg1".into())]);
+                assert!(!current);
+                assert!(!global_transforms);
             }
             other => panic!("expected ProfileInUse, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn validation_failure_leaves_disk_untouched() {
+        let (client, dir) = seeded_client().await;
+        let err = client
+            .set_current(Some(ProfileId("ghost".into())))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ProfilesError::ValidationFailed(_)));
+        drop(client);
+
+        let reopened = ProfilesClient::new(
+            temp_profiles_path(&dir),
+            std::sync::Arc::new(MockProfileFsPort::new()),
+            std::sync::Arc::new(MockSubscriptionFetcher::new()),
+            std::sync::Arc::new(MockRebuildNotifier::new()),
+        )
+        .await
+        .expect("reopen after failed mutation");
+        let snapshot = reopened.get().await.unwrap();
+        assert!(snapshot.current.is_none());
+        assert_eq!(snapshot.items.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn delete_protects_composition_base_and_contributors() {
+        let (client, _dir) = test_client_with(MockProfileFsPort::new()).await;
+        let mut profiles = seeded_profiles();
+        profiles.append_item(nyanpasu_config::profile::ProfileItem {
+            uid: ProfileId("comp".into()),
+            metadata: ProfileMetadata {
+                name: "COMP".into(),
+                desc: None,
+            },
+            definition: ProfileDefinition::Config {
+                config: ConfigDefinition::Composition(
+                    nyanpasu_config::profile::CompositionConfig {
+                        base: Some(ProfileId("cfg1".into())),
+                        extend_proxies_from: vec![ProfileId("cfg2".into())],
+                        transforms: vec![],
+                    },
+                ),
+            },
+        });
+        client.replace(profiles).await.unwrap();
+
+        let err = client.delete(ProfileId("cfg1".into())).await.unwrap_err();
+        match err {
+            ProfilesError::ProfileInUse {
+                referrers,
+                current,
+                global_transforms,
+            } => {
+                assert_eq!(referrers, vec![ProfileId("comp".into())]);
+                assert!(!current);
+                assert!(!global_transforms);
+            }
+            other => panic!("expected ProfileInUse, got {other:?}"),
+        }
+        let err = client.delete(ProfileId("cfg2".into())).await.unwrap_err();
+        match err {
+            ProfilesError::ProfileInUse { referrers, .. } => {
+                assert_eq!(referrers, vec![ProfileId("comp".into())]);
+            }
+            other => panic!("expected ProfileInUse, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_reports_document_level_references() {
+        let (client, _dir) = seeded_client().await;
+        client
+            .set_current(Some(ProfileId("cfg1".into())))
+            .await
+            .unwrap();
+        let err = client.delete(ProfileId("cfg1".into())).await.unwrap_err();
+        match err {
+            ProfilesError::ProfileInUse {
+                referrers,
+                current,
+                global_transforms,
+            } => {
+                assert!(referrers.is_empty());
+                assert!(current);
+                assert!(!global_transforms);
+            }
+            other => panic!("expected ProfileInUse, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_cleanup_per_binding_kind() {
+        let outside_a = if cfg!(windows) {
+            "C:\\outside\\a.yaml"
+        } else {
+            "/outside/a.yaml"
+        };
+        let outside_b = if cfg!(windows) {
+            "C:\\outside\\b.yaml"
+        } else {
+            "/outside/b.yaml"
+        };
+
+        // External Symlink: only the app-managed link is removed.
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_remove()
+            .withf(|path| path.as_str() == "sym1.yaml")
+            .times(1)
+            .returning(|_| Ok(()));
+        let (client, _dir) = test_client_with(fs).await;
+        let mut profiles = Profiles::default();
+        profiles.append_item(external_item(
+            "sym1",
+            ExternalMode::Symlink,
+            external_path(std::path::Path::new(outside_a)),
+        ));
+        client.replace(profiles).await.unwrap();
+        client.delete(ProfileId("sym1".into())).await.unwrap();
+
+        // External Mirror: the mirror copy is removed.
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_remove()
+            .withf(|path| path.as_str() == "mir1.yaml")
+            .times(1)
+            .returning(|_| Ok(()));
+        let (client, _dir) = test_client_with(fs).await;
+        let mut profiles = Profiles::default();
+        profiles.append_item(external_item(
+            "mir1",
+            ExternalMode::Mirror,
+            external_path(std::path::Path::new(outside_b)),
+        ));
+        client.replace(profiles).await.unwrap();
+        client.delete(ProfileId("mir1".into())).await.unwrap();
+
+        // Composition: no filesystem call at all (mock without expectations
+        // panics on any use).
+        let (client, _dir) = test_client_with(MockProfileFsPort::new()).await;
+        let mut profiles = seeded_profiles();
+        profiles.append_item(nyanpasu_config::profile::ProfileItem {
+            uid: ProfileId("comp".into()),
+            metadata: ProfileMetadata {
+                name: "COMP".into(),
+                desc: None,
+            },
+            definition: ProfileDefinition::Config {
+                config: ConfigDefinition::Composition(
+                    nyanpasu_config::profile::CompositionConfig {
+                        base: Some(ProfileId("cfg1".into())),
+                        extend_proxies_from: vec![],
+                        transforms: vec![],
+                    },
+                ),
+            },
+        });
+        client.replace(profiles).await.unwrap();
+        client.delete(ProfileId("comp".into())).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn load_fails_fast_on_invalid_document() {
+        let dir = tempdir().unwrap();
+        let path = temp_profiles_path(&dir);
+        std::fs::write(
+            &path,
+            "current: ghost\nitems:\n- uid: a\n  name: A\n  type: config\n  config:\n    type: file\n    source:\n      type: local\n      binding:\n        type: managed\n        file: a.yaml\n",
+        )
+        .unwrap();
+        let result = ProfilesClient::new(
+            path,
+            std::sync::Arc::new(MockProfileFsPort::new()),
+            std::sync::Arc::new(MockSubscriptionFetcher::new()),
+            std::sync::Arc::new(MockRebuildNotifier::new()),
+        )
+        .await;
+        assert!(result.is_err(), "invalid persisted document must fail fast");
+    }
+
+    #[tokio::test]
+    async fn add_remote_resets_materialization_metadata() {
+        let (client, _dir) = test_client_with(MockProfileFsPort::new()).await;
+        let mut item = remote_config_item("placeholder");
+        if let Some(source) = item.definition.source_mut() {
+            source.materialized_mut().updated_at = Some(time::OffsetDateTime::UNIX_EPOCH);
+            if let ProfileSource::Remote { subscription, .. } = source {
+                subscription.upload = Some(1);
+            }
+        }
+        let report = client
+            .add(
+                NewProfileRequest {
+                    metadata: item.metadata.clone(),
+                    definition: item.definition,
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        let (uid, added) = report.snapshot.items.first().unwrap();
+        let source = added.definition.source().unwrap();
+        assert_eq!(source.materialized().file.as_str(), format!("{uid}.yaml"));
+        assert!(source.materialized().updated_at.is_none());
+        match source {
+            ProfileSource::Remote { subscription, .. } => assert!(subscription.is_empty()),
+            _ => panic!("expected remote source"),
+        }
+    }
+
+    #[tokio::test]
+    async fn replace_definition_rejects_invalid_and_keeps_state() {
+        let (client, dir) = seeded_client().await;
+        let mut definition = seeded_profiles().items[&ProfileId("cfg1".into())]
+            .definition
+            .clone();
+        if let ProfileDefinition::Config {
+            config: ConfigDefinition::File(file),
+        } = &mut definition
+        {
+            file.transforms = vec![ProfileId("ghost".into())];
+        }
+        let err = client
+            .replace_definition(ProfileId("cfg1".into()), definition)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ProfilesError::ValidationFailed(_)));
+        drop(client);
+
+        let reopened = ProfilesClient::new(
+            temp_profiles_path(&dir),
+            std::sync::Arc::new(MockProfileFsPort::new()),
+            std::sync::Arc::new(MockSubscriptionFetcher::new()),
+            std::sync::Arc::new(MockRebuildNotifier::new()),
+        )
+        .await
+        .unwrap();
+        let snapshot = reopened.get().await.unwrap();
+        let item = &snapshot.items[&ProfileId("cfg1".into())];
+        match &item.definition {
+            ProfileDefinition::Config { config } => assert!(config.transforms().is_empty()),
+            other => panic!("cfg1 must stay a config, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn replace_definition_kind_switch_rewrites_path_and_cleans_orphan() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_remove()
+            .withf(|path| path.as_str() == "cfg2.yaml")
+            .times(1)
+            .returning(|_| Ok(()));
+        let (client, _dir) = test_client_with(fs).await;
+        client.replace(seeded_profiles()).await.unwrap();
+
+        let definition = ProfileDefinition::Transform {
+            transform: TransformDefinition::Script(nyanpasu_config::profile::ScriptTransform {
+                source: ProfileSource::Local {
+                    binding: LocalBinding::Managed {
+                        materialized: MaterializedFile {
+                            file: ManagedProfilePath::new("client-supplied.lua").unwrap(),
+                            updated_at: Some(time::OffsetDateTime::UNIX_EPOCH),
+                        },
+                    },
+                },
+                runtime: nyanpasu_config::profile::ScriptRuntime::Lua,
+            }),
+        };
+        let report = client
+            .replace_definition(ProfileId("cfg2".into()), definition)
+            .await
+            .unwrap();
+        let item = &report.snapshot.items[&ProfileId("cfg2".into())];
+        let source = item.definition.source().unwrap();
+        assert_eq!(source.materialized().file.as_str(), "cfg2.lua");
+        assert!(source.materialized().updated_at.is_none());
     }
 }

--- a/backend/tauri/src/client/profiles.rs
+++ b/backend/tauri/src/client/profiles.rs
@@ -161,6 +161,22 @@ impl ProfilesClient {
         .await
     }
 
+    pub async fn refresh(
+        &self,
+        uid: ProfileId,
+        patch: Option<RemoteProfileOptionsPatch>,
+    ) -> Result<CommitReport, ProfilesError> {
+        self.call(
+            |reply| ProfilesActorMessage::RefreshRemote {
+                uid,
+                patch,
+                reply: Some(reply),
+            },
+            None,
+        )
+        .await
+    }
+
     pub async fn replace_definition(
         &self,
         uid: ProfileId,
@@ -189,6 +205,44 @@ impl ProfilesClient {
             Err(e) => Err(ProfilesError::Rpc(e.to_string())),
         }
     }
+
+    #[cfg(test)]
+    fn debug_pending_refresh(
+        &self,
+        uid: ProfileId,
+    ) -> (
+        tokio::sync::oneshot::Receiver<()>,
+        tokio::task::JoinHandle<Result<CommitReport, ProfilesError>>,
+    ) {
+        let (inserted, inserted_rx) = tokio::sync::oneshot::channel();
+        let client = self.clone();
+        let handle = tokio::spawn(async move {
+            client
+                .call(
+                    |reply| ProfilesActorMessage::DebugInsertPendingRefresh {
+                        uid,
+                        reply,
+                        inserted,
+                    },
+                    None,
+                )
+                .await
+        });
+        (inserted_rx, handle)
+    }
+
+    #[cfg(test)]
+    async fn debug_cast_commit_refreshed(
+        &self,
+        uid: ProfileId,
+        outcome: crate::state::profiles::RefreshOutcome,
+    ) {
+        let _ = self
+            .inner
+            .actor_ref
+            .cast(ProfilesActorMessage::CommitRefreshed { uid, outcome });
+        tokio::task::yield_now().await;
+    }
 }
 
 impl Drop for ProfilesClientInner {
@@ -201,12 +255,13 @@ impl Drop for ProfilesClientInner {
 mod tests {
     use super::*;
     use crate::state::profiles::ports::{
-        MockProfileFsPort, MockRebuildNotifier, MockSubscriptionFetcher,
+        FetchedSubscription, MockProfileFsPort, MockRebuildNotifier, MockSubscriptionFetcher,
     };
     use nyanpasu_config::profile::{
         ConfigDefinition, FileConfig, LocalBinding, ManagedProfilePath, MaterializedFile,
         OverlayTransform, ProfileDefinition, ProfileId, ProfileMetadata, ProfileSource, Profiles,
-        ScriptRuntime, ScriptTransform, TransformDefinition,
+        RemoteProfileOptions, ScriptRuntime, ScriptTransform, SubscriptionInfo,
+        TransformDefinition,
     };
     use struct_patch::Patch as _;
     use tempfile::{TempDir, tempdir};
@@ -297,6 +352,235 @@ mod tests {
             .await
             .expect("seed replace");
         (client, dir)
+    }
+
+    pub(crate) fn remote_config_item(uid: &str) -> nyanpasu_config::profile::ProfileItem {
+        nyanpasu_config::profile::ProfileItem {
+            uid: ProfileId(uid.into()),
+            metadata: ProfileMetadata {
+                name: uid.to_uppercase(),
+                desc: None,
+            },
+            definition: ProfileDefinition::Config {
+                config: ConfigDefinition::File(FileConfig {
+                    source: ProfileSource::Remote {
+                        materialized: MaterializedFile {
+                            file: ManagedProfilePath::new(format!("{uid}.yaml")).unwrap(),
+                            updated_at: None,
+                        },
+                        url: url::Url::parse("https://example.com/sub").unwrap(),
+                        option: RemoteProfileOptions::default(),
+                        subscription: SubscriptionInfo::default(),
+                    },
+                    transforms: vec![],
+                }),
+            },
+        }
+    }
+
+    fn ok_fetch(content: &'static str) -> MockSubscriptionFetcher {
+        let mut fetcher = MockSubscriptionFetcher::new();
+        fetcher.expect_fetch().returning(move |_, _| {
+            Ok(FetchedSubscription {
+                content: content.to_string(),
+                filename: None,
+                subscription: SubscriptionInfo {
+                    upload: Some(1),
+                    ..Default::default()
+                },
+            })
+        });
+        fetcher
+    }
+
+    async fn remote_seeded_client(
+        fs: MockProfileFsPort,
+        fetcher: MockSubscriptionFetcher,
+        notifier: MockRebuildNotifier,
+    ) -> (ProfilesClient, TempDir) {
+        remote_seeded_client_with_fetcher(fs, std::sync::Arc::new(fetcher), notifier).await
+    }
+
+    async fn remote_seeded_client_with_fetcher(
+        fs: MockProfileFsPort,
+        fetcher: std::sync::Arc<dyn SubscriptionFetcher>,
+        notifier: MockRebuildNotifier,
+    ) -> (ProfilesClient, TempDir) {
+        let dir = tempdir().unwrap();
+        let client = ProfilesClient::new(
+            temp_profiles_path(&dir),
+            std::sync::Arc::new(fs),
+            fetcher,
+            std::sync::Arc::new(notifier),
+        )
+        .await
+        .unwrap();
+        let mut profiles = Profiles::default();
+        profiles.append_item(remote_config_item("r1"));
+        client.replace(profiles).await.unwrap();
+        (client, dir)
+    }
+
+    struct HoldingFetcher {
+        started: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        release: std::sync::Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl SubscriptionFetcher for HoldingFetcher {
+        async fn fetch(
+            &self,
+            _url: &url::Url,
+            _options: &RemoteProfileOptions,
+        ) -> anyhow::Result<FetchedSubscription> {
+            if let Some(started) = self.started.lock().unwrap().take() {
+                let _ = started.send(());
+            }
+            self.release.notified().await;
+            Ok(FetchedSubscription {
+                content: "a: 1\n".into(),
+                filename: None,
+                subscription: SubscriptionInfo::default(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_downloads_writes_and_commits_subscription() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_ensure_not_symlink().returning(|_| Ok(()));
+        fs.expect_write_atomic()
+            .withf(|path, content| path.as_str() == "r1.yaml" && content == "proxies: []\n")
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let (client, _dir) =
+            remote_seeded_client(fs, ok_fetch("proxies: []\n"), MockRebuildNotifier::new()).await;
+
+        let report = client
+            .refresh(ProfileId("r1".into()), None)
+            .await
+            .expect("refresh ok");
+        let item = &report.snapshot.items[&ProfileId("r1".into())];
+        let source = item.definition.source().unwrap();
+        assert!(source.materialized().updated_at.is_some());
+        match source {
+            ProfileSource::Remote { subscription, .. } => {
+                assert_eq!(subscription.upload, Some(1));
+            }
+            _ => unreachable!(),
+        }
+        assert!(!report.affects_current);
+    }
+
+    #[tokio::test]
+    async fn refresh_failure_settles_reply_with_error() {
+        let mut fetcher = MockSubscriptionFetcher::new();
+        fetcher
+            .expect_fetch()
+            .returning(|_, _| anyhow::bail!("dns exploded"));
+        let (client, _dir) = remote_seeded_client(
+            MockProfileFsPort::new(),
+            fetcher,
+            MockRebuildNotifier::new(),
+        )
+        .await;
+        let err = client
+            .refresh(ProfileId("r1".into()), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ProfilesError::RefreshFailed { .. }));
+        let snapshot = client.get().await.unwrap();
+        let source = snapshot.items[&ProfileId("r1".into())]
+            .definition
+            .source()
+            .unwrap();
+        assert!(source.materialized().updated_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn refresh_rejects_non_remote_and_unknown_and_concurrent() {
+        let (client, _dir) = seeded_client().await;
+        let err = client
+            .refresh(ProfileId("cfg1".into()), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ProfilesError::NotARemoteProfile));
+        let err = client
+            .refresh(ProfileId("ghost".into()), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ProfilesError::ProfileNotFound(_)));
+
+        let (started, started_rx) = tokio::sync::oneshot::channel();
+        let release_fetch = std::sync::Arc::new(tokio::sync::Notify::new());
+        let fetcher = HoldingFetcher {
+            started: std::sync::Mutex::new(Some(started)),
+            release: std::sync::Arc::clone(&release_fetch),
+        };
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_ensure_not_symlink().returning(|_| Ok(()));
+        fs.expect_write_atomic().returning(|_, _| Ok(()));
+        let (client, _dir) = remote_seeded_client_with_fetcher(
+            fs,
+            std::sync::Arc::new(fetcher),
+            MockRebuildNotifier::new(),
+        )
+        .await;
+        let c2 = client.clone();
+        let first = tokio::spawn(async move { c2.refresh(ProfileId("r1".into()), None).await });
+        started_rx.await.unwrap();
+        let err = loop {
+            match client.refresh(ProfileId("r1".into()), None).await {
+                Err(ProfilesError::RefreshFailed { message })
+                    if message.contains("in progress") =>
+                {
+                    break ProfilesError::RefreshFailed { message };
+                }
+                Ok(_) => panic!("second refresh must not both succeed before first settles"),
+                Err(_) => tokio::task::yield_now().await,
+            }
+        };
+        assert!(matches!(err, ProfilesError::RefreshFailed { .. }));
+        release_fetch.notify_waiters();
+        first.await.unwrap().expect("first refresh completes");
+    }
+
+    #[tokio::test]
+    async fn refresh_commit_refreshed_deleted_profile_settles_reply_and_cleans_orphan() {
+        let removals = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let mut fs = MockProfileFsPort::new();
+        let observed = std::sync::Arc::clone(&removals);
+        fs.expect_remove().returning(move |path| {
+            observed.lock().unwrap().push(path.as_str().to_string());
+            Ok(())
+        });
+        let (client, _dir) = remote_seeded_client(
+            fs,
+            MockSubscriptionFetcher::new(),
+            MockRebuildNotifier::new(),
+        )
+        .await;
+
+        let (inserted, pending) = client.debug_pending_refresh(ProfileId("r1".into()));
+        inserted.await.unwrap();
+        client.delete(ProfileId("r1".into())).await.unwrap();
+        client
+            .debug_cast_commit_refreshed(
+                ProfileId("r1".into()),
+                crate::state::profiles::RefreshOutcome::Succeeded {
+                    subscription: SubscriptionInfo::default(),
+                },
+            )
+            .await;
+
+        let err = pending.await.unwrap().unwrap_err();
+        assert!(
+            matches!(err, ProfilesError::RefreshFailed { message } if message.contains("deleted"))
+        );
+        let removals = removals.lock().unwrap();
+        assert!(removals.iter().filter(|path| *path == "r1.yaml").count() >= 2);
+        assert!(removals.iter().any(|path| path == "r1.js"));
+        assert!(removals.iter().any(|path| path == "r1.lua"));
     }
 
     #[tokio::test]

--- a/backend/tauri/src/client/profiles.rs
+++ b/backend/tauri/src/client/profiles.rs
@@ -4,13 +4,15 @@ use std::{sync::Arc, time::Duration};
 
 use anyhow::Context as _;
 use camino::Utf8PathBuf;
-use nyanpasu_config::profile::{ProfileId, Profiles};
+use nyanpasu_config::profile::{
+    ProfileDefinition, ProfileId, ProfileMetadataPatch, Profiles, RemoteProfileOptionsPatch,
+};
 use nyanpasu_core::state::PersistentStateManagerSetup;
 use ractor::{Actor, ActorRef, RpcReplyPort, rpc::CallResult};
 
 use crate::state::profiles::{
     CommitReport, NewProfileRequest, ProfilesActor, ProfilesActorArgs, ProfilesActorMessage,
-    ProfilesError,
+    ProfilesError, ReorderOp,
     ports::{ProfileFsPort, RebuildNotifier, SubscriptionFetcher},
 };
 
@@ -130,6 +132,51 @@ impl ProfilesClient {
             .await
     }
 
+    pub async fn reorder(&self, op: ReorderOp) -> Result<CommitReport, ProfilesError> {
+        self.call(|reply| ProfilesActorMessage::Reorder { op, reply }, None)
+            .await
+    }
+
+    pub async fn patch_metadata(
+        &self,
+        uid: ProfileId,
+        patch: ProfileMetadataPatch,
+    ) -> Result<CommitReport, ProfilesError> {
+        self.call(
+            |reply| ProfilesActorMessage::PatchMetadata { uid, patch, reply },
+            None,
+        )
+        .await
+    }
+
+    pub async fn patch_remote_options(
+        &self,
+        uid: ProfileId,
+        patch: RemoteProfileOptionsPatch,
+    ) -> Result<CommitReport, ProfilesError> {
+        self.call(
+            |reply| ProfilesActorMessage::PatchRemoteOptions { uid, patch, reply },
+            None,
+        )
+        .await
+    }
+
+    pub async fn replace_definition(
+        &self,
+        uid: ProfileId,
+        definition: ProfileDefinition,
+    ) -> Result<CommitReport, ProfilesError> {
+        self.call(
+            |reply| ProfilesActorMessage::ReplaceDefinition {
+                uid,
+                definition,
+                reply,
+            },
+            None,
+        )
+        .await
+    }
+
     async fn call<F, T>(&self, make: F, timeout: Option<Duration>) -> Result<T, ProfilesError>
     where
         F: FnOnce(RpcReplyPort<Result<T, ProfilesError>>) -> ProfilesActorMessage,
@@ -161,6 +208,7 @@ mod tests {
         OverlayTransform, ProfileDefinition, ProfileId, ProfileMetadata, ProfileSource, Profiles,
         ScriptRuntime, ScriptTransform, TransformDefinition,
     };
+    use struct_patch::Patch as _;
     use tempfile::{TempDir, tempdir};
 
     pub(crate) fn temp_profiles_path(dir: &TempDir) -> Utf8PathBuf {
@@ -449,5 +497,106 @@ mod tests {
                 .get(&ProfileId("cfg2".into()))
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn reorder_move_and_by_list() {
+        let (client, _dir) = seeded_client().await;
+        let report = client
+            .reorder(ReorderOp::Move {
+                active: ProfileId("cfg2".into()),
+                over: ProfileId("cfg1".into()),
+            })
+            .await
+            .unwrap();
+        assert!(!report.affects_current);
+        let uids: Vec<_> = report.snapshot.items.keys().map(|u| u.0.clone()).collect();
+        assert_eq!(uids, vec!["cfg2", "cfg1", "ovl1"]);
+
+        let report = client
+            .reorder(ReorderOp::ByList(vec![
+                ProfileId("ovl1".into()),
+                ProfileId("cfg1".into()),
+                ProfileId("cfg2".into()),
+            ]))
+            .await
+            .unwrap();
+        let uids: Vec<_> = report.snapshot.items.keys().map(|u| u.0.clone()).collect();
+        assert_eq!(uids, vec!["ovl1", "cfg1", "cfg2"]);
+
+        let err = client
+            .reorder(ReorderOp::ByList(vec![ProfileId("cfg1".into())]))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ProfilesError::ValidationFailed(_) | ProfilesError::ProfileNotFound(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn patch_metadata_and_remote_options() {
+        let (client, _dir) = seeded_client().await;
+        let mut patch = ProfileMetadata::new_empty_patch();
+        patch.name = Some("Renamed".into());
+        let report = client
+            .patch_metadata(ProfileId("cfg1".into()), patch)
+            .await
+            .unwrap();
+        assert!(!report.affects_current);
+        assert_eq!(
+            report.snapshot.items[&ProfileId("cfg1".into())]
+                .metadata
+                .name,
+            "Renamed"
+        );
+
+        let options_patch = nyanpasu_config::profile::RemoteProfileOptions::new_empty_patch();
+        let err = client
+            .patch_remote_options(ProfileId("cfg1".into()), options_patch)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ProfilesError::NotARemoteProfile));
+    }
+
+    #[tokio::test]
+    async fn replace_definition_is_atomic_and_reports_closure_hit() {
+        let (client, _dir) = seeded_client().await;
+        client
+            .set_current(Some(ProfileId("cfg1".into())))
+            .await
+            .unwrap();
+
+        let mut definition = seeded_profiles().items[&ProfileId("cfg1".into())]
+            .definition
+            .clone();
+        if let ProfileDefinition::Config {
+            config: ConfigDefinition::File(file),
+        } = &mut definition
+        {
+            file.transforms = vec![ProfileId("ovl1".into())];
+        }
+        let report = client
+            .replace_definition(ProfileId("cfg1".into()), definition)
+            .await
+            .unwrap();
+        assert!(report.affects_current);
+
+        let definition = seeded_profiles().items[&ProfileId("cfg2".into())]
+            .definition
+            .clone();
+        let report = client
+            .replace_definition(ProfileId("cfg2".into()), definition)
+            .await
+            .unwrap();
+        assert!(!report.affects_current);
+
+        let err = client.delete(ProfileId("ovl1".into())).await.unwrap_err();
+        match err {
+            ProfilesError::ProfileInUse { referrers } => {
+                assert_eq!(referrers, vec![ProfileId("cfg1".into())]);
+            }
+            other => panic!("expected ProfileInUse, got {other:?}"),
+        }
     }
 }

--- a/backend/tauri/src/client/profiles.rs
+++ b/backend/tauri/src/client/profiles.rs
@@ -583,6 +583,130 @@ mod tests {
         assert!(removals.iter().any(|path| path == "r1.lua"));
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn scheduler_fires_refresh_on_interval() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_ensure_not_symlink().returning(|_| Ok(()));
+        fs.expect_write_atomic().returning(|_, _| Ok(()));
+        let fetch_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut fetcher = MockSubscriptionFetcher::new();
+        let counter = std::sync::Arc::clone(&fetch_count);
+        fetcher.expect_fetch().returning(move |_, _| {
+            counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(FetchedSubscription {
+                content: "a: 1\n".into(),
+                filename: None,
+                subscription: SubscriptionInfo::default(),
+            })
+        });
+        let dir = tempdir().unwrap();
+        let client = ProfilesClient::new(
+            temp_profiles_path(&dir),
+            std::sync::Arc::new(fs),
+            std::sync::Arc::new(fetcher),
+            std::sync::Arc::new(MockRebuildNotifier::new()),
+        )
+        .await
+        .unwrap();
+        let mut item = remote_config_item("r1");
+        if let Some(source) = item.definition.source_mut() {
+            source.materialized_mut().updated_at = Some(time::OffsetDateTime::now_utc());
+        }
+        let mut profiles = Profiles::default();
+        profiles.append_item(item);
+        client.replace(profiles).await.unwrap();
+
+        assert_eq!(fetch_count.load(std::sync::atomic::Ordering::SeqCst), 0);
+        tokio::time::advance(std::time::Duration::from_secs(120 * 60 + 1)).await;
+        for _ in 0..200 {
+            if fetch_count.load(std::sync::atomic::Ordering::SeqCst) >= 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(fetch_count.load(std::sync::atomic::Ordering::SeqCst) >= 1);
+        drop(client);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn scheduler_reconcile_add_remove_and_kind_switch() {
+        let fetch_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut fetcher = MockSubscriptionFetcher::new();
+        let counter = std::sync::Arc::clone(&fetch_count);
+        fetcher.expect_fetch().returning(move |_, _| {
+            counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            anyhow::bail!("count only")
+        });
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_remove().returning(|_| Ok(()));
+        let (client, _dir) = remote_seeded_client(fs, fetcher, MockRebuildNotifier::new()).await;
+
+        client
+            .replace_definition(ProfileId("r1".into()), file_config_item("r1").definition)
+            .await
+            .unwrap();
+        tokio::time::advance(std::time::Duration::from_secs(240 * 60)).await;
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(fetch_count.load(std::sync::atomic::Ordering::SeqCst), 0);
+
+        let mut profiles = Profiles::default();
+        profiles.append_item(remote_config_item("r1"));
+        client.replace(profiles).await.unwrap();
+        client.delete(ProfileId("r1".into())).await.unwrap();
+        tokio::time::advance(std::time::Duration::from_secs(240 * 60)).await;
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(fetch_count.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn scheduler_catches_up_overdue_profiles_on_start() {
+        let fetch_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut fetcher = MockSubscriptionFetcher::new();
+        let counter = std::sync::Arc::clone(&fetch_count);
+        fetcher.expect_fetch().returning(move |_, _| {
+            counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            anyhow::bail!("count only")
+        });
+        let dir = tempdir().unwrap();
+        {
+            let client = ProfilesClient::new(
+                temp_profiles_path(&dir),
+                std::sync::Arc::new(MockProfileFsPort::new()),
+                std::sync::Arc::new(MockSubscriptionFetcher::new()),
+                std::sync::Arc::new(MockRebuildNotifier::new()),
+            )
+            .await
+            .unwrap();
+            let mut item = remote_config_item("r1");
+            if let Some(source) = item.definition.source_mut() {
+                source.materialized_mut().updated_at =
+                    Some(time::OffsetDateTime::now_utc() - time::Duration::days(30));
+            }
+            let mut profiles = Profiles::default();
+            profiles.append_item(item);
+            client.replace(profiles).await.unwrap();
+        }
+        let _client = ProfilesClient::new(
+            temp_profiles_path(&dir),
+            std::sync::Arc::new(MockProfileFsPort::new()),
+            std::sync::Arc::new(fetcher),
+            std::sync::Arc::new(MockRebuildNotifier::new()),
+        )
+        .await
+        .unwrap();
+        for _ in 0..200 {
+            if fetch_count.load(std::sync::atomic::Ordering::SeqCst) >= 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(fetch_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
     #[tokio::test]
     async fn set_current_commits_and_reports_affects_current() {
         let (client, dir) = seeded_client().await;

--- a/backend/tauri/src/client/profiles.rs
+++ b/backend/tauri/src/client/profiles.rs
@@ -1,0 +1,134 @@
+//! Typed client for the ProfilesActor. Read Some(5s) / write None.
+
+use std::{sync::Arc, time::Duration};
+
+use anyhow::Context as _;
+use camino::Utf8PathBuf;
+use nyanpasu_config::profile::Profiles;
+use nyanpasu_core::state::PersistentStateManagerSetup;
+use ractor::{Actor, ActorRef, RpcReplyPort, rpc::CallResult};
+
+use crate::state::profiles::{
+    ProfilesActor, ProfilesActorArgs, ProfilesActorMessage, ProfilesError,
+    ports::{ProfileFsPort, RebuildNotifier, SubscriptionFetcher},
+};
+
+pub const PROFILES_READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+pub struct ProfilesClient {
+    inner: Arc<ProfilesClientInner>,
+}
+
+struct ProfilesClientInner {
+    actor_ref: ActorRef<ProfilesActorMessage>,
+}
+
+impl ProfilesClient {
+    pub(crate) async fn new(
+        profiles_path: Utf8PathBuf,
+        fs: Arc<dyn ProfileFsPort>,
+        fetcher: Arc<dyn SubscriptionFetcher>,
+        notifier: Arc<dyn RebuildNotifier>,
+    ) -> anyhow::Result<Self> {
+        let should_load = profiles_path.exists();
+        let setup = PersistentStateManagerSetup::<Profiles>::builder()
+            .config_path(profiles_path)
+            .assemble();
+        let manager = if should_load {
+            setup
+                .load()
+                .await
+                .context("failed to load profiles persistent state manager")?
+        } else {
+            setup
+                .from_state(Profiles::default())
+                .await
+                .context("failed to initialize profiles persistent state manager")?
+        };
+
+        manager
+            .snapshot_handle()
+            .load()
+            .state
+            .validate()
+            .map_err(|errors| anyhow::anyhow!("profiles.yaml failed validation: {errors:?}"))?;
+
+        let actor_ref = Actor::spawn(
+            None,
+            ProfilesActor,
+            ProfilesActorArgs {
+                manager,
+                fs,
+                fetcher,
+                notifier,
+            },
+        )
+        .await
+        .context("failed to spawn profiles actor")?
+        .0;
+
+        Ok(Self {
+            inner: Arc::new(ProfilesClientInner { actor_ref }),
+        })
+    }
+
+    pub async fn get(&self) -> Result<Arc<Profiles>, ProfilesError> {
+        self.call(ProfilesActorMessage::Get, Some(PROFILES_READ_TIMEOUT))
+            .await
+    }
+
+    async fn call<F, T>(&self, make: F, timeout: Option<Duration>) -> Result<T, ProfilesError>
+    where
+        F: FnOnce(RpcReplyPort<Result<T, ProfilesError>>) -> ProfilesActorMessage,
+        T: Send + 'static,
+    {
+        match self.inner.actor_ref.call(make, timeout).await {
+            Ok(CallResult::Success(result)) => result,
+            Ok(CallResult::SenderError) => Err(ProfilesError::Rpc("reply dropped".into())),
+            Ok(CallResult::Timeout) => Err(ProfilesError::Rpc("call timed out".into())),
+            Err(e) => Err(ProfilesError::Rpc(e.to_string())),
+        }
+    }
+}
+
+impl Drop for ProfilesClientInner {
+    fn drop(&mut self) {
+        self.actor_ref.stop(None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::profiles::ports::{
+        MockProfileFsPort, MockRebuildNotifier, MockSubscriptionFetcher,
+    };
+    use tempfile::{TempDir, tempdir};
+
+    pub(crate) fn temp_profiles_path(dir: &TempDir) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(dir.path().join("profiles.yaml")).expect("utf-8 temp path")
+    }
+
+    pub(crate) async fn test_client_with(fs: MockProfileFsPort) -> (ProfilesClient, TempDir) {
+        let dir = tempdir().unwrap();
+        let client = ProfilesClient::new(
+            temp_profiles_path(&dir),
+            std::sync::Arc::new(fs),
+            std::sync::Arc::new(MockSubscriptionFetcher::new()),
+            std::sync::Arc::new(MockRebuildNotifier::new()),
+        )
+        .await
+        .expect("profiles client should spawn");
+        (client, dir)
+    }
+
+    #[tokio::test]
+    async fn fresh_store_starts_with_default_profiles() {
+        let (client, _dir) = test_client_with(MockProfileFsPort::new()).await;
+        let snapshot = client.get().await.expect("get should succeed");
+        assert!(snapshot.current.is_none());
+        assert!(snapshot.items.is_empty());
+        assert_eq!(snapshot.valid.len(), 3);
+    }
+}

--- a/backend/tauri/src/client/profiles.rs
+++ b/backend/tauri/src/client/profiles.rs
@@ -9,7 +9,8 @@ use nyanpasu_core::state::PersistentStateManagerSetup;
 use ractor::{Actor, ActorRef, RpcReplyPort, rpc::CallResult};
 
 use crate::state::profiles::{
-    CommitReport, ProfilesActor, ProfilesActorArgs, ProfilesActorMessage, ProfilesError,
+    CommitReport, NewProfileRequest, ProfilesActor, ProfilesActorArgs, ProfilesActorMessage,
+    ProfilesError,
     ports::{ProfileFsPort, RebuildNotifier, SubscriptionFetcher},
 };
 
@@ -108,6 +109,27 @@ impl ProfilesClient {
         .await
     }
 
+    pub async fn add(
+        &self,
+        request: NewProfileRequest,
+        initial_file: Option<String>,
+    ) -> Result<CommitReport, ProfilesError> {
+        self.call(
+            |reply| ProfilesActorMessage::Add {
+                request,
+                initial_file,
+                reply,
+            },
+            None,
+        )
+        .await
+    }
+
+    pub async fn delete(&self, uid: ProfileId) -> Result<CommitReport, ProfilesError> {
+        self.call(|reply| ProfilesActorMessage::Delete { uid, reply }, None)
+            .await
+    }
+
     async fn call<F, T>(&self, make: F, timeout: Option<Duration>) -> Result<T, ProfilesError>
     where
         F: FnOnce(RpcReplyPort<Result<T, ProfilesError>>) -> ProfilesActorMessage,
@@ -137,7 +159,7 @@ mod tests {
     use nyanpasu_config::profile::{
         ConfigDefinition, FileConfig, LocalBinding, ManagedProfilePath, MaterializedFile,
         OverlayTransform, ProfileDefinition, ProfileId, ProfileMetadata, ProfileSource, Profiles,
-        TransformDefinition,
+        ScriptRuntime, ScriptTransform, TransformDefinition,
     };
     use tempfile::{TempDir, tempdir};
 
@@ -294,5 +316,138 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, ProfilesError::ValidationFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn add_generates_uid_canonical_path_and_writes_initial_file() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_write_atomic()
+            .withf(|path, content| path.as_str().ends_with(".yaml") && content == "proxies: []\n")
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let (client, _dir) = test_client_with(fs).await;
+
+        let report = client
+            .add(
+                NewProfileRequest {
+                    metadata: ProfileMetadata {
+                        name: "New".into(),
+                        desc: None,
+                    },
+                    definition: file_config_item("placeholder").definition,
+                },
+                Some("proxies: []\n".to_string()),
+            )
+            .await
+            .expect("add should succeed");
+
+        assert!(!report.affects_current);
+        assert!(report.warnings.is_empty());
+        let snapshot = report.snapshot;
+        assert_eq!(snapshot.items.len(), 1);
+        let (uid, item) = snapshot.items.first().unwrap();
+        assert!(uid.0.starts_with('c'), "config uid prefixed with c: {uid}");
+        let file = item
+            .definition
+            .source()
+            .unwrap()
+            .materialized()
+            .file
+            .as_str();
+        assert_eq!(file, format!("{uid}.yaml"));
+    }
+
+    #[tokio::test]
+    async fn add_script_transform_uses_runtime_extension() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_write_atomic()
+            .withf(|path, _| path.as_str().ends_with(".lua"))
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let (client, _dir) = test_client_with(fs).await;
+        let mut item = overlay_item("placeholder");
+        item.definition = ProfileDefinition::Transform {
+            transform: TransformDefinition::Script(ScriptTransform {
+                source: overlay_item("p").definition.source().unwrap().clone(),
+                runtime: ScriptRuntime::Lua,
+            }),
+        };
+        let report = client
+            .add(
+                NewProfileRequest {
+                    metadata: item.metadata.clone(),
+                    definition: item.definition,
+                },
+                Some("-- lua".to_string()),
+            )
+            .await
+            .unwrap();
+        let (uid, _) = report.snapshot.items.first().unwrap();
+        assert!(uid.0.starts_with('t'), "transform uid prefixed with t");
+    }
+
+    #[tokio::test]
+    async fn delete_enforces_reference_protection() {
+        let (client, _dir) = seeded_client().await;
+        client
+            .set_current(Some(ProfileId("cfg1".into())))
+            .await
+            .unwrap();
+        let err = client.delete(ProfileId("cfg1".into())).await.unwrap_err();
+        assert!(matches!(err, ProfilesError::ProfileInUse { .. }));
+
+        client
+            .set_global_transforms(vec![ProfileId("ovl1".into())])
+            .await
+            .unwrap();
+        let err = client.delete(ProfileId("ovl1".into())).await.unwrap_err();
+        assert!(matches!(err, ProfilesError::ProfileInUse { .. }));
+
+        let err = client.delete(ProfileId("ghost".into())).await.unwrap_err();
+        assert!(matches!(err, ProfilesError::ProfileNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn delete_unreferenced_managed_profile_removes_file() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_remove()
+            .withf(|path| path.as_str() == "cfg2.yaml")
+            .times(1)
+            .returning(|_| Ok(()));
+        let (client, _dir) = test_client_with(fs).await;
+        client.replace(seeded_profiles()).await.unwrap();
+        let report = client
+            .delete(ProfileId("cfg2".into()))
+            .await
+            .expect("delete cfg2");
+        assert!(!report.affects_current);
+        assert!(
+            report
+                .snapshot
+                .items
+                .get(&ProfileId("cfg2".into()))
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_cleanup_failure_degrades_to_warning() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_remove()
+            .returning(|_| anyhow::bail!("disk on fire"));
+        let (client, _dir) = test_client_with(fs).await;
+        client.replace(seeded_profiles()).await.unwrap();
+        let report = client
+            .delete(ProfileId("cfg2".into()))
+            .await
+            .expect("delete commits anyway");
+        assert_eq!(report.warnings.len(), 1);
+        assert!(
+            report
+                .snapshot
+                .items
+                .get(&ProfileId("cfg2".into()))
+                .is_none()
+        );
     }
 }

--- a/backend/tauri/src/client/profiles.rs
+++ b/backend/tauri/src/client/profiles.rs
@@ -4,12 +4,12 @@ use std::{sync::Arc, time::Duration};
 
 use anyhow::Context as _;
 use camino::Utf8PathBuf;
-use nyanpasu_config::profile::Profiles;
+use nyanpasu_config::profile::{ProfileId, Profiles};
 use nyanpasu_core::state::PersistentStateManagerSetup;
 use ractor::{Actor, ActorRef, RpcReplyPort, rpc::CallResult};
 
 use crate::state::profiles::{
-    ProfilesActor, ProfilesActorArgs, ProfilesActorMessage, ProfilesError,
+    CommitReport, ProfilesActor, ProfilesActorArgs, ProfilesActorMessage, ProfilesError,
     ports::{ProfileFsPort, RebuildNotifier, SubscriptionFetcher},
 };
 
@@ -78,6 +78,36 @@ impl ProfilesClient {
             .await
     }
 
+    pub async fn set_current(
+        &self,
+        current: Option<ProfileId>,
+    ) -> Result<CommitReport, ProfilesError> {
+        self.call(
+            |reply| ProfilesActorMessage::SetCurrent { current, reply },
+            None,
+        )
+        .await
+    }
+
+    pub async fn set_global_transforms(
+        &self,
+        ids: Vec<ProfileId>,
+    ) -> Result<CommitReport, ProfilesError> {
+        self.call(
+            |reply| ProfilesActorMessage::SetGlobalTransforms { ids, reply },
+            None,
+        )
+        .await
+    }
+
+    pub async fn replace(&self, profiles: Profiles) -> Result<CommitReport, ProfilesError> {
+        self.call(
+            |reply| ProfilesActorMessage::Replace { profiles, reply },
+            None,
+        )
+        .await
+    }
+
     async fn call<F, T>(&self, make: F, timeout: Option<Duration>) -> Result<T, ProfilesError>
     where
         F: FnOnce(RpcReplyPort<Result<T, ProfilesError>>) -> ProfilesActorMessage,
@@ -103,6 +133,11 @@ mod tests {
     use super::*;
     use crate::state::profiles::ports::{
         MockProfileFsPort, MockRebuildNotifier, MockSubscriptionFetcher,
+    };
+    use nyanpasu_config::profile::{
+        ConfigDefinition, FileConfig, LocalBinding, ManagedProfilePath, MaterializedFile,
+        OverlayTransform, ProfileDefinition, ProfileId, ProfileMetadata, ProfileSource, Profiles,
+        TransformDefinition,
     };
     use tempfile::{TempDir, tempdir};
 
@@ -130,5 +165,134 @@ mod tests {
         assert!(snapshot.current.is_none());
         assert!(snapshot.items.is_empty());
         assert_eq!(snapshot.valid.len(), 3);
+    }
+
+    pub(crate) fn file_config_item(uid: &str) -> nyanpasu_config::profile::ProfileItem {
+        nyanpasu_config::profile::ProfileItem {
+            uid: ProfileId(uid.into()),
+            metadata: ProfileMetadata {
+                name: uid.to_uppercase(),
+                desc: None,
+            },
+            definition: ProfileDefinition::Config {
+                config: ConfigDefinition::File(FileConfig {
+                    source: ProfileSource::Local {
+                        binding: LocalBinding::Managed {
+                            materialized: MaterializedFile {
+                                file: ManagedProfilePath::new(format!("{uid}.yaml")).unwrap(),
+                                updated_at: None,
+                            },
+                        },
+                    },
+                    transforms: vec![],
+                }),
+            },
+        }
+    }
+
+    pub(crate) fn overlay_item(uid: &str) -> nyanpasu_config::profile::ProfileItem {
+        nyanpasu_config::profile::ProfileItem {
+            uid: ProfileId(uid.into()),
+            metadata: ProfileMetadata {
+                name: uid.to_uppercase(),
+                desc: None,
+            },
+            definition: ProfileDefinition::Transform {
+                transform: TransformDefinition::Overlay(OverlayTransform {
+                    source: ProfileSource::Local {
+                        binding: LocalBinding::Managed {
+                            materialized: MaterializedFile {
+                                file: ManagedProfilePath::new(format!("{uid}.yaml")).unwrap(),
+                                updated_at: None,
+                            },
+                        },
+                    },
+                }),
+            },
+        }
+    }
+
+    pub(crate) fn seeded_profiles() -> Profiles {
+        let mut profiles = Profiles::default();
+        profiles.append_item(file_config_item("cfg1"));
+        profiles.append_item(file_config_item("cfg2"));
+        profiles.append_item(overlay_item("ovl1"));
+        profiles
+    }
+
+    async fn seeded_client() -> (ProfilesClient, TempDir) {
+        let (client, dir) = test_client_with(MockProfileFsPort::new()).await;
+        client
+            .replace(seeded_profiles())
+            .await
+            .expect("seed replace");
+        (client, dir)
+    }
+
+    #[tokio::test]
+    async fn set_current_commits_and_reports_affects_current() {
+        let (client, dir) = seeded_client().await;
+        let report = client
+            .set_current(Some(ProfileId("cfg1".into())))
+            .await
+            .expect("activate cfg1");
+        assert!(report.affects_current);
+        assert_eq!(report.snapshot.current, Some(ProfileId("cfg1".into())));
+
+        let report = client
+            .set_current(Some(ProfileId("cfg1".into())))
+            .await
+            .unwrap();
+        assert!(!report.affects_current);
+
+        drop(client);
+        let (client, _dir2) = {
+            let path = temp_profiles_path(&dir);
+            let client = ProfilesClient::new(
+                path,
+                std::sync::Arc::new(MockProfileFsPort::new()),
+                std::sync::Arc::new(MockSubscriptionFetcher::new()),
+                std::sync::Arc::new(MockRebuildNotifier::new()),
+            )
+            .await
+            .unwrap();
+            (client, dir)
+        };
+        assert_eq!(
+            client.get().await.unwrap().current,
+            Some(ProfileId("cfg1".into()))
+        );
+    }
+
+    #[tokio::test]
+    async fn set_current_rejects_missing_and_transform_targets() {
+        let (client, _dir) = seeded_client().await;
+        let err = client
+            .set_current(Some(ProfileId("ghost".into())))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ProfilesError::ValidationFailed(_)));
+        let err = client
+            .set_current(Some(ProfileId("ovl1".into())))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ProfilesError::ValidationFailed(_)));
+        assert!(client.get().await.unwrap().current.is_none());
+    }
+
+    #[tokio::test]
+    async fn set_global_transforms_validates_kind_and_reports_change() {
+        let (client, _dir) = seeded_client().await;
+        let report = client
+            .set_global_transforms(vec![ProfileId("ovl1".into())])
+            .await
+            .expect("set transforms");
+        assert!(report.affects_current);
+
+        let err = client
+            .set_global_transforms(vec![ProfileId("cfg1".into())])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ProfilesError::ValidationFailed(_)));
     }
 }

--- a/backend/tauri/src/client/profiles.rs
+++ b/backend/tauri/src/client/profiles.rs
@@ -243,6 +243,15 @@ impl ProfilesClient {
             .cast(ProfilesActorMessage::CommitRefreshed { uid, outcome });
         tokio::task::yield_now().await;
     }
+
+    #[cfg(test)]
+    async fn debug_cast_external_changed(&self, uid: ProfileId) {
+        let _ = self
+            .inner
+            .actor_ref
+            .cast(ProfilesActorMessage::ExternalFileChanged { uid });
+        tokio::task::yield_now().await;
+    }
 }
 
 impl Drop for ProfilesClientInner {
@@ -254,17 +263,29 @@ impl Drop for ProfilesClientInner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::profiles::ports::{
-        FetchedSubscription, MockProfileFsPort, MockRebuildNotifier, MockSubscriptionFetcher,
+    use crate::{
+        service::profile_file::{ProfileFileService, SelfProxyPortSource},
+        state::profiles::ports::{
+            FetchedSubscription, MockProfileFsPort, MockRebuildNotifier, MockSubscriptionFetcher,
+        },
+        utils::path::PathResolver,
     };
     use nyanpasu_config::profile::{
-        ConfigDefinition, FileConfig, LocalBinding, ManagedProfilePath, MaterializedFile,
-        OverlayTransform, ProfileDefinition, ProfileId, ProfileMetadata, ProfileSource, Profiles,
-        RemoteProfileOptions, ScriptRuntime, ScriptTransform, SubscriptionInfo,
-        TransformDefinition,
+        ConfigDefinition, ExternalMode, ExternalProfilePath, FileConfig, LocalBinding,
+        ManagedProfilePath, MaterializedFile, OverlayTransform, ProfileDefinition, ProfileId,
+        ProfileMetadata, ProfileSource, Profiles, RemoteProfileOptions, ScriptRuntime,
+        ScriptTransform, SubscriptionInfo, TransformDefinition,
     };
     use struct_patch::Patch as _;
     use tempfile::{TempDir, tempdir};
+
+    struct NoProxyPort;
+
+    impl SelfProxyPortSource for NoProxyPort {
+        fn mixed_port(&self) -> Option<u16> {
+            None
+        }
+    }
 
     pub(crate) fn temp_profiles_path(dir: &TempDir) -> Utf8PathBuf {
         Utf8PathBuf::from_path_buf(dir.path().join("profiles.yaml")).expect("utf-8 temp path")
@@ -375,6 +396,59 @@ mod tests {
                     transforms: vec![],
                 }),
             },
+        }
+    }
+
+    fn external_item(
+        uid: &str,
+        mode: ExternalMode,
+        target: ExternalProfilePath,
+    ) -> nyanpasu_config::profile::ProfileItem {
+        nyanpasu_config::profile::ProfileItem {
+            uid: ProfileId(uid.into()),
+            metadata: ProfileMetadata {
+                name: uid.to_uppercase(),
+                desc: None,
+            },
+            definition: ProfileDefinition::Config {
+                config: ConfigDefinition::File(FileConfig {
+                    source: ProfileSource::Local {
+                        binding: LocalBinding::External {
+                            materialized: MaterializedFile {
+                                file: ManagedProfilePath::new(format!("{uid}.yaml")).unwrap(),
+                                updated_at: None,
+                            },
+                            target,
+                            mode,
+                        },
+                    },
+                    transforms: vec![],
+                }),
+            },
+        }
+    }
+
+    fn external_path(path: &std::path::Path) -> ExternalProfilePath {
+        ExternalProfilePath::new(path.to_string_lossy().into_owned()).unwrap()
+    }
+
+    async fn wait_for_updated_at(client: &ProfilesClient, uid: &str) -> Arc<Profiles> {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let snapshot = client.get().await.unwrap();
+            let updated = snapshot
+                .items
+                .get(&ProfileId(uid.into()))
+                .and_then(|item| item.definition.source())
+                .and_then(|source| source.materialized().updated_at);
+            if updated.is_some() {
+                return snapshot;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "profile {uid} was not updated before timeout"
+            );
+            tokio::task::yield_now().await;
         }
     }
 
@@ -705,6 +779,161 @@ mod tests {
             tokio::task::yield_now().await;
         }
         assert_eq!(fetch_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn external_mirror_change_syncs_copy_and_bumps_updated_at() {
+        let target_dir = tempdir().unwrap();
+        let target_path = target_dir.path().join("external.yaml");
+        std::fs::write(&target_path, "proxies: []\n").unwrap();
+        let target = external_path(&target_path);
+
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_read_external()
+            .withf({
+                let target = target.clone();
+                move |observed| observed == &target
+            })
+            .times(1)
+            .returning(|_| Ok("proxies: []\n".into()));
+        fs.expect_write_atomic()
+            .withf(|path, content| path.as_str() == "ext1.yaml" && content == "proxies: []\n")
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let (client, _dir) = test_client_with(fs).await;
+        let mut profiles = Profiles::default();
+        profiles.append_item(external_item("ext1", ExternalMode::Mirror, target));
+        client.replace(profiles).await.unwrap();
+
+        client
+            .debug_cast_external_changed(ProfileId("ext1".into()))
+            .await;
+
+        let snapshot = wait_for_updated_at(&client, "ext1").await;
+        assert!(
+            snapshot.items[&ProfileId("ext1".into())]
+                .definition
+                .source()
+                .unwrap()
+                .materialized()
+                .updated_at
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn external_symlink_change_bumps_updated_at_without_copy() {
+        let target_dir = tempdir().unwrap();
+        let target_path = target_dir.path().join("external.yaml");
+        std::fs::write(&target_path, "proxies: []\n").unwrap();
+        let target = external_path(&target_path);
+
+        let (client, _dir) = test_client_with(MockProfileFsPort::new()).await;
+        let mut profiles = Profiles::default();
+        profiles.append_item(external_item("ext1", ExternalMode::Symlink, target));
+        client.replace(profiles).await.unwrap();
+
+        client
+            .debug_cast_external_changed(ProfileId("ext1".into()))
+            .await;
+
+        wait_for_updated_at(&client, "ext1").await;
+    }
+
+    #[tokio::test]
+    async fn external_background_commit_requests_rebuild_once_for_current() {
+        let target_dir = tempdir().unwrap();
+        let target_path = target_dir.path().join("external.yaml");
+        std::fs::write(&target_path, "proxies: []\n").unwrap();
+        let target = external_path(&target_path);
+
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_read_external()
+            .times(1)
+            .returning(|_| Ok("proxies: []\n".into()));
+        fs.expect_write_atomic().times(1).returning(|_, _| Ok(()));
+        let mut notifier = MockRebuildNotifier::new();
+        notifier.expect_request_rebuild().times(1).returning(|| ());
+        let dir = tempdir().unwrap();
+        let client = ProfilesClient::new(
+            temp_profiles_path(&dir),
+            std::sync::Arc::new(fs),
+            std::sync::Arc::new(MockSubscriptionFetcher::new()),
+            std::sync::Arc::new(notifier),
+        )
+        .await
+        .unwrap();
+        let mut profiles = Profiles::default();
+        profiles.append_item(external_item("ext1", ExternalMode::Mirror, target));
+        profiles.set_current(Some(ProfileId("ext1".into())));
+        client.replace(profiles).await.unwrap();
+
+        client
+            .debug_cast_external_changed(ProfileId("ext1".into()))
+            .await;
+
+        wait_for_updated_at(&client, "ext1").await;
+    }
+
+    #[tokio::test]
+    async fn external_watcher_smoke_mirror_real_file_event() {
+        let config_dir = tempdir().unwrap();
+        let data_dir = tempdir().unwrap();
+        let target_dir = tempdir().unwrap();
+        let target_path = target_dir.path().join("external.yaml");
+        std::fs::write(&target_path, "proxies: []\n").unwrap();
+        let paths = PathResolver::with_base_dirs(
+            config_dir.path().to_path_buf(),
+            data_dir.path().to_path_buf(),
+        );
+        let fs = std::sync::Arc::new(ProfileFileService::new(
+            paths,
+            std::sync::Arc::new(NoProxyPort),
+        ));
+        let profiles_path =
+            Utf8PathBuf::from_path_buf(config_dir.path().join("profiles.yaml")).unwrap();
+        let client = ProfilesClient::new(
+            profiles_path,
+            fs,
+            std::sync::Arc::new(MockSubscriptionFetcher::new()),
+            std::sync::Arc::new(MockRebuildNotifier::new()),
+        )
+        .await
+        .unwrap();
+        let mut profiles = Profiles::default();
+        profiles.append_item(external_item(
+            "ext1",
+            ExternalMode::Mirror,
+            external_path(&target_path),
+        ));
+        client.replace(profiles).await.unwrap();
+
+        tokio::fs::write(&target_path, "mode: rule\nproxies: []\n")
+            .await
+            .unwrap();
+
+        let managed_path = config_dir.path().join("profiles").join("ext1.yaml");
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let updated = client
+                    .get()
+                    .await
+                    .unwrap()
+                    .items
+                    .get(&ProfileId("ext1".into()))
+                    .and_then(|item| item.definition.source())
+                    .and_then(|source| source.materialized().updated_at)
+                    .is_some();
+                let mirrored = std::fs::read_to_string(&managed_path)
+                    .is_ok_and(|content| content.contains("mode: rule"));
+                if updated && mirrored {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("real external watcher event should commit within 5s");
     }
 
     #[tokio::test]

--- a/backend/tauri/src/lib.rs
+++ b/backend/tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod feat;
 mod ipc;
 mod logging;
 mod server;
+mod service;
 mod setup;
 mod specta_export;
 mod state;

--- a/backend/tauri/src/service/mod.rs
+++ b/backend/tauri/src/service/mod.rs
@@ -1,0 +1,3 @@
+//! Concrete infrastructure services (adapters) consumed via ports.
+
+pub mod profile_file;

--- a/backend/tauri/src/service/profile_file.rs
+++ b/backend/tauri/src/service/profile_file.rs
@@ -149,6 +149,11 @@ impl ProfileFsPort for ProfileFileService {
         }
     }
 
+    fn read_external(&self, target: &ExternalProfilePath) -> anyhow::Result<String> {
+        std::fs::read_to_string(target.as_path())
+            .with_context(|| format!("read external profile target {target}"))
+    }
+
     fn ensure_not_symlink(&self, path: &ManagedProfilePath) -> anyhow::Result<()> {
         let full = self.resolve(path)?;
         match std::fs::symlink_metadata(&full) {

--- a/backend/tauri/src/service/profile_file.rs
+++ b/backend/tauri/src/service/profile_file.rs
@@ -7,9 +7,15 @@ use std::{io::Write, path::PathBuf, sync::Arc, time::Duration};
 
 use anyhow::{Context, bail};
 use atomicwrites::{AtomicFile, OverwriteBehavior};
-use nyanpasu_config::profile::{ExternalProfilePath, ManagedProfilePath};
+use nyanpasu_config::profile::{
+    ExternalProfilePath, ManagedProfilePath, RemoteProfileOptions, SubscriptionInfo,
+};
+use url::Url;
 
-use crate::{state::profiles::ports::ProfileFsPort, utils::path::PathResolver};
+use crate::{
+    state::profiles::ports::{FetchedSubscription, ProfileFsPort, SubscriptionFetcher},
+    utils::path::PathResolver,
+};
 
 /// Where the fetcher looks up the app's own mixed port when `self_proxy` is
 /// requested. Wired at the composition root (T07); tests inject a constant.
@@ -122,11 +128,169 @@ impl ProfileFsPort for ProfileFileService {
     }
 }
 
+#[async_trait::async_trait]
+impl SubscriptionFetcher for ProfileFileService {
+    async fn fetch(
+        &self,
+        url: &Url,
+        options: &RemoteProfileOptions,
+    ) -> anyhow::Result<FetchedSubscription> {
+        use backon::Retryable;
+
+        let mut builder = reqwest::ClientBuilder::new()
+            .use_rustls_tls()
+            .no_proxy()
+            .timeout(self.http_timeout);
+
+        // Proxy precedence mirrors the legacy subscriber (remote.rs:129-150):
+        // self_proxy wins, then system proxy, else direct.
+        let proxy_url = if options.self_proxy {
+            self.self_proxy_port
+                .mixed_port()
+                .map(|port| format!("http://127.0.0.1:{port}"))
+        } else if options.with_proxy {
+            match sysproxy::Sysproxy::get_system_proxy() {
+                Ok(p @ sysproxy::Sysproxy { enable: true, .. }) => {
+                    Some(format!("http://{}:{}", p.host, p.port))
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+        if let Some(proxy_url) = proxy_url {
+            use crate::utils::config::NyanpasuReqwestProxyExt;
+            builder = builder.swift_set_proxy(&proxy_url);
+        }
+
+        let user_agent = options
+            .user_agent
+            .clone()
+            .unwrap_or_else(|| format!("clash-nyanpasu/v{}", crate::utils::dirs::APP_VERSION));
+        let client = builder.user_agent(user_agent).build()?;
+
+        let device_info = crate::utils::hwid::get_device_info();
+        let sanitize = crate::utils::hwid::sanitize_for_header;
+        let perform = || async {
+            client
+                .get(url.as_str())
+                .header("x-hwid", &device_info.hwid)
+                .header("x-device-os", sanitize(&device_info.device_os))
+                .header("x-ver-os", sanitize(&device_info.os_version))
+                .header("x-device-model", sanitize(&device_info.device_model))
+                .send()
+                .await?
+                .error_for_status()
+        };
+        let resp = perform
+            .retry(backon::ExponentialBuilder::default())
+            .when(|error: &reqwest::Error| {
+                !error.is_status()
+                    || error.status().is_some_and(|status| {
+                        !matches!(
+                            status,
+                            reqwest::StatusCode::FORBIDDEN
+                                | reqwest::StatusCode::NOT_FOUND
+                                | reqwest::StatusCode::UNAUTHORIZED
+                        )
+                    })
+            })
+            .await
+            .with_context(|| format!("subscription download failed: {url}"))?;
+
+        let subscription = parse_subscription_userinfo(resp.headers());
+        let filename = parse_profile_title(resp.headers());
+        let content = resp
+            .text_with_charset("utf-8")
+            .await
+            .with_context(|| format!("read subscription response body: {url}"))?;
+        let content = content.trim_start_matches('\u{feff}').to_owned();
+        Ok(FetchedSubscription {
+            content,
+            filename,
+            subscription,
+        })
+    }
+}
+
+fn parse_subscription_userinfo(headers: &reqwest::header::HeaderMap) -> SubscriptionInfo {
+    let Some(value) = headers
+        .get("subscription-userinfo")
+        .or_else(|| headers.get("Subscription-Userinfo"))
+    else {
+        return SubscriptionInfo::default();
+    };
+    let raw = value.to_str().unwrap_or("");
+    let field = |key: &str| crate::utils::help::parse_str::<u64>(raw, key);
+    SubscriptionInfo {
+        upload: field("upload"),
+        download: field("download"),
+        total: field("total"),
+        expire: field("expire")
+            .filter(|secs| *secs != 0)
+            .and_then(|secs| time::OffsetDateTime::from_unix_timestamp(secs as i64).ok()),
+    }
+}
+
+fn parse_profile_title(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    if let Some(value) = headers.get("profile-title").and_then(|v| v.to_str().ok()) {
+        if let Some(encoded) = value.strip_prefix("base64:") {
+            use base64::Engine;
+            if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(encoded) {
+                if let Ok(decoded) = String::from_utf8(bytes) {
+                    return Some(decoded);
+                }
+            }
+        } else {
+            return Some(value.to_owned());
+        }
+    }
+
+    parse_filename_from_content_disposition(headers)
+}
+
+fn parse_filename_from_content_disposition(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    let value = headers
+        .get(reqwest::header::CONTENT_DISPOSITION)
+        .and_then(|v| v.to_str().ok())?;
+
+    value
+        .split(';')
+        .map(str::trim)
+        .find_map(|part| {
+            part.strip_prefix("filename*=")
+                .and_then(decode_rfc5987_filename)
+                .or_else(|| {
+                    part.strip_prefix("filename=")
+                        .map(|filename| filename.trim().trim_matches(['"', '\'']).to_owned())
+                })
+        })
+        .filter(|filename| !filename.is_empty())
+}
+
+fn decode_rfc5987_filename(value: &str) -> Option<String> {
+    let value = value.trim().trim_matches(['"', '\'']);
+    let encoded = value.split("''").last().unwrap_or(value);
+    percent_encoding::percent_decode(encoded.as_bytes())
+        .decode_utf8()
+        .ok()
+        .map(|decoded| decoded.into_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nyanpasu_config::profile::ManagedProfilePath;
-    use std::sync::Arc;
+    use crate::state::profiles::ports::SubscriptionFetcher;
+    use axum::{Router, http::HeaderMap as AxumHeaderMap, response::IntoResponse, routing::get};
+    use nyanpasu_config::profile::{ManagedProfilePath, RemoteProfileOptions};
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::{Duration, Instant},
+    };
+    use url::Url;
 
     struct NoProxy;
     impl SelfProxyPortSource for NoProxy {
@@ -146,6 +310,24 @@ mod tests {
 
     fn managed(name: &str) -> ManagedProfilePath {
         ManagedProfilePath::new(name).unwrap()
+    }
+
+    async fn serve(router: Router) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        (format!("http://{addr}/"), handle)
+    }
+
+    fn options_direct() -> RemoteProfileOptions {
+        RemoteProfileOptions {
+            user_agent: None,
+            with_proxy: false,
+            self_proxy: false,
+            update_interval_minutes: 120,
+        }
     }
 
     #[test]
@@ -216,5 +398,95 @@ mod tests {
         let value: serde_yaml::Mapping = serde_yaml::from_str(&normalized).unwrap();
         assert_eq!(value.len(), 2);
         assert!(normalize_yaml_document(": not yaml [").is_err());
+    }
+
+    #[tokio::test]
+    async fn fetch_parses_userinfo_and_title_headers() {
+        let router = Router::new().route(
+            "/",
+            get(|| async {
+                let mut headers = AxumHeaderMap::new();
+                headers.insert(
+                    "subscription-userinfo",
+                    "upload=1; download=2; total=3; expire=0".parse().unwrap(),
+                );
+                headers.insert("profile-title", "My Sub".parse().unwrap());
+                (headers, "proxies: []\n")
+            }),
+        );
+        let (url, _server) = serve(router).await;
+        let (_temp, service) = service();
+        let fetched = service
+            .fetch(&Url::parse(&url).unwrap(), &options_direct())
+            .await
+            .unwrap();
+        assert_eq!(fetched.content, "proxies: []\n");
+        assert_eq!(fetched.filename.as_deref(), Some("My Sub"));
+        assert_eq!(fetched.subscription.upload, Some(1));
+        assert_eq!(fetched.subscription.download, Some(2));
+        assert_eq!(fetched.subscription.total, Some(3));
+        assert!(fetched.subscription.expire.is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_retries_transient_errors_but_not_auth_failures() {
+        static HITS: AtomicUsize = AtomicUsize::new(0);
+        let flaky = Router::new().route(
+            "/",
+            get(|| async {
+                if HITS.fetch_add(1, Ordering::SeqCst) == 0 {
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                } else {
+                    "ok: true\n".into_response()
+                }
+            }),
+        );
+        let (url, _server) = serve(flaky).await;
+        let (_temp, service) = service();
+        let fetched = service
+            .fetch(&Url::parse(&url).unwrap(), &options_direct())
+            .await
+            .unwrap();
+        assert_eq!(fetched.content, "ok: true\n");
+        assert!(HITS.load(Ordering::SeqCst) >= 2);
+
+        static AUTH_HITS: AtomicUsize = AtomicUsize::new(0);
+        let forbidden = Router::new().route(
+            "/",
+            get(|| async {
+                AUTH_HITS.fetch_add(1, Ordering::SeqCst);
+                axum::http::StatusCode::FORBIDDEN
+            }),
+        );
+        let (url, _server) = serve(forbidden).await;
+        assert!(
+            service
+                .fetch(&Url::parse(&url).unwrap(), &options_direct())
+                .await
+                .is_err()
+        );
+        assert_eq!(AUTH_HITS.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn fetch_timeout_is_managed_internally() {
+        let slow = Router::new().route(
+            "/",
+            get(|| async {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                "never"
+            }),
+        );
+        let (url, _server) = serve(slow).await;
+        let (_temp, service) = service();
+        let service = service.with_http_timeout(Duration::from_millis(300));
+        let started = Instant::now();
+        assert!(
+            service
+                .fetch(&Url::parse(&url).unwrap(), &options_direct())
+                .await
+                .is_err()
+        );
+        assert!(started.elapsed() < Duration::from_secs(10));
     }
 }

--- a/backend/tauri/src/service/profile_file.rs
+++ b/backend/tauri/src/service/profile_file.rs
@@ -1,0 +1,1 @@
+//! ProfileFsPort + SubscriptionFetcher implementation (T03 Task 2/3).

--- a/backend/tauri/src/service/profile_file.rs
+++ b/backend/tauri/src/service/profile_file.rs
@@ -3,7 +3,12 @@
 //! self-proxy port arrives via [`SelfProxyPortSource`] instead of the legacy
 //! global read (config/profile/item/remote.rs:130-136 FIXME).
 
-use std::{io::Write, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::{Context, bail};
 use atomicwrites::{AtomicFile, OverwriteBehavior};
@@ -45,9 +50,69 @@ impl ProfileFileService {
         self
     }
 
-    fn resolve(&self, path: &ManagedProfilePath) -> PathBuf {
-        self.paths.app_profiles_dir().join(path.as_path())
+    fn resolve(&self, path: &ManagedProfilePath) -> anyhow::Result<PathBuf> {
+        let full = self.paths.app_profiles_dir().join(path.as_path());
+        self.ensure_parent_contained(&full)?;
+        Ok(full)
     }
+
+    fn ensure_parent_contained(&self, full: &Path) -> anyhow::Result<()> {
+        let profiles_dir = self.paths.app_profiles_dir();
+        let Some(parent) = full.parent() else {
+            return Ok(());
+        };
+        let profiles_dir = match canonicalize_for_compare(&profiles_dir) {
+            Ok(path) => path,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error).context("canonicalize profile directory"),
+        };
+
+        let mut ancestor = parent;
+        loop {
+            if ancestor.exists() || std::fs::symlink_metadata(ancestor).is_ok() {
+                let ancestor = canonicalize_for_compare(ancestor).with_context(|| {
+                    format!("canonicalize profile parent {}", ancestor.display())
+                })?;
+                if !ancestor.starts_with(&profiles_dir) {
+                    bail!(
+                        "profile path containment violation: {} escapes {}",
+                        full.display(),
+                        profiles_dir.display()
+                    );
+                }
+                return Ok(());
+            }
+            if ancestor == profiles_dir {
+                return Ok(());
+            }
+            let Some(parent) = ancestor.parent() else {
+                return Ok(());
+            };
+            ancestor = parent;
+        }
+    }
+}
+
+fn canonicalize_for_compare(path: &Path) -> std::io::Result<PathBuf> {
+    std::fs::canonicalize(path)
+}
+
+fn symlink_points_to(link: &Path, target: &Path) -> anyhow::Result<bool> {
+    let existing = std::fs::read_link(link)?;
+    let existing = if existing.is_absolute() {
+        existing
+    } else {
+        link.parent()
+            .map(|parent| parent.join(&existing))
+            .unwrap_or(existing)
+    };
+    let Ok(existing) = canonicalize_for_compare(&existing) else {
+        return Ok(false);
+    };
+    let Ok(target) = canonicalize_for_compare(target) else {
+        return Ok(false);
+    };
+    Ok(existing == target)
 }
 
 /// Parse and reserialize a YAML mapping so editor saves and File-config reads
@@ -60,13 +125,13 @@ pub fn normalize_yaml_document(content: &str) -> anyhow::Result<String> {
 
 impl ProfileFsPort for ProfileFileService {
     fn read(&self, path: &ManagedProfilePath) -> anyhow::Result<String> {
-        let full = self.resolve(path);
+        let full = self.resolve(path)?;
         std::fs::read_to_string(&full)
             .with_context(|| format!("read profile file {}", full.display()))
     }
 
     fn write_atomic(&self, path: &ManagedProfilePath, content: &str) -> anyhow::Result<()> {
-        let full = self.resolve(path);
+        let full = self.resolve(path)?;
         if let Some(parent) = full.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -76,7 +141,7 @@ impl ProfileFsPort for ProfileFileService {
     }
 
     fn remove(&self, path: &ManagedProfilePath) -> anyhow::Result<()> {
-        let full = self.resolve(path);
+        let full = self.resolve(path)?;
         match std::fs::remove_file(&full) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -85,7 +150,7 @@ impl ProfileFsPort for ProfileFileService {
     }
 
     fn ensure_not_symlink(&self, path: &ManagedProfilePath) -> anyhow::Result<()> {
-        let full = self.resolve(path);
+        let full = self.resolve(path)?;
         match std::fs::symlink_metadata(&full) {
             Ok(meta) if meta.file_type().is_symlink() => bail!(
                 "refusing to write through unexpected symlink at {}",
@@ -102,13 +167,13 @@ impl ProfileFsPort for ProfileFileService {
         path: &ManagedProfilePath,
         target: &ExternalProfilePath,
     ) -> anyhow::Result<()> {
-        let full = self.resolve(path);
+        let full = self.resolve(path)?;
         if let Some(parent) = full.parent() {
             std::fs::create_dir_all(parent)?;
         }
         match std::fs::symlink_metadata(&full) {
             Ok(meta) if meta.file_type().is_symlink() => {
-                if std::fs::read_link(&full)? == target.as_path() {
+                if symlink_points_to(&full, target.as_path())? {
                     return Ok(());
                 }
                 std::fs::remove_file(&full)?;
@@ -148,16 +213,21 @@ impl SubscriptionFetcher for ProfileFileService {
             self.self_proxy_port
                 .mixed_port()
                 .map(|port| format!("http://127.0.0.1:{port}"))
-        } else if options.with_proxy {
-            match sysproxy::Sysproxy::get_system_proxy() {
-                Ok(p @ sysproxy::Sysproxy { enable: true, .. }) => {
-                    Some(format!("http://{}:{}", p.host, p.port))
-                }
-                _ => None,
-            }
         } else {
             None
         };
+        let proxy_url = proxy_url.or_else(|| {
+            if options.with_proxy {
+                match sysproxy::Sysproxy::get_system_proxy() {
+                    Ok(p @ sysproxy::Sysproxy { enable: true, .. }) => {
+                        Some(format!("http://{}:{}", p.host, p.port))
+                    }
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        });
         if let Some(proxy_url) = proxy_url {
             use crate::utils::config::NyanpasuReqwestProxyExt;
             builder = builder.swift_set_proxy(&proxy_url);
@@ -204,7 +274,11 @@ impl SubscriptionFetcher for ProfileFileService {
             .text_with_charset("utf-8")
             .await
             .with_context(|| format!("read subscription response body: {url}"))?;
-        let content = content.trim_start_matches('\u{feff}').to_owned();
+        let content = if let Some(content) = content.strip_prefix('\u{feff}') {
+            content.to_owned()
+        } else {
+            content
+        };
         Ok(FetchedSubscription {
             content,
             filename,
@@ -228,17 +302,23 @@ fn parse_subscription_userinfo(headers: &reqwest::header::HeaderMap) -> Subscrip
         total: field("total"),
         expire: field("expire")
             .filter(|secs| *secs != 0)
-            .and_then(|secs| time::OffsetDateTime::from_unix_timestamp(secs as i64).ok()),
+            .and_then(|secs| i64::try_from(secs).ok())
+            .and_then(|secs| time::OffsetDateTime::from_unix_timestamp(secs).ok()),
     }
 }
 
 fn parse_profile_title(headers: &reqwest::header::HeaderMap) -> Option<String> {
     if let Some(value) = headers.get("profile-title").and_then(|v| v.to_str().ok()) {
+        if value.trim().is_empty() {
+            return parse_filename_from_content_disposition(headers);
+        }
         if let Some(encoded) = value.strip_prefix("base64:") {
             use base64::Engine;
             if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(encoded) {
                 if let Ok(decoded) = String::from_utf8(bytes) {
-                    return Some(decoded);
+                    if !decoded.trim().is_empty() {
+                        return Some(decoded);
+                    }
                 }
             }
         } else {
@@ -257,20 +337,27 @@ fn parse_filename_from_content_disposition(headers: &reqwest::header::HeaderMap)
     value
         .split(';')
         .map(str::trim)
-        .find_map(|part| {
-            part.strip_prefix("filename*=")
-                .and_then(decode_rfc5987_filename)
-                .or_else(|| {
-                    part.strip_prefix("filename=")
-                        .map(|filename| filename.trim().trim_matches(['"', '\'']).to_owned())
-                })
+        .filter_map(|part| part.split_once('='))
+        .find_map(|(name, value)| {
+            let name = name.trim();
+            let value = value.trim();
+            if name.eq_ignore_ascii_case("filename*") {
+                decode_rfc5987_filename(value)
+            } else if name.eq_ignore_ascii_case("filename") {
+                Some(value.trim_matches(['"', '\'']).to_owned())
+            } else {
+                None
+            }
         })
         .filter(|filename| !filename.is_empty())
 }
 
 fn decode_rfc5987_filename(value: &str) -> Option<String> {
     let value = value.trim().trim_matches(['"', '\'']);
-    let encoded = value.split("''").last().unwrap_or(value);
+    let encoded = value
+        .split_once('\'')
+        .and_then(|(_, rest)| rest.split_once('\'').map(|(_, encoded)| encoded))
+        .unwrap_or(value);
     percent_encoding::percent_decode(encoded.as_bytes())
         .decode_utf8()
         .ok()
@@ -281,11 +368,16 @@ fn decode_rfc5987_filename(value: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::state::profiles::ports::SubscriptionFetcher;
-    use axum::{Router, http::HeaderMap as AxumHeaderMap, response::IntoResponse, routing::get};
+    use axum::{
+        Router,
+        http::{HeaderMap as AxumHeaderMap, StatusCode, header},
+        response::IntoResponse,
+        routing::get,
+    };
     use nyanpasu_config::profile::{ManagedProfilePath, RemoteProfileOptions};
     use std::{
         sync::{
-            Arc,
+            Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
         },
         time::{Duration, Instant},
@@ -299,13 +391,30 @@ mod tests {
         }
     }
 
+    struct CountingNoProxy {
+        hits: Arc<AtomicUsize>,
+    }
+
+    impl SelfProxyPortSource for CountingNoProxy {
+        fn mixed_port(&self) -> Option<u16> {
+            self.hits.fetch_add(1, Ordering::SeqCst);
+            None
+        }
+    }
+
     fn service() -> (tempfile::TempDir, ProfileFileService) {
+        service_with(Arc::new(NoProxy))
+    }
+
+    fn service_with(
+        self_proxy_port: Arc<dyn SelfProxyPortSource>,
+    ) -> (tempfile::TempDir, ProfileFileService) {
         let temp = tempfile::tempdir().unwrap();
         let paths = crate::utils::path::PathResolver::with_base_dirs(
             temp.path().join("config"),
             temp.path().join("data"),
         );
-        (temp, ProfileFileService::new(paths, Arc::new(NoProxy)))
+        (temp, ProfileFileService::new(paths, self_proxy_port))
     }
 
     fn managed(name: &str) -> ManagedProfilePath {
@@ -322,10 +431,14 @@ mod tests {
     }
 
     fn options_direct() -> RemoteProfileOptions {
+        options(false, false)
+    }
+
+    fn options(self_proxy: bool, with_proxy: bool) -> RemoteProfileOptions {
         RemoteProfileOptions {
             user_agent: None,
-            with_proxy: false,
-            self_proxy: false,
+            with_proxy,
+            self_proxy,
             update_interval_minutes: 120,
         }
     }
@@ -338,6 +451,30 @@ mod tests {
         assert_eq!(service.read(&path).unwrap(), "proxies: []\n");
         service.write_atomic(&path, "mode: rule\n").unwrap();
         assert_eq!(service.read(&path).unwrap(), "mode: rule\n");
+    }
+
+    #[test]
+    fn write_atomic_rejects_parent_symlink_escape() {
+        let (temp, service) = service();
+        let profiles_dir = service.paths.app_profiles_dir();
+        std::fs::create_dir_all(&profiles_dir).unwrap();
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        let link_dir = profiles_dir.join("nested");
+        #[cfg(windows)]
+        let made = std::os::windows::fs::symlink_dir(&outside, &link_dir);
+        #[cfg(unix)]
+        let made = std::os::unix::fs::symlink(&outside, &link_dir);
+        if made.is_err() {
+            eprintln!("directory symlink unsupported in this environment, skipping");
+            return;
+        }
+
+        let err = service
+            .write_atomic(&managed("nested/x.yaml"), "escaped: true\n")
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("containment"));
+        assert!(!outside.join("x.yaml").exists());
     }
 
     #[test]
@@ -359,8 +496,8 @@ mod tests {
         service.ensure_not_symlink(&path).unwrap();
 
         let link = managed("link.yaml");
-        let target_file = service.resolve(&path);
-        let link_file = service.resolve(&link);
+        let target_file = service.resolve(&path).unwrap();
+        let link_file = service.resolve(&link).unwrap();
         #[cfg(windows)]
         let made = std::os::windows::fs::symlink_file(&target_file, &link_file);
         #[cfg(unix)]
@@ -393,11 +530,86 @@ mod tests {
     }
 
     #[test]
+    fn ensure_symlink_keeps_existing_link_when_canonical_targets_match() {
+        let (temp, service) = service();
+        let outside = temp.path().join("outside.yaml");
+        std::fs::write(&outside, "external: true\n").unwrap();
+        let target =
+            nyanpasu_config::profile::ExternalProfilePath::new(outside.to_string_lossy()).unwrap();
+        let link = managed("ext.yaml");
+        if service.ensure_symlink(&link, &target).is_err() {
+            eprintln!("symlink unsupported in this environment, skipping");
+            return;
+        }
+
+        let link_path = service.resolve(&link).unwrap();
+        let before = std::fs::read_link(&link_path).unwrap();
+        let canonical_target = std::fs::canonicalize(&outside).unwrap();
+        let equivalent_target =
+            nyanpasu_config::profile::ExternalProfilePath::new(canonical_target.to_string_lossy())
+                .unwrap();
+
+        service.ensure_symlink(&link, &equivalent_target).unwrap();
+        assert_eq!(std::fs::read_link(&link_path).unwrap(), before);
+    }
+
+    #[test]
     fn normalize_yaml_document_round_trips_mappings_and_rejects_garbage() {
         let normalized = normalize_yaml_document("b: 2\na: 1\n").unwrap();
         let value: serde_yaml::Mapping = serde_yaml::from_str(&normalized).unwrap();
         assert_eq!(value.len(), 2);
         assert!(normalize_yaml_document(": not yaml [").is_err());
+    }
+
+    #[test]
+    fn content_disposition_filename_parsing_matches_legacy_variants() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::CONTENT_DISPOSITION,
+            reqwest::header::HeaderValue::from_static("attachment; Filename=\"a.yaml\""),
+        );
+        assert_eq!(
+            parse_filename_from_content_disposition(&headers).as_deref(),
+            Some("a.yaml")
+        );
+
+        headers.insert(
+            reqwest::header::CONTENT_DISPOSITION,
+            reqwest::header::HeaderValue::from_static(
+                "attachment; filename*=UTF-8'en'my%20cfg.yaml",
+            ),
+        );
+        assert_eq!(
+            parse_filename_from_content_disposition(&headers).as_deref(),
+            Some("my cfg.yaml")
+        );
+
+        headers.insert(
+            "profile-title",
+            reqwest::header::HeaderValue::from_static("   "),
+        );
+        headers.insert(
+            reqwest::header::CONTENT_DISPOSITION,
+            reqwest::header::HeaderValue::from_static("attachment; filename=fallback.yaml"),
+        );
+        assert_eq!(
+            parse_profile_title(&headers).as_deref(),
+            Some("fallback.yaml")
+        );
+    }
+
+    #[test]
+    fn subscription_expire_ignores_absurd_overflow_values() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "subscription-userinfo",
+            reqwest::header::HeaderValue::from_static(
+                "upload=1; download=2; total=3; expire=18446744073709551615",
+            ),
+        );
+        let parsed = parse_subscription_userinfo(&headers);
+        assert_eq!(parsed.upload, Some(1));
+        assert!(parsed.expire.is_none());
     }
 
     #[tokio::test]
@@ -429,15 +641,105 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fetch_sends_default_user_agent_and_hwid() {
+        let seen = Arc::new(Mutex::new(None::<(String, bool)>));
+        let seen_request = Arc::clone(&seen);
+        let router = Router::new().route(
+            "/",
+            get(move |headers: AxumHeaderMap| {
+                let seen_request = Arc::clone(&seen_request);
+                async move {
+                    let ua = headers
+                        .get(header::USER_AGENT)
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("")
+                        .to_owned();
+                    let has_hwid = headers
+                        .get("x-hwid")
+                        .and_then(|v| v.to_str().ok())
+                        .is_some_and(|value| !value.trim().is_empty());
+                    *seen_request.lock().unwrap() = Some((ua, has_hwid));
+                    "ok: true\n"
+                }
+            }),
+        );
+        let (url, _server) = serve(router).await;
+        let (_temp, service) = service();
+        service
+            .fetch(&Url::parse(&url).unwrap(), &options_direct())
+            .await
+            .unwrap();
+
+        let (ua, has_hwid) = seen.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            ua,
+            format!("clash-nyanpasu/v{}", crate::utils::dirs::APP_VERSION)
+        );
+        assert!(has_hwid);
+    }
+
+    #[tokio::test]
+    async fn fetch_falls_back_to_direct_when_self_proxy_port_is_unavailable() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let source_hits = Arc::new(AtomicUsize::new(0));
+        let request_hits = Arc::clone(&hits);
+        let router = Router::new().route(
+            "/",
+            get(move || {
+                let request_hits = Arc::clone(&request_hits);
+                async move {
+                    request_hits.fetch_add(1, Ordering::SeqCst);
+                    "ok: true\n"
+                }
+            }),
+        );
+        let (url, _server) = serve(router).await;
+        let (_temp, service) = service_with(Arc::new(CountingNoProxy {
+            hits: Arc::clone(&source_hits),
+        }));
+
+        let fetched = service
+            .fetch(&Url::parse(&url).unwrap(), &options(true, false))
+            .await
+            .unwrap();
+
+        assert_eq!(fetched.content, "ok: true\n");
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        assert_eq!(source_hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn fetch_continues_proxy_chain_when_self_proxy_port_is_unavailable() {
+        let source_hits = Arc::new(AtomicUsize::new(0));
+        let router = Router::new().route("/", get(|| async { "ok: true\n" }));
+        let (url, _server) = serve(router).await;
+        let (_temp, service) = service_with(Arc::new(CountingNoProxy {
+            hits: Arc::clone(&source_hits),
+        }));
+
+        let fetched = service
+            .fetch(&Url::parse(&url).unwrap(), &options(true, true))
+            .await
+            .unwrap();
+
+        assert_eq!(fetched.content, "ok: true\n");
+        assert_eq!(source_hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn fetch_retries_transient_errors_but_not_auth_failures() {
-        static HITS: AtomicUsize = AtomicUsize::new(0);
+        let hits = Arc::new(AtomicUsize::new(0));
+        let flaky_hits = Arc::clone(&hits);
         let flaky = Router::new().route(
             "/",
-            get(|| async {
-                if HITS.fetch_add(1, Ordering::SeqCst) == 0 {
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
-                } else {
-                    "ok: true\n".into_response()
+            get(move || {
+                let flaky_hits = Arc::clone(&flaky_hits);
+                async move {
+                    if flaky_hits.fetch_add(1, Ordering::SeqCst) == 0 {
+                        StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                    } else {
+                        "ok: true\n".into_response()
+                    }
                 }
             }),
         );
@@ -448,24 +750,34 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(fetched.content, "ok: true\n");
-        assert!(HITS.load(Ordering::SeqCst) >= 2);
+        assert!(hits.load(Ordering::SeqCst) >= 2);
 
-        static AUTH_HITS: AtomicUsize = AtomicUsize::new(0);
-        let forbidden = Router::new().route(
-            "/",
-            get(|| async {
-                AUTH_HITS.fetch_add(1, Ordering::SeqCst);
-                axum::http::StatusCode::FORBIDDEN
-            }),
-        );
-        let (url, _server) = serve(forbidden).await;
-        assert!(
-            service
-                .fetch(&Url::parse(&url).unwrap(), &options_direct())
-                .await
-                .is_err()
-        );
-        assert_eq!(AUTH_HITS.load(Ordering::SeqCst), 1);
+        for status in [
+            StatusCode::FORBIDDEN,
+            StatusCode::UNAUTHORIZED,
+            StatusCode::NOT_FOUND,
+        ] {
+            let hits = Arc::new(AtomicUsize::new(0));
+            let status_hits = Arc::clone(&hits);
+            let router = Router::new().route(
+                "/",
+                get(move || {
+                    let status_hits = Arc::clone(&status_hits);
+                    async move {
+                        status_hits.fetch_add(1, Ordering::SeqCst);
+                        status
+                    }
+                }),
+            );
+            let (url, _server) = serve(router).await;
+            assert!(
+                service
+                    .fetch(&Url::parse(&url).unwrap(), &options_direct())
+                    .await
+                    .is_err()
+            );
+            assert_eq!(hits.load(Ordering::SeqCst), 1);
+        }
     }
 
     #[tokio::test]

--- a/backend/tauri/src/service/profile_file.rs
+++ b/backend/tauri/src/service/profile_file.rs
@@ -1,1 +1,220 @@
-//! ProfileFsPort + SubscriptionFetcher implementation (T03 Task 2/3).
+//! ProfileFsPort + SubscriptionFetcher over the real filesystem, reqwest and
+//! the OS proxy state (design §7). Tauri-free and legacy-Config-free; the
+//! self-proxy port arrives via [`SelfProxyPortSource`] instead of the legacy
+//! global read (config/profile/item/remote.rs:130-136 FIXME).
+
+use std::{io::Write, path::PathBuf, sync::Arc, time::Duration};
+
+use anyhow::{Context, bail};
+use atomicwrites::{AtomicFile, OverwriteBehavior};
+use nyanpasu_config::profile::{ExternalProfilePath, ManagedProfilePath};
+
+use crate::{state::profiles::ports::ProfileFsPort, utils::path::PathResolver};
+
+/// Where the fetcher looks up the app's own mixed port when `self_proxy` is
+/// requested. Wired at the composition root (T07); tests inject a constant.
+#[cfg_attr(test, mockall::automock)]
+pub trait SelfProxyPortSource: Send + Sync + 'static {
+    fn mixed_port(&self) -> Option<u16>;
+}
+
+pub struct ProfileFileService {
+    paths: PathResolver,
+    self_proxy_port: Arc<dyn SelfProxyPortSource>,
+    http_timeout: Duration,
+}
+
+impl ProfileFileService {
+    pub fn new(paths: PathResolver, self_proxy_port: Arc<dyn SelfProxyPortSource>) -> Self {
+        Self {
+            paths,
+            self_proxy_port,
+            http_timeout: Duration::from_secs(30),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_http_timeout(mut self, timeout: Duration) -> Self {
+        self.http_timeout = timeout;
+        self
+    }
+
+    fn resolve(&self, path: &ManagedProfilePath) -> PathBuf {
+        self.paths.app_profiles_dir().join(path.as_path())
+    }
+}
+
+/// Parse and reserialize a YAML mapping so editor saves and File-config reads
+/// share one canonical shape (legacy `read_profile_file` normalization).
+pub fn normalize_yaml_document(content: &str) -> anyhow::Result<String> {
+    let mapping: serde_yaml::Mapping =
+        serde_yaml::from_str(content).context("document is not a YAML mapping")?;
+    serde_yaml::to_string(&mapping).context("failed to reserialize YAML mapping")
+}
+
+impl ProfileFsPort for ProfileFileService {
+    fn read(&self, path: &ManagedProfilePath) -> anyhow::Result<String> {
+        let full = self.resolve(path);
+        std::fs::read_to_string(&full)
+            .with_context(|| format!("read profile file {}", full.display()))
+    }
+
+    fn write_atomic(&self, path: &ManagedProfilePath, content: &str) -> anyhow::Result<()> {
+        let full = self.resolve(path);
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        AtomicFile::new(&full, OverwriteBehavior::AllowOverwrite)
+            .write(|file| file.write_all(content.as_bytes()))
+            .with_context(|| format!("atomic write {}", full.display()))
+    }
+
+    fn remove(&self, path: &ManagedProfilePath) -> anyhow::Result<()> {
+        let full = self.resolve(path);
+        match std::fs::remove_file(&full) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("remove profile file {}", full.display())),
+        }
+    }
+
+    fn ensure_not_symlink(&self, path: &ManagedProfilePath) -> anyhow::Result<()> {
+        let full = self.resolve(path);
+        match std::fs::symlink_metadata(&full) {
+            Ok(meta) if meta.file_type().is_symlink() => bail!(
+                "refusing to write through unexpected symlink at {}",
+                full.display()
+            ),
+            Ok(_) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("inspect profile file {}", full.display())),
+        }
+    }
+
+    fn ensure_symlink(
+        &self,
+        path: &ManagedProfilePath,
+        target: &ExternalProfilePath,
+    ) -> anyhow::Result<()> {
+        let full = self.resolve(path);
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        match std::fs::symlink_metadata(&full) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                if std::fs::read_link(&full)? == target.as_path() {
+                    return Ok(());
+                }
+                std::fs::remove_file(&full)?;
+            }
+            Ok(_) => bail!(
+                "existing non-symlink file at {}, refusing to replace",
+                full.display()
+            ),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => Err(e).with_context(|| format!("inspect profile file {}", full.display()))?,
+        }
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(target.as_path(), &full)?;
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(target.as_path(), &full)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nyanpasu_config::profile::ManagedProfilePath;
+    use std::sync::Arc;
+
+    struct NoProxy;
+    impl SelfProxyPortSource for NoProxy {
+        fn mixed_port(&self) -> Option<u16> {
+            None
+        }
+    }
+
+    fn service() -> (tempfile::TempDir, ProfileFileService) {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = crate::utils::path::PathResolver::with_base_dirs(
+            temp.path().join("config"),
+            temp.path().join("data"),
+        );
+        (temp, ProfileFileService::new(paths, Arc::new(NoProxy)))
+    }
+
+    fn managed(name: &str) -> ManagedProfilePath {
+        ManagedProfilePath::new(name).unwrap()
+    }
+
+    #[test]
+    fn write_atomic_then_read_round_trips_and_creates_parent() {
+        let (_temp, service) = service();
+        let path = managed("abc.yaml");
+        service.write_atomic(&path, "proxies: []\n").unwrap();
+        assert_eq!(service.read(&path).unwrap(), "proxies: []\n");
+        service.write_atomic(&path, "mode: rule\n").unwrap();
+        assert_eq!(service.read(&path).unwrap(), "mode: rule\n");
+    }
+
+    #[test]
+    fn remove_is_idempotent() {
+        let (_temp, service) = service();
+        let path = managed("gone.yaml");
+        service.remove(&path).unwrap();
+        service.write_atomic(&path, "x: 1\n").unwrap();
+        service.remove(&path).unwrap();
+        assert!(service.read(&path).is_err());
+    }
+
+    #[test]
+    fn ensure_not_symlink_rejects_links_and_accepts_files() {
+        let (_temp, service) = service();
+        let path = managed("real.yaml");
+        service.ensure_not_symlink(&path).unwrap();
+        service.write_atomic(&path, "x: 1\n").unwrap();
+        service.ensure_not_symlink(&path).unwrap();
+
+        let link = managed("link.yaml");
+        let target_file = service.resolve(&path);
+        let link_file = service.resolve(&link);
+        #[cfg(windows)]
+        let made = std::os::windows::fs::symlink_file(&target_file, &link_file);
+        #[cfg(unix)]
+        let made = std::os::unix::fs::symlink(&target_file, &link_file);
+        if made.is_err() {
+            eprintln!("symlink unsupported in this environment, skipping");
+            return;
+        }
+        assert!(service.ensure_not_symlink(&link).is_err());
+    }
+
+    #[test]
+    fn ensure_symlink_creates_and_repairs() {
+        let (temp, service) = service();
+        let outside = temp.path().join("outside.yaml");
+        std::fs::write(&outside, "external: true\n").unwrap();
+        let target =
+            nyanpasu_config::profile::ExternalProfilePath::new(outside.to_string_lossy()).unwrap();
+        let link = managed("ext.yaml");
+        if service.ensure_symlink(&link, &target).is_err() {
+            eprintln!("symlink unsupported in this environment, skipping");
+            return;
+        }
+        assert_eq!(service.read(&link).unwrap(), "external: true\n");
+        service.ensure_symlink(&link, &target).unwrap();
+
+        let occupied = managed("occupied.yaml");
+        service.write_atomic(&occupied, "x: 1\n").unwrap();
+        assert!(service.ensure_symlink(&occupied, &target).is_err());
+    }
+
+    #[test]
+    fn normalize_yaml_document_round_trips_mappings_and_rejects_garbage() {
+        let normalized = normalize_yaml_document("b: 2\na: 1\n").unwrap();
+        let value: serde_yaml::Mapping = serde_yaml::from_str(&normalized).unwrap();
+        assert_eq!(value.len(), 2);
+        assert!(normalize_yaml_document(": not yaml [").is_err());
+    }
+}

--- a/backend/tauri/src/state/mod.rs
+++ b/backend/tauri/src/state/mod.rs
@@ -1,4 +1,5 @@
 pub mod application;
 pub mod clash_config;
 pub mod mirror;
+pub mod profiles;
 pub mod session_state;

--- a/backend/tauri/src/state/profiles/actor.rs
+++ b/backend/tauri/src/state/profiles/actor.rs
@@ -1,0 +1,124 @@
+//! ProfilesActor: single owner of the profiles document.
+//! Tauri-free; every filesystem/network effect goes through the ports.
+
+use std::sync::Arc;
+
+use nyanpasu_config::profile::{
+    ProfileDefinition, ProfileDependencyIndex, ProfileId, ProfileMetadata, ProfileValidationError,
+    Profiles,
+};
+use nyanpasu_core::state::PersistentStateManager;
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+
+use super::ports::{ProfileFsPort, RebuildNotifier, SubscriptionFetcher};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProfilesError {
+    #[error("profile not found: {0}")]
+    ProfileNotFound(ProfileId),
+    #[error("profile is referenced and cannot be deleted (referrers: {referrers:?})")]
+    ProfileInUse { referrers: Vec<ProfileId> },
+    #[error("profile has no materialized file")]
+    ProfileHasNoFile,
+    #[error("validation failed: {0:?}")]
+    ValidationFailed(Vec<ProfileValidationError>),
+    #[error("profile is not a remote profile")]
+    NotARemoteProfile,
+    #[error("file not writable: {reason}")]
+    FileNotWritable { reason: String },
+    #[error("refresh failed: {message}")]
+    RefreshFailed { message: String },
+    #[error("failed to persist profiles: {0}")]
+    Persist(String),
+    #[error("profiles actor rpc failed: {0}")]
+    Rpc(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct CommitReport {
+    pub snapshot: Arc<Profiles>,
+    /// Dependency-closure judgement per the T04 affects_current rule table.
+    pub affects_current: bool,
+    /// Post-commit side-effect failures are degraded, not rolled back.
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewProfileRequest {
+    pub metadata: ProfileMetadata,
+    /// Add rewrites the materialized path to `{uid}.{ext}`.
+    pub definition: ProfileDefinition,
+}
+
+#[derive(Debug, Clone)]
+pub enum ReorderOp {
+    Move { active: ProfileId, over: ProfileId },
+    ByList(Vec<ProfileId>),
+}
+
+pub struct ProfilesActorArgs {
+    pub manager: PersistentStateManager<Profiles>,
+    pub fs: Arc<dyn ProfileFsPort>,
+    pub fetcher: Arc<dyn SubscriptionFetcher>,
+    pub notifier: Arc<dyn RebuildNotifier>,
+}
+
+pub struct ProfilesActorState {
+    manager: PersistentStateManager<Profiles>,
+    #[allow(dead_code)]
+    index: ProfileDependencyIndex,
+    #[allow(dead_code)]
+    fs: Arc<dyn ProfileFsPort>,
+    #[allow(dead_code)]
+    fetcher: Arc<dyn SubscriptionFetcher>,
+    #[allow(dead_code)]
+    notifier: Arc<dyn RebuildNotifier>,
+}
+
+#[derive(Debug)]
+pub enum ProfilesActorMessage {
+    Get(RpcReplyPort<Result<Arc<Profiles>, ProfilesError>>),
+}
+
+pub struct ProfilesActor;
+
+impl ProfilesActor {
+    fn current_state(state: &ProfilesActorState) -> Profiles {
+        state.manager.snapshot_handle().load().state.clone()
+    }
+}
+
+impl Actor for ProfilesActor {
+    type Msg = ProfilesActorMessage;
+    type State = ProfilesActorState;
+    type Arguments = ProfilesActorArgs;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let index = ProfileDependencyIndex::build(&args.manager.snapshot_handle().load().state);
+        Ok(ProfilesActorState {
+            manager: args.manager,
+            index,
+            fs: args.fs,
+            fetcher: args.fetcher,
+            notifier: args.notifier,
+        })
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            ProfilesActorMessage::Get(reply) => {
+                let _ = reply.send(Ok(Arc::new(Self::current_state(state))));
+            }
+        }
+        Ok(())
+    }
+}

--- a/backend/tauri/src/state/profiles/actor.rs
+++ b/backend/tauri/src/state/profiles/actor.rs
@@ -12,7 +12,10 @@ use nyanpasu_config::profile::{
 use nyanpasu_core::state::PersistentStateManager;
 use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
 
-use super::ports::{ProfileFsPort, RebuildNotifier, SubscriptionFetcher};
+use super::{
+    ports::{ProfileFsPort, RebuildNotifier, SubscriptionFetcher},
+    scheduler::RemoteUpdateScheduler,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProfilesError {
@@ -73,6 +76,7 @@ pub struct ProfilesActorState {
     fetcher: Arc<dyn SubscriptionFetcher>,
     notifier: Arc<dyn RebuildNotifier>,
     pending_refresh: HashMap<ProfileId, Option<RpcReplyPort<Result<CommitReport, ProfilesError>>>>,
+    scheduler: RemoteUpdateScheduler,
 }
 
 #[derive(Debug)]
@@ -234,6 +238,7 @@ impl ProfilesActor {
     }
 
     async fn run_write<F>(
+        myself: &ActorRef<ProfilesActorMessage>,
         state: &mut ProfilesActorState,
         mutate: F,
     ) -> Result<CommitReport, ProfilesError>
@@ -250,6 +255,7 @@ impl ProfilesActor {
             .await
             .map_err(|e| ProfilesError::Persist(e.to_string()))?;
         state.index = ProfileDependencyIndex::build(&next);
+        state.scheduler.reconcile(&next, myself, false);
 
         let mut warnings = Vec::new();
         for op in outcome.post_ops {
@@ -366,7 +372,18 @@ impl Actor for ProfilesActor {
             fetcher: args.fetcher,
             notifier: args.notifier,
             pending_refresh: HashMap::new(),
+            scheduler: RemoteUpdateScheduler::default(),
         })
+    }
+
+    async fn post_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        let snapshot = Self::current_state(state);
+        state.scheduler.reconcile(&snapshot, &myself, true);
+        Ok(())
     }
 
     async fn handle(
@@ -380,7 +397,7 @@ impl Actor for ProfilesActor {
                 let _ = reply.send(Ok(Arc::new(Self::current_state(state))));
             }
             ProfilesActorMessage::SetCurrent { current, reply } => {
-                let result = Self::run_write(state, |profiles| {
+                let result = Self::run_write(&myself, state, |profiles| {
                     profiles.set_current(current);
                     Ok(WriteOutcome {
                         affects: AffectsRule::CurrentChanged,
@@ -391,7 +408,7 @@ impl Actor for ProfilesActor {
                 let _ = reply.send(result);
             }
             ProfilesActorMessage::SetGlobalTransforms { ids, reply } => {
-                let result = Self::run_write(state, |profiles| {
+                let result = Self::run_write(&myself, state, |profiles| {
                     profiles.global_transforms = ids;
                     Ok(WriteOutcome {
                         affects: AffectsRule::GlobalChanged,
@@ -405,7 +422,7 @@ impl Actor for ProfilesActor {
                 profiles: next,
                 reply,
             } => {
-                let result = Self::run_write(state, |profiles| {
+                let result = Self::run_write(&myself, state, |profiles| {
                     *profiles = next;
                     Ok(WriteOutcome {
                         affects: AffectsRule::Always,
@@ -459,7 +476,7 @@ impl Actor for ProfilesActor {
                         metadata: request.metadata,
                         definition,
                     };
-                    Self::run_write(state, move |profiles| {
+                    Self::run_write(&myself, state, move |profiles| {
                         if !profiles.append_item(item) {
                             return Err(ProfilesError::Persist("uid collision".into()));
                         }
@@ -490,7 +507,7 @@ impl Actor for ProfilesActor {
                                 }]
                             })
                             .unwrap_or_default();
-                        Self::run_write(state, move |profiles| {
+                        Self::run_write(&myself, state, move |profiles| {
                             profiles.remove_item_unchecked(&uid);
                             Ok(WriteOutcome {
                                 affects: AffectsRule::Never,
@@ -503,7 +520,7 @@ impl Actor for ProfilesActor {
                 let _ = reply.send(result);
             }
             ProfilesActorMessage::Reorder { op, reply } => {
-                let result = Self::run_write(state, move |profiles| {
+                let result = Self::run_write(&myself, state, move |profiles| {
                     match op {
                         ReorderOp::Move { active, over } => {
                             if profiles.items.get(&active).is_none() {
@@ -547,7 +564,7 @@ impl Actor for ProfilesActor {
                 let _ = reply.send(result);
             }
             ProfilesActorMessage::PatchMetadata { uid, patch, reply } => {
-                let result = Self::run_write(state, move |profiles| {
+                let result = Self::run_write(&myself, state, move |profiles| {
                     let Some(item) = profiles.items.get_mut(&uid) else {
                         return Err(ProfilesError::ProfileNotFound(uid));
                     };
@@ -561,7 +578,7 @@ impl Actor for ProfilesActor {
                 let _ = reply.send(result);
             }
             ProfilesActorMessage::PatchRemoteOptions { uid, patch, reply } => {
-                let result = Self::run_write(state, move |profiles| {
+                let result = Self::run_write(&myself, state, move |profiles| {
                     let Some(item) = profiles.items.get_mut(&uid) else {
                         return Err(ProfilesError::ProfileNotFound(uid));
                     };
@@ -591,7 +608,7 @@ impl Actor for ProfilesActor {
                 }
 
                 if let Some(patch) = patch {
-                    let patched = Self::run_write(state, {
+                    let patched = Self::run_write(&myself, state, {
                         let uid = uid.clone();
                         move |profiles| {
                             let Some(item) = profiles.items.get_mut(&uid) else {
@@ -691,7 +708,7 @@ impl Actor for ProfilesActor {
                         Err(ProfilesError::RefreshFailed { message })
                     }
                     RefreshOutcome::Succeeded { subscription } => {
-                        Self::run_write(state, {
+                        Self::run_write(&myself, state, {
                             let uid = uid.clone();
                             move |profiles| {
                                 let Some(item) = profiles.items.get_mut(&uid) else {
@@ -735,7 +752,7 @@ impl Actor for ProfilesActor {
                 definition,
                 reply,
             } => {
-                let result = Self::run_write(state, move |profiles| {
+                let result = Self::run_write(&myself, state, move |profiles| {
                     let Some(item) = profiles.items.get_mut(&uid) else {
                         return Err(ProfilesError::ProfileNotFound(uid.clone()));
                     };
@@ -758,6 +775,15 @@ impl Actor for ProfilesActor {
                 let _ = inserted.send(());
             }
         }
+        Ok(())
+    }
+
+    async fn post_stop(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        state.scheduler.shutdown();
         Ok(())
     }
 }

--- a/backend/tauri/src/state/profiles/actor.rs
+++ b/backend/tauri/src/state/profiles/actor.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use nyanpasu_config::profile::{
     ConfigDefinition, ExternalMode, ExternalProfilePath, LocalBinding, ManagedProfilePath,
     ProfileDefinition, ProfileDependencyIndex, ProfileId, ProfileItem, ProfileMetadata,
-    ProfileSource, ProfileValidationError, Profiles, ScriptRuntime, TransformDefinition,
+    ProfileMetadataPatch, ProfileSource, ProfileValidationError, Profiles,
+    RemoteProfileOptionsPatch, ScriptRuntime, TransformDefinition,
 };
 use nyanpasu_core::state::PersistentStateManager;
 use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
@@ -97,6 +98,25 @@ pub enum ProfilesActorMessage {
     },
     Delete {
         uid: ProfileId,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    Reorder {
+        op: ReorderOp,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    PatchMetadata {
+        uid: ProfileId,
+        patch: ProfileMetadataPatch,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    PatchRemoteOptions {
+        uid: ProfileId,
+        patch: RemoteProfileOptionsPatch,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    ReplaceDefinition {
+        uid: ProfileId,
+        definition: ProfileDefinition,
         reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
     },
 }
@@ -434,6 +454,102 @@ impl Actor for ProfilesActor {
                         .await
                     }
                 };
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::Reorder { op, reply } => {
+                let result = Self::run_write(state, move |profiles| {
+                    match op {
+                        ReorderOp::Move { active, over } => {
+                            if profiles.items.get(&active).is_none() {
+                                return Err(ProfilesError::ProfileNotFound(active));
+                            }
+                            if profiles.items.get(&over).is_none() {
+                                return Err(ProfilesError::ProfileNotFound(over));
+                            }
+                            profiles.reorder(&active, &over);
+                        }
+                        ReorderOp::ByList(list) => {
+                            if list.len() != profiles.items.len() {
+                                return Err(ProfilesError::ValidationFailed(vec![]));
+                            }
+                            let mut seen = indexmap::IndexSet::with_capacity(list.len());
+                            for uid in &list {
+                                if !seen.insert(uid.clone()) {
+                                    return Err(ProfilesError::ValidationFailed(vec![]));
+                                }
+                                if profiles.items.get(uid).is_none() {
+                                    return Err(ProfilesError::ProfileNotFound(uid.clone()));
+                                }
+                            }
+                            let mut reordered = indexmap::IndexMap::with_capacity(list.len());
+                            for uid in list {
+                                let item = profiles
+                                    .items
+                                    .shift_remove(&uid)
+                                    .ok_or_else(|| ProfilesError::ProfileNotFound(uid.clone()))?;
+                                reordered.insert(uid, item);
+                            }
+                            profiles.items = reordered;
+                        }
+                    }
+                    Ok(WriteOutcome {
+                        affects: AffectsRule::Never,
+                        post_ops: vec![],
+                    })
+                })
+                .await;
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::PatchMetadata { uid, patch, reply } => {
+                let result = Self::run_write(state, move |profiles| {
+                    let Some(item) = profiles.items.get_mut(&uid) else {
+                        return Err(ProfilesError::ProfileNotFound(uid));
+                    };
+                    item.apply_metadata_patch(patch);
+                    Ok(WriteOutcome {
+                        affects: AffectsRule::Never,
+                        post_ops: vec![],
+                    })
+                })
+                .await;
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::PatchRemoteOptions { uid, patch, reply } => {
+                let result = Self::run_write(state, move |profiles| {
+                    let Some(item) = profiles.items.get_mut(&uid) else {
+                        return Err(ProfilesError::ProfileNotFound(uid));
+                    };
+                    match item.definition.source_mut() {
+                        Some(ProfileSource::Remote { option, .. }) => {
+                            use struct_patch::Patch as _;
+                            option.apply(patch);
+                            Ok(WriteOutcome {
+                                affects: AffectsRule::Never,
+                                post_ops: vec![],
+                            })
+                        }
+                        _ => Err(ProfilesError::NotARemoteProfile),
+                    }
+                })
+                .await;
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::ReplaceDefinition {
+                uid,
+                definition,
+                reply,
+            } => {
+                let result = Self::run_write(state, move |profiles| {
+                    let Some(item) = profiles.items.get_mut(&uid) else {
+                        return Err(ProfilesError::ProfileNotFound(uid.clone()));
+                    };
+                    item.set_definition(definition);
+                    Ok(WriteOutcome {
+                        affects: AffectsRule::Touched(uid),
+                        post_ops: vec![],
+                    })
+                })
+                .await;
                 let _ = reply.send(result);
             }
         }

--- a/backend/tauri/src/state/profiles/actor.rs
+++ b/backend/tauri/src/state/profiles/actor.rs
@@ -4,8 +4,8 @@
 use std::sync::Arc;
 
 use nyanpasu_config::profile::{
-    ProfileDefinition, ProfileDependencyIndex, ProfileId, ProfileMetadata, ProfileValidationError,
-    Profiles,
+    ConfigDefinition, ExternalProfilePath, ManagedProfilePath, ProfileDefinition,
+    ProfileDependencyIndex, ProfileId, ProfileMetadata, ProfileValidationError, Profiles,
 };
 use nyanpasu_core::state::PersistentStateManager;
 use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
@@ -67,7 +67,6 @@ pub struct ProfilesActorState {
     manager: PersistentStateManager<Profiles>,
     #[allow(dead_code)]
     index: ProfileDependencyIndex,
-    #[allow(dead_code)]
     fs: Arc<dyn ProfileFsPort>,
     #[allow(dead_code)]
     fetcher: Arc<dyn SubscriptionFetcher>,
@@ -78,13 +77,148 @@ pub struct ProfilesActorState {
 #[derive(Debug)]
 pub enum ProfilesActorMessage {
     Get(RpcReplyPort<Result<Arc<Profiles>, ProfilesError>>),
+    SetCurrent {
+        current: Option<ProfileId>,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    SetGlobalTransforms {
+        ids: Vec<ProfileId>,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    Replace {
+        profiles: Profiles,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
 }
 
 pub struct ProfilesActor;
 
+pub(super) enum PostCommitOp {
+    WriteInitial {
+        path: ManagedProfilePath,
+        content: String,
+    },
+    Remove {
+        path: ManagedProfilePath,
+    },
+    EnsureSymlink {
+        path: ManagedProfilePath,
+        target: ExternalProfilePath,
+    },
+}
+
+pub(super) struct WriteOutcome {
+    pub affects: AffectsRule,
+    pub post_ops: Vec<PostCommitOp>,
+}
+
+pub(super) enum AffectsRule {
+    Never,
+    CurrentChanged,
+    GlobalChanged,
+    Touched(ProfileId),
+    Always,
+}
+
 impl ProfilesActor {
     fn current_state(state: &ProfilesActorState) -> Profiles {
         state.manager.snapshot_handle().load().state.clone()
+    }
+
+    fn current_closure(profiles: &Profiles) -> indexmap::IndexSet<ProfileId> {
+        let mut closure: indexmap::IndexSet<ProfileId> =
+            profiles.global_transforms.iter().cloned().collect();
+        let Some(current) = &profiles.current else {
+            return closure;
+        };
+
+        closure.insert(current.clone());
+        let mut configs = vec![current.clone()];
+        if let Some(item) = profiles.items.get(current) {
+            if let ProfileDefinition::Config {
+                config: ConfigDefinition::Composition(composition),
+            } = &item.definition
+            {
+                if let Some(base) = &composition.base {
+                    closure.insert(base.clone());
+                    configs.push(base.clone());
+                }
+                for member in &composition.extend_proxies_from {
+                    closure.insert(member.clone());
+                    configs.push(member.clone());
+                }
+            }
+        }
+
+        for config in configs {
+            if let Some(item) = profiles.items.get(&config) {
+                if let ProfileDefinition::Config { config } = &item.definition {
+                    for transform in config.transforms() {
+                        closure.insert(transform.clone());
+                    }
+                }
+            }
+        }
+
+        closure
+    }
+
+    fn evaluate_affects(rule: &AffectsRule, before: &Profiles, after: &Profiles) -> bool {
+        match rule {
+            AffectsRule::Never => false,
+            AffectsRule::Always => true,
+            AffectsRule::CurrentChanged => before.current != after.current,
+            AffectsRule::GlobalChanged => before.global_transforms != after.global_transforms,
+            AffectsRule::Touched(uid) => {
+                let closure_before = Self::current_closure(before);
+                let closure_after = Self::current_closure(after);
+                closure_before != closure_after
+                    || closure_before.contains(uid)
+                    || closure_after.contains(uid)
+            }
+        }
+    }
+
+    async fn run_write<F>(
+        state: &mut ProfilesActorState,
+        mutate: F,
+    ) -> Result<CommitReport, ProfilesError>
+    where
+        F: FnOnce(&mut Profiles) -> Result<WriteOutcome, ProfilesError>,
+    {
+        let before = Self::current_state(state);
+        let mut next = before.clone();
+        let outcome = mutate(&mut next)?;
+        next.validate().map_err(ProfilesError::ValidationFailed)?;
+        state
+            .manager
+            .upsert(next.clone())
+            .await
+            .map_err(|e| ProfilesError::Persist(e.to_string()))?;
+        state.index = ProfileDependencyIndex::build(&next);
+
+        let mut warnings = Vec::new();
+        for op in outcome.post_ops {
+            let result = match &op {
+                PostCommitOp::WriteInitial { path, content } => {
+                    state.fs.write_atomic(path, content)
+                }
+                PostCommitOp::Remove { path } => state.fs.remove(path),
+                PostCommitOp::EnsureSymlink { path, target } => {
+                    state.fs.ensure_symlink(path, target)
+                }
+            };
+            if let Err(error) = result {
+                warnings.push(format!("post-commit file operation failed: {error}"));
+            }
+        }
+
+        let affects_current = Self::evaluate_affects(&outcome.affects, &before, &next);
+        Ok(CommitReport {
+            snapshot: Arc::new(next),
+            affects_current,
+            warnings,
+        })
     }
 }
 
@@ -117,6 +251,42 @@ impl Actor for ProfilesActor {
         match message {
             ProfilesActorMessage::Get(reply) => {
                 let _ = reply.send(Ok(Arc::new(Self::current_state(state))));
+            }
+            ProfilesActorMessage::SetCurrent { current, reply } => {
+                let result = Self::run_write(state, |profiles| {
+                    profiles.set_current(current);
+                    Ok(WriteOutcome {
+                        affects: AffectsRule::CurrentChanged,
+                        post_ops: vec![],
+                    })
+                })
+                .await;
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::SetGlobalTransforms { ids, reply } => {
+                let result = Self::run_write(state, |profiles| {
+                    profiles.global_transforms = ids;
+                    Ok(WriteOutcome {
+                        affects: AffectsRule::GlobalChanged,
+                        post_ops: vec![],
+                    })
+                })
+                .await;
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::Replace {
+                profiles: next,
+                reply,
+            } => {
+                let result = Self::run_write(state, |profiles| {
+                    *profiles = next;
+                    Ok(WriteOutcome {
+                        affects: AffectsRule::Always,
+                        post_ops: vec![],
+                    })
+                })
+                .await;
+                let _ = reply.send(result);
             }
         }
         Ok(())

--- a/backend/tauri/src/state/profiles/actor.rs
+++ b/backend/tauri/src/state/profiles/actor.rs
@@ -4,8 +4,9 @@
 use std::sync::Arc;
 
 use nyanpasu_config::profile::{
-    ConfigDefinition, ExternalProfilePath, ManagedProfilePath, ProfileDefinition,
-    ProfileDependencyIndex, ProfileId, ProfileMetadata, ProfileValidationError, Profiles,
+    ConfigDefinition, ExternalMode, ExternalProfilePath, LocalBinding, ManagedProfilePath,
+    ProfileDefinition, ProfileDependencyIndex, ProfileId, ProfileItem, ProfileMetadata,
+    ProfileSource, ProfileValidationError, Profiles, ScriptRuntime, TransformDefinition,
 };
 use nyanpasu_core::state::PersistentStateManager;
 use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
@@ -87,6 +88,15 @@ pub enum ProfilesActorMessage {
     },
     Replace {
         profiles: Profiles,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    Add {
+        request: NewProfileRequest,
+        initial_file: Option<String>,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    Delete {
+        uid: ProfileId,
         reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
     },
 }
@@ -220,6 +230,57 @@ impl ProfilesActor {
             warnings,
         })
     }
+
+    fn generate_uid(definition: &ProfileDefinition, existing: &Profiles) -> ProfileId {
+        let prefix = match definition {
+            ProfileDefinition::Config { .. } => 'c',
+            ProfileDefinition::Transform { .. } => 't',
+        };
+        loop {
+            let candidate = ProfileId(format!("{prefix}{}", nanoid::nanoid!(11)));
+            if existing.items.get(&candidate).is_none() {
+                return candidate;
+            }
+        }
+    }
+
+    fn canonical_extension(definition: &ProfileDefinition) -> &'static str {
+        match definition {
+            ProfileDefinition::Config { .. } => "yaml",
+            ProfileDefinition::Transform { transform } => match transform {
+                TransformDefinition::Overlay(_) => "yaml",
+                TransformDefinition::Script(script) => match script.runtime {
+                    ScriptRuntime::JavaScript => "js",
+                    ScriptRuntime::Lua => "lua",
+                },
+            },
+        }
+    }
+
+    fn referrers_of(
+        state: &ProfilesActorState,
+        profiles: &Profiles,
+        uid: &ProfileId,
+    ) -> Option<Vec<ProfileId>> {
+        let mut referrers: indexmap::IndexSet<ProfileId> = Default::default();
+        if let Some(set) = state.index.composition_base_dependents.get(uid) {
+            referrers.extend(set.iter().cloned());
+        }
+        if let Some(set) = state.index.extend_proxies_dependents.get(uid) {
+            referrers.extend(set.iter().cloned());
+        }
+        if let Some(set) = state.index.transform_dependents.get(uid) {
+            referrers.extend(set.iter().cloned());
+        }
+
+        let document_level = profiles.current.as_ref() == Some(uid)
+            || state.index.global_transform_ids.contains(uid);
+        if referrers.is_empty() && !document_level {
+            None
+        } else {
+            Some(referrers.into_iter().collect())
+        }
+    }
 }
 
 impl Actor for ProfilesActor {
@@ -286,6 +347,93 @@ impl Actor for ProfilesActor {
                     })
                 })
                 .await;
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::Add {
+                request,
+                initial_file,
+                reply,
+            } => {
+                let result = {
+                    let existing = Self::current_state(state);
+                    let uid = Self::generate_uid(&request.definition, &existing);
+                    let ext = Self::canonical_extension(&request.definition);
+                    let canonical = ManagedProfilePath::new(format!("{uid}.{ext}"))
+                        .expect("uid-derived path is always a valid managed path");
+                    let mut definition = request.definition;
+                    let mut post_ops = Vec::new();
+                    if let Some(source) = definition.source_mut() {
+                        source.materialized_mut().file = canonical.clone();
+                        match source {
+                            ProfileSource::Local {
+                                binding: LocalBinding::External { target, mode, .. },
+                            } => {
+                                if *mode == ExternalMode::Symlink {
+                                    post_ops.push(PostCommitOp::EnsureSymlink {
+                                        path: canonical.clone(),
+                                        target: target.clone(),
+                                    });
+                                }
+                                // T05 watcher reconcile owns the first mirror sync.
+                            }
+                            ProfileSource::Remote { .. } => {
+                                // T05 RefreshRemote owns the first remote download.
+                            }
+                            _ => {
+                                post_ops.push(PostCommitOp::WriteInitial {
+                                    path: canonical.clone(),
+                                    content: initial_file.clone().unwrap_or_default(),
+                                });
+                            }
+                        }
+                    }
+
+                    let item = ProfileItem {
+                        uid: uid.clone(),
+                        metadata: request.metadata,
+                        definition,
+                    };
+                    Self::run_write(state, move |profiles| {
+                        if !profiles.append_item(item) {
+                            return Err(ProfilesError::Persist("uid collision".into()));
+                        }
+                        Ok(WriteOutcome {
+                            affects: AffectsRule::Never,
+                            post_ops,
+                        })
+                    })
+                    .await
+                };
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::Delete { uid, reply } => {
+                let result = {
+                    let existing = Self::current_state(state);
+                    if existing.items.get(&uid).is_none() {
+                        Err(ProfilesError::ProfileNotFound(uid.clone()))
+                    } else if let Some(referrers) = Self::referrers_of(state, &existing, &uid) {
+                        Err(ProfilesError::ProfileInUse { referrers })
+                    } else {
+                        let removed = existing.items.get(&uid).cloned();
+                        let post_ops = removed
+                            .as_ref()
+                            .and_then(|item| item.definition.source())
+                            .map(|source| {
+                                vec![PostCommitOp::Remove {
+                                    path: source.materialized().file.clone(),
+                                }]
+                            })
+                            .unwrap_or_default();
+                        Self::run_write(state, move |profiles| {
+                            profiles.remove_item_unchecked(&uid);
+                            Ok(WriteOutcome {
+                                affects: AffectsRule::Never,
+                                post_ops,
+                            })
+                        })
+                        .await
+                    }
+                };
                 let _ = reply.send(result);
             }
         }

--- a/backend/tauri/src/state/profiles/actor.rs
+++ b/backend/tauri/src/state/profiles/actor.rs
@@ -7,7 +7,7 @@ use nyanpasu_config::profile::{
     ConfigDefinition, ExternalMode, ExternalProfilePath, LocalBinding, ManagedProfilePath,
     ProfileDefinition, ProfileDependencyIndex, ProfileId, ProfileItem, ProfileMetadata,
     ProfileMetadataPatch, ProfileSource, ProfileValidationError, Profiles,
-    RemoteProfileOptionsPatch, ScriptRuntime, TransformDefinition,
+    RemoteProfileOptionsPatch, ScriptRuntime, SubscriptionInfo, TransformDefinition,
 };
 use nyanpasu_core::state::PersistentStateManager;
 use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
@@ -21,12 +21,22 @@ use super::{
 pub enum ProfilesError {
     #[error("profile not found: {0}")]
     ProfileNotFound(ProfileId),
-    #[error("profile is referenced and cannot be deleted (referrers: {referrers:?})")]
-    ProfileInUse { referrers: Vec<ProfileId> },
+    #[error(
+        "profile is referenced and cannot be deleted (referrers: {referrers:?}, current: {current}, global_transforms: {global_transforms})"
+    )]
+    ProfileInUse {
+        referrers: Vec<ProfileId>,
+        /// Referenced by the document-level `current` selection.
+        current: bool,
+        /// Referenced by the document-level `global_transforms` list.
+        global_transforms: bool,
+    },
     #[error("profile has no materialized file")]
     ProfileHasNoFile,
     #[error("validation failed: {0:?}")]
     ValidationFailed(Vec<ProfileValidationError>),
+    #[error("invalid reorder list: {reason}")]
+    InvalidReorderList { reason: String },
     #[error("profile is not a remote profile")]
     NotARemoteProfile,
     #[error("file not writable: {reason}")]
@@ -333,11 +343,14 @@ impl ProfilesActor {
         }
     }
 
+    /// design §17 five reference categories. Item-level referrers plus the two
+    /// document-level flags (current / global_transforms) so the IPC layer can
+    /// render an unambiguous message even when the referrer list is empty.
     fn referrers_of(
         state: &ProfilesActorState,
         profiles: &Profiles,
         uid: &ProfileId,
-    ) -> Option<Vec<ProfileId>> {
+    ) -> Option<(Vec<ProfileId>, bool, bool)> {
         let mut referrers: indexmap::IndexSet<ProfileId> = Default::default();
         if let Some(set) = state.index.composition_base_dependents.get(uid) {
             referrers.extend(set.iter().cloned());
@@ -349,12 +362,26 @@ impl ProfilesActor {
             referrers.extend(set.iter().cloned());
         }
 
-        let document_level = profiles.current.as_ref() == Some(uid)
-            || state.index.global_transform_ids.contains(uid);
-        if referrers.is_empty() && !document_level {
+        let current = profiles.current.as_ref() == Some(uid);
+        let global_transforms = state.index.global_transform_ids.contains(uid);
+        if referrers.is_empty() && !current && !global_transforms {
             None
         } else {
-            Some(referrers.into_iter().collect())
+            Some((referrers.into_iter().collect(), current, global_transforms))
+        }
+    }
+
+    /// Source slot discriminant used by ReplaceDefinition to decide whether the
+    /// previously stored materialization metadata still describes the same file.
+    fn source_kind(source: &ProfileSource) -> u8 {
+        match source {
+            ProfileSource::Local {
+                binding: LocalBinding::Managed { .. },
+            } => 0,
+            ProfileSource::Local {
+                binding: LocalBinding::External { .. },
+            } => 1,
+            ProfileSource::Remote { .. } => 2,
         }
     }
 }
@@ -453,7 +480,16 @@ impl Actor for ProfilesActor {
                     let mut definition = request.definition;
                     let mut post_ops = Vec::new();
                     if let Some(source) = definition.source_mut() {
-                        source.materialized_mut().file = canonical.clone();
+                        {
+                            // Server owns materialization metadata: new profiles
+                            // start unmaterialized regardless of client input.
+                            let materialized = source.materialized_mut();
+                            materialized.file = canonical.clone();
+                            materialized.updated_at = None;
+                        }
+                        if let ProfileSource::Remote { subscription, .. } = source {
+                            *subscription = SubscriptionInfo::default();
+                        }
                         match source {
                             ProfileSource::Local {
                                 binding: LocalBinding::External { target, mode, .. },
@@ -501,8 +537,14 @@ impl Actor for ProfilesActor {
                     let existing = Self::current_state(state);
                     if existing.items.get(&uid).is_none() {
                         Err(ProfilesError::ProfileNotFound(uid.clone()))
-                    } else if let Some(referrers) = Self::referrers_of(state, &existing, &uid) {
-                        Err(ProfilesError::ProfileInUse { referrers })
+                    } else if let Some((referrers, current, global_transforms)) =
+                        Self::referrers_of(state, &existing, &uid)
+                    {
+                        Err(ProfilesError::ProfileInUse {
+                            referrers,
+                            current,
+                            global_transforms,
+                        })
                     } else {
                         let removed = existing.items.get(&uid).cloned();
                         let post_ops = removed
@@ -540,12 +582,20 @@ impl Actor for ProfilesActor {
                         }
                         ReorderOp::ByList(list) => {
                             if list.len() != profiles.items.len() {
-                                return Err(ProfilesError::ValidationFailed(vec![]));
+                                return Err(ProfilesError::InvalidReorderList {
+                                    reason: format!(
+                                        "expected {} uids, got {}",
+                                        profiles.items.len(),
+                                        list.len()
+                                    ),
+                                });
                             }
                             let mut seen = indexmap::IndexSet::with_capacity(list.len());
                             for uid in &list {
                                 if !seen.insert(uid.clone()) {
-                                    return Err(ProfilesError::ValidationFailed(vec![]));
+                                    return Err(ProfilesError::InvalidReorderList {
+                                        reason: format!("duplicate uid {uid}"),
+                                    });
                                 }
                                 if profiles.items.get(uid).is_none() {
                                     return Err(ProfilesError::ProfileNotFound(uid.clone()));
@@ -845,17 +895,92 @@ impl Actor for ProfilesActor {
                 definition,
                 reply,
             } => {
-                let result = Self::run_write(&myself, state, move |profiles| {
-                    let Some(item) = profiles.items.get_mut(&uid) else {
-                        return Err(ProfilesError::ProfileNotFound(uid.clone()));
-                    };
-                    item.set_definition(definition);
-                    Ok(WriteOutcome {
-                        affects: AffectsRule::Touched(uid),
-                        post_ops: vec![],
-                    })
-                })
-                .await;
+                let result = {
+                    let existing = Self::current_state(state);
+                    match existing.items.get(&uid) {
+                        None => Err(ProfilesError::ProfileNotFound(uid.clone())),
+                        Some(previous_item) => {
+                            let mut definition = definition;
+                            let ext = Self::canonical_extension(&definition);
+                            let canonical = ManagedProfilePath::new(format!("{uid}.{ext}"))
+                                .expect("uid-derived path is always a valid managed path");
+                            let previous_source = previous_item.definition.source().cloned();
+                            let mut post_ops = Vec::new();
+
+                            // Server owns materialization metadata (same policy
+                            // as Add): only an unchanged source slot keeps the
+                            // previously stored updated_at/subscription.
+                            let same_slot = match (&previous_source, definition.source()) {
+                                (Some(previous), Some(next)) => {
+                                    Self::source_kind(previous) == Self::source_kind(next)
+                                        && previous.materialized().file == canonical
+                                }
+                                _ => false,
+                            };
+                            if let Some(source) = definition.source_mut() {
+                                {
+                                    let materialized = source.materialized_mut();
+                                    materialized.file = canonical.clone();
+                                    materialized.updated_at = if same_slot {
+                                        previous_source
+                                            .as_ref()
+                                            .and_then(|p| p.materialized().updated_at)
+                                    } else {
+                                        None
+                                    };
+                                }
+                                if let ProfileSource::Remote { subscription, .. } = source {
+                                    *subscription = match (same_slot, previous_source.as_ref()) {
+                                        (
+                                            true,
+                                            Some(ProfileSource::Remote {
+                                                subscription: previous,
+                                                ..
+                                            }),
+                                        ) => previous.clone(),
+                                        _ => SubscriptionInfo::default(),
+                                    };
+                                }
+                            }
+                            // Orphan cleanup: the old materialized file is
+                            // unreachable once the path changes or the new
+                            // definition has no source (Composition).
+                            if let Some(previous) = previous_source.as_ref() {
+                                let old_path = previous.materialized().file.clone();
+                                if definition.source().is_none() || old_path != canonical {
+                                    post_ops.push(PostCommitOp::Remove { path: old_path });
+                                }
+                            }
+                            // Parity with Add: a newly introduced External
+                            // Symlink binding must get its link created.
+                            if !same_slot {
+                                if let Some(ProfileSource::Local {
+                                    binding: LocalBinding::External { target, mode, .. },
+                                }) = definition.source()
+                                {
+                                    if *mode == ExternalMode::Symlink {
+                                        post_ops.push(PostCommitOp::EnsureSymlink {
+                                            path: canonical.clone(),
+                                            target: target.clone(),
+                                        });
+                                    }
+                                }
+                            }
+
+                            Self::run_write(&myself, state, move |profiles| {
+                                let Some(item) = profiles.items.get_mut(&uid) else {
+                                    return Err(ProfilesError::ProfileNotFound(uid.clone()));
+                                };
+                                item.set_definition(definition);
+                                Ok(WriteOutcome {
+                                    affects: AffectsRule::Touched(uid),
+                                    post_ops,
+                                })
+                            })
+                            .await
+                        }
+                    }
+                };
                 let _ = reply.send(result);
             }
             #[cfg(test)]

--- a/backend/tauri/src/state/profiles/actor.rs
+++ b/backend/tauri/src/state/profiles/actor.rs
@@ -14,7 +14,7 @@ use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
 
 use super::{
     ports::{ProfileFsPort, RebuildNotifier, SubscriptionFetcher},
-    scheduler::RemoteUpdateScheduler,
+    scheduler::{ExternalWatchers, RemoteUpdateScheduler},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -77,6 +77,7 @@ pub struct ProfilesActorState {
     notifier: Arc<dyn RebuildNotifier>,
     pending_refresh: HashMap<ProfileId, Option<RpcReplyPort<Result<CommitReport, ProfilesError>>>>,
     scheduler: RemoteUpdateScheduler,
+    external_watchers: ExternalWatchers,
 }
 
 #[derive(Debug)]
@@ -135,6 +136,9 @@ pub enum ProfilesActorMessage {
     CommitRefreshed {
         uid: ProfileId,
         outcome: RefreshOutcome,
+    },
+    ExternalFileChanged {
+        uid: ProfileId,
     },
     ReplaceDefinition {
         uid: ProfileId,
@@ -256,6 +260,7 @@ impl ProfilesActor {
             .map_err(|e| ProfilesError::Persist(e.to_string()))?;
         state.index = ProfileDependencyIndex::build(&next);
         state.scheduler.reconcile(&next, myself, false);
+        state.external_watchers.reconcile(&next, myself);
 
         let mut warnings = Vec::new();
         for op in outcome.post_ops {
@@ -373,6 +378,7 @@ impl Actor for ProfilesActor {
             notifier: args.notifier,
             pending_refresh: HashMap::new(),
             scheduler: RemoteUpdateScheduler::default(),
+            external_watchers: ExternalWatchers::default(),
         })
     }
 
@@ -383,6 +389,7 @@ impl Actor for ProfilesActor {
     ) -> Result<(), ActorProcessingErr> {
         let snapshot = Self::current_state(state);
         state.scheduler.reconcile(&snapshot, &myself, true);
+        state.external_watchers.reconcile(&snapshot, &myself);
         Ok(())
     }
 
@@ -747,6 +754,92 @@ impl Actor for ProfilesActor {
                     let _ = reply.send(result);
                 }
             }
+            ProfilesActorMessage::ExternalFileChanged { uid } => {
+                let snapshot = Self::current_state(state);
+                let Some(item) = snapshot.items.get(&uid) else {
+                    return Ok(());
+                };
+                let Some(ProfileSource::Local {
+                    binding:
+                        LocalBinding::External {
+                            materialized,
+                            target,
+                            mode,
+                        },
+                }) = item.definition.source()
+                else {
+                    return Ok(());
+                };
+
+                if *mode == ExternalMode::Mirror {
+                    let content = match state.fs.read_external(target) {
+                        Ok(content) => content,
+                        Err(error) => {
+                            tracing::warn!(
+                                uid = %uid,
+                                target = %target,
+                                error = %error,
+                                "failed to read changed external profile"
+                            );
+                            return Ok(());
+                        }
+                    };
+                    if let Err(message) = Self::validate_fetched_content(&item.definition, &content)
+                    {
+                        tracing::warn!(
+                            uid = %uid,
+                            target = %target,
+                            error = %message,
+                            "changed external profile failed validation"
+                        );
+                        return Ok(());
+                    }
+                    if let Err(error) = state.fs.write_atomic(&materialized.file, &content) {
+                        tracing::warn!(
+                            uid = %uid,
+                            path = %materialized.file,
+                            error = %error,
+                            "failed to mirror changed external profile"
+                        );
+                        return Ok(());
+                    }
+                }
+
+                let result = Self::run_write(&myself, state, {
+                    let uid = uid.clone();
+                    move |profiles| {
+                        let Some(item) = profiles.items.get_mut(&uid) else {
+                            return Err(ProfilesError::ProfileNotFound(uid.clone()));
+                        };
+                        match item.definition.source_mut() {
+                            Some(ProfileSource::Local {
+                                binding: LocalBinding::External { materialized, .. },
+                            }) => {
+                                materialized.updated_at = Some(time::OffsetDateTime::now_utc());
+                                Ok(WriteOutcome {
+                                    affects: AffectsRule::Touched(uid.clone()),
+                                    post_ops: vec![],
+                                })
+                            }
+                            _ => Err(ProfilesError::ProfileNotFound(uid.clone())),
+                        }
+                    }
+                })
+                .await;
+                match result {
+                    Ok(report) if report.affects_current => {
+                        state.notifier.request_rebuild();
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            uid = %uid,
+                            error = %error,
+                            "failed to commit external profile change"
+                        );
+                    }
+                }
+            }
             ProfilesActorMessage::ReplaceDefinition {
                 uid,
                 definition,
@@ -784,6 +877,7 @@ impl Actor for ProfilesActor {
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
         state.scheduler.shutdown();
+        state.external_watchers.shutdown();
         Ok(())
     }
 }

--- a/backend/tauri/src/state/profiles/actor.rs
+++ b/backend/tauri/src/state/profiles/actor.rs
@@ -1,7 +1,7 @@
 //! ProfilesActor: single owner of the profiles document.
 //! Tauri-free; every filesystem/network effect goes through the ports.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use nyanpasu_config::profile::{
     ConfigDefinition, ExternalMode, ExternalProfilePath, LocalBinding, ManagedProfilePath,
@@ -70,10 +70,19 @@ pub struct ProfilesActorState {
     #[allow(dead_code)]
     index: ProfileDependencyIndex,
     fs: Arc<dyn ProfileFsPort>,
-    #[allow(dead_code)]
     fetcher: Arc<dyn SubscriptionFetcher>,
-    #[allow(dead_code)]
     notifier: Arc<dyn RebuildNotifier>,
+    pending_refresh: HashMap<ProfileId, Option<RpcReplyPort<Result<CommitReport, ProfilesError>>>>,
+}
+
+#[derive(Debug)]
+pub enum RefreshOutcome {
+    Succeeded {
+        subscription: nyanpasu_config::profile::SubscriptionInfo,
+    },
+    Failed {
+        message: String,
+    },
 }
 
 #[derive(Debug)]
@@ -114,10 +123,25 @@ pub enum ProfilesActorMessage {
         patch: RemoteProfileOptionsPatch,
         reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
     },
+    RefreshRemote {
+        uid: ProfileId,
+        patch: Option<RemoteProfileOptionsPatch>,
+        reply: Option<RpcReplyPort<Result<CommitReport, ProfilesError>>>,
+    },
+    CommitRefreshed {
+        uid: ProfileId,
+        outcome: RefreshOutcome,
+    },
     ReplaceDefinition {
         uid: ProfileId,
         definition: ProfileDefinition,
         reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    #[cfg(test)]
+    DebugInsertPendingRefresh {
+        uid: ProfileId,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+        inserted: tokio::sync::oneshot::Sender<()>,
     },
 }
 
@@ -277,6 +301,27 @@ impl ProfilesActor {
         }
     }
 
+    fn validate_fetched_content(
+        definition: &ProfileDefinition,
+        content: &str,
+    ) -> Result<(), String> {
+        let needs_yaml = match definition {
+            ProfileDefinition::Config { .. } => true,
+            ProfileDefinition::Transform { transform } => {
+                matches!(transform, TransformDefinition::Overlay(_))
+            }
+        };
+        if needs_yaml {
+            serde_yaml::from_str::<serde_yaml::Mapping>(content)
+                .map(|_| ())
+                .map_err(|e| format!("downloaded content is not a YAML mapping: {e}"))
+        } else if content.trim().is_empty() {
+            Err("downloaded script is empty".into())
+        } else {
+            Ok(())
+        }
+    }
+
     fn referrers_of(
         state: &ProfilesActorState,
         profiles: &Profiles,
@@ -320,12 +365,13 @@ impl Actor for ProfilesActor {
             fs: args.fs,
             fetcher: args.fetcher,
             notifier: args.notifier,
+            pending_refresh: HashMap::new(),
         })
     }
 
     async fn handle(
         &self,
-        _myself: ActorRef<Self::Msg>,
+        myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -534,6 +580,156 @@ impl Actor for ProfilesActor {
                 .await;
                 let _ = reply.send(result);
             }
+            ProfilesActorMessage::RefreshRemote { uid, patch, reply } => {
+                if state.pending_refresh.contains_key(&uid) {
+                    if let Some(reply) = reply {
+                        let _ = reply.send(Err(ProfilesError::RefreshFailed {
+                            message: "refresh already in progress".into(),
+                        }));
+                    }
+                    return Ok(());
+                }
+
+                if let Some(patch) = patch {
+                    let patched = Self::run_write(state, {
+                        let uid = uid.clone();
+                        move |profiles| {
+                            let Some(item) = profiles.items.get_mut(&uid) else {
+                                return Err(ProfilesError::ProfileNotFound(uid.clone()));
+                            };
+                            match item.definition.source_mut() {
+                                Some(ProfileSource::Remote { option, .. }) => {
+                                    use struct_patch::Patch as _;
+                                    option.apply(patch);
+                                    Ok(WriteOutcome {
+                                        affects: AffectsRule::Never,
+                                        post_ops: vec![],
+                                    })
+                                }
+                                _ => Err(ProfilesError::NotARemoteProfile),
+                            }
+                        }
+                    })
+                    .await;
+                    if let Err(err) = patched {
+                        if let Some(reply) = reply {
+                            let _ = reply.send(Err(err));
+                        }
+                        return Ok(());
+                    }
+                }
+
+                let snapshot = Self::current_state(state);
+                let Some(item) = snapshot.items.get(&uid) else {
+                    if let Some(reply) = reply {
+                        let _ = reply.send(Err(ProfilesError::ProfileNotFound(uid.clone())));
+                    }
+                    return Ok(());
+                };
+                let Some(ProfileSource::Remote {
+                    url,
+                    option,
+                    materialized,
+                    ..
+                }) = item.definition.source()
+                else {
+                    if let Some(reply) = reply {
+                        let _ = reply.send(Err(ProfilesError::NotARemoteProfile));
+                    }
+                    return Ok(());
+                };
+
+                let definition = item.definition.clone();
+                let url = url.clone();
+                let option = option.clone();
+                let path = materialized.file.clone();
+                state.pending_refresh.insert(uid.clone(), reply);
+                let fetcher = Arc::clone(&state.fetcher);
+                let fs = Arc::clone(&state.fs);
+                let actor = myself.clone();
+                tokio::spawn(async move {
+                    let outcome = async {
+                        let fetched = fetcher
+                            .fetch(&url, &option)
+                            .await
+                            .map_err(|e| format!("download failed: {e}"))?;
+                        Self::validate_fetched_content(&definition, &fetched.content)?;
+                        fs.ensure_not_symlink(&path).map_err(|e| e.to_string())?;
+                        fs.write_atomic(&path, &fetched.content)
+                            .map_err(|e| e.to_string())?;
+                        Ok::<_, String>(fetched.subscription)
+                    }
+                    .await;
+                    let outcome = match outcome {
+                        Ok(subscription) => RefreshOutcome::Succeeded { subscription },
+                        Err(message) => RefreshOutcome::Failed { message },
+                    };
+                    let _ = actor.cast(ProfilesActorMessage::CommitRefreshed { uid, outcome });
+                });
+            }
+            ProfilesActorMessage::CommitRefreshed { uid, outcome } => {
+                let reply = state.pending_refresh.remove(&uid).flatten();
+                let snapshot = Self::current_state(state);
+                if snapshot.items.get(&uid).is_none() {
+                    if let RefreshOutcome::Succeeded { .. } = outcome {
+                        for ext in ["yaml", "js", "lua"] {
+                            if let Ok(path) = ManagedProfilePath::new(format!("{uid}.{ext}")) {
+                                let _ = state.fs.remove(&path);
+                            }
+                        }
+                    }
+                    if let Some(reply) = reply {
+                        let _ = reply.send(Err(ProfilesError::RefreshFailed {
+                            message: "profile deleted during refresh".into(),
+                        }));
+                    }
+                    return Ok(());
+                }
+
+                let result = match outcome {
+                    RefreshOutcome::Failed { message } => {
+                        Err(ProfilesError::RefreshFailed { message })
+                    }
+                    RefreshOutcome::Succeeded { subscription } => {
+                        Self::run_write(state, {
+                            let uid = uid.clone();
+                            move |profiles| {
+                                let Some(item) = profiles.items.get_mut(&uid) else {
+                                    return Err(ProfilesError::ProfileNotFound(uid.clone()));
+                                };
+                                match item.definition.source_mut() {
+                                    Some(ProfileSource::Remote {
+                                        materialized,
+                                        subscription: slot,
+                                        ..
+                                    }) => {
+                                        materialized.updated_at =
+                                            Some(time::OffsetDateTime::now_utc());
+                                        *slot = subscription;
+                                        Ok(WriteOutcome {
+                                            affects: AffectsRule::Touched(uid.clone()),
+                                            post_ops: vec![],
+                                        })
+                                    }
+                                    _ => Err(ProfilesError::NotARemoteProfile),
+                                }
+                            }
+                        })
+                        .await
+                    }
+                };
+
+                if reply.is_none() {
+                    if let Ok(report) = &result {
+                        if report.affects_current {
+                            state.notifier.request_rebuild();
+                        }
+                    }
+                }
+                if let Some(reply) = reply {
+                    let _ = reply.send(result);
+                }
+            }
             ProfilesActorMessage::ReplaceDefinition {
                 uid,
                 definition,
@@ -551,6 +747,15 @@ impl Actor for ProfilesActor {
                 })
                 .await;
                 let _ = reply.send(result);
+            }
+            #[cfg(test)]
+            ProfilesActorMessage::DebugInsertPendingRefresh {
+                uid,
+                reply,
+                inserted,
+            } => {
+                state.pending_refresh.insert(uid, Some(reply));
+                let _ = inserted.send(());
             }
         }
         Ok(())

--- a/backend/tauri/src/state/profiles/mod.rs
+++ b/backend/tauri/src/state/profiles/mod.rs
@@ -1,0 +1,4 @@
+//! Profiles domain state (PR-3). Actor lands in `actor.rs` (T04), background
+//! scheduler in `scheduler.rs` (T05); this module stays Tauri-free (D10).
+
+pub mod ports;

--- a/backend/tauri/src/state/profiles/mod.rs
+++ b/backend/tauri/src/state/profiles/mod.rs
@@ -1,4 +1,6 @@
-//! Profiles domain state (PR-3). Actor lands in `actor.rs` (T04), background
-//! scheduler in `scheduler.rs` (T05); this module stays Tauri-free (D10).
+//! Profiles domain state (PR-3). Tauri-free.
 
+pub mod actor;
 pub mod ports;
+
+pub use actor::*;

--- a/backend/tauri/src/state/profiles/mod.rs
+++ b/backend/tauri/src/state/profiles/mod.rs
@@ -2,5 +2,6 @@
 
 pub mod actor;
 pub mod ports;
+mod scheduler;
 
 pub use actor::*;

--- a/backend/tauri/src/state/profiles/ports.rs
+++ b/backend/tauri/src/state/profiles/ports.rs
@@ -1,0 +1,66 @@
+//! Consumer-owned ports for the profiles actor (design §7, D10). Concrete
+//! implementations live in `crate::service::profile_file`.
+
+use nyanpasu_config::profile::{
+    ExternalProfilePath, ManagedProfilePath, RemoteProfileOptions, SubscriptionInfo,
+};
+use url::Url;
+
+/// Filesystem access for materialized profile files. Paths are relative to the
+/// app profiles dir; resolution is the implementation's concern.
+#[cfg_attr(test, mockall::automock)]
+pub trait ProfileFsPort: Send + Sync + 'static {
+    fn read(&self, path: &ManagedProfilePath) -> anyhow::Result<String>;
+    fn write_atomic(&self, path: &ManagedProfilePath, content: &str) -> anyhow::Result<()>;
+    /// Idempotent: removing a missing file succeeds.
+    fn remove(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
+    /// Remote-updater write guard: the target must not be an unexpected
+    /// symlink (clean-design §9 last paragraph).
+    fn ensure_not_symlink(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
+    /// Create or repair `path -> target` (External Symlink binding, clean-design §10.1).
+    fn ensure_symlink(
+        &self,
+        path: &ManagedProfilePath,
+        target: &ExternalProfilePath,
+    ) -> anyhow::Result<()>;
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchedSubscription {
+    pub content: String,
+    /// Server-provided display name (`profile-title` / `Content-Disposition`).
+    pub filename: Option<String>,
+    pub subscription: SubscriptionInfo,
+}
+
+/// Subscription download. Network timeouts are managed inside the
+/// implementation (D9); content validation is the caller's concern (per
+/// target profile kind, design fig. 13.3).
+#[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
+pub trait SubscriptionFetcher: Send + Sync + 'static {
+    async fn fetch(
+        &self,
+        url: &Url,
+        options: &RemoteProfileOptions,
+    ) -> anyhow::Result<FetchedSubscription>;
+}
+
+/// Background-commit rebuild signal (design §6.4). Fire-and-forget; debouncing
+/// is the receiver's concern.
+#[cfg_attr(test, mockall::automock)]
+pub trait RebuildNotifier: Send + Sync + 'static {
+    fn request_rebuild(&self);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ports_are_mockable_and_object_safe() {
+        let _fs: Box<dyn ProfileFsPort> = Box::new(MockProfileFsPort::new());
+        let _fetcher: Box<dyn SubscriptionFetcher> = Box::new(MockSubscriptionFetcher::new());
+        let _notifier: Box<dyn RebuildNotifier> = Box::new(MockRebuildNotifier::new());
+    }
+}

--- a/backend/tauri/src/state/profiles/ports.rs
+++ b/backend/tauri/src/state/profiles/ports.rs
@@ -14,6 +14,8 @@ pub trait ProfileFsPort: Send + Sync + 'static {
     fn write_atomic(&self, path: &ManagedProfilePath, content: &str) -> anyhow::Result<()>;
     /// Idempotent: removing a missing file succeeds.
     fn remove(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
+    /// Read an External binding target for Mirror synchronization.
+    fn read_external(&self, target: &ExternalProfilePath) -> anyhow::Result<String>;
     /// Remote-updater write guard: the target must not be an unexpected
     /// symlink (clean-design §9 last paragraph).
     fn ensure_not_symlink(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;

--- a/backend/tauri/src/state/profiles/scheduler.rs
+++ b/backend/tauri/src/state/profiles/scheduler.rs
@@ -1,0 +1,104 @@
+//! Per-uid remote refresh timers owned by ProfilesActor.
+
+use std::collections::HashMap;
+
+use nyanpasu_config::profile::{ProfileId, ProfileSource, Profiles};
+use ractor::ActorRef;
+use tokio::task::JoinHandle;
+
+use super::actor::ProfilesActorMessage;
+
+struct Entry {
+    interval_minutes: u64,
+    handle: JoinHandle<()>,
+}
+
+#[derive(Default)]
+pub(super) struct RemoteUpdateScheduler {
+    entries: HashMap<ProfileId, Entry>,
+}
+
+impl RemoteUpdateScheduler {
+    pub(super) fn reconcile(
+        &mut self,
+        profiles: &Profiles,
+        actor: &ActorRef<ProfilesActorMessage>,
+        catch_up: bool,
+    ) {
+        let desired: HashMap<ProfileId, (u64, Option<time::OffsetDateTime>)> = profiles
+            .items
+            .iter()
+            .filter_map(|(uid, item)| match item.definition.source() {
+                Some(ProfileSource::Remote {
+                    option,
+                    materialized,
+                    ..
+                }) if option.update_interval_minutes > 0 => Some((
+                    uid.clone(),
+                    (option.update_interval_minutes, materialized.updated_at),
+                )),
+                _ => None,
+            })
+            .collect();
+
+        let stale: Vec<ProfileId> = self
+            .entries
+            .iter()
+            .filter(|(uid, entry)| {
+                desired
+                    .get(*uid)
+                    .is_none_or(|(interval, _)| *interval != entry.interval_minutes)
+            })
+            .map(|(uid, _)| uid.clone())
+            .collect();
+        for uid in stale {
+            if let Some(entry) = self.entries.remove(&uid) {
+                entry.handle.abort();
+            }
+        }
+
+        for (uid, (interval_minutes, updated_at)) in desired {
+            if self.entries.contains_key(&uid) {
+                continue;
+            }
+            let overdue = catch_up
+                && updated_at.is_none_or(|at| {
+                    time::OffsetDateTime::now_utc() - at
+                        >= time::Duration::minutes(interval_minutes as i64)
+                });
+            let actor = actor.clone();
+            let tick_uid = uid.clone();
+            let handle = tokio::spawn(async move {
+                if overdue {
+                    let _ = actor.cast(ProfilesActorMessage::RefreshRemote {
+                        uid: tick_uid.clone(),
+                        patch: None,
+                        reply: None,
+                    });
+                }
+                let period = std::time::Duration::from_secs(interval_minutes * 60);
+                loop {
+                    tokio::time::sleep(period).await;
+                    let _ = actor.cast(ProfilesActorMessage::RefreshRemote {
+                        uid: tick_uid.clone(),
+                        patch: None,
+                        reply: None,
+                    });
+                }
+            });
+            self.entries.insert(
+                uid,
+                Entry {
+                    interval_minutes,
+                    handle,
+                },
+            );
+        }
+    }
+
+    pub(super) fn shutdown(&mut self) {
+        for (_, entry) in self.entries.drain() {
+            entry.handle.abort();
+        }
+    }
+}

--- a/backend/tauri/src/state/profiles/scheduler.rs
+++ b/backend/tauri/src/state/profiles/scheduler.rs
@@ -1,8 +1,15 @@
-//! Per-uid remote refresh timers owned by ProfilesActor.
+//! Per-uid background refresh/watch services owned by ProfilesActor.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
-use nyanpasu_config::profile::{ProfileId, ProfileSource, Profiles};
+use anyhow::Context as _;
+use notify_debouncer_full::{
+    DebounceEventResult, Debouncer, RecommendedCache, new_debouncer,
+    notify::{RecommendedWatcher, RecursiveMode},
+};
+use nyanpasu_config::profile::{
+    ExternalMode, ExternalProfilePath, LocalBinding, ProfileId, ProfileSource, Profiles,
+};
 use ractor::ActorRef;
 use tokio::task::JoinHandle;
 
@@ -11,6 +18,114 @@ use super::actor::ProfilesActorMessage;
 struct Entry {
     interval_minutes: u64,
     handle: JoinHandle<()>,
+}
+
+struct WatchEntry {
+    watch_path: PathBuf,
+    _debouncer: Debouncer<RecommendedWatcher, RecommendedCache>,
+}
+
+#[derive(Default)]
+pub(super) struct ExternalWatchers {
+    entries: HashMap<ProfileId, WatchEntry>,
+}
+
+impl ExternalWatchers {
+    pub(super) fn reconcile(
+        &mut self,
+        profiles: &Profiles,
+        actor: &ActorRef<ProfilesActorMessage>,
+    ) {
+        let desired: HashMap<ProfileId, PathBuf> = profiles
+            .items
+            .iter()
+            .filter_map(|(uid, item)| match item.definition.source() {
+                Some(ProfileSource::Local {
+                    binding: LocalBinding::External { target, mode, .. },
+                }) => Some((uid.clone(), watch_path(target, *mode))),
+                _ => None,
+            })
+            .collect();
+
+        let stale: Vec<ProfileId> = self
+            .entries
+            .iter()
+            .filter(|(uid, entry)| desired.get(*uid) != Some(&entry.watch_path))
+            .map(|(uid, _)| uid.clone())
+            .collect();
+        for uid in stale {
+            self.entries.remove(&uid);
+        }
+
+        for (uid, watch_path) in desired {
+            if self.entries.contains_key(&uid) {
+                continue;
+            }
+
+            let actor = actor.clone();
+            let event_uid = uid.clone();
+            let mut debouncer = match new_debouncer(
+                std::time::Duration::from_millis(500),
+                None,
+                move |events: DebounceEventResult| match events {
+                    Ok(events) => {
+                        if !events.is_empty() {
+                            let _ = actor.cast(ProfilesActorMessage::ExternalFileChanged {
+                                uid: event_uid.clone(),
+                            });
+                        }
+                    }
+                    Err(errors) => {
+                        tracing::warn!(?errors, "failed to debounce external profile event");
+                    }
+                },
+            ) {
+                Ok(debouncer) => debouncer,
+                Err(error) => {
+                    tracing::warn!(
+                        uid = %uid,
+                        path = %watch_path.display(),
+                        error = %error,
+                        "failed to create external profile watcher"
+                    );
+                    continue;
+                }
+            };
+
+            if let Err(error) = debouncer
+                .watch(&watch_path, RecursiveMode::NonRecursive)
+                .with_context(|| format!("watch external profile {}", watch_path.display()))
+            {
+                tracing::warn!(
+                    uid = %uid,
+                    path = %watch_path.display(),
+                    error = %error,
+                    "failed to watch external profile target"
+                );
+                continue;
+            }
+
+            self.entries.insert(
+                uid,
+                WatchEntry {
+                    watch_path,
+                    _debouncer: debouncer,
+                },
+            );
+        }
+    }
+
+    pub(super) fn shutdown(&mut self) {
+        self.entries.clear();
+    }
+}
+
+fn watch_path(target: &ExternalProfilePath, mode: ExternalMode) -> PathBuf {
+    match mode {
+        ExternalMode::Symlink => std::fs::canonicalize(target.as_path())
+            .unwrap_or_else(|_| target.as_path().to_path_buf()),
+        ExternalMode::Mirror => target.as_path().to_path_buf(),
+    }
 }
 
 #[derive(Default)]

--- a/docs/superpowers/plans/2026-07-06-pr3-t03-ports-profile-file-service.md
+++ b/docs/superpowers/plans/2026-07-06-pr3-t03-ports-profile-file-service.md
@@ -1,0 +1,746 @@
+# PR-3 T03 — ports + ProfileFileService Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 落地消费方拥有的三个窄 trait(`ProfileFsPort`/`SubscriptionFetcher`/`RebuildNotifier`,Tauri-free、mockall 兼容)与具体实现 `ProfileFileService`(fs 原子写、符号链接防御、reqwest 订阅下载);纯增量、零调用方。
+
+**Architecture:** trait 定义在消费方模块 `state/profiles/ports.rs`(D10 边界);实现在 `service/profile_file.rs`,持 `PathResolver`(相对 `ManagedProfilePath` → `app_profiles_dir()` 解析)与注入的 `SelfProxyPortSource`(self_proxy 端口来源,替代 legacy 直读 `Config::verge()` 的 FIXME,remote.rs:130-136)。下载语义 1:1 移植 legacy `subscribe_url`(代理优先级/UA/hwid 头/backon 重试/subscription-userinfo 解析),**不做内容格式校验**(按目标类型的校验属于 T05 下载任务,design 图 13.3)。
+
+**Tech Stack:** async-trait 0.1(已有)、mockall 0.13(**本卡加入 dev-deps**)、atomicwrites 0.4(已有)、reqwest(workspace)、backon(已有)、sysproxy(已有)、axum 0.8(已有,测试服务器)、tempfile(已有)。
+
+## Global Constraints(task.md §0)
+
+- `state/profiles/**` 禁止 `tauri::*` / `crate::config` import(grep 断言);`service/profile_file.rs` 允许 fs/网络,同样禁止 `tauri::*` 与 legacy `Config`。
+- ports 兼容 `mockall::automock`;测试不 sleep(轮询/超时用 tokio 时间与有界等待)。
+- 模块布局(plan 预决策):`state/profiles/{mod.rs, ports.rs}`(actor.rs/scheduler.rs 留给 T04/T05)。
+- 每个 commit `cargo build` + `cargo test` 绿。
+
+## 基线事实(2026-07-06 实测)
+
+- `PathResolver::with_base_dirs(config, data)` 可注入测试根(`utils/path.rs:60`);`app_profiles_dir() = config_dir/profiles`(`:94`)、`profiles_path()`(`:99`)。
+- `backend/tauri/src/service/` 不存在——本卡新建;`state/` 现为平铺文件(application.rs 等),本卡引入 `profiles/` 子目录。
+- legacy 下载语义源 `config/profile/item/remote.rs:118-215`:30s 超时、`self_proxy` 优先于 `with_proxy`、系统代理经 `Sysproxy::get_system_proxy()`、UA 默认 `clash-nyanpasu/v{APP_VERSION}`、hwid 四头、backon 指数重试(401/403/404 不重试)、`subscription-userinfo` 头解析、`profile-title`(支持 `base64:` 前缀)/`Content-Disposition` 文件名解析。
+- mockall 全 workspace 未引入;async trait 的 automock 需 `#[cfg_attr(test, mockall::automock)]` 位于 `#[async_trait::async_trait]` **之上**。
+
+## 契约补遗(执行后回写 T03 卡,§5.3)
+
+1. `FetchedSubscription` 增加 `filename: Option<String>`(legacy 用响应头命名导入的 profile,T08 `import_profile` 需要)。
+2. 新增 service 侧 trait `SelfProxyPortSource { fn mixed_port(&self) -> Option<u16> }`——`ProfileFileService::new(paths, self_proxy_port)` 取代卡内草签 `new(paths, http: reqwest::Client)`(reqwest 代理是 per-client 配置,必须按 options 逐次建 client,固定 Client 参数无法表达)。
+3. `ProfileFsPort::remove` 语义 = 幂等(文件缺失也 Ok)。
+
+---
+
+### Task 1: 依赖 + 模块骨架 + ports 定义
+
+**Files:**
+
+- Modify: `backend/tauri/Cargo.toml`(`[dev-dependencies]` 追加 `mockall = "0.13"`)
+- Create: `backend/tauri/src/state/profiles/mod.rs`
+- Create: `backend/tauri/src/state/profiles/ports.rs`
+- Modify: `backend/tauri/src/state/mod.rs`(追加 `pub mod profiles;`)
+- Create: `backend/tauri/src/service/mod.rs`
+- Modify: `backend/tauri/src/lib.rs`(在现有 `mod state;` 声明附近追加 `mod service;`;先 `grep -n "^mod \|^pub mod " backend/tauri/src/lib.rs` 定位声明区)
+
+**Interfaces:**
+
+- Produces(T04/T05/T07 依赖,签名冻结):
+
+```rust
+// state/profiles/ports.rs
+pub trait ProfileFsPort: Send + Sync + 'static { read / write_atomic / remove / ensure_not_symlink / ensure_symlink }
+pub trait SubscriptionFetcher: Send + Sync + 'static { async fetch(&self, &Url, &RemoteProfileOptions) -> anyhow::Result<FetchedSubscription> }
+pub trait RebuildNotifier: Send + Sync + 'static { request_rebuild(&self) }
+pub struct FetchedSubscription { content: String, filename: Option<String>, subscription: SubscriptionInfo }
+```
+
+- [ ] **Step 1: Cargo dev-dep**
+
+`backend/tauri/Cargo.toml` 的 `[dev-dependencies]` 段追加一行:
+
+```toml
+mockall = "0.13"
+```
+
+- [ ] **Step 2: 写 `state/profiles/mod.rs`**
+
+```rust
+//! Profiles domain state (PR-3). Actor lands in `actor.rs` (T04), background
+//! scheduler in `scheduler.rs` (T05); this module stays Tauri-free (D10).
+
+pub mod ports;
+```
+
+- [ ] **Step 3: 写 `state/profiles/ports.rs`(完整内容)**
+
+```rust
+//! Consumer-owned ports for the profiles actor (design §7, D10). Concrete
+//! implementations live in `crate::service::profile_file`.
+
+use nyanpasu_config::profile::{
+    ExternalProfilePath, ManagedProfilePath, RemoteProfileOptions, SubscriptionInfo,
+};
+use url::Url;
+
+/// Filesystem access for materialized profile files. Paths are relative to the
+/// app profiles dir; resolution is the implementation's concern.
+#[cfg_attr(test, mockall::automock)]
+pub trait ProfileFsPort: Send + Sync + 'static {
+    fn read(&self, path: &ManagedProfilePath) -> anyhow::Result<String>;
+    fn write_atomic(&self, path: &ManagedProfilePath, content: &str) -> anyhow::Result<()>;
+    /// Idempotent: removing a missing file succeeds.
+    fn remove(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
+    /// Remote-updater write guard: the target must not be an unexpected
+    /// symlink (clean-design §9 last paragraph).
+    fn ensure_not_symlink(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
+    /// Create or repair `path -> target` (External Symlink binding, clean-design §10.1).
+    fn ensure_symlink(
+        &self,
+        path: &ManagedProfilePath,
+        target: &ExternalProfilePath,
+    ) -> anyhow::Result<()>;
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchedSubscription {
+    pub content: String,
+    /// Server-provided display name (`profile-title` / `Content-Disposition`).
+    pub filename: Option<String>,
+    pub subscription: SubscriptionInfo,
+}
+
+/// Subscription download. Network timeouts are managed inside the
+/// implementation (D9); content validation is the caller's concern (per
+/// target profile kind, design fig. 13.3).
+#[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
+pub trait SubscriptionFetcher: Send + Sync + 'static {
+    async fn fetch(
+        &self,
+        url: &Url,
+        options: &RemoteProfileOptions,
+    ) -> anyhow::Result<FetchedSubscription>;
+}
+
+/// Background-commit rebuild signal (design §6.4). Fire-and-forget; debouncing
+/// is the receiver's concern.
+#[cfg_attr(test, mockall::automock)]
+pub trait RebuildNotifier: Send + Sync + 'static {
+    fn request_rebuild(&self);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ports_are_mockable_and_object_safe() {
+        let _fs: Box<dyn ProfileFsPort> = Box::new(MockProfileFsPort::new());
+        let _fetcher: Box<dyn SubscriptionFetcher> = Box::new(MockSubscriptionFetcher::new());
+        let _notifier: Box<dyn RebuildNotifier> = Box::new(MockRebuildNotifier::new());
+    }
+}
+```
+
+- [ ] **Step 4: 写 `service/mod.rs` + 模块声明**
+
+```rust
+//! Concrete infrastructure services (adapters) consumed via ports.
+
+pub mod profile_file;
+```
+
+`state/mod.rs` 追加 `pub mod profiles;`;`lib.rs` 声明区追加 `mod service;`。`service/profile_file.rs` 本 Task 先建占位空文件(Task 2 填充):
+
+```rust
+//! ProfileFsPort + SubscriptionFetcher implementation (T03 Task 2/3).
+```
+
+- [ ] **Step 5: 编译 + 纯度断言 + mock 冒烟**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu ports_are_mockable`
+Expected: PASS。
+Run(Git Bash): `grep -rn "tauri::\|crate::config" backend/tauri/src/state/profiles/ && echo LEAK || echo CLEAN`
+Expected: `CLEAN`。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/tauri/Cargo.toml backend/Cargo.lock backend/tauri/src/state/profiles backend/tauri/src/state/mod.rs backend/tauri/src/service backend/tauri/src/lib.rs
+git commit -m "feat(tauri): add profile fs/subscription/rebuild ports (PR-3 T03)"
+```
+
+---
+
+### Task 2: `ProfileFileService` 文件系统半(ProfileFsPort impl)
+
+**Files:**
+
+- Modify: `backend/tauri/src/service/profile_file.rs`
+
+**Interfaces:**
+
+- Produces: `ProfileFileService::new(paths: PathResolver, self_proxy_port: Arc<dyn SelfProxyPortSource>) -> Self`(同时 impl `ProfileFsPort` + `SubscriptionFetcher`)、`pub trait SelfProxyPortSource { fn mixed_port(&self) -> Option<u16>; }`、`pub fn normalize_yaml_document(content: &str) -> anyhow::Result<String>`。
+
+- [ ] **Step 1: 写失败测试(tempdir)**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nyanpasu_config::profile::ManagedProfilePath;
+    use std::sync::Arc;
+
+    struct NoProxy;
+    impl SelfProxyPortSource for NoProxy {
+        fn mixed_port(&self) -> Option<u16> {
+            None
+        }
+    }
+
+    fn service() -> (tempfile::TempDir, ProfileFileService) {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = crate::utils::path::PathResolver::with_base_dirs(
+            temp.path().join("config"),
+            temp.path().join("data"),
+        );
+        (temp, ProfileFileService::new(paths, Arc::new(NoProxy)))
+    }
+
+    fn managed(name: &str) -> ManagedProfilePath {
+        ManagedProfilePath::new(name).unwrap()
+    }
+
+    #[test]
+    fn write_atomic_then_read_round_trips_and_creates_parent() {
+        let (_temp, service) = service();
+        let path = managed("abc.yaml");
+        service.write_atomic(&path, "proxies: []\n").unwrap();
+        assert_eq!(service.read(&path).unwrap(), "proxies: []\n");
+        // overwrite keeps working (AllowOverwrite)
+        service.write_atomic(&path, "mode: rule\n").unwrap();
+        assert_eq!(service.read(&path).unwrap(), "mode: rule\n");
+    }
+
+    #[test]
+    fn remove_is_idempotent() {
+        let (_temp, service) = service();
+        let path = managed("gone.yaml");
+        service.remove(&path).unwrap(); // missing → Ok
+        service.write_atomic(&path, "x: 1\n").unwrap();
+        service.remove(&path).unwrap();
+        assert!(service.read(&path).is_err());
+    }
+
+    #[test]
+    fn ensure_not_symlink_rejects_links_and_accepts_files() {
+        let (_temp, service) = service();
+        let path = managed("real.yaml");
+        service.ensure_not_symlink(&path).unwrap(); // missing → Ok
+        service.write_atomic(&path, "x: 1\n").unwrap();
+        service.ensure_not_symlink(&path).unwrap(); // regular file → Ok
+
+        // 构造符号链接;无权限环境(Windows 非开发者模式)跳过
+        let link = managed("link.yaml");
+        let target_file = service.resolve(&path);
+        let link_file = service.resolve(&link);
+        #[cfg(windows)]
+        let made = std::os::windows::fs::symlink_file(&target_file, &link_file);
+        #[cfg(unix)]
+        let made = std::os::unix::fs::symlink(&target_file, &link_file);
+        if made.is_err() {
+            eprintln!("symlink unsupported in this environment, skipping");
+            return;
+        }
+        assert!(service.ensure_not_symlink(&link).is_err());
+    }
+
+    #[test]
+    fn ensure_symlink_creates_and_repairs() {
+        let (temp, service) = service();
+        let outside = temp.path().join("outside.yaml");
+        std::fs::write(&outside, "external: true\n").unwrap();
+        let target =
+            nyanpasu_config::profile::ExternalProfilePath::new(outside.to_string_lossy()).unwrap();
+        let link = managed("ext.yaml");
+        if service.ensure_symlink(&link, &target).is_err() {
+            eprintln!("symlink unsupported in this environment, skipping");
+            return;
+        }
+        assert_eq!(service.read(&link).unwrap(), "external: true\n");
+        // 幂等:重复调用 Ok
+        service.ensure_symlink(&link, &target).unwrap();
+        // 既存普通文件 → 拒绝
+        let occupied = managed("occupied.yaml");
+        service.write_atomic(&occupied, "x: 1\n").unwrap();
+        assert!(service.ensure_symlink(&occupied, &target).is_err());
+    }
+
+    #[test]
+    fn normalize_yaml_document_round_trips_mappings_and_rejects_garbage() {
+        let normalized = normalize_yaml_document("b: 2\na: 1\n").unwrap();
+        let value: serde_yaml::Mapping = serde_yaml::from_str(&normalized).unwrap();
+        assert_eq!(value.len(), 2);
+        assert!(normalize_yaml_document(": not yaml [").is_err());
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu profile_file`
+Expected: FAIL(类型未定义)。
+
+- [ ] **Step 3: 实现(文件系统半 + 服务骨架)**
+
+```rust
+//! ProfileFsPort + SubscriptionFetcher over the real filesystem, reqwest and
+//! the OS proxy state (design §7). Tauri-free and legacy-Config-free; the
+//! self-proxy port arrives via [`SelfProxyPortSource`] instead of the legacy
+//! global read (config/profile/item/remote.rs:130-136 FIXME).
+
+use std::{io::Write, path::PathBuf, sync::Arc, time::Duration};
+
+use anyhow::{Context, bail};
+use atomicwrites::{AtomicFile, OverwriteBehavior};
+use nyanpasu_config::profile::{
+    ExternalProfilePath, ManagedProfilePath, RemoteProfileOptions, SubscriptionInfo,
+};
+use url::Url;
+
+use crate::{
+    state::profiles::ports::{FetchedSubscription, ProfileFsPort, SubscriptionFetcher},
+    utils::path::PathResolver,
+};
+
+/// Where the fetcher looks up the app's own mixed port when `self_proxy` is
+/// requested. Wired at the composition root (T07); tests inject a constant.
+#[cfg_attr(test, mockall::automock)]
+pub trait SelfProxyPortSource: Send + Sync + 'static {
+    fn mixed_port(&self) -> Option<u16>;
+}
+
+pub struct ProfileFileService {
+    paths: PathResolver,
+    self_proxy_port: Arc<dyn SelfProxyPortSource>,
+    http_timeout: Duration,
+}
+
+impl ProfileFileService {
+    pub fn new(paths: PathResolver, self_proxy_port: Arc<dyn SelfProxyPortSource>) -> Self {
+        Self {
+            paths,
+            self_proxy_port,
+            http_timeout: Duration::from_secs(30),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_http_timeout(mut self, timeout: Duration) -> Self {
+        self.http_timeout = timeout;
+        self
+    }
+
+    fn resolve(&self, path: &ManagedProfilePath) -> PathBuf {
+        self.paths.app_profiles_dir().join(path.as_path())
+    }
+}
+
+/// Parse → reserialize a YAML mapping so editor saves and File-config reads
+/// share one canonical shape (legacy `read_profile_file` normalization).
+pub fn normalize_yaml_document(content: &str) -> anyhow::Result<String> {
+    let mapping: serde_yaml::Mapping =
+        serde_yaml::from_str(content).context("document is not a YAML mapping")?;
+    serde_yaml::to_string(&mapping).context("failed to reserialize YAML mapping")
+}
+
+impl ProfileFsPort for ProfileFileService {
+    fn read(&self, path: &ManagedProfilePath) -> anyhow::Result<String> {
+        let full = self.resolve(path);
+        std::fs::read_to_string(&full)
+            .with_context(|| format!("read profile file {}", full.display()))
+    }
+
+    fn write_atomic(&self, path: &ManagedProfilePath, content: &str) -> anyhow::Result<()> {
+        let full = self.resolve(path);
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        AtomicFile::new(&full, OverwriteBehavior::AllowOverwrite)
+            .write(|file| file.write_all(content.as_bytes()))
+            .with_context(|| format!("atomic write {}", full.display()))
+    }
+
+    fn remove(&self, path: &ManagedProfilePath) -> anyhow::Result<()> {
+        let full = self.resolve(path);
+        match std::fs::remove_file(&full) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("remove profile file {}", full.display())),
+        }
+    }
+
+    fn ensure_not_symlink(&self, path: &ManagedProfilePath) -> anyhow::Result<()> {
+        let full = self.resolve(path);
+        match std::fs::symlink_metadata(&full) {
+            Ok(meta) if meta.file_type().is_symlink() => bail!(
+                "refusing to write through unexpected symlink at {}",
+                full.display()
+            ),
+            _ => Ok(()),
+        }
+    }
+
+    fn ensure_symlink(
+        &self,
+        path: &ManagedProfilePath,
+        target: &ExternalProfilePath,
+    ) -> anyhow::Result<()> {
+        let full = self.resolve(path);
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        match std::fs::symlink_metadata(&full) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                if std::fs::read_link(&full)? == target.as_path() {
+                    return Ok(());
+                }
+                std::fs::remove_file(&full)?;
+            }
+            Ok(_) => bail!(
+                "existing non-symlink file at {}, refusing to replace",
+                full.display()
+            ),
+            Err(_) => {}
+        }
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(target.as_path(), &full)?;
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(target.as_path(), &full)?;
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu profile_file`
+Expected: 除 fetch 相关(尚未写)外全 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tauri/src/service/profile_file.rs
+git commit -m "feat(tauri): implement profile file service filesystem port"
+```
+
+---
+
+### Task 3: `SubscriptionFetcher` 网络半(legacy 语义 1:1)
+
+**Files:**
+
+- Modify: `backend/tauri/src/service/profile_file.rs`
+
+- [ ] **Step 1: 写失败测试(axum 本地服务器,零新依赖)**
+
+```rust
+    // ---- fetch tests --------------------------------------------------------
+    use axum::{Router, http::HeaderMap as AxumHeaderMap, routing::get};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    async fn serve(router: Router) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        (format!("http://{addr}/"), handle)
+    }
+
+    fn options_direct() -> RemoteProfileOptions {
+        RemoteProfileOptions {
+            user_agent: None,
+            with_proxy: false,
+            self_proxy: false,
+            update_interval_minutes: 120,
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_parses_userinfo_and_title_headers() {
+        let router = Router::new().route(
+            "/",
+            get(|| async {
+                let mut headers = AxumHeaderMap::new();
+                headers.insert(
+                    "subscription-userinfo",
+                    "upload=1; download=2; total=3; expire=0".parse().unwrap(),
+                );
+                headers.insert("profile-title", "My Sub".parse().unwrap());
+                (headers, "proxies: []\n")
+            }),
+        );
+        let (url, _server) = serve(router).await;
+        let (_temp, service) = service();
+        let fetched = service
+            .fetch(&Url::parse(&url).unwrap(), &options_direct())
+            .await
+            .unwrap();
+        assert_eq!(fetched.content, "proxies: []\n");
+        assert_eq!(fetched.filename.as_deref(), Some("My Sub"));
+        assert_eq!(fetched.subscription.upload, Some(1));
+        assert_eq!(fetched.subscription.download, Some(2));
+        assert_eq!(fetched.subscription.total, Some(3));
+        assert!(fetched.subscription.expire.is_none()); // expire=0 → None
+    }
+
+    #[tokio::test]
+    async fn fetch_retries_transient_errors_but_not_auth_failures() {
+        static HITS: AtomicUsize = AtomicUsize::new(0);
+        let flaky = Router::new().route(
+            "/",
+            get(|| async {
+                if HITS.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
+                } else {
+                    Ok("ok: true\n")
+                }
+            }),
+        );
+        let (url, _server) = serve(flaky).await;
+        let (_temp, service) = service();
+        let fetched = service
+            .fetch(&Url::parse(&url).unwrap(), &options_direct())
+            .await
+            .unwrap();
+        assert_eq!(fetched.content, "ok: true\n");
+        assert!(HITS.load(Ordering::SeqCst) >= 2);
+
+        static AUTH_HITS: AtomicUsize = AtomicUsize::new(0);
+        let forbidden = Router::new().route(
+            "/",
+            get(|| async {
+                AUTH_HITS.fetch_add(1, Ordering::SeqCst);
+                axum::http::StatusCode::FORBIDDEN
+            }),
+        );
+        let (url, _server) = serve(forbidden).await;
+        assert!(
+            service
+                .fetch(&Url::parse(&url).unwrap(), &options_direct())
+                .await
+                .is_err()
+        );
+        assert_eq!(AUTH_HITS.load(Ordering::SeqCst), 1); // 403 不重试
+    }
+
+    #[tokio::test]
+    async fn fetch_timeout_is_managed_internally() {
+        let slow = Router::new().route(
+            "/",
+            get(|| async {
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                "never"
+            }),
+        );
+        let (url, _server) = serve(slow).await;
+        let (_temp, service) = service();
+        let service = service.with_http_timeout(std::time::Duration::from_millis(300));
+        let started = std::time::Instant::now();
+        assert!(
+            service
+                .fetch(&Url::parse(&url).unwrap(), &options_direct())
+                .await
+                .is_err()
+        );
+        assert!(started.elapsed() < std::time::Duration::from_secs(10));
+    }
+```
+
+(注:`service()` 返回的 `_temp` 守卫必须持有到测试结束;`RemoteProfileOptions` 字段名以 `nyanpasu-config/src/profile/source.rs:109-122` 为准。)
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu fetch_`
+Expected: FAIL(`SubscriptionFetcher` 未实现)。
+
+- [ ] **Step 3: 实现网络半**
+
+```rust
+#[async_trait::async_trait]
+impl SubscriptionFetcher for ProfileFileService {
+    async fn fetch(
+        &self,
+        url: &Url,
+        options: &RemoteProfileOptions,
+    ) -> anyhow::Result<FetchedSubscription> {
+        use backon::Retryable;
+
+        let mut builder = reqwest::ClientBuilder::new()
+            .use_rustls_tls()
+            .no_proxy()
+            .timeout(self.http_timeout);
+
+        // Proxy precedence mirrors the legacy subscriber (remote.rs:129-150):
+        // self_proxy wins, then system proxy, else direct.
+        let proxy_url = if options.self_proxy {
+            self.self_proxy_port
+                .mixed_port()
+                .map(|port| format!("http://127.0.0.1:{port}"))
+        } else if options.with_proxy {
+            match sysproxy::Sysproxy::get_system_proxy() {
+                Ok(p @ sysproxy::Sysproxy { enable: true, .. }) => {
+                    Some(format!("http://{}:{}", p.host, p.port))
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+        if let Some(proxy_url) = proxy_url {
+            use crate::utils::config::NyanpasuReqwestProxyExt;
+            builder = builder.swift_set_proxy(&proxy_url);
+        }
+
+        let user_agent = options.user_agent.clone().unwrap_or_else(|| {
+            format!("clash-nyanpasu/v{}", crate::utils::dirs::APP_VERSION)
+        });
+        let client = builder.user_agent(user_agent).build()?;
+
+        let device_info = crate::utils::hwid::get_device_info();
+        let sanitize = crate::utils::hwid::sanitize_for_header;
+        let perform = || async {
+            client
+                .get(url.as_str())
+                .header("x-hwid", &device_info.hwid)
+                .header("x-device-os", sanitize(&device_info.device_os))
+                .header("x-ver-os", sanitize(&device_info.os_version))
+                .header("x-device-model", sanitize(&device_info.device_model))
+                .send()
+                .await?
+                .error_for_status()
+        };
+        let resp = perform
+            .retry(backon::ExponentialBuilder::default())
+            .when(|error: &reqwest::Error| {
+                !error.is_status()
+                    || error.status().is_some_and(|status| {
+                        !matches!(
+                            status,
+                            reqwest::StatusCode::FORBIDDEN
+                                | reqwest::StatusCode::NOT_FOUND
+                                | reqwest::StatusCode::UNAUTHORIZED
+                        )
+                    })
+            })
+            .await
+            .with_context(|| format!("subscription download failed: {url}"))?;
+
+        let subscription = parse_subscription_userinfo(resp.headers());
+        let filename = parse_profile_title(resp.headers());
+        let content = resp.text().await?;
+        Ok(FetchedSubscription {
+            content,
+            filename,
+            subscription,
+        })
+    }
+}
+
+/// `subscription-userinfo: upload=..; download=..; total=..; expire=..` →
+/// typed info. Missing header → empty; `expire=0` → None (matches migration R6).
+fn parse_subscription_userinfo(headers: &reqwest::header::HeaderMap) -> SubscriptionInfo {
+    let Some(value) = headers
+        .get("subscription-userinfo")
+        .or_else(|| headers.get("Subscription-Userinfo"))
+    else {
+        return SubscriptionInfo::default();
+    };
+    let raw = value.to_str().unwrap_or("");
+    let field = |key: &str| crate::utils::help::parse_str::<u64>(raw, key);
+    SubscriptionInfo {
+        upload: field("upload"),
+        download: field("download"),
+        total: field("total"),
+        expire: field("expire")
+            .filter(|secs| *secs != 0)
+            .and_then(|secs| time::OffsetDateTime::from_unix_timestamp(secs as i64).ok()),
+    }
+}
+
+/// `profile-title`(支持 `base64:` 前缀)→ `Content-Disposition filename=` 兜底
+/// (legacy remote.rs:213-215 + item/remote.rs `parse_profile_title_header`)。
+fn parse_profile_title(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    if let Some(value) = headers.get("profile-title").and_then(|v| v.to_str().ok()) {
+        if let Some(encoded) = value.strip_prefix("base64:") {
+            use base64::Engine;
+            if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(encoded) {
+                if let Ok(decoded) = String::from_utf8(bytes) {
+                    return Some(decoded);
+                }
+            }
+        } else if !value.is_empty() {
+            return Some(value.to_owned());
+        }
+    }
+    headers
+        .get(reqwest::header::CONTENT_DISPOSITION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.split("filename=").nth(1))
+        .map(|s| s.trim().trim_matches(['"', '\'']).to_owned())
+        .filter(|s| !s.is_empty())
+}
+```
+
+(若 `time` crate 未在 tauri 依赖中:`grep -n "^time" backend/tauri/Cargo.toml`;缺失则通过 `nyanpasu_config` 重导出或在 Cargo.toml 加 `time = { version = "0.3", features = ["serde"] }`——以编译错误为准,最小改动。)
+
+- [ ] **Step 4: 跑全部 T03 测试**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu profile_file fetch_ ports_are_mockable`
+Expected: 全 PASS。
+
+- [ ] **Step 5: 纯度终检 + Commit**
+
+Run(Git Bash): `grep -rn "tauri::\|crate::config::" backend/tauri/src/service/profile_file.rs backend/tauri/src/state/profiles/ && echo LEAK || echo CLEAN`
+Expected: `CLEAN`。
+
+```bash
+git add backend/tauri/src/service/profile_file.rs
+git commit -m "feat(tauri): implement subscription fetcher with legacy download semantics"
+```
+
+---
+
+### Task 4: 契约回写(task.md §5.3)
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md`(T03 卡 Interfaces — Produces 段)
+
+- [ ] **Step 1: 按实际落地更新 T03 卡**
+
+1. `FetchedSubscription` 增加 `filename: Option<String>` 字段(T08 `import_profile` Consumes);
+2. `ProfileFileService::new(paths: PathResolver, self_proxy_port: Arc<dyn SelfProxyPortSource>)` 替换草签的 `new(paths, http: reqwest::Client)`,并追记 `SelfProxyPortSource` trait(T07 在 composition root 提供实现);
+3. `ProfileFsPort::remove` 标注幂等语义;
+4. 追记 `normalize_yaml_document` 辅助函数(T07 `read_profile_file`/`save_profile_file` Consumes)。
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+git commit -m "docs(pr3): record T03 contract addenda (fetcher signature, filename)"
+```
+
+---
+
+## 验证总表(对应 T03 卡验证段)
+
+| 判据                                     | 覆盖                                         |
+| ---------------------------------------- | -------------------------------------------- |
+| 原子写(tempdir)                          | Task 2 `write_atomic_then_read_...`          |
+| `ensure_not_symlink` 拒绝符号链接        | Task 2 `ensure_not_symlink_rejects_...`      |
+| YAML 规范化读                            | Task 2 `normalize_yaml_document_...`         |
+| fetch 网络超时自管                       | Task 3 `fetch_timeout_is_managed_internally` |
+| 重试语义(401/403/404 不重试)             | Task 3 `fetch_retries_transient_...`         |
+| `state/profiles/` 无 tauri/config import | Task 1 Step 5 + Task 3 Step 5 grep           |
+| ports 兼容 mockall                       | Task 1 `ports_are_mockable_and_object_safe`  |

--- a/docs/superpowers/plans/2026-07-06-pr3-t04-profiles-actor-client.md
+++ b/docs/superpowers/plans/2026-07-06-pr3-t04-profiles-actor-client.md
@@ -1,0 +1,1237 @@
+# PR-3 T04 — ProfilesActor + ProfilesClient(核心事务)Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** profiles 状态归属 `ProfilesActor`(owns `PersistentStateManager<Profiles>` + `ProfileDependencyIndex`);全部同步写消息(Add/Delete/Reorder/PatchMetadata/PatchRemoteOptions/ReplaceDefinition/SetCurrent/SetGlobalTransforms/Replace)+ Get 读;七步事务;`CommitReport{snapshot, affects_current, warnings}`。**不含** RefreshRemote/scheduler/watcher(→T05)。
+
+**Architecture:** 严格沿用 PR-2b 实物样板——actor 形态照 `state/application.rs`(Args 注入、`manager.snapshot_handle().load()` 快照、`manager.upsert().await` 持久化);client 形态照 `client/application.rs`(client 构造器自建 manager 并 spawn actor、`CallResult` 三态映射、Drop stop、读 `Some(5s)`/写 `None`)。所有写 handler 走统一 `run_write` 事务助手:clone → mutate → `validate()` → 原子持久化 → 提交 + 重建索引 → post-commit 文件副作用(失败=降级 warning,不回滚,D5)→ `CommitReport`。
+
+**Tech Stack:** ractor(已有)、`nyanpasu_core::state::{PersistentStateManager, PersistentStateManagerSetup}`、`nyanpasu_config::profile::*`(mutators/`ProfileDependencyIndex::build`/`validate`)、T03 三 ports(mock 注入)、nanoid 0.5(已有,服务端 uid)、camino `Utf8PathBuf`。
+
+## Global Constraints(task.md §0)
+
+- `state/profiles/**` + `client/profiles.rs` 禁止 `tauri::*` / `crate::config`(grep 断言)。
+- 读 `call(_, Some(PROFILES_READ_TIMEOUT))`、写 `call(_, None)`;写 handler 禁无界 I/O(本卡全部写消息只做内存/本地 fs 操作,网络在 T05)。
+- 测试不 sleep;mock ports + tempdir manager。
+- 每个 commit `cargo build` + `cargo test` 绿。
+
+## 基线事实(2026-07-06 实测)
+
+- actor 样板:`state/application.rs:17-109`;client 样板:`client/application.rs:27-107`(含 `PersistentStateManagerSetup::<T>::builder().config_path(Utf8PathBuf).assemble()` → `load().await` / `from_state(seed).await`、`Drop → actor_ref.stop(None)`、tempdir 测试模式 `:109-164`)。
+- 域 API:`Profiles::{get_item, append_item, replace_item, remove_item_unchecked, reorder, validate, sanitize_top_level}`(profiles.rs);mutators `ProfileItem::{apply_metadata_patch, set_definition}`、`Profiles::{set_current, add/remove/move_global_transform}`、`list_*`(patch.rs);`ProfileDependencyIndex::build(&Profiles)`(dependency.rs:25)。
+- **`reorder_by_list` 域 API 不存在**——ByList 在 actor 内实现(置换校验 + IndexMap 重建)。
+- `RemoteProfileOptionsPatch` 经 `struct_patch::Patch::apply` 应用到 `ProfileSource::Remote.option`。
+
+## 契约修正(执行后回写 T04 卡,§5.3)
+
+1. **Args 形态**:actor 不需要 `PathResolver`(fs 全走 ports;manager 由 client 构造器按 PR-2b 先例自建)——`ProfilesActorArgs{ manager, fs, fetcher, notifier }`;`ProfilesClient::new(profiles_path: Utf8PathBuf, fs, fetcher, notifier)`(fetcher 本卡仅存入 State 供 T05 使用)。
+2. `CommitReport` 增加 `warnings: Vec<String>`(O4 落定:post-commit 副作用降级上报通道)。
+3. `ProfilesError` 增加 `Persist(String)` 变体(持久化失败 ≠ Rpc 失败)。
+4. **Add 的路径规约**:服务端生成 uid(`c`/`t` 前缀 + nanoid(11),按 definition 类别),并**强制重写** `definition.source.materialized.file` 为规范路径 `{uid}.{ext}`(File/Overlay→`yaml`,Script→按 runtime `js`/`lua`;请求内携带的占位路径一律忽略);External binding 的 `target` 保留请求值。
+5. **加载策略**:client 构造时 `profiles_path` 存在→`load()`,否则 `from_state(Profiles::default())`;加载后 `validate()` 失败→构造失败(fail-fast;migration 保证合法,手改坏文件应显式失败而非静默兜底)。
+6. **affects_current 规则表**(逐消息,均可测):Get n/a;Add=false;Delete=false(受引用保护,可删者必不在闭包内);Reorder=false;PatchMetadata=false;PatchRemoteOptions=false;SetCurrent=(前后 current 不等);SetGlobalTransforms=(前后列表不等);ReplaceDefinition=(闭包前后变化 ∨ uid ∈ 前/后闭包);Replace=true。闭包 = `current` + (Composition 的 base/extend 成员) + 上述各项的 scoped transforms + `global_transforms`;current=None 时 = `global_transforms`(bare 路径仍消费)。
+
+---
+
+### Task 1: 类型 + actor 骨架 + client 骨架(Get 通路)
+
+**Files:**
+
+- Create: `backend/tauri/src/state/profiles/actor.rs`
+- Modify: `backend/tauri/src/state/profiles/mod.rs`(`pub mod actor;` + `pub use actor::*;`)
+- Create: `backend/tauri/src/client/profiles.rs`
+- Modify: `backend/tauri/src/client/mod.rs`(仅模块声明 `pub mod profiles;`,facade 方法留给 T07)
+
+**Interfaces:**
+
+- Produces(T05/T07/T08 依赖,冻结):
+
+```rust
+pub const PROFILES_READ_TIMEOUT: Duration = Duration::from_secs(5);   // client/profiles.rs
+pub struct CommitReport { pub snapshot: Arc<Profiles>, pub affects_current: bool, pub warnings: Vec<String> }
+pub struct NewProfileRequest { pub metadata: ProfileMetadata, pub definition: ProfileDefinition }
+pub enum ReorderOp { Move { active: ProfileId, over: ProfileId }, ByList(Vec<ProfileId>) }
+pub enum ProfilesError { ProfileNotFound(ProfileId), ProfileInUse { referrers: Vec<ProfileId> },
+    ProfileHasNoFile, ValidationFailed(Vec<ProfileValidationError>), NotARemoteProfile,
+    FileNotWritable { reason: String }, RefreshFailed { message: String },
+    Persist(String), Rpc(String) }
+impl ProfilesClient {
+    pub(crate) async fn new(profiles_path: Utf8PathBuf, fs: Arc<dyn ProfileFsPort>,
+        fetcher: Arc<dyn SubscriptionFetcher>, notifier: Arc<dyn RebuildNotifier>) -> anyhow::Result<Self>;
+    pub async fn get(&self) -> Result<Arc<Profiles>, ProfilesError>;
+    // 九个写方法 → Result<CommitReport, ProfilesError>(Task 2–4 逐个接通)
+}
+```
+
+- [ ] **Step 1: 写失败测试(client/profiles.rs 底部)**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::profiles::ports::{
+        MockProfileFsPort, MockRebuildNotifier, MockSubscriptionFetcher,
+    };
+    use tempfile::{TempDir, tempdir};
+
+    pub(crate) fn temp_profiles_path(dir: &TempDir) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(dir.path().join("profiles.yaml")).expect("utf-8 temp path")
+    }
+
+    pub(crate) async fn test_client_with(fs: MockProfileFsPort) -> (ProfilesClient, TempDir) {
+        let dir = tempdir().unwrap();
+        let client = ProfilesClient::new(
+            temp_profiles_path(&dir),
+            std::sync::Arc::new(fs),
+            std::sync::Arc::new(MockSubscriptionFetcher::new()),
+            std::sync::Arc::new(MockRebuildNotifier::new()),
+        )
+        .await
+        .expect("profiles client should spawn");
+        (client, dir)
+    }
+
+    #[tokio::test]
+    async fn fresh_store_starts_with_default_profiles() {
+        let (client, _dir) = test_client_with(MockProfileFsPort::new()).await;
+        let snapshot = client.get().await.expect("get should succeed");
+        assert!(snapshot.current.is_none());
+        assert!(snapshot.items.is_empty());
+        assert_eq!(snapshot.valid.len(), 3); // default_valid
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu fresh_store_starts`
+Expected: FAIL(类型未定义)。
+
+- [ ] **Step 3: 实现 `state/profiles/actor.rs`(本 Task 仅 Get + 骨架;写消息枚举齐全但 handler 返回 todo 错误会违反「每步编译且测试绿」——因此消息枚举本 Task 只含 `Get`,后续 Task 增量添加变体)**
+
+```rust
+//! ProfilesActor: single owner of the profiles document (design §6).
+//! Tauri-free (D10); every filesystem/network effect goes through the ports.
+
+use std::sync::Arc;
+
+use nyanpasu_config::profile::{
+    ConfigDefinition, ProfileDefinition, ProfileDependencyIndex, ProfileId, ProfileMetadata,
+    ProfileValidationError, Profiles,
+};
+use nyanpasu_core::state::PersistentStateManager;
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+
+use super::ports::{ProfileFsPort, RebuildNotifier, SubscriptionFetcher};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProfilesError {
+    #[error("profile not found: {0}")]
+    ProfileNotFound(ProfileId),
+    #[error("profile is referenced and cannot be deleted (referrers: {referrers:?})")]
+    ProfileInUse { referrers: Vec<ProfileId> },
+    #[error("profile has no materialized file")]
+    ProfileHasNoFile,
+    #[error("validation failed: {0:?}")]
+    ValidationFailed(Vec<ProfileValidationError>),
+    #[error("profile is not a remote profile")]
+    NotARemoteProfile,
+    #[error("file not writable: {reason}")]
+    FileNotWritable { reason: String },
+    #[error("refresh failed: {message}")]
+    RefreshFailed { message: String },
+    #[error("failed to persist profiles: {0}")]
+    Persist(String),
+    #[error("profiles actor rpc failed: {0}")]
+    Rpc(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct CommitReport {
+    pub snapshot: Arc<Profiles>,
+    /// Dependency-closure judgement per the T04 affects_current rule table.
+    pub affects_current: bool,
+    /// Post-commit side-effect failures (degraded, not rolled back — D5).
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewProfileRequest {
+    pub metadata: ProfileMetadata,
+    /// The materialized path inside is a placeholder: Add rewrites it to the
+    /// canonical `{uid}.{ext}` derived from the server-generated uid.
+    pub definition: ProfileDefinition,
+}
+
+#[derive(Debug, Clone)]
+pub enum ReorderOp {
+    Move { active: ProfileId, over: ProfileId },
+    ByList(Vec<ProfileId>),
+}
+
+pub struct ProfilesActorArgs {
+    pub manager: PersistentStateManager<Profiles>,
+    pub fs: Arc<dyn ProfileFsPort>,
+    pub fetcher: Arc<dyn SubscriptionFetcher>,
+    pub notifier: Arc<dyn RebuildNotifier>,
+}
+
+pub struct ProfilesActorState {
+    manager: PersistentStateManager<Profiles>,
+    index: ProfileDependencyIndex,
+    fs: Arc<dyn ProfileFsPort>,
+    // T05 consumes these; stored now so Args stay stable across T04/T05.
+    #[allow(dead_code)]
+    fetcher: Arc<dyn SubscriptionFetcher>,
+    #[allow(dead_code)]
+    notifier: Arc<dyn RebuildNotifier>,
+}
+
+#[derive(Debug)]
+pub enum ProfilesActorMessage {
+    Get(RpcReplyPort<Result<Arc<Profiles>, ProfilesError>>),
+    // 写消息变体由 Task 2–4 增量补齐
+}
+
+pub struct ProfilesActor;
+
+impl ProfilesActor {
+    fn current_state(state: &ProfilesActorState) -> Profiles {
+        state.manager.snapshot_handle().load().state.clone()
+    }
+}
+
+impl Actor for ProfilesActor {
+    type Msg = ProfilesActorMessage;
+    type State = ProfilesActorState;
+    type Arguments = ProfilesActorArgs;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let index = ProfileDependencyIndex::build(&args.manager.snapshot_handle().load().state);
+        Ok(ProfilesActorState {
+            manager: args.manager,
+            index,
+            fs: args.fs,
+            fetcher: args.fetcher,
+            notifier: args.notifier,
+        })
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            ProfilesActorMessage::Get(reply) => {
+                let _ = reply.send(Ok(Arc::new(Self::current_state(state))));
+            }
+        }
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 4: 实现 `client/profiles.rs`**
+
+```rust
+//! Typed client for the ProfilesActor (design §6). Read Some(5s) / write None.
+
+use std::{sync::Arc, time::Duration};
+
+use anyhow::Context as _;
+use camino::Utf8PathBuf;
+use nyanpasu_config::profile::Profiles;
+use nyanpasu_core::state::PersistentStateManagerSetup;
+use ractor::{Actor, ActorRef, RpcReplyPort, rpc::CallResult};
+
+use crate::state::profiles::{
+    ProfilesActor, ProfilesActorArgs, ProfilesActorMessage, ProfilesError,
+    ports::{ProfileFsPort, RebuildNotifier, SubscriptionFetcher},
+};
+
+pub const PROFILES_READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+pub struct ProfilesClient {
+    inner: Arc<ProfilesClientInner>,
+}
+
+struct ProfilesClientInner {
+    actor_ref: ActorRef<ProfilesActorMessage>,
+}
+
+impl ProfilesClient {
+    pub(crate) async fn new(
+        profiles_path: Utf8PathBuf,
+        fs: Arc<dyn ProfileFsPort>,
+        fetcher: Arc<dyn SubscriptionFetcher>,
+        notifier: Arc<dyn RebuildNotifier>,
+    ) -> anyhow::Result<Self> {
+        let should_load = profiles_path.exists();
+        let setup = PersistentStateManagerSetup::<Profiles>::builder()
+            .config_path(profiles_path)
+            .assemble();
+        let manager = if should_load {
+            setup
+                .load()
+                .await
+                .context("failed to load profiles persistent state manager")?
+        } else {
+            setup
+                .from_state(Profiles::default())
+                .await
+                .context("failed to initialize profiles persistent state manager")?
+        };
+
+        // Fail fast on hand-edited invalid documents: migration guarantees a
+        // valid file, so anything else is an explicit error, not a fallback.
+        manager
+            .snapshot_handle()
+            .load()
+            .state
+            .validate()
+            .map_err(|errors| anyhow::anyhow!("profiles.yaml failed validation: {errors:?}"))?;
+
+        let actor_ref = Actor::spawn(
+            None,
+            ProfilesActor,
+            ProfilesActorArgs {
+                manager,
+                fs,
+                fetcher,
+                notifier,
+            },
+        )
+        .await
+        .context("failed to spawn profiles actor")?
+        .0;
+
+        Ok(Self {
+            inner: Arc::new(ProfilesClientInner { actor_ref }),
+        })
+    }
+
+    pub async fn get(&self) -> Result<Arc<Profiles>, ProfilesError> {
+        self.call(ProfilesActorMessage::Get, Some(PROFILES_READ_TIMEOUT))
+            .await
+    }
+
+    async fn call<F, T>(&self, make: F, timeout: Option<Duration>) -> Result<T, ProfilesError>
+    where
+        F: FnOnce(RpcReplyPort<Result<T, ProfilesError>>) -> ProfilesActorMessage,
+        T: Send + 'static,
+    {
+        match self.inner.actor_ref.call(make, timeout).await {
+            Ok(CallResult::Success(result)) => result,
+            Ok(CallResult::SenderError) => Err(ProfilesError::Rpc("reply dropped".into())),
+            Ok(CallResult::Timeout) => Err(ProfilesError::Rpc("call timed out".into())),
+            Err(e) => Err(ProfilesError::Rpc(e.to_string())),
+        }
+    }
+}
+
+impl Drop for ProfilesClientInner {
+    fn drop(&mut self) {
+        self.actor_ref.stop(None);
+    }
+}
+```
+
+`state/profiles/mod.rs` 更新为:
+
+```rust
+//! Profiles domain state (PR-3). Tauri-free (D10).
+
+pub mod actor;
+pub mod ports;
+
+pub use actor::*;
+```
+
+`client/mod.rs` 声明区追加 `pub mod profiles;`。
+
+- [ ] **Step 5: 跑测试确认通过 + Commit**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu fresh_store_starts`
+Expected: PASS。
+
+```bash
+git add backend/tauri/src/state/profiles backend/tauri/src/client/profiles.rs backend/tauri/src/client/mod.rs
+git commit -m "feat(tauri): scaffold ProfilesActor and ProfilesClient with read path"
+```
+
+---
+
+### Task 2: 事务助手 + SetCurrent / SetGlobalTransforms / Replace
+
+**Files:**
+
+- Modify: `backend/tauri/src/state/profiles/actor.rs`、`backend/tauri/src/client/profiles.rs`
+
+- [ ] **Step 1: 写失败测试**
+
+```rust
+    use nyanpasu_config::profile::{
+        ConfigDefinition, FileConfig, LocalBinding, ManagedProfilePath, MaterializedFile,
+        OverlayTransform, ProfileDefinition, ProfileId, ProfileMetadata, ProfileSource,
+        Profiles, TransformDefinition,
+    };
+
+    pub(crate) fn file_config_item(uid: &str) -> nyanpasu_config::profile::ProfileItem {
+        nyanpasu_config::profile::ProfileItem {
+            uid: ProfileId(uid.into()),
+            metadata: ProfileMetadata { name: uid.to_uppercase(), desc: None },
+            definition: ProfileDefinition::Config {
+                config: ConfigDefinition::File(FileConfig {
+                    source: ProfileSource::Local {
+                        binding: LocalBinding::Managed {
+                            materialized: MaterializedFile {
+                                file: ManagedProfilePath::new(format!("{uid}.yaml")).unwrap(),
+                                updated_at: None,
+                            },
+                        },
+                    },
+                    transforms: vec![],
+                }),
+            },
+        }
+    }
+
+    pub(crate) fn overlay_item(uid: &str) -> nyanpasu_config::profile::ProfileItem {
+        nyanpasu_config::profile::ProfileItem {
+            uid: ProfileId(uid.into()),
+            metadata: ProfileMetadata { name: uid.to_uppercase(), desc: None },
+            definition: ProfileDefinition::Transform {
+                transform: TransformDefinition::Overlay(OverlayTransform {
+                    source: ProfileSource::Local {
+                        binding: LocalBinding::Managed {
+                            materialized: MaterializedFile {
+                                file: ManagedProfilePath::new(format!("{uid}.yaml")).unwrap(),
+                                updated_at: None,
+                            },
+                        },
+                    },
+                }),
+            },
+        }
+    }
+
+    pub(crate) fn seeded_profiles() -> Profiles {
+        let mut profiles = Profiles::default();
+        profiles.append_item(file_config_item("cfg1"));
+        profiles.append_item(file_config_item("cfg2"));
+        profiles.append_item(overlay_item("ovl1"));
+        profiles
+    }
+
+    async fn seeded_client() -> (ProfilesClient, TempDir) {
+        let (client, dir) = test_client_with(MockProfileFsPort::new()).await;
+        client.replace(seeded_profiles()).await.expect("seed replace");
+        (client, dir)
+    }
+
+    #[tokio::test]
+    async fn set_current_commits_and_reports_affects_current() {
+        let (client, dir) = seeded_client().await;
+        let report = client
+            .set_current(Some(ProfileId("cfg1".into())))
+            .await
+            .expect("activate cfg1");
+        assert!(report.affects_current);
+        assert_eq!(report.snapshot.current, Some(ProfileId("cfg1".into())));
+
+        // 同值再设 → 不影响 current
+        let report = client.set_current(Some(ProfileId("cfg1".into()))).await.unwrap();
+        assert!(!report.affects_current);
+
+        // 落盘验证:重启后仍在
+        drop(client);
+        let (client, _dir2) = {
+            let path = temp_profiles_path(&dir);
+            let client = ProfilesClient::new(
+                path,
+                std::sync::Arc::new(MockProfileFsPort::new()),
+                std::sync::Arc::new(MockSubscriptionFetcher::new()),
+                std::sync::Arc::new(MockRebuildNotifier::new()),
+            )
+            .await
+            .unwrap();
+            (client, dir)
+        };
+        assert_eq!(client.get().await.unwrap().current, Some(ProfileId("cfg1".into())));
+    }
+
+    #[tokio::test]
+    async fn set_current_rejects_missing_and_transform_targets() {
+        let (client, _dir) = seeded_client().await;
+        let err = client.set_current(Some(ProfileId("ghost".into()))).await.unwrap_err();
+        assert!(matches!(err, ProfilesError::ValidationFailed(_)));
+        let err = client.set_current(Some(ProfileId("ovl1".into()))).await.unwrap_err();
+        assert!(matches!(err, ProfilesError::ValidationFailed(_)));
+        // 失败不落盘不改内存
+        assert!(client.get().await.unwrap().current.is_none());
+    }
+
+    #[tokio::test]
+    async fn set_global_transforms_validates_kind_and_reports_change() {
+        let (client, _dir) = seeded_client().await;
+        let report = client
+            .set_global_transforms(vec![ProfileId("ovl1".into())])
+            .await
+            .expect("set transforms");
+        assert!(report.affects_current);
+        // Config uid 进 global_transforms → ValidationFailed(design §8.2)
+        let err = client
+            .set_global_transforms(vec![ProfileId("cfg1".into())])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ProfilesError::ValidationFailed(_)));
+    }
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu set_current set_global`
+Expected: FAIL(方法未定义)。
+
+- [ ] **Step 3: 实现事务助手 + 三消息**
+
+actor.rs 追加(核心事务助手,后续全部写消息复用):
+
+```rust
+/// Post-commit filesystem side effects (executed after the state is durable;
+/// failures degrade into CommitReport.warnings — D5).
+pub(super) enum PostCommitOp {
+    WriteInitial { path: nyanpasu_config::profile::ManagedProfilePath, content: String },
+    Remove { path: nyanpasu_config::profile::ManagedProfilePath },
+    EnsureSymlink {
+        path: nyanpasu_config::profile::ManagedProfilePath,
+        target: nyanpasu_config::profile::ExternalProfilePath,
+    },
+}
+
+pub(super) struct WriteOutcome {
+    pub affects: AffectsRule,
+    pub post_ops: Vec<PostCommitOp>,
+}
+
+/// affects_current rule table (T04 contract addendum #6).
+pub(super) enum AffectsRule {
+    Never,
+    CurrentChanged,
+    GlobalChanged,
+    Touched(ProfileId),
+    Always,
+}
+
+impl ProfilesActor {
+    /// current 的传递闭包:current + Composition 成员 + 各自 scoped transforms
+    /// + global transforms;current=None 时 = global transforms(bare 路径)。
+    fn current_closure(profiles: &Profiles) -> indexmap::IndexSet<ProfileId> {
+        let mut closure: indexmap::IndexSet<ProfileId> =
+            profiles.global_transforms.iter().cloned().collect();
+        let Some(current) = &profiles.current else {
+            return closure;
+        };
+        closure.insert(current.clone());
+        let mut configs = vec![current.clone()];
+        if let Some(item) = profiles.items.get(current) {
+            if let ProfileDefinition::Config {
+                config: ConfigDefinition::Composition(composition),
+            } = &item.definition
+            {
+                if let Some(base) = &composition.base {
+                    closure.insert(base.clone());
+                    configs.push(base.clone());
+                }
+                for member in &composition.extend_proxies_from {
+                    closure.insert(member.clone());
+                    configs.push(member.clone());
+                }
+            }
+        }
+        for config in configs {
+            if let Some(item) = profiles.items.get(&config) {
+                if let ProfileDefinition::Config { config } = &item.definition {
+                    for transform in config.transforms() {
+                        closure.insert(transform.clone());
+                    }
+                }
+            }
+        }
+        closure
+    }
+
+    fn evaluate_affects(rule: &AffectsRule, before: &Profiles, after: &Profiles) -> bool {
+        match rule {
+            AffectsRule::Never => false,
+            AffectsRule::Always => true,
+            AffectsRule::CurrentChanged => before.current != after.current,
+            AffectsRule::GlobalChanged => before.global_transforms != after.global_transforms,
+            AffectsRule::Touched(uid) => {
+                let closure_before = Self::current_closure(before);
+                let closure_after = Self::current_closure(after);
+                closure_before != closure_after
+                    || closure_before.contains(uid)
+                    || closure_after.contains(uid)
+            }
+        }
+    }
+
+    /// Seven-step transaction (design §6.3): clone → mutate → validate →
+    /// persist → commit + rebuild index → post-commit side effects → report.
+    async fn run_write<F>(
+        state: &mut ProfilesActorState,
+        mutate: F,
+    ) -> Result<CommitReport, ProfilesError>
+    where
+        F: FnOnce(&mut Profiles) -> Result<WriteOutcome, ProfilesError>,
+    {
+        let before = Self::current_state(state);
+        let mut next = before.clone();
+        let outcome = mutate(&mut next)?;
+        next.validate().map_err(ProfilesError::ValidationFailed)?;
+        state
+            .manager
+            .upsert(next.clone())
+            .await
+            .map_err(|e| ProfilesError::Persist(e.to_string()))?;
+        state.index = ProfileDependencyIndex::build(&next);
+
+        let mut warnings = Vec::new();
+        for op in outcome.post_ops {
+            let result = match &op {
+                PostCommitOp::WriteInitial { path, content } => state.fs.write_atomic(path, content),
+                PostCommitOp::Remove { path } => state.fs.remove(path),
+                PostCommitOp::EnsureSymlink { path, target } => state.fs.ensure_symlink(path, target),
+            };
+            if let Err(error) = result {
+                warnings.push(format!("post-commit file operation failed: {error}"));
+            }
+        }
+
+        let affects_current = Self::evaluate_affects(&outcome.affects, &before, &next);
+        Ok(CommitReport {
+            snapshot: Arc::new(next),
+            affects_current,
+            warnings,
+        })
+    }
+}
+```
+
+消息变体 + handler 分支(追加到既有 enum/match):
+
+```rust
+    SetCurrent {
+        current: Option<ProfileId>,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    SetGlobalTransforms {
+        ids: Vec<ProfileId>,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    Replace {
+        profiles: Profiles,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+```
+
+```rust
+            ProfilesActorMessage::SetCurrent { current, reply } => {
+                let result = Self::run_write(state, |profiles| {
+                    profiles.set_current(current);
+                    Ok(WriteOutcome { affects: AffectsRule::CurrentChanged, post_ops: vec![] })
+                })
+                .await;
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::SetGlobalTransforms { ids, reply } => {
+                let result = Self::run_write(state, |profiles| {
+                    profiles.global_transforms = ids;
+                    Ok(WriteOutcome { affects: AffectsRule::GlobalChanged, post_ops: vec![] })
+                })
+                .await;
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::Replace { profiles: next, reply } => {
+                let result = Self::run_write(state, |profiles| {
+                    *profiles = next;
+                    Ok(WriteOutcome { affects: AffectsRule::Always, post_ops: vec![] })
+                })
+                .await;
+                let _ = reply.send(result);
+            }
+```
+
+client 方法(全部写 = `call(_, None)`):
+
+```rust
+    pub async fn set_current(&self, current: Option<ProfileId>) -> Result<CommitReport, ProfilesError> {
+        self.call(|reply| ProfilesActorMessage::SetCurrent { current, reply }, None).await
+    }
+
+    pub async fn set_global_transforms(&self, ids: Vec<ProfileId>) -> Result<CommitReport, ProfilesError> {
+        self.call(|reply| ProfilesActorMessage::SetGlobalTransforms { ids, reply }, None).await
+    }
+
+    pub async fn replace(&self, profiles: Profiles) -> Result<CommitReport, ProfilesError> {
+        self.call(|reply| ProfilesActorMessage::Replace { profiles, reply }, None).await
+    }
+```
+
+- [ ] **Step 4: 跑测试确认通过 + Commit**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu set_current set_global fresh_store`
+Expected: 全 PASS。
+
+```bash
+git add backend/tauri/src/state/profiles/actor.rs backend/tauri/src/client/profiles.rs
+git commit -m "feat(tauri): add profiles write transaction with current/global/replace"
+```
+
+---
+
+### Task 3: Add + Delete(uid 生成、规范路径、引用保护、按 binding 清理)
+
+**Files:**
+
+- Modify: `backend/tauri/src/state/profiles/actor.rs`、`backend/tauri/src/client/profiles.rs`
+
+- [ ] **Step 1: 写失败测试**
+
+```rust
+    #[tokio::test]
+    async fn add_generates_uid_canonical_path_and_writes_initial_file() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_write_atomic()
+            .withf(|path, content| path.as_str().ends_with(".yaml") && content == "proxies: []\n")
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let (client, _dir) = test_client_with(fs).await;
+
+        let report = client
+            .add(
+                NewProfileRequest {
+                    metadata: ProfileMetadata { name: "New".into(), desc: None },
+                    definition: file_config_item("placeholder").definition,
+                },
+                Some("proxies: []\n".to_string()),
+            )
+            .await
+            .expect("add should succeed");
+
+        assert!(!report.affects_current); // Add 规则:false
+        assert!(report.warnings.is_empty());
+        let snapshot = report.snapshot;
+        assert_eq!(snapshot.items.len(), 1);
+        let (uid, item) = snapshot.items.first().unwrap();
+        assert!(uid.0.starts_with('c'), "config uid prefixed with c: {uid}");
+        // 规范路径 = {uid}.yaml,请求内的 placeholder 路径被忽略
+        let file = item.definition.source().unwrap().materialized().file.as_str();
+        assert_eq!(file, format!("{uid}.yaml"));
+    }
+
+    #[tokio::test]
+    async fn add_script_transform_uses_runtime_extension() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_write_atomic()
+            .withf(|path, _| path.as_str().ends_with(".lua"))
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let (client, _dir) = test_client_with(fs).await;
+        let mut item = overlay_item("placeholder");
+        item.definition = ProfileDefinition::Transform {
+            transform: TransformDefinition::Script(nyanpasu_config::profile::ScriptTransform {
+                source: overlay_item("p").definition.source().unwrap().clone(),
+                runtime: nyanpasu_config::profile::ScriptRuntime::Lua,
+            }),
+        };
+        let report = client
+            .add(
+                NewProfileRequest { metadata: item.metadata.clone(), definition: item.definition },
+                Some("-- lua".to_string()),
+            )
+            .await
+            .unwrap();
+        let (uid, _) = report.snapshot.items.first().unwrap();
+        assert!(uid.0.starts_with('t'), "transform uid prefixed with t");
+    }
+
+    #[tokio::test]
+    async fn delete_enforces_reference_protection() {
+        let (client, _dir) = seeded_client().await;
+        // current 引用
+        client.set_current(Some(ProfileId("cfg1".into()))).await.unwrap();
+        let err = client.delete(ProfileId("cfg1".into())).await.unwrap_err();
+        assert!(matches!(err, ProfilesError::ProfileInUse { .. }));
+        // global transform 引用
+        client.set_global_transforms(vec![ProfileId("ovl1".into())]).await.unwrap();
+        let err = client.delete(ProfileId("ovl1".into())).await.unwrap_err();
+        assert!(matches!(err, ProfilesError::ProfileInUse { .. }));
+        // 不存在
+        let err = client.delete(ProfileId("ghost".into())).await.unwrap_err();
+        assert!(matches!(err, ProfilesError::ProfileNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn delete_unreferenced_managed_profile_removes_file() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_remove()
+            .withf(|path| path.as_str() == "cfg2.yaml")
+            .times(1)
+            .returning(|_| Ok(()));
+        let (client, _dir) = test_client_with(fs).await;
+        client.replace(seeded_profiles()).await.unwrap();
+        let report = client.delete(ProfileId("cfg2".into())).await.expect("delete cfg2");
+        assert!(!report.affects_current);
+        assert!(report.snapshot.items.get(&ProfileId("cfg2".into())).is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_cleanup_failure_degrades_to_warning() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_remove().returning(|_| anyhow::bail!("disk on fire"));
+        let (client, _dir) = test_client_with(fs).await;
+        client.replace(seeded_profiles()).await.unwrap();
+        let report = client.delete(ProfileId("cfg2".into())).await.expect("delete commits anyway");
+        assert_eq!(report.warnings.len(), 1); // 降级不回滚(D5)
+        assert!(report.snapshot.items.get(&ProfileId("cfg2".into())).is_none());
+    }
+```
+
+(引用保护的 base/extend/scoped-transform 三类由 Task 4 的 ReplaceDefinition 测试补齐场景后追加同构断言;本 Task 先覆盖 current/global/不存在三类。)
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu add_ delete_`
+Expected: FAIL。
+
+- [ ] **Step 3: 实现 Add/Delete**
+
+消息变体:
+
+```rust
+    Add {
+        request: NewProfileRequest,
+        initial_file: Option<String>,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    Delete {
+        uid: ProfileId,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+```
+
+actor 逻辑:
+
+```rust
+impl ProfilesActor {
+    fn generate_uid(definition: &ProfileDefinition, existing: &Profiles) -> ProfileId {
+        let prefix = match definition {
+            ProfileDefinition::Config { .. } => 'c',
+            ProfileDefinition::Transform { .. } => 't',
+        };
+        loop {
+            let candidate = ProfileId(format!("{prefix}{}", nanoid::nanoid!(11)));
+            if existing.items.get(&candidate).is_none() {
+                return candidate;
+            }
+        }
+    }
+
+    fn canonical_extension(definition: &ProfileDefinition) -> &'static str {
+        match definition {
+            ProfileDefinition::Config { .. } => "yaml",
+            ProfileDefinition::Transform { transform } => match transform {
+                nyanpasu_config::profile::TransformDefinition::Overlay(_) => "yaml",
+                nyanpasu_config::profile::TransformDefinition::Script(script) => {
+                    match script.runtime {
+                        nyanpasu_config::profile::ScriptRuntime::JavaScript => "js",
+                        nyanpasu_config::profile::ScriptRuntime::Lua => "lua",
+                    }
+                }
+            },
+        }
+    }
+
+    /// design §17 五类引用;referrers 装 item 级引用者,current/global 命中时
+    /// 也返回 ProfileInUse(引用者为文档级,不进列表)。
+    fn referrers_of(state: &ProfilesActorState, profiles: &Profiles, uid: &ProfileId) -> Option<Vec<ProfileId>> {
+        let mut referrers: indexmap::IndexSet<ProfileId> = Default::default();
+        if let Some(set) = state.index.composition_base_dependents.get(uid) {
+            referrers.extend(set.iter().cloned());
+        }
+        if let Some(set) = state.index.extend_proxies_dependents.get(uid) {
+            referrers.extend(set.iter().cloned());
+        }
+        if let Some(set) = state.index.transform_dependents.get(uid) {
+            referrers.extend(set.iter().cloned());
+        }
+        let document_level = profiles.current.as_ref() == Some(uid)
+            || state.index.global_transform_ids.contains(uid);
+        if referrers.is_empty() && !document_level {
+            None
+        } else {
+            Some(referrers.into_iter().collect())
+        }
+    }
+}
+```
+
+handler 分支:
+
+```rust
+            ProfilesActorMessage::Add { request, initial_file, reply } => {
+                let result = {
+                    let existing = Self::current_state(state);
+                    let uid = Self::generate_uid(&request.definition, &existing);
+                    let ext = Self::canonical_extension(&request.definition);
+                    let canonical =
+                        nyanpasu_config::profile::ManagedProfilePath::new(format!("{uid}.{ext}"))
+                            .expect("uid-derived path is always a valid managed path");
+                    let mut definition = request.definition;
+                    let mut post_ops = Vec::new();
+                    if let Some(source) = definition.source_mut() {
+                        source.materialized_mut().file = canonical.clone();
+                        match source {
+                            nyanpasu_config::profile::ProfileSource::Local {
+                                binding:
+                                    nyanpasu_config::profile::LocalBinding::External { target, mode, .. },
+                            } => {
+                                if *mode == nyanpasu_config::profile::ExternalMode::Symlink {
+                                    post_ops.push(PostCommitOp::EnsureSymlink {
+                                        path: canonical.clone(),
+                                        target: target.clone(),
+                                    });
+                                }
+                                // Mirror 的首次同步由 T05 watcher reconcile 负责
+                            }
+                            nyanpasu_config::profile::ProfileSource::Remote { .. } => {
+                                // 首次内容由 T05 RefreshRemote 链路下载
+                            }
+                            _ => {
+                                post_ops.push(PostCommitOp::WriteInitial {
+                                    path: canonical.clone(),
+                                    content: initial_file.clone().unwrap_or_default(),
+                                });
+                            }
+                        }
+                    }
+                    let item = nyanpasu_config::profile::ProfileItem {
+                        uid: uid.clone(),
+                        metadata: request.metadata,
+                        definition,
+                    };
+                    Self::run_write(state, move |profiles| {
+                        if !profiles.append_item(item) {
+                            return Err(ProfilesError::Persist("uid collision".into()));
+                        }
+                        Ok(WriteOutcome { affects: AffectsRule::Never, post_ops })
+                    })
+                    .await
+                };
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::Delete { uid, reply } => {
+                let result = {
+                    let existing = Self::current_state(state);
+                    if existing.items.get(&uid).is_none() {
+                        Err(ProfilesError::ProfileNotFound(uid.clone()))
+                    } else if let Some(referrers) = Self::referrers_of(state, &existing, &uid) {
+                        Err(ProfilesError::ProfileInUse { referrers })
+                    } else {
+                        let removed = existing.items.get(&uid).cloned();
+                        let post_ops = removed
+                            .as_ref()
+                            .and_then(|item| item.definition.source())
+                            .map(|source| {
+                                // 图 13.5:Managed/Remote 删物化文件;External Symlink
+                                // 只删应用管理的链接;Mirror 删副本;target 永不动
+                                vec![PostCommitOp::Remove {
+                                    path: source.materialized().file.clone(),
+                                }]
+                            })
+                            .unwrap_or_default(); // Composition:无文件操作
+                        Self::run_write(state, move |profiles| {
+                            profiles.remove_item_unchecked(&uid);
+                            Ok(WriteOutcome { affects: AffectsRule::Never, post_ops })
+                        })
+                        .await
+                    }
+                };
+                let _ = reply.send(result);
+            }
+```
+
+client 方法:
+
+```rust
+    pub async fn add(&self, request: NewProfileRequest, initial_file: Option<String>) -> Result<CommitReport, ProfilesError> {
+        self.call(|reply| ProfilesActorMessage::Add { request, initial_file, reply }, None).await
+    }
+
+    pub async fn delete(&self, uid: ProfileId) -> Result<CommitReport, ProfilesError> {
+        self.call(|reply| ProfilesActorMessage::Delete { uid, reply }, None).await
+    }
+```
+
+- [ ] **Step 4: 跑测试确认通过 + Commit**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu add_ delete_ set_ fresh_store`
+Expected: 全 PASS。
+
+```bash
+git add backend/tauri/src/state/profiles/actor.rs backend/tauri/src/client/profiles.rs
+git commit -m "feat(tauri): add profile create/delete with reference protection"
+```
+
+---
+
+### Task 4: Reorder + PatchMetadata + PatchRemoteOptions + ReplaceDefinition
+
+**Files:**
+
+- Modify: `backend/tauri/src/state/profiles/actor.rs`、`backend/tauri/src/client/profiles.rs`
+
+- [ ] **Step 1: 写失败测试**
+
+```rust
+    #[tokio::test]
+    async fn reorder_move_and_by_list() {
+        let (client, _dir) = seeded_client().await;
+        let report = client
+            .reorder(ReorderOp::Move { active: ProfileId("cfg2".into()), over: ProfileId("cfg1".into()) })
+            .await
+            .unwrap();
+        assert!(!report.affects_current);
+        let uids: Vec<_> = report.snapshot.items.keys().map(|u| u.0.clone()).collect();
+        assert_eq!(uids, vec!["cfg2", "cfg1", "ovl1"]);
+
+        let report = client
+            .reorder(ReorderOp::ByList(vec![
+                ProfileId("ovl1".into()), ProfileId("cfg1".into()), ProfileId("cfg2".into()),
+            ]))
+            .await
+            .unwrap();
+        let uids: Vec<_> = report.snapshot.items.keys().map(|u| u.0.clone()).collect();
+        assert_eq!(uids, vec!["ovl1", "cfg1", "cfg2"]);
+
+        // 非置换列表 → 错误(缺元素)
+        let err = client.reorder(ReorderOp::ByList(vec![ProfileId("cfg1".into())])).await.unwrap_err();
+        assert!(matches!(err, ProfilesError::ValidationFailed(_) | ProfilesError::ProfileNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn patch_metadata_and_remote_options() {
+        let (client, _dir) = seeded_client().await;
+        let mut patch = ProfileMetadata { name: String::new(), desc: None }.new_empty_patch();
+        patch.name = Some("Renamed".into());
+        let report = client.patch_metadata(ProfileId("cfg1".into()), patch).await.unwrap();
+        assert!(!report.affects_current);
+        assert_eq!(report.snapshot.items[&ProfileId("cfg1".into())].metadata.name, "Renamed");
+
+        // 非 Remote → NotARemoteProfile
+        let options_patch = nyanpasu_config::profile::RemoteProfileOptions::default().new_empty_patch();
+        let err = client
+            .patch_remote_options(ProfileId("cfg1".into()), options_patch)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ProfilesError::NotARemoteProfile));
+    }
+
+    #[tokio::test]
+    async fn replace_definition_is_atomic_and_reports_closure_hit() {
+        let (client, _dir) = seeded_client().await;
+        client.set_current(Some(ProfileId("cfg1".into()))).await.unwrap();
+
+        // cfg1(current)追加 scoped transform → 闭包变化 → affects_current
+        let mut definition = seeded_profiles().items[&ProfileId("cfg1".into())].definition.clone();
+        if let ProfileDefinition::Config { config: ConfigDefinition::File(file) } = &mut definition {
+            file.transforms = vec![ProfileId("ovl1".into())];
+        }
+        let report = client
+            .replace_definition(ProfileId("cfg1".into()), definition)
+            .await
+            .unwrap();
+        assert!(report.affects_current);
+
+        // 闭包外的 cfg2 变更 → 不影响
+        let definition = seeded_profiles().items[&ProfileId("cfg2".into())].definition.clone();
+        let report = client.replace_definition(ProfileId("cfg2".into()), definition).await.unwrap();
+        assert!(!report.affects_current);
+
+        // scoped transform 被引用后,删除 ovl1 → ProfileInUse{referrers=[cfg1]}
+        let err = client.delete(ProfileId("ovl1".into())).await.unwrap_err();
+        match err {
+            ProfilesError::ProfileInUse { referrers } => {
+                assert_eq!(referrers, vec![ProfileId("cfg1".into())]);
+            }
+            other => panic!("expected ProfileInUse, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu reorder_ patch_metadata replace_definition`
+Expected: FAIL。
+
+- [ ] **Step 3: 实现四消息**
+
+消息变体:
+
+```rust
+    Reorder { op: ReorderOp, reply: RpcReplyPort<Result<CommitReport, ProfilesError>> },
+    PatchMetadata {
+        uid: ProfileId,
+        patch: nyanpasu_config::profile::ProfileMetadataPatch,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    PatchRemoteOptions {
+        uid: ProfileId,
+        patch: nyanpasu_config::profile::RemoteProfileOptionsPatch,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+    ReplaceDefinition {
+        uid: ProfileId,
+        definition: ProfileDefinition,
+        reply: RpcReplyPort<Result<CommitReport, ProfilesError>>,
+    },
+```
+
+handler 分支:
+
+```rust
+            ProfilesActorMessage::Reorder { op, reply } => {
+                let result = Self::run_write(state, move |profiles| {
+                    match op {
+                        ReorderOp::Move { active, over } => {
+                            if profiles.items.get(&active).is_none() {
+                                return Err(ProfilesError::ProfileNotFound(active));
+                            }
+                            if profiles.items.get(&over).is_none() {
+                                return Err(ProfilesError::ProfileNotFound(over));
+                            }
+                            profiles.reorder(&active, &over);
+                        }
+                        ReorderOp::ByList(list) => {
+                            // 必须是现有 uid 集的一个置换
+                            if list.len() != profiles.items.len() {
+                                return Err(ProfilesError::ValidationFailed(vec![]));
+                            }
+                            let mut reordered = indexmap::IndexMap::with_capacity(list.len());
+                            for uid in list {
+                                let Some(item) = profiles.items.shift_remove(&uid) else {
+                                    return Err(ProfilesError::ProfileNotFound(uid));
+                                };
+                                reordered.insert(uid, item);
+                            }
+                            profiles.items = reordered;
+                        }
+                    }
+                    Ok(WriteOutcome { affects: AffectsRule::Never, post_ops: vec![] })
+                })
+                .await;
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::PatchMetadata { uid, patch, reply } => {
+                let result = Self::run_write(state, move |profiles| {
+                    let Some(item) = profiles.items.get_mut(&uid) else {
+                        return Err(ProfilesError::ProfileNotFound(uid));
+                    };
+                    item.apply_metadata_patch(patch);
+                    Ok(WriteOutcome { affects: AffectsRule::Never, post_ops: vec![] })
+                })
+                .await;
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::PatchRemoteOptions { uid, patch, reply } => {
+                let result = Self::run_write(state, move |profiles| {
+                    let Some(item) = profiles.items.get_mut(&uid) else {
+                        return Err(ProfilesError::ProfileNotFound(uid));
+                    };
+                    match item.definition.source_mut() {
+                        Some(nyanpasu_config::profile::ProfileSource::Remote { option, .. }) => {
+                            use struct_patch::Patch as _;
+                            option.apply(patch);
+                            Ok(WriteOutcome { affects: AffectsRule::Never, post_ops: vec![] })
+                        }
+                        _ => Err(ProfilesError::NotARemoteProfile),
+                    }
+                })
+                .await;
+                let _ = reply.send(result);
+            }
+            ProfilesActorMessage::ReplaceDefinition { uid, definition, reply } => {
+                let result = Self::run_write(state, move |profiles| {
+                    let Some(item) = profiles.items.get_mut(&uid) else {
+                        return Err(ProfilesError::ProfileNotFound(uid.clone()));
+                    };
+                    item.set_definition(definition);
+                    Ok(WriteOutcome { affects: AffectsRule::Touched(uid), post_ops: vec![] })
+                })
+                .await;
+                let _ = reply.send(result);
+            }
+```
+
+client 方法(签名同 T04 卡 Produces,全部 `call(_, None)`):`reorder`、`patch_metadata`、`patch_remote_options`、`replace_definition`。
+
+(注:ByList 的空 `ValidationFailed(vec![])` 若语义不适,可在 `ProfilesError` 增 `InvalidReorderList` 变体——执行时二选一并回写卡。)
+
+- [ ] **Step 4: 跑全部 T04 测试 + 纯度断言 + Commit**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu --lib profiles`
+Expected: 全 PASS。
+Run(Git Bash): `grep -rn "tauri::\|crate::config" backend/tauri/src/state/profiles/ backend/tauri/src/client/profiles.rs && echo LEAK || echo CLEAN`
+Expected: `CLEAN`。
+Run(Git Bash): `grep -n "call(" backend/tauri/src/client/profiles.rs` — 人工核对:唯一 `Some(PROFILES_READ_TIMEOUT)` 出现在 `get`,其余全为 `None`。
+
+```bash
+git add backend/tauri/src/state/profiles/actor.rs backend/tauri/src/client/profiles.rs
+git commit -m "feat(tauri): complete profiles actor synchronous write protocol"
+```
+
+---
+
+### Task 5: 契约回写 + 全量回归
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md`(T04 卡)
+
+- [ ] **Step 1: 全量回归**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu && cargo clippy --manifest-path ./backend/Cargo.toml -p clash-nyanpasu --all-targets --all-features`
+Expected: 全绿(clippy 无新警告)。
+
+- [ ] **Step 2: 按「契约修正」节 1–6 更新 T04 卡(Args/CommitReport.warnings/Persist 变体/Add 路径规约/加载策略/affects_current 规则表),并同步 T05/T07 卡的 Consumes 引用**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+git commit -m "docs(pr3): record T04 contract addenda (args, warnings, affects rules)"
+```
+
+---
+
+## 验证总表(对应 T04 卡验证段)
+
+| 判据                                       | 覆盖                                                   |
+| ------------------------------------------ | ------------------------------------------------------ |
+| 每条消息 happy path                        | Task 2/3/4 逐消息测试                                  |
+| `ValidationFailed` 不落盘不改内存          | Task 2 `set_current_rejects_...`(重启持久性另证)       |
+| Delete 引用保护(current/global/item 级)    | Task 3 `delete_enforces_...` + Task 4 referrers 断言   |
+| `affects_current` 判定(闭包内/外)          | Task 2 SetCurrent/SetGlobal + Task 4 ReplaceDefinition |
+| Add 写初始文件、Delete 按 binding 清理     | Task 3 mock 期望(Managed/清理失败降级)                 |
+| 写 `call(_,None)`、读 `call(_,Some)`       | Task 4 Step 4 grep 核对                                |
+| 不 sleep                                   | 全部测试经 RpcReplyPort ack                            |
+| `cargo test -p clash-nyanpasu profiles` 绿 | Task 4 Step 4 / Task 5 Step 1                          |

--- a/docs/superpowers/plans/2026-07-06-pr3-t05-refresh-scheduler-watcher.md
+++ b/docs/superpowers/plans/2026-07-06-pr3-t05-refresh-scheduler-watcher.md
@@ -1,0 +1,936 @@
+# PR-3 T05 — RefreshRemote + RemoteUpdateScheduler + External watcher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 订阅刷新与外部文件同步纳入 ProfilesActor:下载-提交分离(`RefreshRemote` 挂起 reply → 子任务下载写盘 → `CommitRefreshed` 串行提交)、定时表幂等 reconcile(含启动补课)、External Symlink/Mirror watcher、后台提交且影响 current 时经 `RebuildNotifier` 通知恰好一次。
+
+**Architecture:** 全部提交仍串行于 actor(T04 `run_write` 复用);写 handler **零网络 I/O**(D9)——`RefreshRemote` 只做校验 + 可选 options patch 事务 + spawn 下载任务;下载任务(tokio::spawn)自己 fetch → 按目标类型校验 → `ensure_not_symlink` → `write_atomic`,完成后 `cast(CommitRefreshed)` 回填。scheduler = actor 内维护的 per-uid tokio 定时任务表(`post_start` 首次 reconcile,每次 commit 后按 diff 增删,语义对齐旧 `ProfilesJob::{refresh,diff,init}`);watcher = notify-debouncer-full(先例 `logging/manager.rs:252`),事件 → `cast(ExternalFileChanged)`。定时逻辑走 tokio 时间,测试用 `start_paused` + `advance`(零真实 sleep)。
+
+**Tech Stack:** T04 actor/事务、T03 ports(mock)、tokio 时间轮、notify 8 + notify-debouncer-full 0.7(已有)、`time::OffsetDateTime`。
+
+## Global Constraints(task.md §0)
+
+- 写 handler 禁无界 I/O;下载超时由 fetcher 实现自管(T03)。
+- 挂起 reply 必结清(成功/失败/uid 已删三路径)。
+- 测试不真实 sleep:定时用 `#[tokio::test(start_paused = true)]` + `tokio::time::advance`;watcher 处理逻辑经直接注入消息测试,真实文件事件仅一个有界(≤5s)接线冒烟。
+- `state/profiles/**` 维持 Tauri-free/Config-free(grep 断言)。
+
+## 基线事实(2026-07-06 实测)
+
+- 被取代者语义(`core/tasks/jobs/profiles.rs`):interval 单位分钟、仅 `interval > 0` 建任务(新 schema 验证已禁 0)、diff 三操作(Add/Remove/Update)、**`init()` 启动补课:`now - updated >= interval` → 立即刷新**(`:84-115`)。
+- watcher 先例:`logging/manager.rs:6-9,252`(`new_debouncer(timeout, None, callback)` + `RecommendedWatcher` + `DebounceEventResult`)。
+- 刷新对象 = 一切 `ProfileSource::Remote` 的文件型 item(含 URL-file 迁移产生的 Remote Overlay/Script,比旧实现仅 remote config 更宽——记入契约补遗)。
+
+## 契约补遗(执行后回写 T03/T04/T05 卡,§5.3)
+
+1. `ProfilesActorMessage::RefreshRemote` 的 reply 形态 = `Option<RpcReplyPort<...>>`(后台定时触发无 reply;卡内草签为必选)。
+2. **`ProfileFsPort` 增加 `read_external(&ExternalProfilePath) -> anyhow::Result<String>`**(Mirror 同步需读外部 target;T03 的 service 补实现,mock 同步再生成)。
+3. 同 uid 刷新进行中再次 `RefreshRemote` → 立即 `RefreshFailed{"refresh already in progress"}`(不排队;避免 pending 表复杂化)。
+4. `CommitRefreshed` 时 uid 已删 → 丢弃结果、结清 reply(`RefreshFailed{"profile deleted during refresh"}`)、best-effort 删除下载任务刚写下的孤儿文件。
+5. 刷新成功的事务:更新 `materialized.updated_at = now` + `subscription`;`AffectsRule::Touched(uid)`(复用 T04 闭包判定);后台提交(reply=None)且 affects → `notifier.request_rebuild()` 恰好一次。
+6. `ExternalFileChanged` 语义:Symlink → 事务 bump `updated_at`(链接目标内容已变);Mirror → `read_external(target)` → 按 kind 校验(Config/Overlay=YAML mapping、Script=非空文本)→ `write_atomic` 镜像副本 → 事务 bump。
+
+---
+
+### Task 1: `RefreshRemote`/`CommitRefreshed` 下载-提交分离
+
+**Files:**
+
+- Modify: `backend/tauri/src/state/profiles/actor.rs`(新消息 + `pending_refresh` 表 + 下载任务)
+- Modify: `backend/tauri/src/client/profiles.rs`(`refresh` 方法)
+- Modify: `backend/tauri/src/state/profiles/ports.rs`(`read_external`,Task 3 才消费,此处一并加避免 mock 两次再生成)
+- Modify: `backend/tauri/src/service/profile_file.rs`(`read_external` 实现:`std::fs::read_to_string(target.as_path())`)
+
+**Interfaces:**
+
+- Produces(T07/T08 依赖):`ProfilesClient::refresh(uid: ProfileId, patch: Option<RemoteProfileOptionsPatch>) -> Result<CommitReport, ProfilesError>`。
+
+- [ ] **Step 1: 写失败测试(client/profiles.rs tests)**
+
+```rust
+    use nyanpasu_config::profile::{RemoteProfileOptions, SubscriptionInfo};
+    use crate::state::profiles::ports::FetchedSubscription;
+
+    pub(crate) fn remote_config_item(uid: &str) -> nyanpasu_config::profile::ProfileItem {
+        nyanpasu_config::profile::ProfileItem {
+            uid: ProfileId(uid.into()),
+            metadata: ProfileMetadata { name: uid.to_uppercase(), desc: None },
+            definition: ProfileDefinition::Config {
+                config: ConfigDefinition::File(FileConfig {
+                    source: ProfileSource::Remote {
+                        materialized: MaterializedFile {
+                            file: ManagedProfilePath::new(format!("{uid}.yaml")).unwrap(),
+                            updated_at: None,
+                        },
+                        url: url::Url::parse("https://example.com/sub").unwrap(),
+                        option: RemoteProfileOptions::default(),
+                        subscription: SubscriptionInfo::default(),
+                    },
+                    transforms: vec![],
+                }),
+            },
+        }
+    }
+
+    fn ok_fetch(content: &'static str) -> MockSubscriptionFetcher {
+        let mut fetcher = MockSubscriptionFetcher::new();
+        fetcher.expect_fetch().returning(move |_, _| {
+            Ok(FetchedSubscription {
+                content: content.to_string(),
+                filename: None,
+                subscription: SubscriptionInfo { upload: Some(1), ..Default::default() },
+            })
+        });
+        fetcher
+    }
+
+    async fn remote_seeded_client(
+        fs: MockProfileFsPort,
+        fetcher: MockSubscriptionFetcher,
+        notifier: MockRebuildNotifier,
+    ) -> (ProfilesClient, TempDir) {
+        let dir = tempdir().unwrap();
+        let client = ProfilesClient::new(
+            temp_profiles_path(&dir),
+            std::sync::Arc::new(fs),
+            std::sync::Arc::new(fetcher),
+            std::sync::Arc::new(notifier),
+        )
+        .await
+        .unwrap();
+        let mut profiles = Profiles::default();
+        profiles.append_item(remote_config_item("r1"));
+        client.replace(profiles).await.unwrap();
+        (client, dir)
+    }
+
+    #[tokio::test]
+    async fn refresh_downloads_writes_and_commits_subscription() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_ensure_not_symlink().returning(|_| Ok(()));
+        fs.expect_write_atomic()
+            .withf(|path, content| path.as_str() == "r1.yaml" && content == "proxies: []\n")
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let (client, _dir) =
+            remote_seeded_client(fs, ok_fetch("proxies: []\n"), MockRebuildNotifier::new()).await;
+
+        let report = client.refresh(ProfileId("r1".into()), None).await.expect("refresh ok");
+        let item = &report.snapshot.items[&ProfileId("r1".into())];
+        let source = item.definition.source().unwrap();
+        assert!(source.materialized().updated_at.is_some());
+        match source {
+            ProfileSource::Remote { subscription, .. } => {
+                assert_eq!(subscription.upload, Some(1));
+            }
+            _ => unreachable!(),
+        }
+        // r1 不在闭包内(无 current)→ 前台刷新不触发 notifier(mock 无期望即断言零调用)
+        assert!(!report.affects_current);
+    }
+
+    #[tokio::test]
+    async fn refresh_failure_settles_reply_with_error() {
+        let mut fetcher = MockSubscriptionFetcher::new();
+        fetcher.expect_fetch().returning(|_, _| anyhow::bail!("dns exploded"));
+        let (client, _dir) =
+            remote_seeded_client(MockProfileFsPort::new(), fetcher, MockRebuildNotifier::new()).await;
+        let err = client.refresh(ProfileId("r1".into()), None).await.unwrap_err();
+        assert!(matches!(err, ProfilesError::RefreshFailed { .. }));
+        // 状态未被污染
+        let snapshot = client.get().await.unwrap();
+        let source = snapshot.items[&ProfileId("r1".into())].definition.source().unwrap();
+        assert!(source.materialized().updated_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn refresh_rejects_non_remote_and_unknown_and_concurrent() {
+        let (client, _dir) = seeded_client().await; // cfg1/cfg2/ovl1,全 Local
+        let err = client.refresh(ProfileId("cfg1".into()), None).await.unwrap_err();
+        assert!(matches!(err, ProfilesError::NotARemoteProfile));
+        let err = client.refresh(ProfileId("ghost".into()), None).await.unwrap_err();
+        assert!(matches!(err, ProfilesError::ProfileNotFound(_)));
+
+        // 并发拒绝:第一个挂起(慢 fetcher),第二个立即失败
+        let mut fetcher = MockSubscriptionFetcher::new();
+        fetcher.expect_fetch().returning(|_, _| {
+            std::thread::sleep(std::time::Duration::from_millis(200)); // fetcher 内部延迟(spawn 线程侧)
+            Ok(FetchedSubscription {
+                content: "a: 1\n".into(),
+                filename: None,
+                subscription: SubscriptionInfo::default(),
+            })
+        });
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_ensure_not_symlink().returning(|_| Ok(()));
+        fs.expect_write_atomic().returning(|_, _| Ok(()));
+        let (client, _dir) = remote_seeded_client(fs, fetcher, MockRebuildNotifier::new()).await;
+        let c2 = client.clone();
+        let first = tokio::spawn(async move { c2.refresh(ProfileId("r1".into()), None).await });
+        // 有界等待第一个进入 pending(轮询 in-progress 错误出现前的窗口)
+        let err = loop {
+            match client.refresh(ProfileId("r1".into()), None).await {
+                Err(ProfilesError::RefreshFailed { message }) if message.contains("in progress") => {
+                    break ProfilesError::RefreshFailed { message };
+                }
+                Ok(_) => panic!("second refresh must not both succeed before first settles"),
+                Err(_) => tokio::task::yield_now().await,
+            }
+        };
+        assert!(matches!(err, ProfilesError::RefreshFailed { .. }));
+        first.await.unwrap().expect("first refresh completes");
+    }
+```
+
+(注:并发测试用真实多任务而非 paused time——fetcher 的 200ms 延迟发生在 mockall 同步闭包内,由下载任务的 `spawn_blocking`/异步适配吸收;若实现选择纯异步 fetch,把延迟改为 `tokio::time::sleep` 并配合真实时钟,上限仍 <1s。)
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu refresh_`
+Expected: FAIL(`refresh` 未定义)。
+
+- [ ] **Step 3: 实现**
+
+ports.rs `ProfileFsPort` 追加:
+
+```rust
+    /// Mirror 同步读外部 target(clean-design §10.2)。
+    fn read_external(&self, target: &ExternalProfilePath) -> anyhow::Result<String>;
+```
+
+service impl:
+
+```rust
+    fn read_external(&self, target: &ExternalProfilePath) -> anyhow::Result<String> {
+        std::fs::read_to_string(target.as_path())
+            .with_context(|| format!("read external profile target {target}"))
+    }
+```
+
+actor.rs 追加:
+
+```rust
+#[derive(Debug)]
+pub enum RefreshOutcome {
+    Succeeded {
+        subscription: nyanpasu_config::profile::SubscriptionInfo,
+    },
+    Failed {
+        message: String,
+    },
+}
+
+// 消息变体:
+    /// reply=None ⇒ 后台定时触发(补遗 #1)
+    RefreshRemote {
+        uid: ProfileId,
+        patch: Option<nyanpasu_config::profile::RemoteProfileOptionsPatch>,
+        reply: Option<RpcReplyPort<Result<CommitReport, ProfilesError>>>,
+    },
+    /// 内部消息:下载任务完成回填(不出现在 client API)
+    CommitRefreshed { uid: ProfileId, outcome: RefreshOutcome },
+```
+
+State 追加 `pending_refresh: std::collections::HashMap<ProfileId, Option<RpcReplyPort<Result<CommitReport, ProfilesError>>>>`(`pre_start` 初始化为空表)。
+
+handler:
+
+```rust
+            ProfilesActorMessage::RefreshRemote { uid, patch, reply } => {
+                let settle_err = |reply: Option<RpcReplyPort<_>>, err: ProfilesError| {
+                    if let Some(reply) = reply {
+                        let _ = reply.send(Err(err));
+                    }
+                };
+                if state.pending_refresh.contains_key(&uid) {
+                    settle_err(reply, ProfilesError::RefreshFailed {
+                        message: "refresh already in progress".into(),
+                    });
+                    return Ok(());
+                }
+                // 可选 options patch:先走标准事务(失败→结清 reply,不 spawn)
+                if let Some(patch) = patch {
+                    let patched = Self::run_write(state, {
+                        let uid = uid.clone();
+                        move |profiles| {
+                            let Some(item) = profiles.items.get_mut(&uid) else {
+                                return Err(ProfilesError::ProfileNotFound(uid.clone()));
+                            };
+                            match item.definition.source_mut() {
+                                Some(nyanpasu_config::profile::ProfileSource::Remote { option, .. }) => {
+                                    use struct_patch::Patch as _;
+                                    option.apply(patch);
+                                    Ok(WriteOutcome { affects: AffectsRule::Never, post_ops: vec![] })
+                                }
+                                _ => Err(ProfilesError::NotARemoteProfile),
+                            }
+                        }
+                    })
+                    .await;
+                    if let Err(err) = patched {
+                        settle_err(reply, err);
+                        return Ok(());
+                    }
+                }
+                // 快照校验 + 提取下载参数(handler 内零网络 I/O,D9)
+                let snapshot = Self::current_state(state);
+                let Some(item) = snapshot.items.get(&uid) else {
+                    settle_err(reply, ProfilesError::ProfileNotFound(uid.clone()));
+                    return Ok(());
+                };
+                let Some(nyanpasu_config::profile::ProfileSource::Remote { url, option, materialized, .. }) =
+                    item.definition.source()
+                else {
+                    settle_err(reply, ProfilesError::NotARemoteProfile);
+                    return Ok(());
+                };
+                let kind = item.definition.clone();
+                let (url, option, path) = (url.clone(), option.clone(), materialized.file.clone());
+                state.pending_refresh.insert(uid.clone(), reply);
+                let fetcher = state.fetcher.clone();
+                let fs = state.fs.clone();
+                let actor = myself.clone();
+                tokio::spawn(async move {
+                    let outcome = async {
+                        let fetched = fetcher
+                            .fetch(&url, &option)
+                            .await
+                            .map_err(|e| format!("download failed: {e}"))?;
+                        validate_fetched_content(&kind, &fetched.content)?;
+                        fs.ensure_not_symlink(&path).map_err(|e| e.to_string())?;
+                        fs.write_atomic(&path, &fetched.content).map_err(|e| e.to_string())?;
+                        Ok::<_, String>(fetched.subscription)
+                    }
+                    .await;
+                    let outcome = match outcome {
+                        Ok(subscription) => RefreshOutcome::Succeeded { subscription },
+                        Err(message) => RefreshOutcome::Failed { message },
+                    };
+                    let _ = actor.cast(ProfilesActorMessage::CommitRefreshed { uid, outcome });
+                });
+            }
+            ProfilesActorMessage::CommitRefreshed { uid, outcome } => {
+                let reply = state.pending_refresh.remove(&uid).flatten();
+                let snapshot = Self::current_state(state);
+                if snapshot.items.get(&uid).is_none() {
+                    // 竞态:刷新期间被删——丢弃结果、清孤儿文件、结清 reply(补遗 #4)
+                    if let RefreshOutcome::Succeeded { .. } = outcome {
+                        // 下载任务可能刚写回文件;路径已不可从状态取得,按规范路径推导清理
+                        // (uid 前缀规范保证 {uid}.yaml/.js/.lua 之一;三者都尝试 best-effort)
+                        for ext in ["yaml", "js", "lua"] {
+                            if let Ok(path) = nyanpasu_config::profile::ManagedProfilePath::new(
+                                format!("{uid}.{ext}"),
+                            ) {
+                                let _ = state.fs.remove(&path);
+                            }
+                        }
+                    }
+                    if let Some(reply) = reply {
+                        let _ = reply.send(Err(ProfilesError::RefreshFailed {
+                            message: "profile deleted during refresh".into(),
+                        }));
+                    }
+                    return Ok(());
+                }
+                let result = match outcome {
+                    RefreshOutcome::Failed { message } => Err(ProfilesError::RefreshFailed { message }),
+                    RefreshOutcome::Succeeded { subscription } => {
+                        Self::run_write(state, {
+                            let uid = uid.clone();
+                            move |profiles| {
+                                let Some(item) = profiles.items.get_mut(&uid) else {
+                                    return Err(ProfilesError::ProfileNotFound(uid.clone()));
+                                };
+                                match item.definition.source_mut() {
+                                    Some(nyanpasu_config::profile::ProfileSource::Remote {
+                                        materialized, subscription: slot, ..
+                                    }) => {
+                                        materialized.updated_at =
+                                            Some(time::OffsetDateTime::now_utc());
+                                        *slot = subscription;
+                                        Ok(WriteOutcome {
+                                            affects: AffectsRule::Touched(uid.clone()),
+                                            post_ops: vec![],
+                                        })
+                                    }
+                                    _ => Err(ProfilesError::NotARemoteProfile),
+                                }
+                            }
+                        })
+                        .await
+                    }
+                };
+                // 后台提交(reply=None)且影响 current → 通知重建恰好一次(补遗 #5)
+                if reply.is_none() {
+                    if let Ok(report) = &result {
+                        if report.affects_current {
+                            state.notifier.request_rebuild();
+                        }
+                    }
+                }
+                if let Some(reply) = reply {
+                    let _ = reply.send(result);
+                }
+            }
+```
+
+内容校验辅助(actor.rs 内自由函数):
+
+```rust
+/// 按目标 Profile 类型校验下载内容(design 图 13.3):Config File 与 Overlay 必须
+/// 是 YAML mapping;Script 只要求非空文本。
+fn validate_fetched_content(
+    definition: &ProfileDefinition,
+    content: &str,
+) -> Result<(), String> {
+    let needs_yaml = match definition {
+        ProfileDefinition::Config { .. } => true,
+        ProfileDefinition::Transform { transform } => matches!(
+            transform,
+            nyanpasu_config::profile::TransformDefinition::Overlay(_)
+        ),
+    };
+    if needs_yaml {
+        serde_yaml::from_str::<serde_yaml::Mapping>(content)
+            .map(|_| ())
+            .map_err(|e| format!("downloaded content is not a YAML mapping: {e}"))
+    } else if content.trim().is_empty() {
+        Err("downloaded script is empty".into())
+    } else {
+        Ok(())
+    }
+}
+```
+
+client 方法:
+
+```rust
+    pub async fn refresh(
+        &self,
+        uid: ProfileId,
+        patch: Option<nyanpasu_config::profile::RemoteProfileOptionsPatch>,
+    ) -> Result<CommitReport, ProfilesError> {
+        self.call(
+            |reply| ProfilesActorMessage::RefreshRemote { uid, patch, reply: Some(reply) },
+            None,
+        )
+        .await
+    }
+```
+
+(`handle` 签名此前忽略 `myself`——本 Task 起改用 `myself: ActorRef<Self::Msg>` 绑定名。)
+
+- [ ] **Step 4: 跑测试确认通过 + Commit**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu refresh_`
+Expected: 全 PASS(含 T03/T04 既有测试回归)。
+
+```bash
+git add backend/tauri/src/state/profiles backend/tauri/src/client/profiles.rs backend/tauri/src/service/profile_file.rs
+git commit -m "feat(tauri): add download-commit split remote refresh to profiles actor"
+```
+
+---
+
+### Task 2: RemoteUpdateScheduler(定时表 reconcile + 启动补课)
+
+**Files:**
+
+- Create: `backend/tauri/src/state/profiles/scheduler.rs`
+- Modify: `backend/tauri/src/state/profiles/{mod.rs, actor.rs}`
+
+**Interfaces:**
+
+- 对外不可见(actor 内部);`ProfilesActorState` 增 `scheduler: RemoteUpdateScheduler`。
+
+- [ ] **Step 1: 写失败测试(paused time,零真实 sleep)**
+
+```rust
+    #[tokio::test(start_paused = true)]
+    async fn scheduler_fires_refresh_on_interval() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_ensure_not_symlink().returning(|_| Ok(()));
+        fs.expect_write_atomic().returning(|_, _| Ok(()));
+        let fetch_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut fetcher = MockSubscriptionFetcher::new();
+        let counter = fetch_count.clone();
+        fetcher.expect_fetch().returning(move |_, _| {
+            counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(FetchedSubscription {
+                content: "a: 1\n".into(),
+                filename: None,
+                subscription: SubscriptionInfo::default(),
+            })
+        });
+        let (client, _dir) =
+            remote_seeded_client(fs, fetcher, MockRebuildNotifier::new()).await;
+        // remote_config_item 的 interval = 默认 120 分钟;updated_at=None → 无补课
+        assert_eq!(fetch_count.load(std::sync::atomic::Ordering::SeqCst), 0);
+        tokio::time::advance(std::time::Duration::from_secs(120 * 60 + 1)).await;
+        // 有界等待 cast→下载→CommitRefreshed 链路排空
+        for _ in 0..200 {
+            if fetch_count.load(std::sync::atomic::Ordering::SeqCst) >= 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(fetch_count.load(std::sync::atomic::Ordering::SeqCst) >= 1);
+        drop(client);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn scheduler_reconcile_add_remove_and_kind_switch() {
+        let fetch_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut fetcher = MockSubscriptionFetcher::new();
+        let counter = fetch_count.clone();
+        fetcher.expect_fetch().returning(move |_, _| {
+            counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            anyhow::bail!("count only")
+        });
+        let (client, _dir) = remote_seeded_client(
+            MockProfileFsPort::new(),
+            fetcher,
+            MockRebuildNotifier::new(),
+        )
+        .await;
+        // 删除 r1 → 定时任务应被拆除
+        client.delete(ProfileId("r1".into())).await.unwrap();
+        tokio::time::advance(std::time::Duration::from_secs(240 * 60)).await;
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(fetch_count.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn scheduler_catches_up_overdue_profiles_on_start() {
+        // updated_at = 很久以前 → post_start reconcile 立即触发一次(旧 init() 语义)
+        let fetch_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut fetcher = MockSubscriptionFetcher::new();
+        let counter = fetch_count.clone();
+        fetcher.expect_fetch().returning(move |_, _| {
+            counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            anyhow::bail!("count only")
+        });
+        let dir = tempdir().unwrap();
+        // 先用一个 client 写入「已过期」的 remote item,再重启触发补课
+        {
+            let client = ProfilesClient::new(
+                temp_profiles_path(&dir),
+                std::sync::Arc::new(MockProfileFsPort::new()),
+                std::sync::Arc::new(MockSubscriptionFetcher::new()),
+                std::sync::Arc::new(MockRebuildNotifier::new()),
+            )
+            .await
+            .unwrap();
+            let mut item = remote_config_item("r1");
+            if let Some(source) = item.definition.source_mut() {
+                source.materialized_mut().updated_at = Some(
+                    time::OffsetDateTime::now_utc() - time::Duration::days(30),
+                );
+            }
+            let mut profiles = Profiles::default();
+            profiles.append_item(item);
+            client.replace(profiles).await.unwrap();
+        }
+        let _client = ProfilesClient::new(
+            temp_profiles_path(&dir),
+            std::sync::Arc::new(MockProfileFsPort::new()),
+            std::sync::Arc::new(fetcher),
+            std::sync::Arc::new(MockRebuildNotifier::new()),
+        )
+        .await
+        .unwrap();
+        for _ in 0..200 {
+            if fetch_count.load(std::sync::atomic::Ordering::SeqCst) >= 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(fetch_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu scheduler_`
+Expected: FAIL(post_start 未 reconcile,定时不触发)。
+
+- [ ] **Step 3: 实现 `scheduler.rs`**
+
+```rust
+//! Per-uid remote refresh timers. Owned by the ProfilesActor; reconciled
+//! idempotently after every commit (design §7/D8; semantics ported from the
+//! legacy ProfilesJob diff, core/tasks/jobs/profiles.rs).
+
+use std::collections::HashMap;
+
+use nyanpasu_config::profile::{ProfileId, ProfileSource, Profiles};
+use ractor::ActorRef;
+use tokio::task::JoinHandle;
+
+use super::actor::ProfilesActorMessage;
+
+struct Entry {
+    interval_minutes: u64,
+    handle: JoinHandle<()>,
+}
+
+#[derive(Default)]
+pub(super) struct RemoteUpdateScheduler {
+    entries: HashMap<ProfileId, Entry>,
+}
+
+impl RemoteUpdateScheduler {
+    /// 幂等 reconcile:新增/修改/移除三类 diff;`catch_up` 时对「已过期」的
+    /// profile 立即触发一次(旧 init() 补课语义)。
+    pub(super) fn reconcile(
+        &mut self,
+        profiles: &Profiles,
+        actor: &ActorRef<ProfilesActorMessage>,
+        catch_up: bool,
+    ) {
+        let desired: HashMap<ProfileId, (u64, Option<time::OffsetDateTime>)> = profiles
+            .items
+            .iter()
+            .filter_map(|(uid, item)| match item.definition.source() {
+                Some(ProfileSource::Remote { option, materialized, .. })
+                    if option.update_interval_minutes > 0 =>
+                {
+                    Some((
+                        uid.clone(),
+                        (option.update_interval_minutes, materialized.updated_at),
+                    ))
+                }
+                _ => None,
+            })
+            .collect();
+
+        // Remove / Update
+        let stale: Vec<ProfileId> = self
+            .entries
+            .iter()
+            .filter(|(uid, entry)| {
+                desired
+                    .get(*uid)
+                    .is_none_or(|(interval, _)| *interval != entry.interval_minutes)
+            })
+            .map(|(uid, _)| uid.clone())
+            .collect();
+        for uid in stale {
+            if let Some(entry) = self.entries.remove(&uid) {
+                entry.handle.abort();
+            }
+        }
+
+        // Add(含 Update 后重建)
+        for (uid, (interval_minutes, updated_at)) in desired {
+            if self.entries.contains_key(&uid) {
+                continue;
+            }
+            let overdue = catch_up
+                && updated_at.is_none_or(|at| {
+                    time::OffsetDateTime::now_utc() - at
+                        >= time::Duration::minutes(interval_minutes as i64)
+                });
+            let actor = actor.clone();
+            let tick_uid = uid.clone();
+            let handle = tokio::spawn(async move {
+                if overdue {
+                    let _ = actor.cast(ProfilesActorMessage::RefreshRemote {
+                        uid: tick_uid.clone(),
+                        patch: None,
+                        reply: None,
+                    });
+                }
+                let period = std::time::Duration::from_secs(interval_minutes * 60);
+                loop {
+                    tokio::time::sleep(period).await;
+                    let _ = actor.cast(ProfilesActorMessage::RefreshRemote {
+                        uid: tick_uid.clone(),
+                        patch: None,
+                        reply: None,
+                    });
+                }
+            });
+            self.entries.insert(uid, Entry { interval_minutes, handle });
+        }
+    }
+
+    pub(super) fn shutdown(&mut self) {
+        for (_, entry) in self.entries.drain() {
+            entry.handle.abort();
+        }
+    }
+}
+```
+
+actor 接线:
+
+- `ProfilesActorState` 增 `scheduler: RemoteUpdateScheduler`;
+- `post_start`(新增 lifecycle 方法)中 `state.scheduler.reconcile(&snapshot, &myself, true)`(catch_up = true;注意 `pre_start` 拿不到稳定 myself 引用时改在 `post_start`);
+- `run_write` 成功提交后追加 `state.scheduler.reconcile(&next, &myself, false)`——`run_write` 需要 `myself` 参数:签名改为 `run_write(myself: &ActorRef<Self::Msg>, state, mutate)`,全部调用点同步更新;
+- `post_stop` 调 `scheduler.shutdown()`。
+
+(catch_up 语义修正:updated_at=None 的 Remote 是「从未物化」——旧语义 `updated=0` 也会补课,故 `is_none_or` 分支对 None 触发补课;Task 1 测试 `scheduler_fires_refresh_on_interval` 里 updated_at=None——**该测试的 seed 需改为 updated_at=Some(now)** 以隔离「纯 interval 触发」,执行时以此为准。)
+
+- [ ] **Step 4: 跑测试确认通过 + Commit**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu scheduler_ refresh_`
+Expected: 全 PASS。
+
+```bash
+git add backend/tauri/src/state/profiles
+git commit -m "feat(tauri): add remote update scheduler with idempotent reconcile"
+```
+
+---
+
+### Task 3: External Symlink/Mirror watcher
+
+**Files:**
+
+- Modify: `backend/tauri/src/state/profiles/scheduler.rs`(watcher 表并入,或平行 `watchers: HashMap<ProfileId, Debouncer<...>>`)
+- Modify: `backend/tauri/src/state/profiles/actor.rs`(`ExternalFileChanged` 消息 + 处理)
+
+- [ ] **Step 1: 写失败测试(处理逻辑 = 注入消息,确定性)**
+
+```rust
+    fn external_item(uid: &str, mode: nyanpasu_config::profile::ExternalMode, target: &std::path::Path)
+        -> nyanpasu_config::profile::ProfileItem
+    {
+        nyanpasu_config::profile::ProfileItem {
+            uid: ProfileId(uid.into()),
+            metadata: ProfileMetadata { name: uid.to_uppercase(), desc: None },
+            definition: ProfileDefinition::Config {
+                config: ConfigDefinition::File(FileConfig {
+                    source: ProfileSource::Local {
+                        binding: nyanpasu_config::profile::LocalBinding::External {
+                            materialized: MaterializedFile {
+                                file: ManagedProfilePath::new(format!("{uid}.yaml")).unwrap(),
+                                updated_at: None,
+                            },
+                            target: nyanpasu_config::profile::ExternalProfilePath::new(
+                                target.to_string_lossy(),
+                            )
+                            .unwrap(),
+                            mode,
+                        },
+                    },
+                    transforms: vec![],
+                }),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn external_mirror_change_syncs_copy_and_bumps_updated_at() {
+        let temp_target = tempfile::tempdir().unwrap();
+        let target = temp_target.path().join("outside.yaml");
+        std::fs::write(&target, "mode: rule\n").unwrap();
+
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_read_external().returning(|_| Ok("mode: rule\n".to_string()));
+        fs.expect_write_atomic()
+            .withf(|path, content| path.as_str() == "m1.yaml" && content == "mode: rule\n")
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let (client, _dir) = test_client_with(fs).await;
+        let mut profiles = Profiles::default();
+        profiles.append_item(external_item(
+            "m1",
+            nyanpasu_config::profile::ExternalMode::Mirror,
+            &target,
+        ));
+        client.replace(profiles).await.unwrap();
+
+        client.debug_cast_external_changed(ProfileId("m1".into())).await;
+        // 有界等待事务提交(updated_at 出现)
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let snapshot = client.get().await.unwrap();
+            let source = snapshot.items[&ProfileId("m1".into())].definition.source().unwrap();
+            if source.materialized().updated_at.is_some() {
+                break;
+            }
+            assert!(std::time::Instant::now() < deadline, "mirror sync never committed");
+            tokio::task::yield_now().await;
+        }
+    }
+```
+
+(`debug_cast_external_changed` = client 上 `#[cfg(test)]` 辅助:`self.inner.actor_ref.cast(ProfilesActorMessage::ExternalFileChanged { uid })`。真实 notify 事件接线用一个有界冒烟测试:tempdir 建 Mirror item → 修改 target 文件 → ≤5s 轮询 `updated_at`;若 CI 文件事件不可靠,标注 `#[ignore]` 并在 PR 描述记录人工验证——执行时按实际稳定性定夺。)
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu external_`
+Expected: FAIL。
+
+- [ ] **Step 3: 实现**
+
+消息变体 + handler:
+
+```rust
+    /// 内部消息:watcher 检测到 External target 变化
+    ExternalFileChanged { uid: ProfileId },
+```
+
+```rust
+            ProfilesActorMessage::ExternalFileChanged { uid } => {
+                let snapshot = Self::current_state(state);
+                let Some(item) = snapshot.items.get(&uid) else { return Ok(()); };
+                let Some(nyanpasu_config::profile::ProfileSource::Local {
+                    binding:
+                        nyanpasu_config::profile::LocalBinding::External { materialized, target, mode },
+                }) = item.definition.source()
+                else {
+                    return Ok(());
+                };
+                let (path, target, mode, definition) = (
+                    materialized.file.clone(),
+                    target.clone(),
+                    *mode,
+                    item.definition.clone(),
+                );
+                // Mirror:读 target → 按 kind 校验 → 原子替换副本(本地 fs,允许在 handler 内)
+                if mode == nyanpasu_config::profile::ExternalMode::Mirror {
+                    let synced = state
+                        .fs
+                        .read_external(&target)
+                        .map_err(|e| e.to_string())
+                        .and_then(|content| {
+                            validate_fetched_content(&definition, &content).map(|_| content)
+                        })
+                        .and_then(|content| {
+                            state.fs.write_atomic(&path, &content).map_err(|e| e.to_string())
+                        });
+                    if let Err(message) = synced {
+                        tracing::warn!("mirror sync failed for {uid}: {message}");
+                        return Ok(());
+                    }
+                }
+                // Symlink 与 Mirror 共同:事务 bump updated_at;后台提交 affects → 通知
+                let result = Self::run_write(&myself, state, {
+                    let uid = uid.clone();
+                    move |profiles| {
+                        let Some(item) = profiles.items.get_mut(&uid) else {
+                            return Err(ProfilesError::ProfileNotFound(uid.clone()));
+                        };
+                        if let Some(source) = item.definition.source_mut() {
+                            source.materialized_mut().updated_at =
+                                Some(time::OffsetDateTime::now_utc());
+                        }
+                        Ok(WriteOutcome { affects: AffectsRule::Touched(uid.clone()), post_ops: vec![] })
+                    }
+                })
+                .await;
+                if let Ok(report) = result {
+                    if report.affects_current {
+                        state.notifier.request_rebuild();
+                    }
+                }
+            }
+```
+
+watcher 表(scheduler.rs 内平行结构,reconcile 时同步增删):
+
+```rust
+use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer};
+use notify_debouncer_full::notify::{RecommendedWatcher, RecursiveMode};
+
+pub(super) struct ExternalWatchers {
+    watchers: HashMap<ProfileId, Debouncer<RecommendedWatcher, RecommendedCache>>,
+}
+
+impl ExternalWatchers {
+    pub(super) fn reconcile(&mut self, profiles: &Profiles, actor: &ActorRef<ProfilesActorMessage>) {
+        use nyanpasu_config::profile::{LocalBinding, ProfileSource};
+        let desired: HashMap<ProfileId, std::path::PathBuf> = profiles
+            .items
+            .iter()
+            .filter_map(|(uid, item)| match item.definition.source() {
+                Some(ProfileSource::Local { binding: LocalBinding::External { target, mode, .. } }) => {
+                    // Symlink 监听解析后的真实路径,解析失败回退 target 本身(clean-design §10.1)
+                    let watch_path = if *mode == nyanpasu_config::profile::ExternalMode::Symlink {
+                        std::fs::canonicalize(target.as_path()).unwrap_or_else(|_| target.as_path().to_owned())
+                    } else {
+                        target.as_path().to_owned()
+                    };
+                    Some((uid.clone(), watch_path))
+                }
+                _ => None,
+            })
+            .collect();
+
+        self.watchers.retain(|uid, _| desired.contains_key(uid));
+        for (uid, path) in desired {
+            if self.watchers.contains_key(&uid) {
+                continue;
+            }
+            let actor = actor.clone();
+            let event_uid = uid.clone();
+            let debouncer = new_debouncer(
+                std::time::Duration::from_millis(500),
+                None,
+                move |result: DebounceEventResult| {
+                    if result.is_ok() {
+                        let _ = actor.cast(ProfilesActorMessage::ExternalFileChanged {
+                            uid: event_uid.clone(),
+                        });
+                    }
+                },
+            );
+            match debouncer {
+                Ok(mut debouncer) => {
+                    if debouncer.watch(&path, RecursiveMode::NonRecursive).is_ok() {
+                        self.watchers.insert(uid, debouncer);
+                    }
+                }
+                Err(error) => tracing::warn!("failed to create watcher for {uid}: {error}"),
+            }
+        }
+    }
+}
+```
+
+(`ExternalWatchers` 并入 `ProfilesActorState`,reconcile 调用点与 scheduler 相同:post_start(catch_up 轮)+ 每次 `run_write` 提交后。notify API 细节以 `logging/manager.rs:252` 现物为准,编译错误时对齐之。)
+
+- [ ] **Step 4: 跑测试确认通过 + 纯度断言 + Commit**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu external_ scheduler_ refresh_ && cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu --lib profiles`
+Expected: 全 PASS。
+Run(Git Bash): `grep -rn "tauri::\|crate::config" backend/tauri/src/state/profiles/ && echo LEAK || echo CLEAN` — Expected: `CLEAN`。
+
+```bash
+git add backend/tauri/src/state/profiles backend/tauri/src/service/profile_file.rs
+git commit -m "feat(tauri): add external symlink/mirror watchers to profiles actor"
+```
+
+---
+
+### Task 4: 契约回写 + 全量回归
+
+- [ ] **Step 1**: Run `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu && cargo clippy --manifest-path ./backend/Cargo.toml -p clash-nyanpasu --all-targets --all-features` — Expected: 全绿。
+- [ ] **Step 2**: 按「契约补遗」1–6 回写 task.md(T03 卡 `read_external`、T05 卡 reply Option 化/并发拒绝/删除竞态清理/通知恰好一次语义),并在 T07 卡 Consumes 标注 `ProfilesClient::refresh` 最终签名。
+- [ ] **Step 3**:
+
+```bash
+git add docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+git commit -m "docs(pr3): record T05 contract addenda (refresh protocol, watchers)"
+```
+
+---
+
+## 验证总表(对应 T05 卡验证段)
+
+| 判据                                       | 覆盖                                                                             |
+| ------------------------------------------ | -------------------------------------------------------------------------------- |
+| handler 内零网络 I/O                       | 实现结构(下载在 tokio::spawn)+ 代码审查                                          |
+| 失败路径必结清挂起 reply                   | Task 1 `refresh_failure_settles_reply_with_error`                                |
+| 并发刷新拒绝                               | Task 1 `refresh_rejects_..._concurrent`                                          |
+| reconcile 幂等(新增/删除/切换)             | Task 2 `scheduler_reconcile_add_remove_...`                                      |
+| 启动补课(旧 init 语义)                     | Task 2 `scheduler_catches_up_overdue_...`                                        |
+| watcher 失效传导(Mirror 同步 + bump)       | Task 3 `external_mirror_change_...`                                              |
+| `CommitRefreshed` 时 uid 已删 → 丢弃并结清 | Task 1 实现 + 补充单测(执行时加:删除后手动 cast CommitRefreshed,断言 reply 结清) |
+| 后台提交 affects → 通知恰好一次            | Task 3 handler + mock `times(1)`(执行时在 external 测试中给 notifier 设期望)     |
+| 全程无真实 sleep                           | paused-time + 有界轮询                                                           |

--- a/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+++ b/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
@@ -156,6 +156,8 @@ pub trait ProfileFsPort: Send + Sync + 'static {
     fn write_atomic(&self, path: &ManagedProfilePath, content: &str) -> anyhow::Result<()>;
     /// Idempotent: removing a missing file succeeds.
     fn remove(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
+    /// Read an External binding target for Mirror synchronization.
+    fn read_external(&self, target: &ExternalProfilePath) -> anyhow::Result<String>;
     fn ensure_not_symlink(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
     fn ensure_symlink(&self, path: &ManagedProfilePath, target: &ExternalProfilePath) -> anyhow::Result<()>;
 }
@@ -281,6 +283,17 @@ pub struct ProfilesActorArgs { pub manager: PersistentStateManager<Profiles>,
 - `CommitRefreshed` 时 uid 已被删除 → 丢弃结果、结清 reply(design §17 竞态行)
 - 后台提交且 `affects_current` → `notifier.request_rebuild()` 恰好一次
 
+**2026-07-06 契约补遗(T05 实物,下游以此为准)**:
+
+- `ProfilesActorMessage::RefreshRemote { uid, patch, reply: Option<RpcReplyPort<Result<CommitReport, ProfilesError>>> }`:手动 `ProfilesClient::refresh(...)` 使用 `Some(reply)`;scheduler 后台刷新使用 `None`。`patch` 先以普通写事务更新 remote options,失败则立即结清 `Some(reply)`。
+- 同一 uid 已有 `pending_refresh` 时,`Some(reply)` 返回 `ProfilesError::RefreshFailed { message: "refresh already in progress" }`;`None` 后台触发静默丢弃。所有已登记 pending 的路径必须在 success/failure/deleted race 中结清。
+- `RefreshRemote` handler 不做网络 I/O:它快照 remote 参数、登记 pending reply,然后 `tokio::spawn` 执行 fetch/校验/`ensure_not_symlink`/`write_atomic`;子任务只回 cast `CommitRefreshed { uid, outcome }`,由 actor 串行提交 `updated_at` 与 `subscription`。
+- `CommitRefreshed` 发现 uid 已删除时,若 outcome 为 success, best-effort 清理 `{uid}.yaml` / `{uid}.js` / `{uid}.lua` 三个可能 orphan;`Some(reply)` 以 `RefreshFailed { message: "profile deleted during refresh" }` 结清。
+- 后台刷新(`reply == None`)只有在成功提交且 `CommitReport.affects_current` 时调用 `RebuildNotifier::request_rebuild()`;每次 background-driven commit 恰好一次。手动 refresh 的 reply 路径不在 actor 内直接 notify,由 T07 facade 按 `CommitReport` 统一编排。
+- `RemoteUpdateScheduler` 为每个 remote uid 持有独立 tokio timer task;每次 committed write 后按 uid+interval diff add/remove/update。`post_start` 会 catch-up overdue remote: `updated_at == None` 视为 overdue,否则 `now - updated_at >= update_interval_minutes` 触发一次后台 refresh。
+- `ExternalWatchers` 使用 `notify-debouncer-full` 按 External binding 建 watcher。Symlink 监听 canonicalized target(失败回退 raw target)且事件只 bump `updated_at`;Mirror 事件先 `ProfileFsPort::read_external`、按 profile definition 校验、`write_atomic` 到 managed materialization,再 bump `updated_at`。成功提交且影响 current 时 notify 恰好一次;读取/校验/写入失败只记录 warn,不改状态、不 notify。
+- 测试入口保留 `#[cfg(test)]` client helper 直接 cast `ExternalFileChanged`,用于覆盖 handler 语义;真实 watcher smoke 使用 bounded `<=5s` 文件事件测试,当前未标 `#[ignore]`。
+
 **验证**: mock fetcher 注入可控延迟/失败;watcher 用 tempdir 真实文件事件或注入触发;全程无 sleep(用消息 ack/通道)。
 
 **单独 plan 时读**: design §7、图 13.3、D8/D9、§18 O1/O3;clean-design §9/§10;现 `core/tasks/jobs/profiles.rs:49-139`(被取代者的 cron diff 语义参考)。
@@ -358,7 +371,7 @@ impl RuntimeBuilder {
 - Modify: `backend/tauri/src/config/core.rs:88`(`generate()` 改调 RuntimeBuilder;产物仍写 runtime draft + `generate_file`,两处标 `TODO(actor-migration)` B8)
 - Modify: `backend/tauri/src/client/mod.rs`(新 facade 方法;旧 `patch_profiles_config:80` 本卡保留——删除在 T10)
 
-**Interfaces — Consumes**: T02 revision 3 后的新 schema;T04 ProfilesClient 全部方法与 2026-07-06 契约修正(`CommitReport.warnings` 不代表事务失败,`affects_current` 按闭包规则触发 rebuild);T05 `refresh`;T06 `RuntimeBuilder`。
+**Interfaces — Consumes**: T02 revision 3 后的新 schema;T04 ProfilesClient 全部方法与 2026-07-06 契约修正(`CommitReport.warnings` 不代表事务失败,`affects_current` 按闭包规则触发 rebuild);T05 final refresh signature `ProfilesClient::refresh(uid: ProfileId, patch: Option<RemoteProfileOptionsPatch>) -> Result<CommitReport, ProfilesError>`;T06 `RuntimeBuilder`。
 
 **Interfaces — Produces**(T08 依赖,方法名以此为准):
 

--- a/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+++ b/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
@@ -239,6 +239,9 @@ pub struct ProfilesActorArgs { pub manager: PersistentStateManager<Profiles>,
 - 所有写 handler 仍走 clone→mutate→`validate()`→持久化→commit+重建索引→post-commit 副作用→`CommitReport`;post-commit 文件副作用失败写入 `CommitReport.warnings`,不回滚已持久化状态。
 - `ProfilesError::Persist(String)` 专指持久化/提交失败;`Rpc(String)` 仅表示 actor call/reply/timeout 层失败。
 - Add 服务端生成 uid:`Config` 用 `c` 前缀、`Transform` 用 `t` 前缀,后接 `nanoid(11)`;忽略请求里的 materialized 路径并改写为规范 `{uid}.{ext}`。`FileConfig`/`OverlayTransform` 用 `.yaml`;`ScriptRuntime::JavaScript` 用 `.js`;`ScriptRuntime::Lua` 用 `.lua`。`ExternalMode::Symlink` 只做 post-commit `ensure_symlink`;Remote 与 Mirror 的初始内容同步由 T05 的 RefreshRemote/watcher reconcile 承接。
+- **(2026-07-06 审查修复)materialization 元数据由服务端所有**:Add 一律重置 `updated_at = None`(Remote 另重置 `subscription = default`);`ReplaceDefinition` 同样把传入定义的路径改写为规范 `{uid}.{新类型 ext}`——source 槽位(Managed/External/Remote 判别 + 规范路径)不变时沿用旧存储的 materialized 元数据、忽略客户端传值;槽位变化时重置元数据,旧路径与新规范路径不同(或新定义无 source,如换成 Composition)时 post-commit `Remove` 清理孤儿文件,新引入 External Symlink 绑定时 post-commit `ensure_symlink`(与 Add 对齐)。
+- **(2026-07-06 审查修复)错误形态**:`ProfileInUse { referrers, current: bool, global_transforms: bool }`(document 级引用不再以空列表歧义表达);新增 `InvalidReorderList { reason }`(ByList 长度不符/重复 uid),未知 uid 仍报 `ProfileNotFound`。
+- **(2026-07-06 审查记录)** 真实文件事件冒烟测试 `external_watcher_smoke_mirror_real_file_event` 标 `#[ignore]`(CI 抖动;注入式测试保有覆盖);Mirror 同步在 actor handler 内做同步 fs I/O,target 位于网络盘时有阻塞风险——候选硬化项(spawn_blocking 化),T07 阶段评估。
 - `affects_current` 判定表:
 
 | 消息                                                                  | 规则                                                              |

--- a/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+++ b/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
@@ -218,17 +218,37 @@ impl ProfilesClient {
     pub async fn set_global_transforms(&self, ids: Vec<ProfileId>) -> Result<CommitReport, ProfilesError>;
     pub async fn replace(&self, profiles: Profiles) -> Result<CommitReport, ProfilesError>;
 }
-pub struct CommitReport { pub snapshot: Arc<Profiles>, pub affects_current: bool }
+pub struct CommitReport { pub snapshot: Arc<Profiles>, pub affects_current: bool, pub warnings: Vec<String> }
 pub struct NewProfileRequest { pub metadata: ProfileMetadata, pub definition: ProfileDefinition }  // uid 服务端生成(D13)
 pub enum ReorderOp { Move { active: ProfileId, over: ProfileId }, ByList(Vec<ProfileId>) }
 pub enum ProfilesError { ProfileNotFound, ProfileInUse { referrers: Vec<ProfileId> }, ProfileHasNoFile,
                          ValidationFailed(Vec<ProfileValidationError>), NotARemoteProfile,
-                         FileNotWritable { reason: String }, RefreshFailed { message: String }, Rpc(String) }
+                         FileNotWritable { reason: String }, RefreshFailed { message: String },
+                         Persist(String), Rpc(String) }
 pub const PROFILES_READ_TIMEOUT: Duration = Duration::from_secs(5);
-pub struct ProfilesActorArgs { pub paths: PathResolver, pub fs: Arc<dyn ProfileFsPort>,
-                               pub fetcher: Arc<dyn SubscriptionFetcher>, pub notifier: Arc<dyn RebuildNotifier>,
-                               pub initial: Profiles }
+pub struct ProfilesActorArgs { pub manager: PersistentStateManager<Profiles>,
+                               pub fs: Arc<dyn ProfileFsPort>, pub fetcher: Arc<dyn SubscriptionFetcher>,
+                               pub notifier: Arc<dyn RebuildNotifier> }
 ```
+
+**2026-07-06 契约修正(T04 实物,下游以此为准)**:
+
+- `ProfilesClient::new(profiles_path, fs, fetcher, notifier)` 是构造边界:若 `profiles_path` 存在则 `load()`;否则 `from_state(Profiles::default())`;随后立即 `validate()` fail-fast 再 spawn actor。`ProfilesActorArgs` 不含 `PathResolver` 或 `initial`。
+- 所有写 handler 仍走 clone→mutate→`validate()`→持久化→commit+重建索引→post-commit 副作用→`CommitReport`;post-commit 文件副作用失败写入 `CommitReport.warnings`,不回滚已持久化状态。
+- `ProfilesError::Persist(String)` 专指持久化/提交失败;`Rpc(String)` 仅表示 actor call/reply/timeout 层失败。
+- Add 服务端生成 uid:`Config` 用 `c` 前缀、`Transform` 用 `t` 前缀,后接 `nanoid(11)`;忽略请求里的 materialized 路径并改写为规范 `{uid}.{ext}`。`FileConfig`/`OverlayTransform` 用 `.yaml`;`ScriptRuntime::JavaScript` 用 `.js`;`ScriptRuntime::Lua` 用 `.lua`。`ExternalMode::Symlink` 只做 post-commit `ensure_symlink`;Remote 与 Mirror 的初始内容同步由 T05 的 RefreshRemote/watcher reconcile 承接。
+- `affects_current` 判定表:
+
+| 消息                                                                  | 规则                                                              |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `Get`                                                                 | 不适用                                                            |
+| `Add` / `Delete` / `Reorder` / `PatchMetadata` / `PatchRemoteOptions` | `false`                                                           |
+| `SetCurrent`                                                          | before/after `current` 不同                                       |
+| `SetGlobalTransforms`                                                 | before/after `global_transforms` 不同                             |
+| `ReplaceDefinition`                                                   | before/after 当前闭包不同,或被替换 uid 在 before/after 当前闭包内 |
+| `Replace`                                                             | `true`                                                            |
+
+当前闭包 = `current` + 若 current 为 Composition 则含 base/extend 成员 + 这些 config 的 scoped transforms + `global_transforms`;`current == None` 时闭包仅为 `global_transforms`。
 
 **验证**(mock ports + tempdir manager spawn,不 sleep):
 
@@ -250,7 +270,7 @@ pub struct ProfilesActorArgs { pub paths: PathResolver, pub fs: Arc<dyn ProfileF
 - Create(如拆文件): `backend/tauri/src/state/profiles/scheduler.rs`
 - Modify: `backend/tauri/src/client/profiles.rs`(+`refresh(uid, Option<RemoteProfileOptionsPatch>) -> Result<CommitReport, ProfilesError>`)
 
-**Interfaces — Consumes**: T04 全部 + T03 `SubscriptionFetcher`/`ProfileFsPort`/`RebuildNotifier`。
+**Interfaces — Consumes**: T04 全部(含 2026-07-06 契约修正:`CommitReport.warnings` 降级通道、`Persist` 错误、Add 规范路径与 Remote/Mirror 初始内容延后规则) + T03 `SubscriptionFetcher`/`ProfileFsPort`/`RebuildNotifier`。
 **Interfaces — Produces**: `ProfilesClient::refresh(...)`(T07/T08 的 `update_profile` 链路);scheduler/watcher 对外不可见(actor 内部)。
 
 **行为要点**(plan 时逐条转测试):
@@ -337,6 +357,8 @@ impl RuntimeBuilder {
 - Modify: `backend/tauri/src/setup.rs` / `client/mod.rs`(spawn 顺序:migration 子进程已完成 → 构造 ProfileFileService → spawn ProfilesActor → 构造 ProfilesClient → facade;`RebuildNotifier` 具体实现接到 facade 重建入口,注意用 `Weak`/channel 避免循环持有)
 - Modify: `backend/tauri/src/config/core.rs:88`(`generate()` 改调 RuntimeBuilder;产物仍写 runtime draft + `generate_file`,两处标 `TODO(actor-migration)` B8)
 - Modify: `backend/tauri/src/client/mod.rs`(新 facade 方法;旧 `patch_profiles_config:80` 本卡保留——删除在 T10)
+
+**Interfaces — Consumes**: T02 revision 3 后的新 schema;T04 ProfilesClient 全部方法与 2026-07-06 契约修正(`CommitReport.warnings` 不代表事务失败,`affects_current` 按闭包规则触发 rebuild);T05 `refresh`;T06 `RuntimeBuilder`。
 
 **Interfaces — Produces**(T08 依赖,方法名以此为准):
 

--- a/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+++ b/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
@@ -154,6 +154,7 @@ flowchart LR
 pub trait ProfileFsPort: Send + Sync + 'static {
     fn read(&self, path: &ManagedProfilePath) -> anyhow::Result<String>;
     fn write_atomic(&self, path: &ManagedProfilePath, content: &str) -> anyhow::Result<()>;
+    /// Idempotent: removing a missing file succeeds.
     fn remove(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
     fn ensure_not_symlink(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
     fn ensure_symlink(&self, path: &ManagedProfilePath, target: &ExternalProfilePath) -> anyhow::Result<()>;
@@ -166,8 +167,18 @@ pub trait SubscriptionFetcher: Send + Sync + 'static {
 pub trait RebuildNotifier: Send + Sync + 'static {
     fn request_rebuild(&self);
 }
-pub struct FetchedSubscription { pub content: String, pub subscription: SubscriptionInfo }
-// ProfileFileService::new(paths: PathResolver, http: reqwest::Client) — 同时 impl ProfileFsPort + SubscriptionFetcher
+pub struct FetchedSubscription {
+    pub content: String,
+    pub filename: Option<String>,
+    pub subscription: SubscriptionInfo,
+}
+#[cfg_attr(test, mockall::automock)]
+pub trait SelfProxyPortSource: Send + Sync + 'static {
+    fn mixed_port(&self) -> Option<u16>;
+}
+// ProfileFileService::new(paths: PathResolver, self_proxy_port: Arc<dyn SelfProxyPortSource>)
+// — 同时 impl ProfileFsPort + SubscriptionFetcher;T07 composition root 提供 SelfProxyPortSource。
+pub fn normalize_yaml_document(content: &str) -> anyhow::Result<String>;
 ```
 
 **验证**:


### PR DESCRIPTION
## Summary

Part **3/6** of the PR-3 "profiles domain switch" stack. Based on `refactor/pr3b-migration-profiles-rev3`.

Adds the **profiles domain layer** — all new code, nothing wired into the composition root yet (zero behavior change):

- **Ports** (`client/ports.rs`): narrow traits for profile filesystem access, subscription fetching, and runtime rebuild notification.
- **`ProfileFileService`** (`service/profile_file.rs`): filesystem port implementation (profile content storage, naming, traversal-safe paths).
- **Subscription fetcher**: preserves legacy download semantics (headers, filename derivation, user-agent selection).
- **`ProfilesActor` + `ProfilesClient`** (`state/profiles/`, ractor): owns the profiles document; read path; synchronous write transaction protocol (`current`/`global`/`replace`); create/delete with chain-reference protection.
- **Remote refresh**: download–commit split refresh, remote update scheduler with idempotent reconcile, external symlink/mirror watchers.
- Review-hardening fixes for the actor and file service.

## Notes for reviewers

- The actor is spawned only in tests here; production spawning + facade exposure happen in part 5/6.
- Dependencies are injected via actor startup arguments (no globals), per the actor-migration architecture rules.

## Verification

- `cargo test -p clash-nyanpasu` actor/service/scheduler suites pass at this cut.


---
**Stack (merge in order)**: #4885 → #4886 → #4887 → #4888 → #4889 → #4890 — this PR is part 3/6.
