### PR TITLE
chore!: drop armv7 (armel/armhf) build targets

### DIFF
--- a/.github/workflows/deps-build-linux.yaml
+++ b/.github/workflows/deps-build-linux.yaml
@@ -21,8 +21,6 @@ on:
           - x86_64
           - i686
           - aarch64
-          - armel
-          - armhf
 
   workflow_call:
     inputs:
@@ -67,10 +65,6 @@ jobs:
               rustup target add i686-unknown-linux-gnu ;;
             "aarch64")
               rustup target add aarch64-unknown-linux-gnu ;;
-            "armel")
-              rustup target add armv7-unknown-linux-gnueabi ;;
-            "armhf")
-              rustup target add armv7-unknown-linux-gnueabihf ;;
           esac
           cargo binstall -y cross
 
@@ -125,10 +119,6 @@ jobs:
               pnpm prepare:check --arch ia32 --sidecar-host i686-unknown-linux-gnu ;;
             "aarch64")
               pnpm prepare:check --arch arm64 --sidecar-host aarch64-unknown-linux-gnu ;;
-            "armel")
-              pnpm prepare:check --arch armel --sidecar-host armv7-unknown-linux-gnueabi ;;
-            "armhf")
-              pnpm prepare:check --arch arm --sidecar-host armv7-unknown-linux-gnueabihf ;;
           esac
 
       - name: Nightly Prepare
@@ -155,10 +145,6 @@ jobs:
               TARGET_DIR="backend/target/i686-unknown-linux-gnu/release" ;;
             "aarch64")
               TARGET_DIR="backend/target/aarch64-unknown-linux-gnu/release" ;;
-            "armel")
-              TARGET_DIR="backend/target/armv7-unknown-linux-gnueabi/release" ;;
-            "armhf")
-              TARGET_DIR="backend/target/armv7-unknown-linux-gnueabihf/release" ;;
             *)
               TARGET_DIR="backend/target/release" ;;
           esac
@@ -208,10 +194,6 @@ jobs:
               ${{ inputs.nightly == true && 'pnpm build:nightly -r cross --target i686-unknown-linux-gnu -b "rpm,deb"' || 'pnpm build -r cross --target i686-unknown-linux-gnu -b "rpm,deb" -c "{ "bundle": { "createUpdaterArtifacts": false } }"' }} ;;
             "aarch64")
               ${{ inputs.nightly == true && 'pnpm build:nightly -r cross --target aarch64-unknown-linux-gnu -b "rpm,deb"' || 'pnpm build -r cross --target aarch64-unknown-linux-gnu -b "rpm,deb" -c "{ "bundle": { "createUpdaterArtifacts": false } }"' }} ;;
-            "armel")
-              ${{ inputs.nightly == true && 'pnpm build:nightly -r cross --target armv7-unknown-linux-gnueabi -b "rpm,deb"' || 'pnpm build -r cross --target armv7-unknown-linux-gnueabi -b "rpm,deb" -c "{ "bundle": { "createUpdaterArtifacts": false } }"' }} ;;
-            "armhf")
-              ${{ inputs.nightly == true && 'pnpm build:nightly -r cross --target armv7-unknown-linux-gnueabihf -b "rpm,deb"' || 'pnpm build -r cross --target armv7-unknown-linux-gnueabihf -b "rpm,deb" -c "{ "bundle": { "createUpdaterArtifacts": false } }"' }} ;;
           esac
 
       - name: Calc the archive signature

--- a/.github/workflows/target-dev-build.yaml
+++ b/.github/workflows/target-dev-build.yaml
@@ -80,26 +80,6 @@ jobs:
       arch: 'aarch64'
     secrets: inherit
 
-  linux_armhf_build:
-    name: Linux armhf Build
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.repository, 'libnyanpasu') }}
-    uses: ./.github/workflows/deps-build-linux.yaml
-    with:
-      nightly: true
-      tag: 'pre-release'
-      arch: 'armhf'
-    secrets: inherit
-
-  linux_armel_build:
-    name: Linux armel Build
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.repository, 'libnyanpasu') }}
-    uses: ./.github/workflows/deps-build-linux.yaml
-    with:
-      nightly: true
-      tag: 'pre-release'
-      arch: 'armel'
-    secrets: inherit
-
   macos_amd64_build:
     name: macOS amd64 Build
     if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.repository, 'libnyanpasu') }}
