### PR TITLE
build!: hardware-AES baseline on all distributed targets (introduce gxhash)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,19 +1,23 @@
-# gxhash requires hardware SIMD intrinsics at COMPILE time, or the crate fails
-# to build (`compile_error!`). Enable them per distributed target triple:
-#   x86-64:  AES-NI (+aes) + SSE2 (+sse2, usually on by default)
-#   aarch64: AES (+aes) + NEON (+neon)
+# gxhash needs the +aes intrinsic (plus +sse2 on x86-64 / +neon on aarch64) at
+# COMPILE time or it fails with `compile_error!`. It has no scalar fallback.
 #
-# These flags apply to the WHOLE binary, so every release target below now
-# requires a CPU with AES-NI / AES at runtime (x86 CPUs since ~2010; a few old
-# low-end Atom/Pentium/Celeron lack it and would crash with an illegal
-# instruction). Accepted tradeoff for gxhash performance.
+# gxhash is currently a dev-dependency (test-only — see nyanpasu-core), so it is
+# compiled only when running `cargo test` / clippy on a CI or developer host,
+# never by the `tauri build` cross-compiles in the daily dev build. The triples
+# below are exactly those hosts (GitHub CI: ubuntu = x86_64 linux, windows =
+# x86_64 msvc, macos-latest = aarch64 darwin; x86_64 darwin for Intel-Mac devs).
 #
-# Gotcha: a bare `RUSTFLAGS` env var OVERRIDES (does not merge with) these
-# settings. Any build/CI step that sets `RUSTFLAGS` must also include
-# `target-feature=+aes,...`, otherwise gxhash will fail to compile.
+# Do NOT promote gxhash to a normal dependency and "just add more triples" here.
+# The daily dev build also targets i686 and 32-bit ARM (armv7 armel/armhf):
+#   - armv7 has no ARMv8 AES crypto extension at all, so gxhash can never build
+#     there (NEON alone is not enough);
+#   - i686 builds target old CPUs that predate AES-NI.
+# Production use of gxhash must be gated behind cfg(target_feature = "aes") with
+# a portable fallback hasher, not enabled globally in this file.
 #
-# Extend this list for any other distributed target (e.g. aarch64 linux/windows,
-# x86_64 musl) — an unlisted target will not build gxhash.
+# Gotcha: a bare RUSTFLAGS env var OVERRIDES (does not merge with) these
+# settings; any build/CI step that sets RUSTFLAGS must also include
+# `target-feature=+aes,...`.
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+aes,+sse2"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,12 +8,10 @@
 # x86_64 msvc, macos-latest = aarch64 darwin; x86_64 darwin for Intel-Mac devs).
 #
 # Do NOT promote gxhash to a normal dependency and "just add more triples" here.
-# The daily dev build also targets i686 and 32-bit ARM (armv7 armel/armhf):
-#   - armv7 has no ARMv8 AES crypto extension at all, so gxhash can never build
-#     there (NEON alone is not enough);
-#   - i686 builds target old CPUs that predate AES-NI.
-# Production use of gxhash must be gated behind cfg(target_feature = "aes") with
-# a portable fallback hasher, not enabled globally in this file.
+# The daily dev build still targets i686, which does not guarantee AES-NI, so
+# gxhash could not run there. Production use must be gated behind
+# cfg(target_feature = "aes") with a portable fallback hasher, not enabled
+# globally in this file.
 #
 # Gotcha: a bare RUSTFLAGS env var OVERRIDES (does not merge with) these
 # settings; any build/CI step that sets RUSTFLAGS must also include

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,28 @@
+# gxhash requires hardware SIMD intrinsics at COMPILE time, or the crate fails
+# to build (`compile_error!`). Enable them per distributed target triple:
+#   x86-64:  AES-NI (+aes) + SSE2 (+sse2, usually on by default)
+#   aarch64: AES (+aes) + NEON (+neon)
+#
+# These flags apply to the WHOLE binary, so every release target below now
+# requires a CPU with AES-NI / AES at runtime (x86 CPUs since ~2010; a few old
+# low-end Atom/Pentium/Celeron lack it and would crash with an illegal
+# instruction). Accepted tradeoff for gxhash performance.
+#
+# Gotcha: a bare `RUSTFLAGS` env var OVERRIDES (does not merge with) these
+# settings. Any build/CI step that sets `RUSTFLAGS` must also include
+# `target-feature=+aes,...`, otherwise gxhash will fail to compile.
+#
+# Extend this list for any other distributed target (e.g. aarch64 linux/windows,
+# x86_64 musl) — an unlisted target will not build gxhash.
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+aes,+sse2"]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-feature=+aes,+sse2"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "target-feature=+aes,+sse2"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "target-feature=+aes,+neon"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,27 +1,43 @@
-# gxhash needs the +aes intrinsic (plus +sse2 on x86-64 / +neon on aarch64) at
-# COMPILE time or it fails with `compile_error!`. It has no scalar fallback.
+# gxhash is a hardware-accelerated hasher: it needs the `+aes` target-feature
+# (plus `+sse2` on x86-64 / `+neon` on aarch64) at COMPILE time and has no scalar
+# fallback — it `compile_error!`s without it. The per-target rustflags below enable
+# that feature for every triple this project distributes, so gxhash builds on all
+# of them.
 #
