### PR TITLE
feat(tauri): add RuntimeBuilder with golden snapshot baseline

### DIFF
--- a/backend/nyanpasu-config/src/profile/tests/validation.rs
+++ b/backend/nyanpasu-config/src/profile/tests/validation.rs
@@ -340,3 +340,30 @@ fn item_key_must_match_item_uid() {
         ProfileValidationError::ItemKeyMismatch { .. }
     )));
 }
+
+/// T06A 回归钉:不可信文档面(磁盘 profiles.yaml)在反序列化时就必须拒绝
+/// 穿越型 managed 路径。防御在 ManagedProfilePath::new(path.rs:30-40),
+/// Deserialize 委托 new(path.rs:60-67);本测试锁死该委托关系。
+#[test]
+fn profiles_document_with_traversal_managed_path_fails_to_deserialize() {
+    let yaml = r#"items:
+  - uid: evil
+    name: evil
+    type: transform
+    transform:
+      type: overlay
+      source:
+        type: local
+        binding:
+          type: managed
+          file: ../escape.yaml
+"#;
+    let error = serde_yaml_ng::from_str::<Profiles>(yaml).unwrap_err();
+    assert!(
+        error.to_string().contains("parent"),
+        "error must name the traversal rejection: {error}"
+    );
+
+    // 直接类型面同理(serde 字符串标量 → ManagedProfilePath)。
+    assert!(serde_yaml_ng::from_str::<ManagedProfilePath>("../escape.yaml").is_err());
+}

--- a/backend/tauri/src/enhance/content_source.rs
+++ b/backend/tauri/src/enhance/content_source.rs
@@ -1,0 +1,48 @@
+//! ProfileContentSource over the real profiles directory (PR-3 T06).
+
+use std::path::PathBuf;
+
+use nyanpasu_config::{
+    profile::ManagedProfilePath,
+    runtime::executor::{PortError, ProfileContentSource},
+};
+
+pub struct FsProfileContentSource {
+    profiles_dir: PathBuf,
+}
+
+impl FsProfileContentSource {
+    pub fn new(profiles_dir: PathBuf) -> Self {
+        Self { profiles_dir }
+    }
+}
+
+impl ProfileContentSource for FsProfileContentSource {
+    fn read(&self, path: &ManagedProfilePath) -> Result<String, PortError> {
+        let full = self.profiles_dir.join(path.as_path());
+        std::fs::read_to_string(&full)
+            .map_err(|e| format!("read profile content {}: {e}", full.display()).into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nyanpasu_config::profile::ManagedProfilePath;
+
+    #[test]
+    fn reads_relative_managed_paths_from_profiles_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("abc.yaml"), "proxies: []\n").unwrap();
+        let source = FsProfileContentSource::new(temp.path().to_path_buf());
+        let content = source
+            .read(&ManagedProfilePath::new("abc.yaml").unwrap())
+            .unwrap();
+        assert_eq!(content, "proxies: []\n");
+        assert!(
+            source
+                .read(&ManagedProfilePath::new("missing.yaml").unwrap())
+                .is_err()
+        );
+    }
+}

--- a/backend/tauri/src/enhance/fixtures/golden/builtin_clash_rs.yaml
+++ b/backend/tauri/src/enhance/fixtures/golden/builtin_clash_rs.yaml
@@ -1,0 +1,16 @@
+mode: rule
+port: 7891
+socks-port: 7892
+mixed-port: 7890
+allow-lan: false
+log-level: info
+secret: golden-secret
+external-controller: 127.0.0.1:9090
+profile:
+  store-selected: true
+  store-fake-ip: false
+unified-delay: true
+tcp-concurrent: true
+proxies: []
+extra-key: keep
+custom-field: 1

--- a/backend/tauri/src/enhance/fixtures/golden/builtin_mihomo.yaml
+++ b/backend/tauri/src/enhance/fixtures/golden/builtin_mihomo.yaml
@@ -1,0 +1,17 @@
+mode: rule
+port: 7891
+socks-port: 7892
+mixed-port: 7890
+allow-lan: false
+log-level: info
+ipv6: false
+secret: golden-secret
+external-controller: 127.0.0.1:9090
+profile:
+  store-selected: true
+  store-fake-ip: false
+unified-delay: true
+tcp-concurrent: true
+proxies: []
+extra-key: keep
+custom-field: 1

--- a/backend/tauri/src/enhance/fixtures/golden/composition_global_chain.yaml
+++ b/backend/tauri/src/enhance/fixtures/golden/composition_global_chain.yaml
@@ -1,0 +1,29 @@
+mode: rule
+port: 7891
+socks-port: 7892
+mixed-port: 7890
+allow-lan: false
+log-level: info
+ipv6: false
+secret: golden-secret
+external-controller: 127.0.0.1:9090
+profile:
+  store-selected: true
+  store-fake-ip: false
+unified-delay: true
+tcp-concurrent: true
+proxies:
+  - name: a1
+    type: ss
+    server: a.example.com
+    port: 443
+  - name: b1
+    type: vmess
+    server: b.example.com
+    port: 8080
+proxy-groups:
+  - name: Auto
+    type: select
+    proxies:
+      - a1
+      - b1

--- a/backend/tauri/src/enhance/fixtures/golden/whitelist_on.yaml
+++ b/backend/tauri/src/enhance/fixtures/golden/whitelist_on.yaml
@@ -1,0 +1,15 @@
+mode: rule
+port: 7891
+socks-port: 7892
+mixed-port: 7890
+allow-lan: false
+log-level: info
+ipv6: false
+secret: golden-secret
+external-controller: 127.0.0.1:9090
+profile:
+  store-selected: true
+  store-fake-ip: false
+unified-delay: true
+tcp-concurrent: true
+proxies: []

--- a/backend/tauri/src/enhance/golden.rs
+++ b/backend/tauri/src/enhance/golden.rs
@@ -53,6 +53,7 @@ fn golden_input(profiles: Profiles) -> RuntimeBuildInput {
     };
     input.clash.overrides = fixed_overrides();
     input.clash.enable_tun_mode = false; // windows_fake_ip_filter 平台相关
+    input.clash.enable_clash_fields = false; // 基线依赖 whitelist off,显式声明
     input.app.enable_builtin_enhanced = false; // 各场景按需显式开启
     input
 }

--- a/backend/tauri/src/enhance/golden.rs
+++ b/backend/tauri/src/enhance/golden.rs
@@ -1,0 +1,227 @@
+//! Golden snapshot suite over RuntimeBuilder + real adapters (PR-3 T06A).
+//! Locks the pre-switch behavior baseline for the T07 `Config::generate()`
+//! cutover: identical inputs must keep producing structurally identical
+//! final configs. Re-bless intentionally with:
+//!   GOLDEN_BLESS=1 cargo test -p clash-nyanpasu golden_
+//! Determinism rules: fixed `secret` (default is a random uuid) and tun off
+//! (`windows_fake_ip_filter` is platform-dependent).
+
+use std::{path::PathBuf, sync::Arc};
+
+use nyanpasu_config::{
+    application::ClashCore,
+    clash::config::overrides::ClashGuardOverrides,
+    profile::{
+        CompositionConfig, ConfigDefinition, FileConfig, LocalBinding, ManagedProfilePath,
+        MaterializedFile, OverlayTransform, ProfileDefinition, ProfileId, ProfileItem,
+        ProfileMetadata, ProfileSource, Profiles, TransformDefinition,
+    },
+    runtime::executor::ResolvedPortBindings,
+};
+
+use super::{EnhanceScriptRunner, FsProfileContentSource, RuntimeBuildInput, RuntimeBuilder};
+
+const SUB_A: &str =
+    "proxies:\n  - name: a1\n    type: ss\n    server: a.example.com\n    port: 443\n";
+const SUB_B: &str =
+    "proxies:\n  - name: b1\n    type: vmess\n    server: b.example.com\n    port: 8080\n";
+const BUILD_GROUPS: &str =
+    "proxy-groups:\n  - name: Auto\n    type: select\n    proxies:\n      - a1\n      - b1\n";
+const GLOBAL_FIX: &str = "append__rules:\n  - MATCH,DIRECT\n";
+const BASE_CONFIG: &str = "mode: direct\nproxies: []\nextra-key: keep\ncustom-field: 1\n";
+
+/// 固定 secret 的 guard overrides(Default 的 secret 是随机 uuid,
+/// nyanpasu-config overrides/mod.rs:75;先例 executor tests/builtin.rs:19-24)。
+fn fixed_overrides() -> ClashGuardOverrides {
+    serde_yaml::from_str(
+        "log-level: info\nallow-lan: false\nmode: rule\nsecret: golden-secret\nunified-delay: true\ntcp-concurrent: true\nipv6: false\n",
+    )
+    .unwrap()
+}
+
+fn golden_input(profiles: Profiles) -> RuntimeBuildInput {
+    let mut input = RuntimeBuildInput {
+        profiles: Arc::new(profiles),
+        clash: Default::default(),
+        app: Default::default(),
+        resolved_ports: ResolvedPortBindings {
+            mixed_port: 7890,
+            port: Some(7891),
+            socks_port: Some(7892),
+            external_controller: Some("127.0.0.1:9090".to_string()),
+        },
+    };
+    input.clash.overrides = fixed_overrides();
+    input.clash.enable_tun_mode = false; // windows_fake_ip_filter 平台相关
+    input.app.enable_builtin_enhanced = false; // 各场景按需显式开启
+    input
+}
+
+fn managed(name: &str) -> MaterializedFile {
+    MaterializedFile {
+        file: ManagedProfilePath::new(name).unwrap(),
+        updated_at: None,
+    }
+}
+
+fn metadata(name: &str) -> ProfileMetadata {
+    ProfileMetadata {
+        name: name.into(),
+        desc: None,
+    }
+}
+
+fn file_config(uid: &str, file: &str, transforms: &[&str]) -> ProfileItem {
+    ProfileItem {
+        uid: ProfileId(uid.into()),
+        metadata: metadata(uid),
+        definition: ProfileDefinition::Config {
+            config: ConfigDefinition::File(FileConfig {
+                source: ProfileSource::Local {
+                    binding: LocalBinding::Managed {
+                        materialized: managed(file),
+                    },
+                },
+                transforms: transforms.iter().map(|t| ProfileId((*t).into())).collect(),
+            }),
+        },
+    }
+}
+
+fn overlay(uid: &str, file: &str) -> ProfileItem {
+    ProfileItem {
+        uid: ProfileId(uid.into()),
+        metadata: metadata(uid),
+        definition: ProfileDefinition::Transform {
+            transform: TransformDefinition::Overlay(OverlayTransform {
+                source: ProfileSource::Local {
+                    binding: LocalBinding::Managed {
+                        materialized: managed(file),
+                    },
+                },
+            }),
+        },
+    }
+}
+
+fn composition(uid: &str, base: Option<&str>, extend: &[&str], transforms: &[&str]) -> ProfileItem {
+    ProfileItem {
+        uid: ProfileId(uid.into()),
+        metadata: metadata(uid),
+        definition: ProfileDefinition::Config {
+            config: ConfigDefinition::Composition(CompositionConfig {
+                base: base.map(|b| ProfileId(b.into())),
+                extend_proxies_from: extend.iter().map(|e| ProfileId((*e).into())).collect(),
+                transforms: transforms.iter().map(|t| ProfileId((*t).into())).collect(),
+            }),
+        },
+    }
+}
+
+fn build_to_yaml(input: &RuntimeBuildInput, dir: &std::path::Path) -> serde_yaml::Value {
+    let content = FsProfileContentSource::new(dir.to_path_buf());
+    let scripts = EnhanceScriptRunner::new().unwrap();
+    let artifact = RuntimeBuilder::build(input, &content, &scripts).expect("golden build");
+    serde_yaml::to_value(&*artifact.final_config).unwrap()
+}
+
+fn assert_matches_fixture(actual: &serde_yaml::Value, name: &str) {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/enhance/fixtures/golden");
+    let path = dir.join(name);
+    let rendered = serde_yaml::to_string(actual).unwrap();
+    if std::env::var_os("GOLDEN_BLESS").is_some() {
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(&path, &rendered).unwrap();
+    }
+    let expected = std::fs::read_to_string(&path).unwrap_or_else(|_| {
+        panic!("missing golden fixture {name}; run with GOLDEN_BLESS=1 to create it")
+    });
+    let expected: serde_yaml::Value = serde_yaml::from_str(&expected).unwrap();
+    assert_eq!(
+        actual, &expected,
+        "golden drift for {name}; re-bless with GOLDEN_BLESS=1 only if the change is intentional"
+    );
+}
+
+/// clean-seed Composition(base=None)+ 成员贡献 proxies + 组合内 overlay
+/// + global chain overlay(append__rules 落在缺失键上 → 按执行器语义处理)。
+#[test]
+fn golden_clean_seed_composition_with_global_chain() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("sub_a.yaml"), SUB_A).unwrap();
+    std::fs::write(temp.path().join("sub_b.yaml"), SUB_B).unwrap();
+    std::fs::write(temp.path().join("build_groups.yaml"), BUILD_GROUPS).unwrap();
+    std::fs::write(temp.path().join("global_fix.yaml"), GLOBAL_FIX).unwrap();
+
+    let mut profiles = Profiles::default();
+    profiles.append_item(file_config("sub-a", "sub_a.yaml", &[]));
+    profiles.append_item(file_config("sub-b", "sub_b.yaml", &[]));
+    profiles.append_item(overlay("build-groups", "build_groups.yaml"));
+    profiles.append_item(overlay("global-fix", "global_fix.yaml"));
+    profiles.append_item(composition(
+        "all",
+        None,
+        &["sub-a", "sub-b"],
+        &["build-groups"],
+    ));
+    profiles.set_current(Some(ProfileId("all".into())));
+    profiles.global_transforms = vec![ProfileId("global-fix".into())];
+
+    let input = golden_input(profiles);
+    let yaml = build_to_yaml(&input, temp.path());
+    assert_matches_fixture(&yaml, "composition_global_chain.yaml");
+}
+
+/// builtin 门控 golden(Mihomo:hy_alpn + meta_guard + config_fixer,真 boa)。
+#[test]
+fn golden_builtin_gating_mihomo() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("base.yaml"), BASE_CONFIG).unwrap();
+
+    let mut profiles = Profiles::default();
+    profiles.append_item(file_config("base", "base.yaml", &[]));
+    profiles.set_current(Some(ProfileId("base".into())));
+
+    let mut input = golden_input(profiles);
+    input.app.enable_builtin_enhanced = true;
+    input.app.core = ClashCore::Mihomo;
+    let yaml = build_to_yaml(&input, temp.path());
+    assert_matches_fixture(&yaml, "builtin_mihomo.yaml");
+}
+
+/// builtin 门控 golden(ClashRs:config_fixer + clash_rs_comp,真 boa + 真 lua)。
+#[test]
+fn golden_builtin_gating_clash_rs() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("base.yaml"), BASE_CONFIG).unwrap();
+
+    let mut profiles = Profiles::default();
+    profiles.append_item(file_config("base", "base.yaml", &[]));
+    profiles.set_current(Some(ProfileId("base".into())));
+
+    let mut input = golden_input(profiles);
+    input.app.enable_builtin_enhanced = true;
+    input.app.core = ClashCore::ClashRs;
+    let yaml = build_to_yaml(&input, temp.path());
+    assert_matches_fixture(&yaml, "builtin_clash_rs.yaml");
+}
+
+/// whitelist-on:enable_clash_fields=true 时未知键被过滤。
+#[test]
+fn golden_whitelist_on_filters_unknown_keys() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("base.yaml"), BASE_CONFIG).unwrap();
+
+    let mut profiles = Profiles::default();
+    profiles.append_item(file_config("base", "base.yaml", &[]));
+    profiles.set_current(Some(ProfileId("base".into())));
+
+    let mut input = golden_input(profiles);
+    input.clash.enable_clash_fields = true;
+    let yaml = build_to_yaml(&input, temp.path());
+    assert!(
+        yaml.get("extra-key").is_none(),
+        "whitelist must drop unknown keys"
+    );
+    assert_matches_fixture(&yaml, "whitelist_on.yaml");
+}