@@ -130,8 +110,6 @@ jobs:
         linux_amd64_build,
         linux_i686_build,
         linux_aarch64_build,
-        linux_armhf_build,
-        linux_armel_build,
         macos_amd64_build,
         macos_aarch64_build,
       ]

--- a/backend/Cross.toml
+++ b/backend/Cross.toml
@@ -24,11 +24,5 @@ image = "ghcr.io/libnyanpasu/builder-debian-trixie-aarch64:latest"
 #   """,
 # ]
 
-[target.armv7-unknown-linux-gnueabihf]
-image = "ghcr.io/libnyanpasu/builder-debian-trixie-armhf:latest"
-
-[target.armv7-unknown-linux-gnueabi]
-image = "ghcr.io/libnyanpasu/builder-debian-trixie-armel:latest"
-
 [target.i686-unknown-linux-gnu]
 image = "ghcr.io/libnyanpasu/builder-debian-trixie-i686:latest"

--- a/backend/tauri/src/core/updater/shared.rs
+++ b/backend/tauri/src/core/updater/shared.rs
@@ -2,10 +2,6 @@ pub(super) fn get_arch() -> anyhow::Result<&'static str> {
     let env = {
         let arch = std::env::consts::ARCH;
         let os = std::env::consts::OS;
-        #[cfg(all(target_arch = "arm", target_abi = "eabihf"))]
-        let arch = "armhf";
-        #[cfg(all(target_arch = "arm", target_abi = ""))]
-        let arch = "armel";
         (arch, os)
     };
 
@@ -15,8 +11,6 @@ pub(super) fn get_arch() -> anyhow::Result<&'static str> {
         ("x86_64", "windows") => Ok("windows-x86_64"),
         ("i686", "windows") => Ok("windows-i386"),
         ("i686", "linux") => Ok("linux-i386"),
-        ("armhf", "linux") => Ok("linux-armv7hf"),
-        ("armel", "linux") => Ok("linux-armv7"),
         ("aarch64", "macos") => Ok("darwin-arm64"),
         ("aarch64", "linux") => Ok("linux-aarch64"),
         ("aarch64", "windows") => Ok("windows-arm64"),

--- a/manifest/version.json
+++ b/manifest/version.json
@@ -16,9 +16,7 @@
       "linux-amd64": "mihomo-linux-amd64-v1-{}.gz",
       "linux-i386": "mihomo-linux-386-{}.gz",
       "darwin-arm64": "mihomo-darwin-arm64-{}.gz",
-      "darwin-x64": "mihomo-darwin-amd64-v1-{}.gz",
-      "linux-armv7": "mihomo-linux-armv5-{}.gz",
-      "linux-armv7hf": "mihomo-linux-armv7-{}.gz"
+      "darwin-x64": "mihomo-darwin-amd64-v1-{}.gz"
     },
     "mihomo_alpha": {
       "windows-i386": "mihomo-windows-386-{}.zip",
@@ -28,9 +26,7 @@
       "linux-amd64": "mihomo-linux-amd64-v1-{}.gz",
       "linux-i386": "mihomo-linux-386-{}.gz",
       "darwin-arm64": "mihomo-darwin-arm64-{}.gz",
-      "darwin-x64": "mihomo-darwin-amd64-v1-{}.gz",
-      "linux-armv7": "mihomo-linux-armv5-{}.gz",
-      "linux-armv7hf": "mihomo-linux-armv7-{}.gz"
+      "darwin-x64": "mihomo-darwin-amd64-v1-{}.gz"
     },
     "clash_rs": {
       "windows-i386": "clash-rs-i686-pc-windows-msvc-static-crt.exe",
@@ -40,9 +36,7 @@
       "linux-amd64": "clash-rs-x86_64-unknown-linux-gnu-static-crt",
       "linux-i386": "clash-rs-i686-unknown-linux-gnu",
       "darwin-arm64": "clash-rs-aarch64-apple-darwin",
-      "darwin-x64": "clash-rs-x86_64-apple-darwin",
-      "linux-armv7": "clash-rs-armv7-unknown-linux-gnueabi",
-      "linux-armv7hf": "clash-rs-armv7-unknown-linux-gnueabihf"
+      "darwin-x64": "clash-rs-x86_64-apple-darwin"
     },
     "clash_premium": {
       "windows-i386": "clash-windows-386-n{}.zip",
@@ -52,9 +46,7 @@
       "linux-amd64": "clash-linux-amd64-n{}.gz",
       "linux-i386": "clash-linux-386-n{}.gz",
       "darwin-arm64": "clash-darwin-arm64-n{}.gz",
-      "darwin-x64": "clash-darwin-amd64-n{}.gz",
-      "linux-armv7": "clash-linux-armv5-n{}.gz",
-      "linux-armv7hf": "clash-linux-armv7-n{}.gz"
+      "darwin-x64": "clash-darwin-amd64-n{}.gz"
     },
     "clash_rs_alpha": {
       "windows-i386": "clash-rs-i686-pc-windows-msvc-static-crt.exe",
@@ -64,9 +56,7 @@
       "linux-amd64": "clash-rs-x86_64-unknown-linux-gnu-static-crt",
       "linux-i386": "clash-rs-i686-unknown-linux-gnu",
       "darwin-arm64": "clash-rs-aarch64-apple-darwin",
-      "darwin-x64": "clash-rs-x86_64-apple-darwin",
-      "linux-armv7": "clash-rs-armv7-unknown-linux-gnueabi",
-      "linux-armv7hf": "clash-rs-armv7-unknown-linux-gnueabihf"
+      "darwin-x64": "clash-rs-x86_64-apple-darwin"
     }
   },
   "updated_at": "2026-07-06T22:41:19.509Z"

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -25,8 +25,6 @@ type SupportedArch =
   | "linux-aarch64"
   | "linux-amd64"
   | "linux-i386"