-# gxhash is currently a dev-dependency (test-only — see nyanpasu-core), so it is
-# compiled only when running `cargo test` / clippy on a CI or developer host,
-# never by the `tauri build` cross-compiles in the daily dev build. The triples
-# below are exactly those hosts (GitHub CI: ubuntu = x86_64 linux, windows =
-# x86_64 msvc, macos-latest = aarch64 darwin; x86_64 darwin for Intel-Mac devs).
+# INTENTIONAL — these flags affect the whole build for each triple, release
+# artifacts included, not just tests. That is the point: they raise the baseline
+# CPU requirement of the distributed binaries to one with hardware AES, as
+# groundwork for migrating the default HashMap hasher to gxhash. Concretely:
+#   * x86_64 (windows / linux / macos): requires AES-NI (Intel Westmere 2010+,
+#     AMD Bulldozer 2011+). `+sse2` is baseline on x86-64 and a no-op here; `+aes`
+#     is the real requirement.
+#   * aarch64 (macos / linux / windows): requires the ARMv8 AES crypto extension.
+#     Present on Apple Silicon and modern server/desktop ARM, but NOT on some
+#     SBCs (e.g. Raspberry Pi 4/5). `+neon` is baseline and a no-op here.
+# 32-bit x86 (i686) cannot guarantee AES and was dropped in #4908.
 #
-# Do NOT promote gxhash to a normal dependency and "just add more triples" here.
-# The daily dev build still targets i686, which does not guarantee AES-NI, so
-# gxhash could not run there. Production use must be gated behind
-# cfg(target_feature = "aes") with a portable fallback hasher, not enabled
-# globally in this file.
+# gxhash itself is still only a dev-dependency (a smoke test — see nyanpasu-core),
+# so it is not yet linked into release binaries; these flags nonetheless apply to
+# the whole build and pre-establish the AES baseline for the default-hasher
+# migration.
 #
-# Gotcha: a bare RUSTFLAGS env var OVERRIDES (does not merge with) these
-# settings; any build/CI step that sets RUSTFLAGS must also include
-# `target-feature=+aes,...`.
+# The six triples below must stay in sync with the distributed build matrix
+# (target-release-build.yaml / target-dev-build.yaml).
+#
+# Gotcha: a bare RUSTFLAGS env var OVERRIDES (does not merge with) these settings;
+# any build/CI step that sets RUSTFLAGS must also include `target-feature=+aes,...`.
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+aes,+sse2"]
 
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+aes,+neon"]
+
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "target-feature=+aes,+sse2"]
+
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "target-feature=+aes,+neon"]
 
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "target-feature=+aes,+sse2"]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4289,6 +4289,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gxhash"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ce1bab7aa741d4e7042b2aae415b78741f267a98a7271ea226cd5ba6c43d7d"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6238,6 +6247,7 @@ dependencies = [
  "camino",
  "dashmap",
  "fs-err",
+ "gxhash",
  "indexmap 2.14.0",
  "nyanpasu-utils",
  "serde",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -42,6 +42,9 @@ tracing-test = { git = "https://github.com/Frando/tracing-test.git", rev = "e81e
 ] }
 fs4 = { version = "1.0.0", features = ["fs-err3-tokio", "fs-err3"] }
 fs-err = { version = "3.1.2", features = ["tokio"] }