--- a/backend/tauri/src/enhance/mod.rs
+++ b/backend/tauri/src/enhance/mod.rs
@@ -1,10 +1,18 @@
 mod advice;
 mod chain;
+mod content_source;
 mod field;
 mod merge;
+mod runtime_builder;
 mod script;
 mod tun;
 mod utils;
+
+pub use content_source::FsProfileContentSource;
+pub use runtime_builder::{
+    RuntimeBuildError, RuntimeBuildInput, RuntimeBuilder, builtin_transforms_for, derive_tun_flavor,
+};
+pub use script::adapter::EnhanceScriptRunner;
 
 pub use self::chain::ScriptType;
 use self::{chain::*, field::*, merge::*, script::*, tun::*};

--- a/backend/tauri/src/enhance/mod.rs
+++ b/backend/tauri/src/enhance/mod.rs
@@ -8,6 +8,9 @@ mod script;
 mod tun;
 mod utils;
 
+#[cfg(test)]
+mod golden;
+
 pub use content_source::FsProfileContentSource;
 pub use runtime_builder::{
     RuntimeBuildError, RuntimeBuildInput, RuntimeBuilder, builtin_transforms_for, derive_tun_flavor,

--- a/backend/tauri/src/enhance/runtime_builder.rs
+++ b/backend/tauri/src/enhance/runtime_builder.rs
@@ -1,0 +1,354 @@
+//! RuntimeBuilder: pure assembly from domain snapshots to the runtime pipeline
+//! executor (PR-3 T06, design §8 + §19). No globals, no IO — port resolution
+//! happens at the caller and file reads/script runs arrive via executor ports.
+//! Must be called from a blocking context (the script adapter blocks on its
+//! own runtime); the facade wraps the whole build in spawn_blocking (T07).
+
+use std::sync::Arc;
+
+use nyanpasu_config::{
+    application::{ClashCore, NyanpasuAppConfig},
+    clash::config::{ClashConfig, tun_stack::TunStack},
+    profile::{ProfileValidationError, Profiles, ScriptRuntime},
+    runtime::executor::{
+        BuiltinTransform, ExecutionTarget, GuardInputs, ProfileContentSource, ResolvedPortBindings,
+        RuntimeArtifact, RuntimePipelineError, RuntimePipelineInputs, ScriptRunner, TunFlavor,
+        TunParams, execute,
+    },
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeBuildError {
+    #[error("profiles snapshot failed validation: {0:?}")]
+    Validation(Vec<ProfileValidationError>),
+    #[error(transparent)]
+    Pipeline(#[from] RuntimePipelineError),
+}
+
+pub struct RuntimeBuildInput {
+    pub profiles: Arc<Profiles>,
+    pub clash: ClashConfig,
+    pub app: NyanpasuAppConfig,
+    pub resolved_ports: ResolvedPortBindings,
+}
+
+const MIHOMO_FAMILY: &[ClashCore] = &[ClashCore::Mihomo, ClashCore::MihomoAlpha];
+const ALL_CORES: &[ClashCore] = &[
+    ClashCore::ClashPremium,
+    ClashCore::ClashRs,
+    ClashCore::Mihomo,
+    ClashCore::MihomoAlpha,
+    ClashCore::ClashRsAlpha,
+];
+// Legacy quirk preserved (chain.rs:174): clash_rs_comp never gated in ClashRsAlpha.
+const CLASH_RS_ONLY: &[ClashCore] = &[ClashCore::ClashRs];
+
+/// Legacy builtin table, ported 1:1 from enhance/chain.rs:145-176. Order is
+/// execution order.
+pub fn builtin_transforms_for(core: ClashCore) -> Vec<BuiltinTransform> {
+    let table: [(&[ClashCore], &str, ScriptRuntime, &str); 4] = [
+        (
+            MIHOMO_FAMILY,
+            "verge_hy_alpn",
+            ScriptRuntime::JavaScript,
+            include_str!("./builtin/meta_hy_alpn.js"),
+        ),
+        (
+            MIHOMO_FAMILY,
+            "verge_meta_guard",
+            ScriptRuntime::JavaScript,
+            include_str!("./builtin/meta_guard.js"),
+        ),
+        (
+            ALL_CORES,
+            "config_fixer",
+            ScriptRuntime::JavaScript,
+            include_str!("./builtin/config_fixer.js"),
+        ),
+        (
+            CLASH_RS_ONLY,
+            "clash_rs_comp",
+            ScriptRuntime::Lua,
+            include_str!("./builtin/clash_rs_comp.lua"),
+        ),
+    ];
+    table
+        .into_iter()
+        .filter(|(gate, ..)| gate.contains(&core))
+        .map(|(_, name, runtime, source)| BuiltinTransform {
+            name: name.to_string(),
+            runtime,
+            source: source.to_string(),
+        })
+        .collect()
+}
+
+/// Legacy tun derivation (enhance/tun.rs:47-60), quirks preserved: only
+/// `ClashRs` (not Alpha) takes the ClashRs branch; Premium+Mixed → Gvisor.
+pub fn derive_tun_flavor(core: ClashCore, stack: TunStack) -> TunFlavor {
+    if core == ClashCore::ClashRs {
+        return TunFlavor::ClashRs;
+    }
+    let stack = if core == ClashCore::ClashPremium && stack == TunStack::Mixed {
+        TunStack::Gvisor
+    } else {
+        stack
+    };
+    TunFlavor::Standard { stack }
+}
+
+pub struct RuntimeBuilder;
+
+impl RuntimeBuilder {
+    pub fn build(
+        input: &RuntimeBuildInput,
+        content: &dyn ProfileContentSource,
+        scripts: &dyn ScriptRunner,
+    ) -> Result<RuntimeArtifact, RuntimeBuildError> {
+        input
+            .profiles
+            .validate()
+            .map_err(RuntimeBuildError::Validation)?;
+
+        let target = match &input.profiles.current {
+            Some(uid) => ExecutionTarget::Selected(uid.clone()),
+            None => ExecutionTarget::Bare,
+        };
+        let builtin_transforms = if input.app.enable_builtin_enhanced {
+            builtin_transforms_for(input.app.core)
+        } else {
+            Vec::new()
+        };
+        let inputs = RuntimePipelineInputs {
+            profiles: &input.profiles,
+            target,
+            guard: GuardInputs {
+                overrides: &input.clash.overrides,
+                ports: input.resolved_ports.clone(),
+            },
+            whitelist_enabled: input.clash.enable_clash_fields,
+            tun: TunParams {
+                enable: input.clash.enable_tun_mode,
+                flavor: derive_tun_flavor(input.app.core, input.clash.tun_stack),
+                windows_fake_ip_filter: cfg!(windows),
+            },
+            builtin_transforms: &builtin_transforms,
+        };
+        execute(&inputs, content, scripts).map_err(RuntimeBuildError::Pipeline)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nyanpasu_config::{
+        profile::{ManagedProfilePath, ProfileId, ScriptRuntime},
+        runtime::{
+            executor::{PortError, ScriptRunOutcome},
+            value::ConfigValue,
+        },
+    };
+
+    /// 极小 fakes(executor 的 support.rs 是 crate 内部,tauri 不可 import)
+    struct EmptyContent;
+    impl ProfileContentSource for EmptyContent {
+        fn read(&self, path: &ManagedProfilePath) -> Result<String, PortError> {
+            Err(format!("no content for {path}").into())
+        }
+    }
+    struct EchoRunner;
+    impl ScriptRunner for EchoRunner {
+        fn run(&self, _: ScriptRuntime, _: &str, config: &ConfigValue) -> ScriptRunOutcome {
+            ScriptRunOutcome {
+                result: Ok(config.clone()),
+                logs: Vec::new(),
+            }
+        }
+        fn eval_item_predicate(&self, _: &str, _: &ConfigValue) -> Result<bool, PortError> {
+            Ok(true)
+        }
+        fn eval_item_expr(&self, _: &str, item: &ConfigValue) -> Result<ConfigValue, PortError> {
+            Ok(item.clone())
+        }
+    }
+
+    fn base_input() -> RuntimeBuildInput {
+        RuntimeBuildInput {
+            profiles: Arc::new(Profiles::default()),
+            clash: ClashConfig::default(),
+            app: NyanpasuAppConfig::default(),
+            resolved_ports: ResolvedPortBindings {
+                mixed_port: 7890,
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn builtin_gating_matches_legacy_table() {
+        let names = |core: ClashCore| -> Vec<String> {
+            builtin_transforms_for(core)
+                .into_iter()
+                .map(|b| b.name)
+                .collect()
+        };
+        assert_eq!(
+            names(ClashCore::Mihomo),
+            vec!["verge_hy_alpn", "verge_meta_guard", "config_fixer"]
+        );
+        assert_eq!(
+            names(ClashCore::ClashRs),
+            vec!["config_fixer", "clash_rs_comp"]
+        );
+        // legacy 怪癖忠实移植:Alpha 不吃 clash_rs_comp(chain.rs:174)
+        assert_eq!(names(ClashCore::ClashRsAlpha), vec!["config_fixer"]);
+        assert_eq!(names(ClashCore::ClashPremium), vec!["config_fixer"]);
+    }
+
+    #[test]
+    fn tun_flavor_derivation_matches_legacy_quirks() {
+        assert_eq!(
+            derive_tun_flavor(ClashCore::ClashRs, TunStack::Mixed),
+            TunFlavor::ClashRs
+        );
+        // Alpha 走 Standard 分支(tun.rs:47 legacy 怪癖)
+        assert_eq!(
+            derive_tun_flavor(ClashCore::ClashRsAlpha, TunStack::Mixed),
+            TunFlavor::Standard {
+                stack: TunStack::Mixed
+            }
+        );
+        // Premium + Mixed → Gvisor 降级(tun.rs:58-60)
+        assert_eq!(
+            derive_tun_flavor(ClashCore::ClashPremium, TunStack::Mixed),
+            TunFlavor::Standard {
+                stack: TunStack::Gvisor
+            }
+        );
+        assert_eq!(
+            derive_tun_flavor(ClashCore::Mihomo, TunStack::System),
+            TunFlavor::Standard {
+                stack: TunStack::System
+            }
+        );
+    }
+
+    #[test]
+    fn bare_build_produces_artifact_with_guarded_ports() {
+        let mut input = base_input(); // current = None → Bare
+        input.app.enable_builtin_enhanced = false; // EchoRunner 下 builtin 无意义
+        let artifact =
+            RuntimeBuilder::build(&input, &EmptyContent, &EchoRunner).expect("bare build");
+        let yaml = serde_yaml::to_value(&*artifact.final_config).expect("artifact to yaml");
+        assert_eq!(yaml["mixed-port"], serde_yaml::Value::from(7890));
+    }
+
+    #[test]
+    fn invalid_profiles_rejected_before_executor() {
+        let mut input = base_input();
+        let mut profiles = Profiles::default();
+        profiles.set_current(Some(ProfileId("ghost".into())));
+        input.profiles = Arc::new(profiles);
+        assert!(matches!(
+            RuntimeBuilder::build(&input, &EmptyContent, &EchoRunner),
+            Err(RuntimeBuildError::Validation(_))
+        ));
+    }
+
+    #[test]
+    fn builtin_disabled_flag_empties_the_list() {
+        let mut input = base_input();
+        input.app.enable_builtin_enhanced = false;
+        input.app.core = ClashCore::Mihomo;
+        let artifact = RuntimeBuilder::build(&input, &EmptyContent, &EchoRunner).unwrap();
+        let debug = format!("{:?}", artifact.graph);
+        assert!(!debug.contains("verge_hy_alpn"));
+    }
+
+    /// End-to-end through the REAL adapters (fs content source + boa runner):
+    /// selected file config with a scoped JS transform, guard ports injected,
+    /// whitelist off keeps unknown keys, step logs anchored for the
+    /// postprocessing_output consumer. Serves as the T06 golden baseline;
+    /// snapshot-file expansion is tracked as a T07 pre-flight follow-up.
+    #[test]
+    fn golden_selected_file_with_script_transform_end_to_end() {
+        use crate::enhance::{EnhanceScriptRunner, FsProfileContentSource};
+        use nyanpasu_config::profile::{
+            ConfigDefinition, FileConfig, LocalBinding, MaterializedFile, ProfileDefinition,
+            ProfileItem, ProfileMetadata, ProfileSource, ScriptTransform, TransformDefinition,
+        };
+
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("cfg1.yaml"),
+            "proxies: []\nmode: direct\nextra-key: keep\n",
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("scr1.js"),
+            "function main(config) { config[\"mode\"] = \"rule\"; console.log(\"scoped ran\"); return config; }\n",
+        )
+        .unwrap();
+
+        let managed = |name: &str| MaterializedFile {
+            file: ManagedProfilePath::new(name).unwrap(),
+            updated_at: None,
+        };
+        let mut profiles = Profiles::default();
+        profiles.append_item(ProfileItem {
+            uid: ProfileId("cfg1".into()),
+            metadata: ProfileMetadata {
+                name: "CFG1".into(),
+                desc: None,
+            },
+            definition: ProfileDefinition::Config {
+                config: ConfigDefinition::File(FileConfig {
+                    source: ProfileSource::Local {
+                        binding: LocalBinding::Managed {
+                            materialized: managed("cfg1.yaml"),
+                        },
+                    },
+                    transforms: vec![ProfileId("scr1".into())],
+                }),
+            },
+        });
+        profiles.append_item(ProfileItem {
+            uid: ProfileId("scr1".into()),
+            metadata: ProfileMetadata {
+                name: "SCR1".into(),
+                desc: None,
+            },
+            definition: ProfileDefinition::Transform {
+                transform: TransformDefinition::Script(ScriptTransform {
+                    source: ProfileSource::Local {
+                        binding: LocalBinding::Managed {
+                            materialized: managed("scr1.js"),
+                        },
+                    },
+                    runtime: ScriptRuntime::JavaScript,
+                }),
+            },
+        });
+        profiles.set_current(Some(ProfileId("cfg1".into())));
+
+        let mut input = base_input();
+        input.profiles = Arc::new(profiles);
+        input.app.enable_builtin_enhanced = false; // isolate assembly + adapters
+
+        let content = FsProfileContentSource::new(temp.path().to_path_buf());
+        let scripts = EnhanceScriptRunner::new().unwrap();
+        let artifact = RuntimeBuilder::build(&input, &content, &scripts).expect("end-to-end build");
+
+        let yaml = serde_yaml::to_value(&*artifact.final_config).unwrap();
+        assert_eq!(yaml["mode"], serde_yaml::Value::from("rule")); // real boa ran the scoped script
+        assert_eq!(yaml["extra-key"], serde_yaml::Value::from("keep")); // whitelist off keeps keys
+        assert_eq!(yaml["mixed-port"], serde_yaml::Value::from(7890)); // guard ports injected
+        assert!(
+            artifact.step_logs.iter().any(|log| log
+                .entries
+                .iter()
+                .any(|entry| entry.message.contains("scoped ran"))),
+            "script logs must be anchored for the postprocessing_output consumer"
+        );
+    }
+}

--- a/backend/tauri/src/enhance/script/adapter.rs
+++ b/backend/tauri/src/enhance/script/adapter.rs
@@ -1,0 +1,193 @@
+//! ScriptRunner adapter over the legacy boa/lua runners (PR-3 T06).
+//! Owns a private current-thread runtime so `run` stays synchronous and the
+//! whole pipeline can execute inside spawn_blocking (roadmap §4.0.4). Do NOT
+//! call it from an async context on a runtime worker thread.
+
+use mlua::LuaSerdeExt as _;
+use nyanpasu_config::{
+    profile::ScriptRuntime,
+    runtime::{
+        executor::{PortError, ScriptRunOutcome, ScriptRunner, StepLogEntry, StepLogLevel},
+        value::ConfigValue,
+    },
+};
+
+use super::{RunnerManager, create_lua_context};
+use crate::enhance::{ScriptType, chain::ScriptWrapper, utils::LogSpan};
+
+pub struct EnhanceScriptRunner {
+    runtime: tokio::runtime::Runtime,
+}
+
+impl EnhanceScriptRunner {
+    pub fn new() -> anyhow::Result<Self> {
+        Ok(Self {
+            runtime: tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?,
+        })
+    }
+}
+
+fn to_step_logs(logs: Vec<(LogSpan, String)>) -> Vec<StepLogEntry> {
+    logs.into_iter()
+        .map(|(span, message)| {
+            let level = match span {
+                LogSpan::Log => StepLogLevel::Log,
+                LogSpan::Info => StepLogLevel::Info,
+                LogSpan::Warn => StepLogLevel::Warn,
+                LogSpan::Error => StepLogLevel::Error,
+            };
+            StepLogEntry::new(level, message)
+        })
+        .collect()
+}
+
+fn config_to_mapping(config: &ConfigValue) -> Result<serde_yaml::Mapping, PortError> {
+    let value = serde_yaml::to_value(config).map_err(|e| format!("config to yaml: {e}"))?;
+    value
+        .as_mapping()
+        .cloned()
+        .ok_or_else(|| "config is not a mapping".into())
+}
+
+fn mapping_to_config(mapping: serde_yaml::Mapping) -> Result<ConfigValue, PortError> {
+    ConfigValue::try_from(serde_yaml::Value::Mapping(mapping))
+        .map_err(|e| format!("yaml to config: {e:?}").into())
+}
+
+impl ScriptRunner for EnhanceScriptRunner {
+    fn run(&self, runtime: ScriptRuntime, source: &str, config: &ConfigValue) -> ScriptRunOutcome {
+        let script_type = match runtime {
+            ScriptRuntime::JavaScript => ScriptType::JavaScript,
+            ScriptRuntime::Lua => ScriptType::Lua,
+        };
+        let mapping = match config_to_mapping(config) {
+            Ok(mapping) => mapping,
+            Err(error) => {
+                return ScriptRunOutcome {
+                    result: Err(error),
+                    logs: Vec::new(),
+                };
+            }
+        };
+        let wrapper = ScriptWrapper(script_type, source.to_string());
+        let (result, logs) = self.runtime.block_on(async {
+            let mut manager = RunnerManager::new();
+            manager.process_script(&wrapper, mapping).await
+        });
+        ScriptRunOutcome {
+            result: result
+                .map_err(|e| PortError::from(e.to_string()))
+                .and_then(mapping_to_config),
+            logs: to_step_logs(logs),
+        }
+    }
+
+    fn eval_item_predicate(&self, expr: &str, item: &ConfigValue) -> Result<bool, PortError> {
+        let lua = create_lua_context().map_err(|e| format!("lua context: {e}"))?;
+        let item_yaml = serde_yaml::to_value(item).map_err(|e| format!("item to yaml: {e}"))?;
+        let lua_item = lua
+            .to_value(&item_yaml)
+            .map_err(|e| format!("item to lua: {e}"))?;
+        lua.globals()
+            .set("item", lua_item)
+            .map_err(|e| format!("set item: {e}"))?;
+        lua.load(expr)
+            .eval::<bool>()
+            .map_err(|e| format!("predicate eval: {e}").into())
+    }
+
+    fn eval_item_expr(&self, expr: &str, item: &ConfigValue) -> Result<ConfigValue, PortError> {
+        let lua = create_lua_context().map_err(|e| format!("lua context: {e}"))?;
+        let item_yaml = serde_yaml::to_value(item).map_err(|e| format!("item to yaml: {e}"))?;
+        let lua_item = lua
+            .to_value(&item_yaml)
+            .map_err(|e| format!("item to lua: {e}"))?;
+        lua.globals()
+            .set("item", lua_item)
+            .map_err(|e| format!("set item: {e}"))?;
+        let result = lua
+            .load(expr)
+            .eval::<mlua::Value>()
+            .map_err(|e| format!("expr eval: {e}"))?;
+        let yaml: serde_yaml::Value = lua
+            .from_value(result)
+            .map_err(|e| format!("lua to yaml: {e}"))?;
+        ConfigValue::try_from(yaml).map_err(|e| format!("yaml to config: {e:?}").into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn value(yaml: &str) -> ConfigValue {
+        let value: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        ConfigValue::try_from(value).unwrap()
+    }
+
+    fn to_yaml(config: &ConfigValue) -> serde_yaml::Value {
+        serde_yaml::to_value(config).unwrap()
+    }
+
+    #[test]
+    fn runs_javascript_transform_and_captures_logs() {
+        let runner = EnhanceScriptRunner::new().unwrap();
+        let script = r#"
+function main(config) {
+  console.log("hello from js");
+  config["mode"] = "rule";
+  return config;
+}
+"#;
+        let outcome = runner.run(
+            ScriptRuntime::JavaScript,
+            script,
+            &value("mixed-port: 7890\n"),
+        );
+        let result = outcome.result.expect("script should succeed");
+        assert_eq!(to_yaml(&result)["mode"], serde_yaml::Value::from("rule"));
+        assert!(
+            !outcome.logs.is_empty(),
+            "console.log must surface as step log"
+        );
+    }
+
+    #[test]
+    fn failing_script_returns_error() {
+        let runner = EnhanceScriptRunner::new().unwrap();
+        let outcome = runner.run(
+            ScriptRuntime::JavaScript,
+            "not valid js ][",
+            &value("a: 1\n"),
+        );
+        assert!(outcome.result.is_err());
+    }
+
+    #[test]
+    fn eval_item_predicate_and_expr_use_lua_item_global() {
+        let runner = EnhanceScriptRunner::new().unwrap();
+        let item = value("name: test-node\ntype: ss\n");
+        assert!(
+            runner
+                .eval_item_predicate(r#"item.name == "test-node""#, &item)
+                .unwrap()
+        );
+        assert!(
+            !runner
+                .eval_item_predicate(r#"item.name == "other""#, &item)
+                .unwrap()
+        );
+        let replaced = runner
+            .eval_item_expr(
+                r#"(function() item.name = "renamed"; return item end)()"#,
+                &item,
+            )
+            .unwrap();
+        assert_eq!(
+            to_yaml(&replaced)["name"],
+            serde_yaml::Value::from("renamed")
+        );
+    }
+}

--- a/backend/tauri/src/enhance/script/js.rs
+++ b/backend/tauri/src/enhance/script/js.rs
@@ -20,6 +20,7 @@ use std::{
     cell::RefCell,
     path::{Path, PathBuf},
     rc::Rc,
+    sync::Mutex,
     time::Duration,
 };
 use tracing_attributes::instrument;
@@ -36,6 +37,11 @@ static CUSTOM_SCRIPTS_DIR: Lazy<PathBuf> = Lazy::new(|| {
     }
     dunce::canonicalize(path).unwrap()
 });
+
+// boa_utils stores the console logger in a process-global slot (see
+// setup_console below); serialize whole runs so parallel executions
+// (e.g. concurrent tests) cannot steal or drain each other's logs.
+static BOA_LOGGER_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 // define a JsRunnerError due to boa engine error is not Send
 #[derive(Debug, thiserror::Error)]
@@ -210,6 +216,9 @@ impl Runner for JSRunner {
         );
         // boa engine is single-thread runner so that we can use it in tokio::task::spawn_blocking
         let res = tokio::task::spawn_blocking(move || {
+            let _logger_guard = BOA_LOGGER_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             let wrapped_fn = move || {
                 let mut logger = BoaConsoleLogger(Logs::new());
                 let boa_runner = wrap_result!(BoaRunner::try_new(), logger.take());

--- a/backend/tauri/src/enhance/script/mod.rs
+++ b/backend/tauri/src/enhance/script/mod.rs
@@ -1,3 +1,4 @@
+pub mod adapter;
 mod js;
 mod lua;
 pub use lua::create_lua_context;

--- a/backend/tauri/src/state/profiles/actor.rs
+++ b/backend/tauri/src/state/profiles/actor.rs
@@ -822,35 +822,58 @@ impl Actor for ProfilesActor {
                 };
 
                 if *mode == ExternalMode::Mirror {
-                    let content = match state.fs.read_external(target) {
-                        Ok(content) => content,
-                        Err(error) => {
+                    // T06A: keep the read→validate→write mirror sync off the
+                    // async actor thread. The handler awaits the blocking task,
+                    // so per-actor message ordering is unchanged.
+                    let fs = state.fs.clone();
+                    let target = target.clone();
+                    let mirror_file = materialized.file.clone();
+                    let definition = item.definition.clone();
+                    let log_uid = uid.clone();
+                    let synced = tokio::task::spawn_blocking(move || {
+                        let content = match fs.read_external(&target) {
+                            Ok(content) => content,
+                            Err(error) => {
+                                tracing::warn!(
+                                    uid = %log_uid,
+                                    target = %target,
+                                    error = %error,
+                                    "failed to read changed external profile"
+                                );
+                                return false;
+                            }
+                        };
+                        if let Err(message) = Self::validate_fetched_content(&definition, &content)
+                        {
                             tracing::warn!(
-                                uid = %uid,
+                                uid = %log_uid,
                                 target = %target,
-                                error = %error,
-                                "failed to read changed external profile"
+                                error = %message,
+                                "changed external profile failed validation"
                             );
-                            return Ok(());
+                            return false;
                         }
-                    };
-                    if let Err(message) = Self::validate_fetched_content(&item.definition, &content)
-                    {
+                        if let Err(error) = fs.write_atomic(&mirror_file, &content) {
+                            tracing::warn!(
+                                uid = %log_uid,
+                                path = %mirror_file,
+                                error = %error,
+                                "failed to mirror changed external profile"
+                            );
+                            return false;
+                        }
+                        true
+                    })
+                    .await
+                    .unwrap_or_else(|join_error| {
                         tracing::warn!(
                             uid = %uid,
-                            target = %target,
-                            error = %message,
-                            "changed external profile failed validation"
+                            error = %join_error,
+                            "mirror sync task failed to run"
                         );
-                        return Ok(());
-                    }
-                    if let Err(error) = state.fs.write_atomic(&materialized.file, &content) {
-                        tracing::warn!(
-                            uid = %uid,
-                            path = %materialized.file,
-                            error = %error,
-                            "failed to mirror changed external profile"
-                        );
+                        false
+                    });
+                    if !synced {
                         return Ok(());
                     }
                 }

--- a/docs/superpowers/plans/2026-07-06-pr3-t04-profiles-actor-client.md
+++ b/docs/superpowers/plans/2026-07-06-pr3-t04-profiles-actor-client.md
@@ -1031,14 +1031,14 @@ git commit -m "feat(tauri): add profile create/delete with reference protection"
     #[tokio::test]
     async fn patch_metadata_and_remote_options() {
         let (client, _dir) = seeded_client().await;
-        let mut patch = ProfileMetadata { name: String::new(), desc: None }.new_empty_patch();
+        let mut patch = ProfileMetadata::new_empty_patch();
         patch.name = Some("Renamed".into());
         let report = client.patch_metadata(ProfileId("cfg1".into()), patch).await.unwrap();
         assert!(!report.affects_current);
         assert_eq!(report.snapshot.items[&ProfileId("cfg1".into())].metadata.name, "Renamed");
 
         // 非 Remote → NotARemoteProfile
-        let options_patch = nyanpasu_config::profile::RemoteProfileOptions::default().new_empty_patch();
+        let options_patch = nyanpasu_config::profile::RemoteProfileOptions::new_empty_patch();
         let err = client
             .patch_remote_options(ProfileId("cfg1".into()), options_patch)
             .await

--- a/docs/superpowers/plans/2026-07-06-pr3-t06-runtime-builder.md
+++ b/docs/superpowers/plans/2026-07-06-pr3-t06-runtime-builder.md
@@ -1,0 +1,663 @@
+# PR-3 T06 — RuntimeBuilder(add-only,不切换调用点)Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新建 `RuntimeBuilder` 纯 service(把域快照确定性降解为 `RuntimePipelineInputs` 并调 executor)+ 两个 executor 适配器(`FsProfileContentSource`、boa/lua `ScriptRunner`);golden 集成测试证明「真实适配器 + executor」产出与旧 `enhance()` 语义等价。**不改 `Config::generate()`、不删旧 enhance 逻辑**(切换在 T07);本卡纯增量、可独立回滚。
+
+**Architecture:** builder 无状态、零全局读:`build(&RuntimeBuildInput, &dyn ProfileContentSource, &dyn ScriptRunner) -> Result<RuntimeArtifact, RuntimeBuildError>`。组装职责(design §19 勘误②):`current→ExecutionTarget::{Selected|Bare}`、`TunFlavor` 推导(**忠实移植 legacy 两处怪癖**:仅 `core==ClashRs` 走 ClashRs 分支、`ClashPremium+Mixed→Gvisor` 降级,tun.rs:47-60)、`ClashCore` bitflags 门控 builtins(**顺序与 gating 与 chain.rs:170-175 逐位一致**,含 `clash_rs_comp` 不含 ClashRsAlpha 的 legacy 事实)、`cfg!(windows)` 传参、guard overrides/whitelist/端口透传。脚本适配器自持一个 current-thread tokio runtime(`build` 是同步纯函数,可在任意 `spawn_blocking` 上下文运行,无 Handle 依赖);`eval_item_*` 直接复用 `enhance/merge.rs:63-90` 的 `create_lua_context` + `item` 全局求值语义。
+
+**Tech Stack:** `nyanpasu_config::runtime::executor::{execute, RuntimePipelineInputs, ...}`(#4877 实物)、既有 `RunnerManager`(`enhance/script/runner.rs:71`,async)、`create_lua_context`、`ConfigValue ⇄ serde_yaml::Value` 转换(`runtime/value/convert.rs`)、tempfile。
+
+## Global Constraints(task.md §0)
+
+- `runtime_builder.rs` 纯度:无 `crate::config::`、无 `tauri::` import(输入全部显式传参;grep 断言)。
+- 本卡不动任何调用点;`enhance/mod.rs` 旧函数原样保留。
+- 每个 commit `cargo build` + `cargo test` 绿。
+
+## 基线事实(2026-07-06 实测)
+
+- executor 入口/输入:`executor/mod.rs:38-105,196`(`RuntimePipelineInputs{profiles, target, guard: GuardInputs{overrides: &ClashGuardOverrides, ports: ResolvedPortBindings}, whitelist_enabled, tun: TunParams{enable, flavor, windows_fake_ip_filter}, builtin_transforms: &[BuiltinTransform{name, runtime, source}]}`);`RuntimeArtifact{final_config: Arc<ConfigValue>, graph, step_logs, applied_fields}`(artifact.rs:57-62)。
+- 新域字段实名:`ClashConfig{overrides, enable_tun_mode, enable_clash_fields, external_controller, mixed_port, socks_port, http_port, tun_stack, ...}`(clash/config/mod.rs:27-59);`NyanpasuAppConfig{core: ClashCore(alias clash_core), enable_builtin_enhanced, ...}`(application/mod.rs:118-129);`ClashCore{ClashPremium, ClashRs, Mihomo, MihomoAlpha, ClashRsAlpha}` 支持 enumflags2(clash_core.rs:7-35);`TunStack{System, Gvisor(默认), Mixed}`。
+- legacy builtin 表(chain.rs:145-176,顺序即执行序):`verge_hy_alpn`(js,Mihomo|MihomoAlpha)→ `verge_meta_guard`(js,Mihomo|MihomoAlpha)→ `config_fixer`(js,all)→ `clash_rs_comp`(lua,**仅 ClashRs**);整表由 `enable_builtin_enhanced`(默认 true)门控;脚本文件在 `enhance/builtin/*.{js,lua}`(include_str!)。
+- legacy tun 怪癖(tun.rs:47-60):`core==ClashRs`(不含 Alpha)→ ClashRs 分支;否则 stack = `tun_stack`,`ClashPremium && Mixed → Gvisor`。
+- 脚本运行:`RunnerManager::process_script(&ScriptWrapper(ScriptType, String), Mapping) -> (Result<Mapping>, Logs)`(async);`Logs = Vec<(LogSpan, String)>`(utils.rs:38),`LogSpan` 与 `StepLogLevel` 逐 variant 同名;逐项 Lua 求值先例 = merge.rs:63-90。
+- executor 自带 tests(`golden/parity/orders/...`)是 crate 内 `#[cfg(test)]`,tauri 侧**不可 import**——T06 单测自备极小 fakes(仿 support.rs 形态),集成 golden 用真实适配器。
+
+## 契约修正(执行后回写 T06 卡,§5.3)
+
+1. `RuntimeBuildInput` 最终形态(替换卡内草签):
+
+```rust
+pub struct RuntimeBuildInput {
+    pub profiles: Arc<Profiles>,                 // ProfilesClient 快照(须已 validate)
+    pub clash: ClashConfig,                      // ClashConfigClient 快照
+    pub app: NyanpasuAppConfig,                  // ApplicationClient 快照
+    pub resolved_ports: ResolvedPortBindings,    // 端口解析(IO)在调用方(T07)完成
+}
+impl RuntimeBuilder {
+    pub fn build(input: &RuntimeBuildInput, content: &dyn ProfileContentSource, scripts: &dyn ScriptRunner)
+        -> Result<RuntimeArtifact, RuntimeBuildError>;
+}
+pub enum RuntimeBuildError { Validation(Vec<ProfileValidationError>), Pipeline(RuntimePipelineError) }
+```
+
+2. `build()` 前置校验 `profiles.validate()`(executor 契约要求输入已验证,builder 防御性背书)。
+3. 脚本适配器 `EnhanceScriptRunner` 自持 current-thread runtime(阻塞式 `block_on`);`RuntimeBuilder::build` 因而必须在阻塞上下文调用(T07 统一 `spawn_blocking`)——记入 T07 卡 Consumes。
+4. 忠实移植的 legacy 怪癖(不"修复"):`clash_rs_comp` 门控不含 `ClashRsAlpha`;tun ClashRs 分支不含 `ClashRsAlpha`。若要修复属行为变更,须走 spec 勘误,不在本卡。
+
+---
+
+### Task 1: `FsProfileContentSource` 适配器
+
+**Files:**
+
+- Create: `backend/tauri/src/enhance/content_source.rs`
+- Modify: `backend/tauri/src/enhance/mod.rs`(`mod content_source; pub use content_source::FsProfileContentSource;`)
+
+**Interfaces:**
+
+- Produces: `FsProfileContentSource::new(profiles_dir: PathBuf)`,impl `nyanpasu_config::runtime::executor::ProfileContentSource`(T07 用 `paths.app_profiles_dir()` 构造)。
+
+- [ ] **Step 1: 写失败测试**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nyanpasu_config::{profile::ManagedProfilePath, runtime::executor::ProfileContentSource};
+
+    #[test]
+    fn reads_relative_managed_paths_from_profiles_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("abc.yaml"), "proxies: []\n").unwrap();
+        let source = FsProfileContentSource::new(temp.path().to_path_buf());
+        let content = source.read(&ManagedProfilePath::new("abc.yaml").unwrap()).unwrap();
+        assert_eq!(content, "proxies: []\n");
+        assert!(source.read(&ManagedProfilePath::new("missing.yaml").unwrap()).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: 确认失败**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu reads_relative_managed`
+Expected: FAIL(类型未定义)。
+
+- [ ] **Step 3: 实现**
+
+```rust
+//! ProfileContentSource over the real profiles directory (PR-3 T06).
+
+use std::path::PathBuf;
+
+use nyanpasu_config::{
+    profile::ManagedProfilePath,
+    runtime::executor::{PortError, ProfileContentSource},
+};
+
+pub struct FsProfileContentSource {
+    profiles_dir: PathBuf,
+}
+
+impl FsProfileContentSource {
+    pub fn new(profiles_dir: PathBuf) -> Self {
+        Self { profiles_dir }
+    }
+}
+
+impl ProfileContentSource for FsProfileContentSource {
+    fn read(&self, path: &ManagedProfilePath) -> Result<String, PortError> {
+        let full = self.profiles_dir.join(path.as_path());
+        std::fs::read_to_string(&full)
+            .map_err(|e| format!("read profile content {}: {e}", full.display()).into())
+    }
+}
+```
+
+- [ ] **Step 4: 确认通过 + Commit**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu reads_relative_managed`
+Expected: PASS。
+
+```bash
+git add backend/tauri/src/enhance/content_source.rs backend/tauri/src/enhance/mod.rs
+git commit -m "feat(tauri): add fs profile content source for runtime executor"
+```
+
+---
+
+### Task 2: `EnhanceScriptRunner` 适配器(boa/lua + 逐项求值)
+
+**Files:**
+
+- Create: `backend/tauri/src/enhance/script/adapter.rs`
+- Modify: `backend/tauri/src/enhance/script/mod.rs`(模块声明 + re-export;现有 runner 不动)
+
+**Interfaces:**
+
+- Produces: `EnhanceScriptRunner::new() -> anyhow::Result<Self>`,impl `nyanpasu_config::runtime::executor::ScriptRunner`(三方法)。
+
+- [ ] **Step 1: 写失败测试(真实 boa/lua,微型脚本)**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nyanpasu_config::{
+        profile::ScriptRuntime,
+        runtime::{executor::ScriptRunner as _, value::ConfigValue},
+    };
+
+    fn value(yaml: &str) -> ConfigValue {
+        let value: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        ConfigValue::try_from(value).unwrap()
+    }
+
+    #[test]
+    fn runs_javascript_transform_and_captures_logs() {
+        let runner = EnhanceScriptRunner::new().unwrap();
+        let script = r#"
+function main(config) {
+  console.log("hello from js");
+  config["mode"] = "rule";
+  return config;
+}
+"#;
+        let outcome = runner.run(ScriptRuntime::JavaScript, script, &value("mixed-port: 7890\n"));
+        let result = outcome.result.expect("script should succeed");
+        let yaml: serde_yaml::Value = (&result).try_into().or_else(|_| {
+            serde_yaml::to_value(serde_json::Value::from(result.to_json())).map_err(|e| format!("{e}"))
+        }).unwrap();
+        assert_eq!(yaml["mode"], serde_yaml::Value::from("rule"));
+        assert!(!outcome.logs.is_empty(), "console.log must surface as step log");
+    }
+
+    #[test]
+    fn failing_script_returns_error_with_logs_preserved() {
+        let runner = EnhanceScriptRunner::new().unwrap();
+        let outcome = runner.run(ScriptRuntime::JavaScript, "not valid js ][", &value("a: 1\n"));
+        assert!(outcome.result.is_err());
+    }
+
+    #[test]
+    fn eval_item_predicate_and_expr_use_lua_item_global() {
+        let runner = EnhanceScriptRunner::new().unwrap();
+        let item = value("name: test-node\ntype: ss\n");
+        let keep = runner.eval_item_predicate(r#"item.name == "test-node""#, &item).unwrap();
+        assert!(keep);
+        let drop = runner.eval_item_predicate(r#"item.name == "other""#, &item).unwrap();
+        assert!(!drop);
+        let replaced = runner
+            .eval_item_expr(r#"(function() item.name = "renamed"; return item end)()"#, &item)
+            .unwrap();
+        let yaml = serde_yaml::to_value(replaced.to_json()).unwrap();
+        assert_eq!(yaml["name"], serde_yaml::Value::from("renamed"));
+    }
+}
+```
+
+(`ConfigValue` 与 serde 值的互转以 `runtime/value/{convert,ser,de}.rs` 实物 API 为准——若无 `to_json()`,改用 `serde_json::to_value(&result)`/`ConfigValue` 的 Serialize impl;编译错误时对齐,断言语义不变。legacy js runner 的入口形态(`function main(config)`)以 `enhance/script/js.rs` 现物为准,若需 `export default` 形态则改脚本文本。)
+
+- [ ] **Step 2: 确认失败**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu --lib script::adapter`
+Expected: FAIL。
+
+- [ ] **Step 3: 实现**
+
+```rust
+//! ScriptRunner adapter over the legacy boa/lua runners (PR-3 T06).
+//! Owns a private current-thread runtime so `run` stays synchronous and the
+//! whole pipeline can execute inside spawn_blocking (roadmap §4.0.4).
+
+use nyanpasu_config::{
+    profile::ScriptRuntime,
+    runtime::{
+        executor::{PortError, ScriptRunOutcome, ScriptRunner, StepLogEntry, StepLogLevel},
+        value::ConfigValue,
+    },
+};
+
+use super::{super::utils::{LogSpan, Logs}, ScriptType, create_lua_context};
+use crate::enhance::{ChainTypeWrapper, ScriptWrapper, script::RunnerManager};
+
+pub struct EnhanceScriptRunner {
+    runtime: tokio::runtime::Runtime,
+}
+
+impl EnhanceScriptRunner {
+    pub fn new() -> anyhow::Result<Self> {
+        Ok(Self {
+            runtime: tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?,
+        })
+    }
+}
+
+fn to_step_logs(logs: Logs) -> Vec<StepLogEntry> {
+    logs.into_iter()
+        .map(|(span, message)| {
+            let level = match span {
+                LogSpan::Log => StepLogLevel::Log,
+                LogSpan::Info => StepLogLevel::Info,
+                LogSpan::Warn => StepLogLevel::Warn,
+                LogSpan::Error => StepLogLevel::Error,
+            };
+            StepLogEntry::new(level, message)
+        })
+        .collect()
+}
+
+fn config_to_mapping(config: &ConfigValue) -> Result<serde_yaml::Mapping, PortError> {
+    let value: serde_yaml::Value =
+        serde_yaml::to_value(config).map_err(|e| format!("config to yaml: {e}"))?;
+    value
+        .as_mapping()
+        .cloned()
+        .ok_or_else(|| "config is not a mapping".into())
+}
+
+fn mapping_to_config(mapping: serde_yaml::Mapping) -> Result<ConfigValue, PortError> {
+    ConfigValue::try_from(serde_yaml::Value::Mapping(mapping))
+        .map_err(|e| format!("yaml to config: {e:?}").into())
+}
+
+impl ScriptRunner for EnhanceScriptRunner {
+    fn run(&self, runtime: ScriptRuntime, source: &str, config: &ConfigValue) -> ScriptRunOutcome {
+        let script_type = match runtime {
+            ScriptRuntime::JavaScript => ScriptType::JavaScript,
+            ScriptRuntime::Lua => ScriptType::Lua,
+        };
+        let mapping = match config_to_mapping(config) {
+            Ok(mapping) => mapping,
+            Err(error) => {
+                return ScriptRunOutcome { result: Err(error), logs: Vec::new() };
+            }
+        };
+        let wrapper = ScriptWrapper(script_type, source.to_string());
+        let (result, logs) = self.runtime.block_on(async {
+            let mut manager = RunnerManager::new();
+            manager.process_script(&wrapper, mapping).await
+        });
+        ScriptRunOutcome {
+            result: result
+                .map_err(|e| PortError::from(e.to_string()))
+                .and_then(mapping_to_config),
+            logs: to_step_logs(logs),
+        }
+    }
+
+    fn eval_item_predicate(&self, expr: &str, item: &ConfigValue) -> Result<bool, PortError> {
+        let lua = create_lua_context().map_err(|e| format!("lua context: {e}"))?;
+        let item_yaml: serde_yaml::Value =
+            serde_yaml::to_value(item).map_err(|e| format!("item to yaml: {e}"))?;
+        use mlua::LuaSerdeExt as _;
+        let lua_item = lua.to_value(&item_yaml).map_err(|e| format!("item to lua: {e}"))?;
+        lua.globals().set("item", lua_item).map_err(|e| format!("set item: {e}"))?;
+        lua.load(expr)
+            .eval::<bool>()
+            .map_err(|e| format!("predicate eval: {e}").into())
+    }
+
+    fn eval_item_expr(&self, expr: &str, item: &ConfigValue) -> Result<ConfigValue, PortError> {
+        let lua = create_lua_context().map_err(|e| format!("lua context: {e}"))?;
+        let item_yaml: serde_yaml::Value =
+            serde_yaml::to_value(item).map_err(|e| format!("item to yaml: {e}"))?;
+        use mlua::LuaSerdeExt as _;
+        let lua_item = lua.to_value(&item_yaml).map_err(|e| format!("item to lua: {e}"))?;
+        lua.globals().set("item", lua_item).map_err(|e| format!("set item: {e}"))?;
+        let result = lua
+            .load(expr)
+            .eval::<mlua::Value>()
+            .map_err(|e| format!("expr eval: {e}"))?;
+        let yaml: serde_yaml::Value =
+            lua.from_value(result).map_err(|e| format!("lua to yaml: {e}"))?;
+        ConfigValue::try_from(yaml).map_err(|e| format!("yaml to config: {e:?}").into())
+    }
+}
+```
+
+(import 路径、`ScriptWrapper`/`ChainTypeWrapper` 可见性、`ConfigValue` 的 serde 能力以现物为准修正;`create_lua_context` 若为 `pub(crate)` 需放宽到 `pub(in crate::enhance)`。语义锚点:merge.rs:63-90。)
+
+- [ ] **Step 4: 确认通过 + Commit**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu --lib script::adapter`
+Expected: 全 PASS。
+
+```bash
+git add backend/tauri/src/enhance/script
+git commit -m "feat(tauri): add script runner adapter over boa/lua for executor"
+```
+
+---
+
+### Task 3: `RuntimeBuilder` 组装逻辑(单测 = 本地 fakes)
+
+**Files:**
+
+- Create: `backend/tauri/src/enhance/runtime_builder.rs`
+- Modify: `backend/tauri/src/enhance/mod.rs`(`mod runtime_builder; pub use runtime_builder::*;`)
+
+**Interfaces:**
+
+- Produces(T07 依赖):契约修正节的 `RuntimeBuildInput`/`RuntimeBuilder::build`/`RuntimeBuildError` + `pub fn builtin_transforms_for(core: ClashCore) -> Vec<BuiltinTransform>`(门控表单独可测)。
+
+- [ ] **Step 1: 写失败测试**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use nyanpasu_config::{
+        application::{ClashCore, NyanpasuAppConfig},
+        clash::config::{ClashConfig, TunStack},
+        profile::{ManagedProfilePath, ProfileId, Profiles, ScriptRuntime},
+        runtime::executor::{
+            PortError, ProfileContentSource, ResolvedPortBindings, ScriptRunOutcome, ScriptRunner,
+            TunFlavor,
+        },
+        runtime::value::ConfigValue,
+    };
+
+    /// 极小 fakes(executor 的 support.rs 是 crate 内部,tauri 不可 import)
+    struct EmptyContent;
+    impl ProfileContentSource for EmptyContent {
+        fn read(&self, path: &ManagedProfilePath) -> Result<String, PortError> {
+            Err(format!("no content for {path}").into())
+        }
+    }
+    struct EchoRunner;
+    impl ScriptRunner for EchoRunner {
+        fn run(&self, _: ScriptRuntime, _: &str, config: &ConfigValue) -> ScriptRunOutcome {
+            ScriptRunOutcome { result: Ok(config.clone()), logs: Vec::new() }
+        }
+        fn eval_item_predicate(&self, _: &str, _: &ConfigValue) -> Result<bool, PortError> {
+            Ok(true)
+        }
+        fn eval_item_expr(&self, _: &str, item: &ConfigValue) -> Result<ConfigValue, PortError> {
+            Ok(item.clone())
+        }
+    }
+
+    fn base_input() -> RuntimeBuildInput {
+        RuntimeBuildInput {
+            profiles: Arc::new(Profiles::default()),
+            clash: ClashConfig::default(),
+            app: NyanpasuAppConfig::default(),
+            resolved_ports: ResolvedPortBindings { mixed_port: 7890, ..Default::default() },
+        }
+    }
+
+    #[test]
+    fn builtin_gating_matches_legacy_table() {
+        let names = |core: ClashCore| -> Vec<String> {
+            builtin_transforms_for(core).into_iter().map(|b| b.name).collect()
+        };
+        assert_eq!(
+            names(ClashCore::Mihomo),
+            vec!["verge_hy_alpn", "verge_meta_guard", "config_fixer"]
+        );
+        assert_eq!(names(ClashCore::ClashRs), vec!["config_fixer", "clash_rs_comp"]);
+        // legacy 怪癖忠实移植:Alpha 不吃 clash_rs_comp(chain.rs:174)
+        assert_eq!(names(ClashCore::ClashRsAlpha), vec!["config_fixer"]);
+        assert_eq!(names(ClashCore::ClashPremium), vec!["config_fixer"]);
+    }
+
+    #[test]
+    fn tun_flavor_derivation_matches_legacy_quirks() {
+        assert_eq!(derive_tun_flavor(ClashCore::ClashRs, TunStack::Mixed), TunFlavor::ClashRs);
+        // Alpha 走 Standard 分支(tun.rs:47 legacy 怪癖)
+        assert_eq!(
+            derive_tun_flavor(ClashCore::ClashRsAlpha, TunStack::Mixed),
+            TunFlavor::Standard { stack: TunStack::Mixed }
+        );
+        // Premium + Mixed → Gvisor 降级(tun.rs:58-60)
+        assert_eq!(
+            derive_tun_flavor(ClashCore::ClashPremium, TunStack::Mixed),
+            TunFlavor::Standard { stack: TunStack::Gvisor }
+        );
+        assert_eq!(
+            derive_tun_flavor(ClashCore::Mihomo, TunStack::System),
+            TunFlavor::Standard { stack: TunStack::System }
+        );
+    }
+
+    #[test]
+    fn bare_build_produces_artifact_with_guarded_ports() {
+        let input = base_input(); // current = None → Bare
+        let artifact = RuntimeBuilder::build(&input, &EmptyContent, &EchoRunner).expect("bare build");
+        let yaml = serde_yaml::to_value(&*artifact.final_config).expect("artifact to yaml");
+        assert_eq!(yaml["mixed-port"], serde_yaml::Value::from(7890));
+    }
+
+    #[test]
+    fn invalid_profiles_rejected_before_executor() {
+        let mut input = base_input();
+        let mut profiles = Profiles::default();
+        profiles.set_current(Some(ProfileId("ghost".into())));
+        input.profiles = Arc::new(profiles);
+        assert!(matches!(
+            RuntimeBuilder::build(&input, &EmptyContent, &EchoRunner),
+            Err(RuntimeBuildError::Validation(_))
+        ));
+    }
+
+    #[test]
+    fn builtin_disabled_flag_empties_the_list() {
+        let mut input = base_input();
+        input.app.enable_builtin_enhanced = false;
+        input.app.core = ClashCore::Mihomo;
+        // 语义断言经 build 输入观察:关闭后 executor 收到空 builtin 列表,
+        // 产物 graph 中不得出现 BuiltinTransform 节点(以 graph API 实名核对)
+        let artifact = RuntimeBuilder::build(&input, &EmptyContent, &EchoRunner).unwrap();
+        let debug = format!("{:?}", artifact.graph);
+        assert!(!debug.contains("verge_hy_alpn"));
+    }
+}
+```
+
+- [ ] **Step 2: 确认失败**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu runtime_builder`
+Expected: FAIL。
+
+- [ ] **Step 3: 实现**
+
+```rust
+//! RuntimeBuilder: pure assembly from domain snapshots to the runtime pipeline
+//! executor (PR-3 T06, design §8 + §19). No globals, no IO — ports resolve and
+//! file reads/script runs arrive via explicit parameters and executor ports.
+
+use std::sync::Arc;
+
+use nyanpasu_config::{
+    application::{ClashCore, NyanpasuAppConfig},
+    clash::config::{ClashConfig, TunStack},
+    profile::{ProfileValidationError, Profiles, ScriptRuntime},
+    runtime::executor::{
+        BuiltinTransform, ExecutionTarget, GuardInputs, ProfileContentSource,
+        ResolvedPortBindings, RuntimeArtifact, RuntimePipelineError, RuntimePipelineInputs,
+        ScriptRunner, TunFlavor, TunParams, execute,
+    },
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeBuildError {
+    #[error("profiles snapshot failed validation: {0:?}")]
+    Validation(Vec<ProfileValidationError>),
+    #[error(transparent)]
+    Pipeline(#[from] RuntimePipelineError),
+}
+
+pub struct RuntimeBuildInput {
+    pub profiles: Arc<Profiles>,
+    pub clash: ClashConfig,
+    pub app: NyanpasuAppConfig,
+    pub resolved_ports: ResolvedPortBindings,
+}
+
+/// Legacy builtin table, ported 1:1 from enhance/chain.rs:145-176 (order is
+/// execution order; ClashRsAlpha intentionally not in clash_rs_comp gating).
+pub fn builtin_transforms_for(core: ClashCore) -> Vec<BuiltinTransform> {
+    use enumflags2::BitFlags;
+    let table: [(BitFlags<ClashCore>, &str, ScriptRuntime, &str); 4] = [
+        (
+            ClashCore::Mihomo | ClashCore::MihomoAlpha,
+            "verge_hy_alpn",
+            ScriptRuntime::JavaScript,
+            include_str!("./builtin/meta_hy_alpn.js"),
+        ),
+        (
+            ClashCore::Mihomo | ClashCore::MihomoAlpha,
+            "verge_meta_guard",
+            ScriptRuntime::JavaScript,
+            include_str!("./builtin/meta_guard.js"),
+        ),
+        (
+            BitFlags::all(),
+            "config_fixer",
+            ScriptRuntime::JavaScript,
+            include_str!("./builtin/config_fixer.js"),
+        ),
+        (
+            ClashCore::ClashRs.into(),
+            "clash_rs_comp",
+            ScriptRuntime::Lua,
+            include_str!("./builtin/clash_rs_comp.lua"),
+        ),
+    ];
+    table
+        .into_iter()
+        .filter(|(gate, ..)| gate.contains(core))
+        .map(|(_, name, runtime, source)| BuiltinTransform {
+            name: name.to_string(),
+            runtime,
+            source: source.to_string(),
+        })
+        .collect()
+}
+
+/// Legacy tun derivation (enhance/tun.rs:47-60), quirks preserved:
+/// only `ClashRs` (not Alpha) takes the ClashRs branch; Premium+Mixed → Gvisor.
+pub fn derive_tun_flavor(core: ClashCore, stack: TunStack) -> TunFlavor {
+    if core == ClashCore::ClashRs {
+        return TunFlavor::ClashRs;
+    }
+    let stack = if core == ClashCore::ClashPremium && stack == TunStack::Mixed {
+        TunStack::Gvisor
+    } else {
+        stack
+    };
+    TunFlavor::Standard { stack }
+}
+
+pub struct RuntimeBuilder;
+
+impl RuntimeBuilder {
+    pub fn build(
+        input: &RuntimeBuildInput,
+        content: &dyn ProfileContentSource,
+        scripts: &dyn ScriptRunner,
+    ) -> Result<RuntimeArtifact, RuntimeBuildError> {
+        input
+            .profiles
+            .validate()
+            .map_err(RuntimeBuildError::Validation)?;
+
+        let target = match &input.profiles.current {
+            Some(uid) => ExecutionTarget::Selected(uid.clone()),
+            None => ExecutionTarget::Bare,
+        };
+        let builtin_transforms = if input.app.enable_builtin_enhanced {
+            builtin_transforms_for(input.app.core)
+        } else {
+            Vec::new()
+        };
+        let inputs = RuntimePipelineInputs {
+            profiles: &input.profiles,
+            target,
+            guard: GuardInputs {
+                overrides: &input.clash.overrides,
+                ports: input.resolved_ports.clone(),
+            },
+            whitelist_enabled: input.clash.enable_clash_fields,
+            tun: TunParams {
+                enable: input.clash.enable_tun_mode,
+                flavor: derive_tun_flavor(input.app.core, input.clash.tun_stack),
+                windows_fake_ip_filter: cfg!(windows),
+            },
+            builtin_transforms: &builtin_transforms,
+        };
+        execute(&inputs, content, scripts).map_err(RuntimeBuildError::Pipeline)
+    }
+}
+```
+
+- [ ] **Step 4: 确认通过 + 纯度断言 + Commit**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu runtime_builder`
+Expected: 全 PASS。
+Run(Git Bash): `grep -n "crate::config\|tauri::" backend/tauri/src/enhance/runtime_builder.rs && echo LEAK || echo CLEAN`
+Expected: `CLEAN`。
+
+```bash
+git add backend/tauri/src/enhance/runtime_builder.rs backend/tauri/src/enhance/mod.rs
+git commit -m "feat(tauri): add RuntimeBuilder over runtime pipeline executor"
+```
+
+---
+
+### Task 4: golden 集成测试(真实适配器)+ 契约回写
+
+**Files:**
+
+- Create: `backend/tauri/src/enhance/runtime_builder.rs` 内 `#[cfg(test)] mod golden`(或独立 `tests/` 集成目标,以编译最快者为准)
+- Create: `backend/tauri/tests/fixtures/pr3-golden/`(profile 文件 + expected YAML)
+
+- [ ] **Step 1: 构造 fixture 场景(覆盖 design §15 golden 清单的可 add-only 部分)**
+
+fixtures:`base.yaml`(含 proxies/proxy-groups/rules 的完整配置)、`ovl.yaml`(Overlay:追加字段 + `filter__proxies`)、`scr.js`(改 mode 的脚本)、`member.yaml`(Composition 贡献者)。场景:
+
+1. 单 current(File + scoped [ovl, scr])+ global [ovl2] + guard overrides + whitelist on + Mihomo builtin;
+2. Composition{base, extend:[member]}(经 migration 语义构造的形态,验证 §18 第 24 条运行半);
+3. bare(current=None);
+4. whitelist off(enable_clash_fields=false)对照。
+
+每个场景:`RuntimeBuilder::build` 用 `FsProfileContentSource`(tempdir 写入 fixtures)+ `EnhanceScriptRunner`,产物 `final_config` 序列化为 YAML 与 `expected_{n}.yaml` 逐值比对(`pretty_assertions`);`step_logs` 断言:脚本步骤有日志锚点(覆盖 `get_postprocessing_output` 消费需求)。
+
+**expected 文件的产生方式(一次性,记录在测试文件头注释):** 首轮运行以 `--nocapture` 打印产物 → 人工对照旧 `enhance()` 语义(HANDLE_FIELDS overlay 结果、whitelist 过滤集、builtin 效果如 alpn 数组化、tun 键形态)与 PR-3-pre② parity 套件的既有期望 → 审阅通过后落盘为 expected;此后回归锁死。**禁止盲录**——审阅记录写入 PR 描述。
+
+- [ ] **Step 2: 跑 golden**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu golden`(测试在 `spawn_blocking` 中调 build,或 `#[test]`(非 tokio)直接调——builder 自身同步,EnhanceScriptRunner 自持 runtime,普通 `#[test]` 即可)
+Expected: 全 PASS。
+
+- [ ] **Step 3: 全量回归**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu && cargo clippy --manifest-path ./backend/Cargo.toml -p clash-nyanpasu --all-targets --all-features`
+Expected: 全绿。
+
+- [ ] **Step 4: 契约回写 + Commit**
+
+按「契约修正」1–4 更新 T06 卡(RuntimeBuildInput 实名、RuntimeBuildError、阻塞上下文要求 → 同步 T07 卡 Consumes、怪癖忠实移植记录)。
+
+```bash
+git add backend/tauri/tests backend/tauri/src/enhance docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+git commit -m "test(tauri): add runtime builder golden suite against legacy semantics"
+```
+
+---
+
+## 验证总表(对应 T06 卡验证段)
+
+| 判据                                        | 覆盖                                                 |
+| ------------------------------------------- | ---------------------------------------------------- |
+| golden 对照(同输入产物与旧 enhance 等价)    | Task 4(真实适配器 + 人工审阅的 expected)             |
+| `step_logs` 覆盖 postprocessing_output 需求 | Task 4 日志锚点断言                                  |
+| 纯度:runtime_builder 无 Config/tauri import | Task 3 Step 4 grep                                   |
+| builtin 门控与顺序 = chain.rs:170-175       | Task 3 `builtin_gating_matches_legacy_table`         |
+| tun 推导两怪癖忠实                          | Task 3 `tun_flavor_derivation_matches_legacy_quirks` |
+| bare 目标支持                               | Task 3 `bare_build_produces_artifact_...`            |
+| 输入未验证防御                              | Task 3 `invalid_profiles_rejected_...`               |

--- a/docs/superpowers/plans/2026-07-06-pr3-t06a-review-hardening.md
+++ b/docs/superpowers/plans/2026-07-06-pr3-t06a-review-hardening.md
@@ -1,0 +1,511 @@
+# PR-3 T06A — 评审加固 + golden 基线(add-only)Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 落地 T06 评审处置遗留的三项加固:① `ManagedProfilePath` 路径穿越拒绝的**反序列化面回归钉**(实测防御已在位,本卡钉死它);② actor Mirror 同步的阻塞 I/O 移入 `spawn_blocking`;③ RuntimeBuilder **golden snapshot 文件套件**——在 T07 切换 `Config::generate()` 之前锁定行为基线。全部 add-only(②是等价重构),不入 §4 原子切换组,可独立回滚。
+
+**Architecture:** ①只加测试(防御在 `nyanpasu-config` 域层,`Deserialize` 委托 `new()`);②把 `ExternalFileChanged` handler 的 Mirror 分支(读外部文件→校验→原子写镜像)整体搬进 `tokio::task::spawn_blocking`,handler `await` 该任务,**actor 消息顺序语义不变**,三条 warn 日志逐字保留;③新增 `#[cfg(test)] mod golden`,用真实适配器(`FsProfileContentSource` + `EnhanceScriptRunner`)驱动 `RuntimeBuilder::build`,`final_config` 与 `src/enhance/fixtures/golden/*.yaml` 期望文件比对,`GOLDEN_BLESS=1` 重铸。
+
+**Tech Stack:** `serde_yaml_ng`(nyanpasu-config 测试)、`tokio::task::spawn_blocking`、`tempfile`、`serde_yaml::Value` 结构比对(免格式噪声)。
+
+## Global Constraints
+
+- 一切 cargo 操作前设 `$env:CARGO_TARGET_DIR='F:\codex-target\clash-nyanpasu-pr3'`(G 盘近满,禁止写默认 target)。
+- add-only:不改 `Config::generate()`、不动任何调用点;②仅等价重构。
+- 每个 commit `cargo build` + `cargo test` 绿;conventional commits;lint-staged 会跑 clippy --all-targets --all-features,测试代码也须 clippy 干净。
+- golden 确定性铁律:**固定 `secret: golden-secret`**(`ClashGuardOverrides::default()` 的 secret 是随机 uuid,overrides/mod.rs:75)、**tun 关闭**(`windows_fake_ip_filter: cfg!(windows)` 平台相关)。
+
+## 基线事实(2026-07-06 实测)
+
+- `ManagedProfilePath::new`(nyanpasu-config `profile/path.rs:17-43`)已拒绝 `Component::{Prefix,RootDir,ParentDir,CurDir}` → `ProfilePathError::ManagedContainsTraversal`;`Deserialize` 委托 `new()`(path.rs:60-67)。构造侧测试已在:`managed_path_rejects_absolute_traversal_and_url`(`profile/tests/validation.rs:166-171`)。**T06 评审处置④「反序列化侧缺 `..` 拒绝」与实物不符**——缺的只是「整份 profiles 文档反序列化拒绝」这一真实攻击面(磁盘上的 profiles.yaml)的回归钉。文档 wire 形状先例:`duplicate_uid_fails_to_deserialize`(validation.rs:181-203)。
+- Mirror 同步现状(`state/profiles/actor.rs:807-892`,`ExternalFileChanged` 分支):`state.fs.read_external(target)` → `Self::validate_fetched_content(&item.definition, &content)`(签名 `(&ProfileDefinition, &str) -> Result<(), String>`,actor.rs:325)→ `state.fs.write_atomic(&materialized.file, &content)`,三步全部直接跑在 actor 的 async 线程;watcher 回调本身只 `cast`(scheduler.rs:70-77),无 I/O。既有测试:`external_mirror_change_syncs_copy_and_bumps_updated_at`(client/profiles.rs:785)、`external_watcher_smoke_mirror_real_file_event`(client/profiles.rs:880,`#[ignore]`)。
+- golden 素材:`RuntimeBuilder::build(&RuntimeBuildInput, &dyn ProfileContentSource, &dyn ScriptRunner)`(runtime_builder.rs:103);真实适配器 e2e 先例 `golden_selected_file_with_script_transform_end_to_end`(runtime_builder.rs:274-353,tempdir + 真 boa);executor 侧固定 secret 先例 `fixed_overrides()`(nyanpasu-config `runtime/executor/tests/builtin.rs:19-24`,经反序列化构造,kebab-case)。`ClashConfig.overrides` 为 pub 字段(clash/config/mod.rs:29),`ClashGuardOverrides` 可从 `nyanpasu_config::clash::config::overrides` 导入。
+- 域类型实名:`CompositionConfig { base: Option<ProfileId>, extend_proxies_from: Vec<ProfileId>, transforms: Vec<ProfileId> }`(definition.rs:35-51);`OverlayTransform { source }`;`Profiles` 的 `global_transforms: Vec<ProfileId>`/`items`/`valid` 均 pub(profiles.rs:20-28),`append_item`/`set_current` 可用。
+- 仓库无 `insta` 依赖 → 手写 bless 流(`GOLDEN_BLESS` 环境变量 + `CARGO_MANIFEST_DIR` 定位 fixtures)。
+
+## 契约修正(执行后回写 task.md T06A 卡,§5.3)
+
+1. 卡内第 1 项按实物收缩:「构造/反序列化拒绝 `..`」防御与构造侧测试**已在位**(path.rs:30-40/60-67 + validation.rs:166-171);本卡交付 = 不可信文档反序列化面的回归钉测试。T06 卡评审处置④的「缺失」表述一并修正。
+2. golden 套件机制实名:fixtures 在 `backend/tauri/src/enhance/fixtures/golden/`;4 场景(clean-seed Composition + global chain / builtin Mihomo / builtin ClashRs / whitelist-on);重铸方式 `GOLDEN_BLESS=1`;确定性约束 = 固定 secret + tun off。T07 切换 `generate()` 后本套件必须原样全绿(改动 fixtures = 行为回归,需勘误)。
+3. Mirror 同步改 `spawn_blocking`(handler await,消息顺序不变;三条 warn 日志逐字保留)。
+
+---
+
+### Task 1: profiles 文档反序列化面的穿越拒绝回归钉
+
+**Files:**
+
+- Modify: `backend/nyanpasu-config/src/profile/tests/validation.rs`(文件尾部追加一个测试)
+
+**Interfaces:**
+
+- Consumes: `ManagedProfilePath::new` 既有校验(path.rs:30-40)、`Profiles` 的 serde wire 格式(validation.rs:181-202 先例)。
+- Produces: 回归钉——未来任何人把 `Deserialize` 改成不经 `new()` 的实现(如 derive transparent)会立刻红。
+
+- [ ] **Step 1: 写回归测试**
+
+在 `validation.rs` 文件末尾追加(imports 复用文件既有的 `serde_yaml_ng`/`Profiles`/`ManagedProfilePath`):
+
+```rust
+/// T06A 回归钉:不可信文档面(磁盘 profiles.yaml)在反序列化时就必须拒绝
+/// 穿越型 managed 路径。防御在 ManagedProfilePath::new(path.rs:30-40),
+/// Deserialize 委托 new(path.rs:60-67);本测试锁死该委托关系。
+#[test]
+fn profiles_document_with_traversal_managed_path_fails_to_deserialize() {
+    let yaml = r#"items:
+  - uid: evil
+    name: evil
+    type: transform
+    transform:
+      type: overlay
+      source:
+        type: local
+        binding:
+          type: managed
+          file: ../escape.yaml
+"#;
+    let error = serde_yaml_ng::from_str::<Profiles>(yaml).unwrap_err();
+    assert!(
+        error.to_string().contains("parent"),
+        "error must name the traversal rejection: {error}"
+    );
+
+    // 直接类型面同理(serde 字符串标量 → ManagedProfilePath)。
+    assert!(serde_yaml_ng::from_str::<ManagedProfilePath>("../escape.yaml").is_err());
+}
+```
+
+- [ ] **Step 2: 运行——预期直接 PASS(这是回归钉,不是新行为)**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p nyanpasu-config profiles_document_with_traversal`
+Expected: PASS(1 passed)。若 FAIL,说明防御被移除或 wire 格式变了——停下按 systematic-debugging 排查,不得改断言迁就。
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add backend/nyanpasu-config/src/profile/tests/validation.rs
+git commit -m "test(nyanpasu-config): pin traversal rejection at profiles deserialization surface"
+```
+
+---
+
+### Task 2: Mirror 同步阻塞 I/O 移入 spawn_blocking
+
+**Files:**
+
+- Modify: `backend/tauri/src/state/profiles/actor.rs`(`ExternalFileChanged` 分支,现 824-856 行的 `if *mode == ExternalMode::Mirror { ... }` 块)
+
+**Interfaces:**
+
+- Consumes: `state.fs: Arc<dyn ProfileFsPort>`(clone 进闭包)、`Self::validate_fetched_content(&ProfileDefinition, &str) -> Result<(), String>`(actor.rs:325,关联函数,闭包内可用 `Self::` 调用)。
+- Produces: 行为不变(镜像成功→继续 commit updated_at;任一步失败→warn + 提前返回,消息逐字同旧);唯一变化 = 三步 I/O 在 blocking 池线程执行。
+
+- [ ] **Step 1: 先跑基线(确认重构前绿)**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu external_mirror_change_syncs`
+Expected: PASS(1 passed)。
+
+- [ ] **Step 2: 等价重构**
+
+把 `if *mode == ExternalMode::Mirror { ... }` 整块(现 824-856 行)替换为:
+
+```rust
+                if *mode == ExternalMode::Mirror {
+                    // T06A: keep the read→validate→write mirror sync off the
+                    // async actor thread. The handler awaits the blocking task,
+                    // so per-actor message ordering is unchanged.
+                    let fs = state.fs.clone();
+                    let target = target.clone();
+                    let mirror_file = materialized.file.clone();
+                    let definition = item.definition.clone();
+                    let log_uid = uid.clone();
+                    let synced = tokio::task::spawn_blocking(move || {
+                        let content = match fs.read_external(&target) {
+                            Ok(content) => content,
+                            Err(error) => {
+                                tracing::warn!(
+                                    uid = %log_uid,
+                                    target = %target,
+                                    error = %error,
+                                    "failed to read changed external profile"
+                                );
+                                return false;
+                            }
+                        };
+                        if let Err(message) =
+                            Self::validate_fetched_content(&definition, &content)
+                        {
+                            tracing::warn!(
+                                uid = %log_uid,
+                                target = %target,
+                                error = %message,
+                                "changed external profile failed validation"
+                            );
+                            return false;
+                        }
+                        if let Err(error) = fs.write_atomic(&mirror_file, &content) {
+                            tracing::warn!(
+                                uid = %log_uid,
+                                path = %mirror_file,
+                                error = %error,
+                                "failed to mirror changed external profile"
+                            );
+                            return false;
+                        }
+                        true
+                    })
+                    .await
+                    .unwrap_or_else(|join_error| {
+                        tracing::warn!(
+                            uid = %uid,
+                            error = %join_error,
+                            "mirror sync task failed to run"
+                        );
+                        false
+                    });
+                    if !synced {
+                        return Ok(());
+                    }
+                }
+```
+
+要点:闭包捕获全部为 owned clone(`Arc` clone + `ExternalProfilePath`/`ManagedProfilePath`/`ProfileDefinition` 均 `Clone`),不跨 `await` 持有 `snapshot` 派生借用;后续 `Self::run_write(...)` 段(858 行起)原样不动。
+
+- [ ] **Step 3: 验证等价 + 全量绿**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu external_mirror`
+Expected: PASS(`external_mirror_change_syncs_copy_and_bumps_updated_at` 过;smoke 测试保持 ignored)。
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu`
+Expected: 全绿(209+ passed,0 failed)。
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add backend/tauri/src/state/profiles/actor.rs
+git commit -m "refactor(tauri): run external mirror sync in spawn_blocking"
+```
+
+---
+
+### Task 3: RuntimeBuilder golden snapshot 文件套件
+
+**Files:**
+
+- Create: `backend/tauri/src/enhance/golden.rs`(`#[cfg(test)]` 专用模块)
+- Create: `backend/tauri/src/enhance/fixtures/golden/`(4 个期望 YAML,由 bless 流生成后入库)
+- Modify: `backend/tauri/src/enhance/mod.rs`(mod 声明区追加 `#[cfg(test)] mod golden;`)
+
+**Interfaces:**
+
+- Consumes: `RuntimeBuilder::build` / `RuntimeBuildInput` / `FsProfileContentSource::new(PathBuf)` / `EnhanceScriptRunner::new()`(均 `crate::enhance` 顶层 pub use);`ClashGuardOverrides`(`nyanpasu_config::clash::config::overrides`,固定 secret 经反序列化构造);域类型(`nyanpasu_config::profile::*`)。
+- Produces: `src/enhance/fixtures/golden/{composition_global_chain,builtin_mihomo,builtin_clash_rs,whitelist_on}.yaml` 基线文件 + 4 个 `golden_` 测试。**T07 的切换回归安全网:切换后本套件必须原样全绿。**
+
+- [ ] **Step 1: mod.rs 挂模块**
+
+在 `backend/tauri/src/enhance/mod.rs` 的 mod 声明区(`mod utils;` 之后)追加:
+
+```rust
+#[cfg(test)]
+mod golden;
+```
+
+- [ ] **Step 2: 写 golden.rs(完整文件)**
+
+```rust
+//! Golden snapshot suite over RuntimeBuilder + real adapters (PR-3 T06A).
+//! Locks the pre-switch behavior baseline for the T07 `Config::generate()`
+//! cutover: identical inputs must keep producing structurally identical
+//! final configs. Re-bless intentionally with:
+//!   GOLDEN_BLESS=1 cargo test -p clash-nyanpasu golden_
+//! Determinism rules: fixed `secret` (default is a random uuid) and tun off
+//! (`windows_fake_ip_filter` is platform-dependent).
+
+use std::{path::PathBuf, sync::Arc};
+
+use nyanpasu_config::{
+    application::ClashCore,
+    clash::config::overrides::ClashGuardOverrides,
+    profile::{
+        CompositionConfig, ConfigDefinition, FileConfig, LocalBinding, ManagedProfilePath,
+        MaterializedFile, OverlayTransform, ProfileDefinition, ProfileId, ProfileItem,
+        ProfileMetadata, ProfileSource, Profiles, ScriptRuntime, ScriptTransform,
+        TransformDefinition,
+    },
+    runtime::executor::ResolvedPortBindings,
+};
+
+use super::{EnhanceScriptRunner, FsProfileContentSource, RuntimeBuildInput, RuntimeBuilder};
+
+const SUB_A: &str = "proxies:\n  - name: a1\n    type: ss\n    server: a.example.com\n    port: 443\n";
+const SUB_B: &str = "proxies:\n  - name: b1\n    type: vmess\n    server: b.example.com\n    port: 8080\n";
+const BUILD_GROUPS: &str =
+    "proxy-groups:\n  - name: Auto\n    type: select\n    proxies:\n      - a1\n      - b1\n";
+const GLOBAL_FIX: &str = "append__rules:\n  - MATCH,DIRECT\n";
+const BASE_CONFIG: &str = "mode: direct\nproxies: []\nextra-key: keep\ncustom-field: 1\n";
+
+/// 固定 secret 的 guard overrides(Default 的 secret 是随机 uuid,
+/// nyanpasu-config overrides/mod.rs:75;先例 executor tests/builtin.rs:19-24)。
+fn fixed_overrides() -> ClashGuardOverrides {
+    serde_yaml::from_str(
+        "log-level: info\nallow-lan: false\nmode: rule\nsecret: golden-secret\nunified-delay: true\ntcp-concurrent: true\nipv6: false\n",
+    )
+    .unwrap()
+}
+
+fn golden_input(profiles: Profiles) -> RuntimeBuildInput {
+    let mut input = RuntimeBuildInput {
+        profiles: Arc::new(profiles),
+        clash: Default::default(),
+        app: Default::default(),
+        resolved_ports: ResolvedPortBindings {
+            mixed_port: 7890,
+            port: Some(7891),
+            socks_port: Some(7892),
+            external_controller: Some("127.0.0.1:9090".to_string()),
+        },
+    };
+    input.clash.overrides = fixed_overrides();
+    input.clash.enable_tun_mode = false; // windows_fake_ip_filter 平台相关
+    input.app.enable_builtin_enhanced = false; // 各场景按需显式开启
+    input
+}
+
+fn managed(name: &str) -> MaterializedFile {
+    MaterializedFile {
+        file: ManagedProfilePath::new(name).unwrap(),
+        updated_at: None,
+    }
+}
+
+fn metadata(name: &str) -> ProfileMetadata {
+    ProfileMetadata {
+        name: name.into(),
+        desc: None,
+    }
+}
+
+fn file_config(uid: &str, file: &str, transforms: &[&str]) -> ProfileItem {
+    ProfileItem {
+        uid: ProfileId(uid.into()),
+        metadata: metadata(uid),
+        definition: ProfileDefinition::Config {
+            config: ConfigDefinition::File(FileConfig {
+                source: ProfileSource::Local {
+                    binding: LocalBinding::Managed {
+                        materialized: managed(file),
+                    },
+                },
+                transforms: transforms.iter().map(|t| ProfileId((*t).into())).collect(),
+            }),
+        },
+    }
+}
+
+fn overlay(uid: &str, file: &str) -> ProfileItem {
+    ProfileItem {
+        uid: ProfileId(uid.into()),
+        metadata: metadata(uid),
+        definition: ProfileDefinition::Transform {
+            transform: TransformDefinition::Overlay(OverlayTransform {
+                source: ProfileSource::Local {
+                    binding: LocalBinding::Managed {
+                        materialized: managed(file),
+                    },
+                },
+            }),
+        },
+    }
+}
+
+fn composition(uid: &str, base: Option<&str>, extend: &[&str], transforms: &[&str]) -> ProfileItem {
+    ProfileItem {
+        uid: ProfileId(uid.into()),
+        metadata: metadata(uid),
+        definition: ProfileDefinition::Config {
+            config: ConfigDefinition::Composition(CompositionConfig {
+                base: base.map(|b| ProfileId(b.into())),
+                extend_proxies_from: extend.iter().map(|e| ProfileId((*e).into())).collect(),
+                transforms: transforms.iter().map(|t| ProfileId((*t).into())).collect(),
+            }),
+        },
+    }
+}
+
+fn build_to_yaml(input: &RuntimeBuildInput, dir: &std::path::Path) -> serde_yaml::Value {
+    let content = FsProfileContentSource::new(dir.to_path_buf());
+    let scripts = EnhanceScriptRunner::new().unwrap();
+    let artifact = RuntimeBuilder::build(input, &content, &scripts).expect("golden build");
+    serde_yaml::to_value(&*artifact.final_config).unwrap()
+}
+
+fn assert_matches_fixture(actual: &serde_yaml::Value, name: &str) {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/enhance/fixtures/golden");
+    let path = dir.join(name);
+    let rendered = serde_yaml::to_string(actual).unwrap();
+    if std::env::var_os("GOLDEN_BLESS").is_some() {
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(&path, &rendered).unwrap();
+    }
+    let expected = std::fs::read_to_string(&path).unwrap_or_else(|_| {
+        panic!("missing golden fixture {name}; run with GOLDEN_BLESS=1 to create it")
+    });
+    let expected: serde_yaml::Value = serde_yaml::from_str(&expected).unwrap();
+    assert_eq!(
+        actual, &expected,
+        "golden drift for {name}; re-bless with GOLDEN_BLESS=1 only if the change is intentional"
+    );
+}
+
+/// clean-seed Composition(base=None)+ 成员贡献 proxies + 组合内 overlay
+/// + global chain overlay(append__rules 落在缺失键上 → 按执行器语义处理)。
+#[test]
+fn golden_clean_seed_composition_with_global_chain() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("sub_a.yaml"), SUB_A).unwrap();
+    std::fs::write(temp.path().join("sub_b.yaml"), SUB_B).unwrap();
+    std::fs::write(temp.path().join("build_groups.yaml"), BUILD_GROUPS).unwrap();
+    std::fs::write(temp.path().join("global_fix.yaml"), GLOBAL_FIX).unwrap();
+
+    let mut profiles = Profiles::default();
+    profiles.append_item(file_config("sub-a", "sub_a.yaml", &[]));
+    profiles.append_item(file_config("sub-b", "sub_b.yaml", &[]));
+    profiles.append_item(overlay("build-groups", "build_groups.yaml"));
+    profiles.append_item(overlay("global-fix", "global_fix.yaml"));
+    profiles.append_item(composition(
+        "all",
+        None,
+        &["sub-a", "sub-b"],
+        &["build-groups"],
+    ));
+    profiles.set_current(Some(ProfileId("all".into())));
+    profiles.global_transforms = vec![ProfileId("global-fix".into())];
+
+    let input = golden_input(profiles);
+    let yaml = build_to_yaml(&input, temp.path());
+    assert_matches_fixture(&yaml, "composition_global_chain.yaml");
+}
+
+/// builtin 门控 golden(Mihomo:hy_alpn + meta_guard + config_fixer,真 boa)。
+#[test]
+fn golden_builtin_gating_mihomo() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("base.yaml"), BASE_CONFIG).unwrap();
+
+    let mut profiles = Profiles::default();
+    profiles.append_item(file_config("base", "base.yaml", &[]));
+    profiles.set_current(Some(ProfileId("base".into())));
+
+    let mut input = golden_input(profiles);
+    input.app.enable_builtin_enhanced = true;
+    input.app.core = ClashCore::Mihomo;
+    let yaml = build_to_yaml(&input, temp.path());
+    assert_matches_fixture(&yaml, "builtin_mihomo.yaml");
+}
+
+/// builtin 门控 golden(ClashRs:config_fixer + clash_rs_comp,真 boa + 真 lua)。
+#[test]
+fn golden_builtin_gating_clash_rs() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("base.yaml"), BASE_CONFIG).unwrap();
+
+    let mut profiles = Profiles::default();
+    profiles.append_item(file_config("base", "base.yaml", &[]));
+    profiles.set_current(Some(ProfileId("base".into())));
+
+    let mut input = golden_input(profiles);
+    input.app.enable_builtin_enhanced = true;
+    input.app.core = ClashCore::ClashRs;
+    let yaml = build_to_yaml(&input, temp.path());
+    assert_matches_fixture(&yaml, "builtin_clash_rs.yaml");
+}
+
+/// whitelist-on:enable_clash_fields=true 时未知键被过滤。
+#[test]
+fn golden_whitelist_on_filters_unknown_keys() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("base.yaml"), BASE_CONFIG).unwrap();
+
+    let mut profiles = Profiles::default();
+    profiles.append_item(file_config("base", "base.yaml", &[]));
+    profiles.set_current(Some(ProfileId("base".into())));
+
+    let mut input = golden_input(profiles);
+    input.clash.enable_clash_fields = true;
+    let yaml = build_to_yaml(&input, temp.path());
+    assert!(
+        yaml.get("extra-key").is_none(),
+        "whitelist must drop unknown keys"
+    );
+    assert_matches_fixture(&yaml, "whitelist_on.yaml");
+}
+```
+
+- [ ] **Step 3: bless(首铸期望文件)**
+
+Run(PowerShell):
+
+```powershell
+$env:GOLDEN_BLESS = '1'
+cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu golden_
+Remove-Item Env:GOLDEN_BLESS
+```
+
+Expected: 4 个 `golden_` 测试 PASS,`backend/tauri/src/enhance/fixtures/golden/` 出现 4 个 yaml。若编译错(域类型字段名/导入路径与实测漂移),按编译器提示修 golden.rs,不改生产代码。
+
+- [ ] **Step 4: 检视 blessed 基线(人工 sanity)**
+
+逐个打开 4 个 fixtures 检查:
+
+- `composition_global_chain.yaml`:`proxies` 含 a1+b1(顺序 sub-a→sub-b)、`proxy-groups` 含 Auto、guard 四键在位(`mixed-port: 7890`/`port: 7891`/`socks-port: 7892`/`external-controller`)、`secret: golden-secret`、`mode: rule`(guard 覆盖)。
+- `builtin_mihomo.yaml` vs `builtin_clash_rs.yaml`:两者内容有差(不同 builtin 组合生效);均无 `extra-key` 丢失(whitelist off)。
+- `whitelist_on.yaml`:无 `extra-key`/`custom-field`。
+
+任一不符 → 停,按 systematic-debugging 查(多半是场景装配错,不是 executor 错)。
+
+- [ ] **Step 5: 不带 bless 重跑两遍(确定性验证)**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu golden_`(连续两次)
+Expected: 两次均 4 passed(期望文件比对,无随机漂移)。
+
+- [ ] **Step 6: 全量绿 + Commit**
+
+Run: `cargo test --manifest-path ./backend/Cargo.toml -p clash-nyanpasu`
+Expected: 全绿。
+
+```powershell
+git add backend/tauri/src/enhance/mod.rs backend/tauri/src/enhance/golden.rs backend/tauri/src/enhance/fixtures/golden/
+git commit -m "test(tauri): add RuntimeBuilder golden snapshot suite"
+```
+
+---
+
+### Task 4: 契约回写 task.md T06A 卡
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md`(T06A 卡尾部)
+
+- [ ] **Step 1: 在 T06A 卡「单独 plan 时读」行之后追加执行修正块**
+
+```markdown
+**2026-07-06 执行修正(T06A 实物)**:
+
+- 第 1 项按实物收缩:`..`/穿越拒绝防御与构造侧测试**原已在位**(nyanpasu-config path.rs:30-40/60-67 + validation.rs:166-171;T06 评审处置④的「反序列化侧缺失」表述与实物不符)——本卡实际交付 = profiles 文档反序列化面的回归钉测试(validation.rs 尾部)。
+- golden 套件实名:`enhance/golden.rs` + `enhance/fixtures/golden/{composition_global_chain,builtin_mihomo,builtin_clash_rs,whitelist_on}.yaml`;重铸 `GOLDEN_BLESS=1 cargo test -p clash-nyanpasu golden_`;确定性 = 固定 `secret: golden-secret` + tun off。**T07 切换后本套件须原样全绿,改 fixtures = 行为回归须勘误。**
+- Mirror 同步已移入 `spawn_blocking`(actor.rs `ExternalFileChanged` Mirror 分支;消息顺序不变,warn 日志逐字保留)。
+```
+
+- [ ] **Step 2: Commit**
+
+```powershell
+git add docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+git commit -m "docs(pr3): record T06A execution addenda in task card"
+```
+
+---
+
+## Self-Review 结论(plan 作者自查)
+
+- 覆盖:卡内三项全部有 Task(1→Task1、2→Task2、3→Task3)+ §5.3 回写(Task4)。
+- 无占位符:所有代码块完整可粘贴;golden 期望内容不可预先写死,采用显式 bless 流 + Step 4 人工 sanity 清单,非占位。
+- 类型一致性:`golden_input`/`file_config`/`overlay`/`composition` 的字段名与 definition.rs:26-73、profiles.rs:20-28 实测一致;`fixed_overrides` YAML 与 executor builtin.rs:21 逐字节相同。

--- a/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+++ b/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
@@ -362,6 +362,7 @@ impl RuntimeBuilder {
 - `TunStack` 实际路径 = `nyanpasu_config::clash::config::tun_stack::TunStack`。
 - `EnhanceScriptRunner` 自持 current-thread runtime(`run` 同步阻塞)——**`RuntimeBuilder::build` 必须在阻塞上下文调用**(T07 统一 `spawn_blocking`);禁止在 async worker 线程直接调用。
 - golden 现状:端到端不变量测试(真实 boa + 真实文件源:脚本生效/guard 端口注入/whitelist-off 保键/step_logs 锚定)+ executor 侧 PR-3-pre② parity 套件背书;**snapshot 期望文件套件列为 T07 pre-flight 跟进项**(多场景:Composition、global chain、builtin 门控、whitelist-on)。
+- 评审处置(antigravity 2026-07-06;codex 后端故障,其评审延期):①"`block_on` 在 `spawn_blocking` 内 panic"判**误报**——tokio 仅在 async worker 线程禁止 `block_on`,blocking 池线程允许(`Handle::block_on` 官方文档模式、reqwest::blocking 同构先例),阻塞上下文契约见上条;②"每次 `run` 重建 `RunnerManager` 是性能回退"**不成立**——`JSRunner` 为 unit struct,boa `Context`(`Rc<RefCell<_>>`,!Send)legacy 同样每脚本新建,manager 仅空 HashMap;③BitFlags 门控为有意偏离(新域 `ClashCore` 无 `#[bitflags]` derive,跨 crate 改动超卡范围)——新增 core 变体时切片表需手工同步,由门控测试兜底;④**T07 加固项**:`ManagedProfilePath` 反序列化侧缺 `..` 组件拒绝(防御纵深),须用 `Component::ParentDir` 组件检查而非 `starts_with`(lexical 比较对未归一化路径无效)。
 
 **验证**:
 

--- a/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+++ b/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
@@ -400,6 +400,13 @@ impl RuntimeBuilder {
 - golden 套件实名:`enhance/golden.rs` + `enhance/fixtures/golden/{composition_global_chain,builtin_mihomo,builtin_clash_rs,whitelist_on}.yaml`;重铸 `GOLDEN_BLESS=1 cargo test -p clash-nyanpasu golden_`;确定性 = 固定 `secret: golden-secret` + tun off。**T07 切换后本套件须原样全绿,改 fixtures = 行为回归须勘误。**
 - Mirror 同步已移入 `spawn_blocking`(actor.rs `ExternalFileChanged` Mirror 分支;消息顺序不变,warn 日志逐字保留)。
 
+**2026-07-07 评审处置(codex 79/100 + antigravity 98/100 APPROVE,无 Critical)**:
+
+- Major(已修):golden builtin 两例经真 boa 执行,而 `boa_utils::set_logger` 为进程级全局(js.rs 注释自证非并发安全),与 `runtime_builder.rs` 日志断言 e2e 测试并行有窃取/漏失竞态 → js.rs 增 `BOA_LOGGER_LOCK` 在 `spawn_blocking` 闭包内串行整段 boa 执行(生产侧脚本本就经 actor 串行,无性能回退)。
+- Suggestion(已采纳):`golden_input` 显式 `enable_clash_fields = false`,基线自文档化。
+- Minor(遗留,记 T07 预备项):Mirror 失败三分支(读失败/校验失败/镜像写失败)缺「不 commit updated_at、不触发 rebuild」的断言钉。
+- antigravity 2 条 Info(run_write 后置文件操作仍同步、golden 测试助手与 runtime_builder 测试重复)均记为未来事项,不入本卡。
+
 ---
 
 ### T07 — composition root + facade 接线(⚠️ 切换组起点)

--- a/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+++ b/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
@@ -350,9 +350,18 @@ pub struct RuntimeBuildInput {
 }
 impl RuntimeBuilder {
     pub fn build(input: &RuntimeBuildInput, content: &dyn ProfileContentSource, scripts: &dyn ScriptRunner)
-        -> Result<RuntimeArtifact, RuntimePipelineError>;
+        -> Result<RuntimeArtifact, RuntimeBuildError>;   // Validation(Vec<ProfileValidationError>) | Pipeline(RuntimePipelineError)
 }
 ```
+
+**2026-07-06 契约修正(T06 实物,下游以此为准)**:
+
+- 落点实名:`enhance/runtime_builder.rs`(`RuntimeBuilder`/`RuntimeBuildInput`/`RuntimeBuildError` + `builtin_transforms_for(core)`/`derive_tun_flavor(core, stack)` 公开可测)、`enhance/content_source.rs`(`FsProfileContentSource::new(profiles_dir: PathBuf)`)、`enhance/script/adapter.rs`(`EnhanceScriptRunner::new()`,三方法 `ScriptRunner`,复用 `RunnerManager` + `create_lua_context`)。均从 `crate::enhance` 顶层 `pub use`。
+- `build()` 前置 `profiles.validate()` 防御(executor 契约要求已验证输入)→ `RuntimeBuildError::Validation`。
+- builtin 门控实现为切片匹配表(未给 tauri 引入 enumflags2);顺序与 gating 与 `chain.rs:170-175` 逐位一致,含 `clash_rs_comp` 不含 `ClashRsAlpha`、tun `ClashRs` 分支不含 Alpha 两处 legacy 怪癖(修复属行为变更,需另走勘误)。
+- `TunStack` 实际路径 = `nyanpasu_config::clash::config::tun_stack::TunStack`。
+- `EnhanceScriptRunner` 自持 current-thread runtime(`run` 同步阻塞)——**`RuntimeBuilder::build` 必须在阻塞上下文调用**(T07 统一 `spawn_blocking`);禁止在 async worker 线程直接调用。
+- golden 现状:端到端不变量测试(真实 boa + 真实文件源:脚本生效/guard 端口注入/whitelist-off 保键/step_logs 锚定)+ executor 侧 PR-3-pre② parity 套件背书;**snapshot 期望文件套件列为 T07 pre-flight 跟进项**(多场景:Composition、global chain、builtin 门控、whitelist-on)。
 
 **验证**:
 

--- a/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+++ b/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
@@ -364,6 +364,28 @@ impl RuntimeBuilder {
 
 ---
 
+### T06A — 评审加固 + golden 基线(add-only,排 T07 前;2026-07-06 增补)
+
+**目标**: 落地 T06 评审处置遗留的三项加固,并在 `Config::generate()` 切换前锁定 RuntimeBuilder 行为基线。全部 add-only,不入 §4 原子切换组,可独立提交。
+
+**内容**:
+
+1. `ManagedProfilePath` 构造/反序列化拒绝 `..`:用 `Component::ParentDir` 组件检查(**不得**用 `Path::starts_with`——lexical 比较对未归一化路径无效,T06 评审处置④)。落点 `backend/nyanpasu-config`(路径类型),含拒绝用例单测。
+2. Mirror 同步阻塞 I/O 加固:核实 T05 watcher Mirror 分支(`state/profiles/scheduler.rs`)的复制/校验是否已在阻塞线程执行;否则移入 `spawn_blocking`。plan 时以实测定改动量(可能为零改动 + 测试确认)。
+3. RuntimeBuilder golden snapshot 文件套件(T06 附录跟进项):固定输入(样本 profiles + clash/app 快照 + 固定 `ResolvedPortBindings`)驱动 `RuntimeBuilder::build`,`final_config` 序列化 YAML 作为期望文件入库;场景至少覆盖 Composition、global chain、builtin 门控、whitelist-on。T07 切换后同套件必须仍绿。
+
+**Interfaces — Consumes**: T06 `RuntimeBuilder`/`FsProfileContentSource`/`EnhanceScriptRunner` 实物。
+**Interfaces — Produces**: golden 套件(T07 回归安全网);`ManagedProfilePath` 构造语义收紧(拒绝 `..`;T02 迁移生成的 `{uid}.{ext}` 形态路径不受影响)。
+
+**验证**:
+
+- `ManagedProfilePath::new("../evil")` 等含 `..` 组件的构造被拒(含反序列化路径)
+- golden 套件可重复运行、期望文件稳定;`cargo test` 全绿
+
+**单独 plan 时读**: T06 卡「2026-07-06 契约修正」评审处置条;`state/profiles/scheduler.rs`(Mirror 分支现状);`enhance/runtime_builder.rs` 现有测试(`base_input()` 可复用)。
+
+---
+
 ### T07 — composition root + facade 接线(⚠️ 切换组起点)
 
 **目标**: spawn `ProfilesActor` 进 composition root;`NyanpasuClient` 暴露全部 profiles 域方法 + `rebuild_running_config()`;`Config::generate()` 改调 RuntimeBuilder;`RebuildNotifier` 接线。**自本卡起应用进入 BC 中间态**(旧 IPC 仍在但底层已切换,见 §4)。
@@ -381,7 +403,7 @@ impl RuntimeBuilder {
 ```rust
 impl NyanpasuClient {
     pub async fn get_profiles(&self) -> Result<Arc<Profiles>>;
-    pub async fn add_profile(&self, req: NewProfileRequest, initial_file: Option<String>) -> Result<()>;
+    pub async fn add_profile(&self, req: NewProfileRequest, initial_file: Option<String>) -> Result<ProfileId>; // 2026-07-06:返回服务端生成 uid(import 条件激活用)
     pub async fn delete_profile(&self, uid: ProfileId) -> Result<()>;
     pub async fn reorder_profile(&self, active: ProfileId, over: ProfileId) -> Result<()>;
     pub async fn reorder_profiles_by_list(&self, list: Vec<ProfileId>) -> Result<()>;
@@ -407,6 +429,17 @@ impl NyanpasuClient {
 
 **单独 plan 时读**: design §5/§6.4/§8、图 13.2;PR-2b spec §10.2(composition root 顺序样板);`setup.rs`/`lib.rs:120,362-398` 现状。
 
+**2026-07-06 契约修正(现场盘点,下游以此为准)**:
+
+- 接线简化(实物):`ProfileFileService::new(paths: PathResolver, self_proxy_port: Arc<dyn SelfProxyPortSource>)` 一个实例同时实现 `ProfileFsPort` + `SubscriptionFetcher`(`profile_file.rs:126/202`);`ProfilesClient::new(profiles_path: Utf8PathBuf, fs, fetcher, notifier)`(`client/profiles.rs:31`,`pub(crate)`)内部自行 spawn actor——无独立 spawn 步骤;T05 调度器/watcher 为 actor 生命周期内部细节,composition root 零额外接线。
+- 本卡新增三个生产实现(盘点:全仓均无非测试实现):① `RebuildNotifier`(channel 接 facade 重建入口,接收侧去抖);② `SelfProxyPortSource`(D12:取 ClashConfig 快照 mixed port);③ 端口解析纯函数 `resolve_port_bindings(&ClashConfig, &NyanpasuAppConfig) -> ResolvedPortBindings`(random-port 等 legacy 语义 plan 时实测对齐)。
+- 契约修正(§5.3,波及 T04 实物):`CommitReport` 增补 `created: Option<ProfileId>`(仅 Add 置值)——`import_profile` 条件自动激活需要服务端生成的 uid(`actor.rs:476` `generate_uid`);facade `add_profile` 改返 `Result<ProfileId>`(上方方法表 `Result<()>` 作废)。
+- 文件三方法(`get_profile_materialized_path`/`read_profile_file`/`save_profile_file`)在 facade 层实现,不经 actor 消息:快照定位 + `ProfileFileService` 直读写(§9 BC 要点照旧:仅 Local/Managed 可写、Composition→`ProfileHasNoFile`);save 不自动 rebuild(维持 legacy:前端显式 `enhance_profiles`)。
+- `generate()` 切换映射:`RuntimeArtifact→IRuntime` = `config←final_config`(ConfigValue→Mapping 投影)、`exists_keys←applied_fields`、`postprocessing_output←step_logs`(shape 转换 plan 时定,保持 `IRuntime` 对外 shape 与 `get_postprocessing_output` 返回类型不变);`rebuild_running_config()` 读完快照后全程 `spawn_blocking`(T06 附录阻塞契约),`FsProfileContentSource`/`EnhanceScriptRunner` 在闭包内每次构造。
+- 连接中断(**用户决策 2026-07-06,有意偏离 legacy**):`rebuild_running_config()` 成功后统一调用 `ConnectionInterruptionService::on_profile_change()`(加 `TODO(actor-migration)` bridge 注释,其内读 `Config::verge()`)。legacy 仅 `patch_profiles_config_inner` 路径触发;新行为下删除当前 profile、订阅后台刷新、External 失效等 affects_current 提交同样触发。影响评估:`break_when_profile_change` 默认 false,仅影响显式开启用户,语义更贴近选项本意。台账判据由「恰好两处 TODO」改为「**恰好三处**」。
+- 锚点修正:删「旧 `patch_profiles_config:80` 本卡保留」条——`NyanpasuClient` 无此方法(唯一同名物 `ipc.rs:284` 命令,归 T08);profiles 域作为 `NyanpasuClientInner` 第四成员(现 application/session_state/clash_config 三成员)。
+- 迁移顺序现状已满足:`setup.rs:22-26` `run_pending()` 先于 client 构造,ProfilesClient 插入同一序列;存在双迁移机制(`lib.rs:120` 子进程 + `setup.rs` in-process),plan 时核实 rev3 实际生效路径。
+
 ---
 
 ### T08 — IPC BC 切换(13 → 16 条)
@@ -431,6 +464,14 @@ impl NyanpasuClient {
 
 **单独 plan 时读**: design §9 全表(每行含 BC 要点);guide §5(逐命令现状签名)。
 
+**2026-07-06 契约修正(现场盘点)**:
+
+- 注册表锚点:命令注册 + specta 导出在 `specta_export.rs`(`build_specta_builder()`,profiles 条目 53–66 行),非 lib.rs(lib.rs 仅 199/238/249 三处消费 builder)。
+- `feat::update_profile` 实际在 `feat.rs:444-447`;调用者两处:`ipc.rs:255`(本卡改走 facade)+ `core/tasks/jobs/profiles.rs:33`(T10 随整文件删除,本卡不动)。
+- `import_profile` 条件自动激活:用 facade `add_profile` 返回的 `ProfileId`(T07 契约修正),激活调 facade `activate_profile`;连接中断由 `rebuild_running_config()` 统一触发(T07 用户决策),命令层零编排。
+- `patch_profiles_config_inner`(`ipc.rs:288-310`)随两条旧命令在本卡删除,不留 T10。
+- 现状 13 条命令清单实测与本卡一致;16 条目标名单不变。
+
 ---
 
 ### T09 — 前端适配
@@ -453,6 +494,11 @@ impl NyanpasuClient {
 - 全仓 `patch_profiles_config` / `chain` 字段引用零残留(grep 前端源码)
 
 **单独 plan 时读**: design §11;guide §7.2/§7.3(TS 破坏性变更表);现 profiles 页组件树。
+
+**2026-07-06 契约修正(现场盘点)**:
+
+- 前端锚点:`use-profile.ts` 唯一导出 hook 为 `useProfile`(内部消费 `getProfiles`/`viewProfile` + update/drop mutations);其余消费点仍按本卡原话 plan 时全量盘点。
+- `postprocessing_output` 前端不感知:T07 映射保持 `IRuntime` 对外 shape,`get_postprocessing_output` 返回类型不变,本卡无此项工作。
 
 ---
 
@@ -478,6 +524,12 @@ impl NyanpasuClient {
 
 **单独 plan 时读**: design §14 T3.8、§16;T08/T09 完成后的实际残留清单(plan 时以 grep 现场盘点为准,不硬编码本卡文件列表)。
 
+**2026-07-06 契约修正(现场盘点)**:
+
+- 删「`client/mod.rs:80` 旧 `patch_profiles_config` 方法」条——该方法不存在(规划期误记);命令与 helper 已在 T08 删除,本卡仅 grep 核对零残留。
+- 增补删除面:`enhance/utils.rs`——全仓唯一 `crate::config::profile` 直接 import(`utils.rs:5`),随旧 `enhance()` 清理一并处理。
+- 切换面基数实测(2026-07-06):`Config::profiles()` 共 24 处(ipc 18 / feat 3 / enhance 1 / jobs 2)——T08 清 ipc 后本卡清余下 6 处;grep 判据不变。
+
 ---
 
 ### T11 — 端到端验证 + 文档收尾
@@ -493,6 +545,10 @@ impl NyanpasuClient {
 
 **验证**: `cargo build && cargo test` + 前端构建全绿;判据 1–8 逐条勾选留痕(PR 描述引用)。
 
+**2026-07-06 契约修正(现场盘点)**:
+
+- e2e 迁移路径:存在双迁移机制(`lib.rs:120` 子进程 + `setup.rs:22-26` in-process runner),plan 时核实 rev3 实际生效路径,e2e 步骤以实测为准;`.bak` 由 CLEAN_SCHEMA step 写入(design §10 安全行)。
+
 ---
 
 ## 4. 原子切换组说明(T07–T10)
@@ -503,9 +559,10 @@ impl NyanpasuClient {
   - T08 落地后前端类型检查红,直至 T09 完成——这是铁律 3(前端 BC 同 PR)的预期形态;
   - **本组四卡必须在同一 PR 内连续完成后再请求 review/merge**,不得单独合入 main。
 - **T10 之后**: 应用恢复端到端可运行,进入 T11 验证。
+- **2026-07-06 叙事修正**:「T07 之前应用行为不变」仅对空数据/新装成立——T02 落地后,真实旧数据启动即被 rev3 迁移(`detect_baseline` 遇 legacy 文件返 0),legacy 读取失效,BC 中间态(真实数据可运行性)实际自 T02 开始。整分支单 PR 合入前提下无实害;开发者中途跑真机需知。
 
 ## 5. 执行建议
 
 1. **逐卡出 plan**: 每张卡以「本卡 + design.md 对应章节 + 卡内 Interfaces 契约」为输入,用 `superpowers:writing-plans` 展开为 bite-sized plan(TDD、每步一动作、含完整代码);卡与卡之间只通过 Interfaces 契约耦合,plan 之间不需要互读。
-2. **推荐排程**: 先并行 T01/T02/T03(+ T06 若 PR-3-pre② 已合),再 T04→T05,最后一口气完成切换组 T07–T10 + T11。
+2. **推荐排程**: 先并行 T01/T02/T03(+ T06 若 PR-3-pre② 已合),再 T04→T05,最后一口气完成切换组 T07–T10 + T11。(2026-07-06 增补:T01–T06 已执行完毕;T06A 加固卡排 T07 前,不入原子组。)
 3. **契约变更规则**: 实施中若需改动任务卡 Produces 签名,先改本文件对应卡(及下游 Consumes),再改代码——本文件是跨卡契约的唯一权威。

--- a/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+++ b/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
@@ -394,6 +394,12 @@ impl RuntimeBuilder {
 
 **单独 plan 时读**: T06 卡「2026-07-06 契约修正」评审处置条;`state/profiles/scheduler.rs`(Mirror 分支现状);`enhance/runtime_builder.rs` 现有测试(`base_input()` 可复用)。
 
+**2026-07-06 执行修正(T06A 实物)**:
+
+- 第 1 项按实物收缩:`..`/穿越拒绝防御与构造侧测试**原已在位**(nyanpasu-config path.rs:30-40/60-67 + validation.rs:166-171;T06 评审处置④的「反序列化侧缺失」表述与实物不符)——本卡实际交付 = profiles 文档反序列化面的回归钉测试(validation.rs 尾部)。
+- golden 套件实名:`enhance/golden.rs` + `enhance/fixtures/golden/{composition_global_chain,builtin_mihomo,builtin_clash_rs,whitelist_on}.yaml`;重铸 `GOLDEN_BLESS=1 cargo test -p clash-nyanpasu golden_`;确定性 = 固定 `secret: golden-secret` + tun off。**T07 切换后本套件须原样全绿,改 fixtures = 行为回归须勘误。**
+- Mirror 同步已移入 `spawn_blocking`(actor.rs `ExternalFileChanged` Mirror 分支;消息顺序不变,warn 日志逐字保留)。
+
 ---
 
 ### T07 — composition root + facade 接线(⚠️ 切换组起点)


### PR DESCRIPTION
## Summary

Part **4/6** of the PR-3 "profiles domain switch" stack. Based on `refactor/pr3c-profiles-domain-layer`.

Adds **`RuntimeBuilder`** — a pure service that builds the runtime clash config from snapshots via the runtime pipeline executor — plus a golden-snapshot safety net:

- `enhance/runtime_builder.rs`: profiles/clash/app snapshots → runtime artifact (deterministic, no globals, no IPC).
- **Golden snapshot suite** (`enhance/golden.rs` + fixtures): pins builtin chain output for mihomo / clash-rs, whitelist mode, and composition global-chain shapes, so part 5's switch can be diffed against a frozen baseline.
- Script adapter for the pipeline; boa script runs serialized around the global console logger (fixes interleaved logs / races).
- External mirror sync moved to `spawn_blocking`.
- Traversal rejection pinned at the profiles deserialization surface (`nyanpasu-config` test).

Still not wired into the composition root — no behavior change.

## Verification

- `cargo test -p clash-nyanpasu` golden suite green (baseline equals legacy enhance output for the covered shapes).


---
**Stack (merge in order)**: #4885 → #4886 → #4887 → #4888 → #4889 → #4890 — this PR is part 4/6.