-  | "linux-armv7"
-  | "linux-armv7hf"
   | "darwin-arm64"
   | "darwin-x64";
 
@@ -264,9 +262,7 @@ function mapArch(platform: string, arch: string): SupportedArch {
     "win32-arm64": "windows-arm64",
     "linux-x64": "linux-amd64",
     "linux-ia32": "linux-i386",
-    "linux-arm": "linux-armv7hf",
     "linux-arm64": "linux-aarch64",
-    "linux-armel": "linux-armv7",
   };
   const result = mapping[`${platform}-${arch}`];
   if (!result) {

--- a/scripts/manifest.ts
+++ b/scripts/manifest.ts
@@ -9,8 +9,6 @@ export type SupportedArch =
   | "linux-aarch64"
   | "linux-amd64"
   | "linux-i386"
-  | "linux-armv7"
-  | "linux-armv7hf"
   | "darwin-arm64"
   | "darwin-x64";
 
@@ -96,8 +94,6 @@ export const resolveMihomo = async (): LatestVersionResolver => {
     "linux-i386": "mihomo-linux-386-{}.gz",
     "darwin-arm64": "mihomo-darwin-arm64-{}.gz",
     "darwin-x64": "mihomo-darwin-amd64-v1-{}.gz",
-    "linux-armv7": "mihomo-linux-armv5-{}.gz",
-    "linux-armv7hf": "mihomo-linux-armv7-{}.gz",
   };
 
   return { name: "mihomo", version, archMapping };
@@ -113,8 +109,6 @@ export const resolveMihomoAlpha = async (): LatestVersionResolver => {
     "linux-i386": "mihomo-linux-386-{}.gz",
     "darwin-arm64": "mihomo-darwin-arm64-{}.gz",
     "darwin-x64": "mihomo-darwin-amd64-v1-{}.gz",
-    "linux-armv7": "mihomo-linux-armv5-{}.gz",
-    "linux-armv7hf": "mihomo-linux-armv7-{}.gz",
   };
 
   const versionFromFile = (await fetchText(MIHOMO_ALPHA_VERSION_URL))?.trim();
@@ -148,8 +142,6 @@ export const resolveClashRs = async (): LatestVersionResolver => {
     "linux-i386": "clash-rs-i686-unknown-linux-gnu",
     "darwin-arm64": "clash-rs-aarch64-apple-darwin",
     "darwin-x64": "clash-rs-x86_64-apple-darwin",
-    "linux-armv7": "clash-rs-armv7-unknown-linux-gnueabi",
-    "linux-armv7hf": "clash-rs-armv7-unknown-linux-gnueabihf",
   };
 
   return { name: "clash_rs", version, archMapping };
@@ -187,8 +179,6 @@ export const resolveClashRsAlpha = async (): LatestVersionResolver => {
     "linux-i386": "clash-rs-i686-unknown-linux-gnu",
     "darwin-arm64": "clash-rs-aarch64-apple-darwin",
     "darwin-x64": "clash-rs-x86_64-apple-darwin",
-    "linux-armv7": "clash-rs-armv7-unknown-linux-gnueabi",
-    "linux-armv7hf": "clash-rs-armv7-unknown-linux-gnueabihf",
   };
 
   return { name: "clash_rs_alpha", version: alphaVersion, archMapping };
@@ -207,8 +197,6 @@ export const resolveClashPremium = async (): LatestVersionResolver => {
     "linux-i386": "clash-linux-386-n{}.gz",
     "darwin-arm64": "clash-darwin-arm64-n{}.gz",
     "darwin-x64": "clash-darwin-amd64-n{}.gz",
-    "linux-armv7": "clash-linux-armv5-n{}.gz",
-    "linux-armv7hf": "clash-linux-armv7-n{}.gz",
   };
 
   return { name: "clash_premium", version, archMapping };

--- a/scripts/telegram-notify.ts
+++ b/scripts/telegram-notify.ts
@@ -169,19 +169,9 @@ const platformGroups: PlatformGroup[] = [
   {
     label: "Linux",
     filter: (item) =>
-      (item.endsWith(".rpm") ||
-        item.endsWith(".deb") ||
-        item.endsWith(".AppImage")) &&
-      !item.includes("armel") &&
-      !item.includes("armhf"),
-  },
-  {
-    label: "Linux (armv7)",
-    filter: (item) =>
-      (item.endsWith(".rpm") ||
-        item.endsWith(".deb") ||
-        item.endsWith(".AppImage")) &&
-      (item.includes("armel") || item.includes("armhf")),
+      item.endsWith(".rpm") ||
+      item.endsWith(".deb") ||
+      item.endsWith(".AppImage"),
   },
 ];
 


### PR DESCRIPTION
## What

Removes the 32-bit ARMv7 Linux build variants and **all** their plumbing:

- `armel` → `armv7-unknown-linux-gnueabi`
- `armhf` → `armv7-unknown-linux-gnueabihf`

## Why

ARMv7 has **no ARMv8 AES cryptographic extension**, which makes it incompatible with hardware-accelerated crates the backend is moving toward (e.g. `gxhash`, which has no fallback and hard-`compile_error!`s without `+aes`). Rather than special-case armv7 everywhere, we drop it.

Removing the build jobs alone is not enough: the **core/updater manifest** (`manifest/version.json` + `scripts/manifest.ts`) and the app's **updater platform mapping** (`updater/shared.rs`) still enumerate `linux-armv7`/`linux-armv7hf`, so they would keep advertising core binaries for a platform we no longer ship. This PR removes the target end-to-end.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/target-dev-build.yaml` | drop `linux_armhf_build` / `linux_armel_build` jobs + their `update_tag` deps |
| `.github/workflows/deps-build-linux.yaml` | drop `armel`/`armhf` from arch options + cross-toolchain / sidecar / GTK-icon / cross-build case branches |
| `backend/Cross.toml` | drop the two armv7 cross-build images |
| `scripts/manifest.ts` | drop `linux-armv7`/`linux-armv7hf` from `SupportedArch` + every arch mapping |
| `scripts/check.ts` | drop armv7 from `SupportedArch` + `mapArch` |
| `scripts/telegram-notify.ts` | drop the `Linux (armv7)` release group |
| `manifest/version.json` | drop armv7 core mappings from all 5 templates |
| `backend/tauri/src/core/updater/shared.rs` | drop `armhf`/`armel` platform detection + mappings |

## Verification

- `git grep -iE 'armv7|armel|armhf|gnueabi'` (excluding `pnpm-lock.yaml`) → **0** residual references.
- `deno check` on the three edited scripts → passes (type-consistent after `SupportedArch` narrowing).
- `manifest/version.json` parses as valid JSON.
- Backend compiles (pre-commit `cargo clippy --all-targets --all-features`).

## Note

Remaining distributed targets: Windows x86_64/i686/aarch64, Linux x86_64/i686/aarch64, macOS x86_64/aarch64.