+# Hardware-accelerated hasher. Requires target-feature +aes (+sse2 / +neon);
+# see .cargo/config.toml for the per-target build flags this depends on.
+gxhash = "3"
 
 [profile.release]
 panic = "unwind"

--- a/backend/nyanpasu-core/Cargo.toml
+++ b/backend/nyanpasu-core/Cargo.toml
@@ -29,5 +29,5 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 tempfile = "3"
 # Test-only for now. Keep as a dev-dependency until production code gates gxhash
 # behind cfg(target_feature = "aes") with a fallback: the daily dev build
-# cross-compiles to i686 and 32-bit armv7, where gxhash cannot build.
+# cross-compiles to i686, which does not guarantee AES-NI.
 gxhash = { workspace = true }

--- a/backend/nyanpasu-core/Cargo.toml
+++ b/backend/nyanpasu-core/Cargo.toml
@@ -27,7 +27,8 @@ serde_yaml_ng = { version = "0.10", branch = "feat/specta-update", git = "https:
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 tempfile = "3"
-# Test-only for now. Keep as a dev-dependency until production code gates gxhash
-# behind cfg(target_feature = "aes") with a fallback: the daily dev build
-# cross-compiles to i686, which does not guarantee AES-NI.
+# Currently exercised only by the gxhash smoke test below. Every distributed
+# target now guarantees hardware AES (see ../../.cargo/config.toml; i686 was
+# dropped in #4908), so gxhash can graduate to a normal dependency once the
+# default HashMap hasher is migrated to it.
 gxhash = { workspace = true }

--- a/backend/nyanpasu-core/Cargo.toml
+++ b/backend/nyanpasu-core/Cargo.toml
@@ -11,7 +11,6 @@ bon = "3"
 arc-swap = "1"
 async-trait = "0.1"
 dashmap = "6"
-gxhash = { workspace = true }
 indexmap = { version = "2.2.3", features = ["serde"] }
 thiserror.workspace = true
 tokio.workspace = true
@@ -28,3 +27,7 @@ serde_yaml_ng = { version = "0.10", branch = "feat/specta-update", git = "https:
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 tempfile = "3"
+# Test-only for now. Keep as a dev-dependency until production code gates gxhash
+# behind cfg(target_feature = "aes") with a fallback: the daily dev build
+# cross-compiles to i686 and 32-bit armv7, where gxhash cannot build.
+gxhash = { workspace = true }

--- a/backend/nyanpasu-core/Cargo.toml
+++ b/backend/nyanpasu-core/Cargo.toml
@@ -11,6 +11,7 @@ bon = "3"
 arc-swap = "1"
 async-trait = "0.1"
 dashmap = "6"
+gxhash = { workspace = true }
 indexmap = { version = "2.2.3", features = ["serde"] }
 thiserror.workspace = true
 tokio.workspace = true

--- a/backend/nyanpasu-core/src/lib.rs
+++ b/backend/nyanpasu-core/src/lib.rs
@@ -1,2 +1,33 @@
 pub mod format;
 pub mod state;
+
+/// Smoke test proving the gxhash dependency compiles and runs under the
+/// target-feature flags configured in `.cargo/config.toml`. gxhash fails to
+/// compile without `+aes` (plus `+sse2` / `+neon`), so a passing build here
+/// confirms the per-target rustflags are actually being applied.
+#[cfg(test)]
+mod gxhash_smoke {
+    use gxhash::{HashMap as GxHashMap, HashMapExt};
+
+    #[test]
+    fn gxhash_map_roundtrip() {
+        let mut map: GxHashMap<&str, u32> = GxHashMap::new();
+        map.insert("clash", 1);
+        map.insert("nyanpasu", 2);
+        assert_eq!(map.get("clash"), Some(&1));
+        assert_eq!(map.get("nyanpasu"), Some(&2));
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn gxhash64_is_deterministic() {
+        let a = gxhash::gxhash64(b"clash-nyanpasu", 0);
+        let b = gxhash::gxhash64(b"clash-nyanpasu", 0);
+        assert_eq!(a, b, "same input + seed must hash identically");
+        assert_ne!(
+            gxhash::gxhash64(b"a", 0),
+            gxhash::gxhash64(b"b", 0),
+            "different inputs should (almost surely) differ"
+        );
+    }
+}

--- a/backend/nyanpasu-core/src/lib.rs
+++ b/backend/nyanpasu-core/src/lib.rs
@@ -1,10 +1,10 @@
 pub mod format;
 pub mod state;
 
-/// Smoke test proving the gxhash dependency compiles and runs under the
+/// Smoke test proving the gxhash dev-dependency compiles and runs under the
 /// target-feature flags configured in `.cargo/config.toml`. gxhash fails to
-/// compile without `+aes` (plus `+sse2` / `+neon`), so a passing build here
-/// confirms the per-target rustflags are actually being applied.
+/// compile without `+aes` (plus `+sse2` / `+neon`), so a passing test build
+/// here confirms the per-target rustflags are actually being applied.
 #[cfg(test)]
 mod gxhash_smoke {
     use gxhash::{HashMap as GxHashMap, HashMapExt};
@@ -21,13 +21,10 @@ mod gxhash_smoke {
 
     #[test]
     fn gxhash64_is_deterministic() {
-        let a = gxhash::gxhash64(b"clash-nyanpasu", 0);
-        let b = gxhash::gxhash64(b"clash-nyanpasu", 0);
-        assert_eq!(a, b, "same input + seed must hash identically");
-        assert_ne!(
-            gxhash::gxhash64(b"a", 0),
-            gxhash::gxhash64(b"b", 0),
-            "different inputs should (almost surely) differ"
+        assert_eq!(
+            gxhash::gxhash64(b"clash-nyanpasu", 0),
+            gxhash::gxhash64(b"clash-nyanpasu", 0),
+            "same input + seed must hash identically",
         );
     }
 }


### PR DESCRIPTION
## What

- Adds `.cargo/config.toml` enabling the `+aes` target-feature (`+sse2` on x86-64 / `+neon` on aarch64) for **all six distributed targets**.
- Introduces [`gxhash`](https://crates.io/crates/gxhash) (v3.5.0) as a **dev-dependency** with a smoke test in `nyanpasu-core`.

## Why

`gxhash` is a hardware-accelerated hasher that requires `+aes` at **compile time** and has **no scalar fallback** (`compile_error!` otherwise). This PR is groundwork for migrating the default `HashMap` hasher to gxhash, and it gives every distributed release binary a hardware-AES SIMD baseline.

The `[target.*] rustflags` deliberately apply to the **whole build** for each triple — release artifacts included, not just tests — so the AES baseline is established uniformly ahead of the hasher migration.

## Target coverage (6 = the full distributed matrix)

| triple | flags |
| --- | --- |
| `x86_64-pc-windows-msvc` | `+aes,+sse2` |
| `aarch64-pc-windows-msvc` | `+aes,+neon` |
| `x86_64-unknown-linux-gnu` | `+aes,+sse2` |
| `aarch64-unknown-linux-gnu` | `+aes,+neon` |
| `x86_64-apple-darwin` | `+aes,+sse2` |
| `aarch64-apple-darwin` | `+aes,+neon` |

`+sse2`/`+neon` are baseline (no-ops); `+aes` is the real requirement. **i686 (32-bit x86) cannot guarantee AES and was removed first in #4908** (prerequisite, merged).

## Breaking change ⚠️

This raises the minimum CPU of the distributed binaries to one with **hardware AES**:

- **x86_64**: AES-NI — Intel Westmere (2010+) / AMD Bulldozer (2011+). Pre-2010 x86_64 chips are no longer supported.
- **aarch64**: the ARMv8 AES crypto extension — present on Apple Silicon and modern server/desktop ARM, but **NOT on some SBCs (e.g. Raspberry Pi 4/5)**, which are therefore dropped.

## Scope

`gxhash` stays a **dev-dependency** here (only the smoke test uses it). Because every distributed target now guarantees `+aes`, promoting it to a normal dependency and switching the default hasher needs no per-target fallback — that migration is a tracked follow-up, not part of this PR.

> Gotcha: a bare `RUSTFLAGS` env var **overrides** (does not merge with) these config settings; any CI/build step that sets `RUSTFLAGS` must also include `target-feature=+aes,...`.

## Verification

```
cargo test -p nyanpasu-core gxhash_smoke   # 2 passed
```

gxhash compiling at all proves the flags are applied (it cannot build without `+aes`).

## Depends on

- #4908 — `chore!: drop i686 (32-bit x86) build targets` (merged)