### PR TITLE
chore!: drop i686 (32-bit x86) build targets

### DIFF
--- a/.github/workflows/deps-build-linux.yaml
+++ b/.github/workflows/deps-build-linux.yaml
@@ -19,7 +19,6 @@ on:
         default: 'x86_64'
         options:
           - x86_64
-          - i686
           - aarch64
 
   workflow_call:
@@ -61,8 +60,6 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.arch }}" in
-            "i686")
-              rustup target add i686-unknown-linux-gnu ;;
             "aarch64")
               rustup target add aarch64-unknown-linux-gnu ;;
           esac
@@ -115,8 +112,6 @@ jobs:
           case "${{ inputs.arch }}" in
             "x86_64")
               pnpm prepare:check ;;
-            "i686")
-              pnpm prepare:check --arch ia32 --sidecar-host i686-unknown-linux-gnu ;;
             "aarch64")
               pnpm prepare:check --arch arm64 --sidecar-host aarch64-unknown-linux-gnu ;;
           esac
@@ -141,8 +136,6 @@ jobs:
           case "${{ inputs.arch }}" in
             "x86_64")
               TARGET_DIR="backend/target/release" ;;
-            "i686")
-              TARGET_DIR="backend/target/i686-unknown-linux-gnu/release" ;;
             "aarch64")
               TARGET_DIR="backend/target/aarch64-unknown-linux-gnu/release" ;;
             *)
@@ -190,8 +183,6 @@ jobs:
           NIGHTLY: ${{ inputs.nightly == true && 'true' || 'false' }}
         run: |
           case "${{ inputs.arch }}" in
-            "i686")
-              ${{ inputs.nightly == true && 'pnpm build:nightly -r cross --target i686-unknown-linux-gnu -b "rpm,deb"' || 'pnpm build -r cross --target i686-unknown-linux-gnu -b "rpm,deb" -c "{ "bundle": { "createUpdaterArtifacts": false } }"' }} ;;
             "aarch64")
               ${{ inputs.nightly == true && 'pnpm build:nightly -r cross --target aarch64-unknown-linux-gnu -b "rpm,deb"' || 'pnpm build -r cross --target aarch64-unknown-linux-gnu -b "rpm,deb" -c "{ "bundle": { "createUpdaterArtifacts": false } }"' }} ;;
           esac

--- a/.github/workflows/deps-build-windows-nsis.yaml
+++ b/.github/workflows/deps-build-windows-nsis.yaml
@@ -37,7 +37,6 @@ on:
         default: 'x86_64'
         options:
           - x86_64
-          - i686
           - aarch64
 
   workflow_call:
@@ -133,9 +132,6 @@ jobs:
             'x86_64' {
               pnpm prepare:check
             }
-            'i686' {
-              pnpm prepare:check --arch ia32 --sidecar-host i686-pc-windows-msvc
-            }
             'aarch64' {
               pnpm prepare:check --arch arm64 --sidecar-host aarch64-pc-windows-msvc
             }
@@ -165,16 +161,6 @@ jobs:
           NIGHTLY: ${{ inputs.nightly == true  && 'true' || 'false' }}
         run: |
           pnpm tauri build ${{ inputs.nightly == true && '-f nightly -c ./backend/tauri/tauri.nightly.conf.json' || '-f default-meta' }}
-
-      - name: Tauri build i686
-        if: ${{ inputs.arch == 'i686' && inputs.bundle-type != 'fixed-webview' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-          NIGHTLY: ${{ inputs.nightly == true  && 'true' || 'false' }}
-        run: |
-          pnpm tauri build ${{ inputs.nightly == true && '-f nightly -c ./backend/tauri/tauri.nightly.conf.json --target i686-pc-windows-msvc' || '-f default-meta --target i686-pc-windows-msvc' }}
 
       - name: Tauri build arm64
         if: ${{ inputs.arch == 'aarch64' && inputs.bundle-type != 'fixed-webview' }}
@@ -251,9 +237,6 @@ jobs:
             'x86_64' {
               $arch= 'x64'
             }
-            'i686' {
-              $arch = 'x86'
-            }
             'aarch64' {
               $arch = 'arm64'
             }
@@ -282,16 +265,6 @@ jobs:
         run: |
           pnpm tauri build ${{ inputs.nightly == true && '-f nightly -c ./backend/tauri/tauri.nightly.conf.json' || '-f default-meta' }}
 
-      - name: Tauri build i686 with fixed WebView
-        if: ${{ inputs.arch == 'i686' && inputs.bundle-type != 'standard' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-          NIGHTLY: ${{ inputs.nightly == true  && 'true' || 'false' }}
-        run: |
-          pnpm tauri build ${{ inputs.nightly == true && '-f nightly -c ./backend/tauri/tauri.nightly.conf.json --target i686-pc-windows-msvc' || '-f default-meta --target i686-pc-windows-msvc' }}
-
       - name: Tauri build arm64 with fixed WebView
         if: ${{ inputs.arch == 'aarch64' && inputs.bundle-type != 'standard' }}
         env:
@@ -310,9 +283,6 @@ jobs:
           switch ($condition) {
             'x86_64' {
               $arch= 'x64'
-            }
-            'i686' {
-              $arch = 'x86'
             }
             'aarch64' {
               $arch = 'arm64'

--- a/.github/workflows/target-dev-build.yaml
+++ b/.github/workflows/target-dev-build.yaml
@@ -38,18 +38,6 @@ jobs:
       tag: 'pre-release'
     secrets: inherit
 
-  windows_i686_build:
-    name: Windows i686 Build
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.repository, 'libnyanpasu') }}
-    uses: ./.github/workflows/deps-build-windows-nsis.yaml
-    with:
-      portable: true
-      nightly: true
-      bundle-type: 'both'
-      arch: 'i686'
-      tag: 'pre-release'
-    secrets: inherit
-
   linux_amd64_build:
     name: Linux amd64 Build
     if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.repository, 'libnyanpasu') }}
@@ -58,16 +46,6 @@ jobs:
       nightly: true
       tag: 'pre-release'
       arch: 'x86_64'
-    secrets: inherit
-
-  linux_i686_build:
-    name: Linux i686 Build
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.repository, 'libnyanpasu') }}
-    uses: ./.github/workflows/deps-build-linux.yaml
-    with:
-      nightly: true
-      tag: 'pre-release'
-      arch: 'i686'
     secrets: inherit
 
   linux_aarch64_build:
@@ -105,10 +83,8 @@ jobs:
     needs:
       [
         windows_amd64_build,
-        windows_i686_build,
         windows_aarch64_build,
         linux_amd64_build,
-        linux_i686_build,
         linux_aarch64_build,
         macos_amd64_build,
         macos_aarch64_build,

--- a/backend/Cross.toml
+++ b/backend/Cross.toml
@@ -23,6 +23,3 @@ image = "ghcr.io/libnyanpasu/builder-debian-trixie-aarch64:latest"
 #     libssl-dev:$CROSS_DEB_ARCH \
 #   """,
 # ]
-
-[target.i686-unknown-linux-gnu]
-image = "ghcr.io/libnyanpasu/builder-debian-trixie-i686:latest"

--- a/backend/tauri/src/core/updater/shared.rs
+++ b/backend/tauri/src/core/updater/shared.rs
@@ -9,8 +9,6 @@ pub(super) fn get_arch() -> anyhow::Result<&'static str> {
         ("x86_64", "macos") => Ok("darwin-x64"),
         ("x86_64", "linux") => Ok("linux-amd64"),
         ("x86_64", "windows") => Ok("windows-x86_64"),
-        ("i686", "windows") => Ok("windows-i386"),
-        ("i686", "linux") => Ok("linux-i386"),
         ("aarch64", "macos") => Ok("darwin-arm64"),
         ("aarch64", "linux") => Ok("linux-aarch64"),
         ("aarch64", "windows") => Ok("windows-arm64"),

--- a/manifest/version.json
+++ b/manifest/version.json
@@ -9,52 +9,42 @@
   },
   "arch_template": {
     "mihomo": {
-      "windows-i386": "mihomo-windows-386-{}.zip",
       "windows-x86_64": "mihomo-windows-amd64-v1-{}.zip",
       "windows-arm64": "mihomo-windows-arm64-{}.zip",
       "linux-aarch64": "mihomo-linux-arm64-{}.gz",
       "linux-amd64": "mihomo-linux-amd64-v1-{}.gz",
-      "linux-i386": "mihomo-linux-386-{}.gz",
       "darwin-arm64": "mihomo-darwin-arm64-{}.gz",
       "darwin-x64": "mihomo-darwin-amd64-v1-{}.gz"
     },
     "mihomo_alpha": {
-      "windows-i386": "mihomo-windows-386-{}.zip",
       "windows-x86_64": "mihomo-windows-amd64-v1-{}.zip",
       "windows-arm64": "mihomo-windows-arm64-{}.zip",
       "linux-aarch64": "mihomo-linux-arm64-{}.gz",
       "linux-amd64": "mihomo-linux-amd64-v1-{}.gz",
-      "linux-i386": "mihomo-linux-386-{}.gz",
       "darwin-arm64": "mihomo-darwin-arm64-{}.gz",
       "darwin-x64": "mihomo-darwin-amd64-v1-{}.gz"
     },
     "clash_rs": {
-      "windows-i386": "clash-rs-i686-pc-windows-msvc-static-crt.exe",
       "windows-x86_64": "clash-rs-x86_64-pc-windows-msvc.exe",
       "windows-arm64": "clash-rs-aarch64-pc-windows-msvc.exe",
       "linux-aarch64": "clash-rs-aarch64-unknown-linux-gnu",
       "linux-amd64": "clash-rs-x86_64-unknown-linux-gnu-static-crt",
-      "linux-i386": "clash-rs-i686-unknown-linux-gnu",
       "darwin-arm64": "clash-rs-aarch64-apple-darwin",
       "darwin-x64": "clash-rs-x86_64-apple-darwin"
     },
     "clash_premium": {
-      "windows-i386": "clash-windows-386-n{}.zip",
       "windows-x86_64": "clash-windows-amd64-n{}.zip",
       "windows-arm64": "clash-windows-arm64-n{}.zip",
       "linux-aarch64": "clash-linux-arm64-n{}.gz",
       "linux-amd64": "clash-linux-amd64-n{}.gz",
-      "linux-i386": "clash-linux-386-n{}.gz",
       "darwin-arm64": "clash-darwin-arm64-n{}.gz",
       "darwin-x64": "clash-darwin-amd64-n{}.gz"
     },
     "clash_rs_alpha": {
-      "windows-i386": "clash-rs-i686-pc-windows-msvc-static-crt.exe",
       "windows-x86_64": "clash-rs-x86_64-pc-windows-msvc.exe",
       "windows-arm64": "clash-rs-aarch64-pc-windows-msvc.exe",
       "linux-aarch64": "clash-rs-aarch64-unknown-linux-gnu",
       "linux-amd64": "clash-rs-x86_64-unknown-linux-gnu-static-crt",
-      "linux-i386": "clash-rs-i686-unknown-linux-gnu",
       "darwin-arm64": "clash-rs-aarch64-apple-darwin",
       "darwin-x64": "clash-rs-x86_64-apple-darwin"
     }

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -19,12 +19,10 @@ interface BinInfo {
 }
 
 type SupportedArch =
-  | "windows-i386"
   | "windows-x86_64"
   | "windows-arm64"
   | "linux-aarch64"
   | "linux-amd64"
-  | "linux-i386"
   | "darwin-arm64"
   | "darwin-x64";
 
@@ -258,10 +256,8 @@ function mapArch(platform: string, arch: string): SupportedArch {
     "darwin-x64": "darwin-x64",
     "darwin-arm64": "darwin-arm64",
     "win32-x64": "windows-x86_64",
-    "win32-ia32": "windows-i386",
     "win32-arm64": "windows-arm64",
     "linux-x64": "linux-amd64",
-    "linux-ia32": "linux-i386",
     "linux-arm64": "linux-aarch64",
   };
   const result = mapping[`${platform}-${arch}`];

--- a/scripts/manifest.ts
+++ b/scripts/manifest.ts
@@ -3,12 +3,10 @@ import { consola } from "./utils/logger.ts";
 // === Types ===
 
 export type SupportedArch =
-  | "windows-i386"
   | "windows-x86_64"
   | "windows-arm64"
   | "linux-aarch64"
   | "linux-amd64"
-  | "linux-i386"
   | "darwin-arm64"
   | "darwin-x64";
 
@@ -86,12 +84,10 @@ export const resolveMihomo = async (): LatestVersionResolver => {
   consola.debug(`mihomo latest release: ${version}`);
 
   const archMapping: ArchMapping = {
-    "windows-i386": "mihomo-windows-386-{}.zip",
     "windows-x86_64": "mihomo-windows-amd64-v1-{}.zip",
     "windows-arm64": "mihomo-windows-arm64-{}.zip",
     "linux-aarch64": "mihomo-linux-arm64-{}.gz",
     "linux-amd64": "mihomo-linux-amd64-v1-{}.gz",
-    "linux-i386": "mihomo-linux-386-{}.gz",
     "darwin-arm64": "mihomo-darwin-arm64-{}.gz",
     "darwin-x64": "mihomo-darwin-amd64-v1-{}.gz",
   };
@@ -101,12 +97,10 @@ export const resolveMihomo = async (): LatestVersionResolver => {
 
 export const resolveMihomoAlpha = async (): LatestVersionResolver => {
   const archMapping: ArchMapping = {
-    "windows-i386": "mihomo-windows-386-{}.zip",
     "windows-x86_64": "mihomo-windows-amd64-v1-{}.zip",
     "windows-arm64": "mihomo-windows-arm64-{}.zip",
     "linux-aarch64": "mihomo-linux-arm64-{}.gz",
     "linux-amd64": "mihomo-linux-amd64-v1-{}.gz",
-    "linux-i386": "mihomo-linux-386-{}.gz",
     "darwin-arm64": "mihomo-darwin-arm64-{}.gz",
     "darwin-x64": "mihomo-darwin-amd64-v1-{}.gz",
   };
@@ -134,12 +128,10 @@ export const resolveClashRs = async (): LatestVersionResolver => {
   consola.debug(`clash-rs latest release: ${version}`);
 
   const archMapping: ArchMapping = {
-    "windows-i386": "clash-rs-i686-pc-windows-msvc-static-crt.exe",
     "windows-x86_64": "clash-rs-x86_64-pc-windows-msvc.exe",
     "windows-arm64": "clash-rs-aarch64-pc-windows-msvc.exe",
     "linux-aarch64": "clash-rs-aarch64-unknown-linux-gnu",
     "linux-amd64": "clash-rs-x86_64-unknown-linux-gnu-static-crt",
-    "linux-i386": "clash-rs-i686-unknown-linux-gnu",
     "darwin-arm64": "clash-rs-aarch64-apple-darwin",
     "darwin-x64": "clash-rs-x86_64-apple-darwin",
   };
@@ -171,12 +163,10 @@ export const resolveClashRsAlpha = async (): LatestVersionResolver => {
   consola.debug(`clash-rs alpha latest release: ${alphaVersion}`);
 
   const archMapping: ArchMapping = {
-    "windows-i386": "clash-rs-i686-pc-windows-msvc-static-crt.exe",
     "windows-x86_64": "clash-rs-x86_64-pc-windows-msvc.exe",
     "windows-arm64": "clash-rs-aarch64-pc-windows-msvc.exe",
     "linux-aarch64": "clash-rs-aarch64-unknown-linux-gnu",
     "linux-amd64": "clash-rs-x86_64-unknown-linux-gnu-static-crt",
-    "linux-i386": "clash-rs-i686-unknown-linux-gnu",
     "darwin-arm64": "clash-rs-aarch64-apple-darwin",
     "darwin-x64": "clash-rs-x86_64-apple-darwin",
   };
@@ -189,12 +179,10 @@ export const resolveClashPremium = async (): LatestVersionResolver => {
   consola.debug(`clash-premium latest release: ${version}`);
 
   const archMapping: ArchMapping = {
-    "windows-i386": "clash-windows-386-n{}.zip",
     "windows-x86_64": "clash-windows-amd64-n{}.zip",
     "windows-arm64": "clash-windows-arm64-n{}.zip",
     "linux-aarch64": "clash-linux-arm64-n{}.gz",
     "linux-amd64": "clash-linux-amd64-n{}.gz",
-    "linux-i386": "clash-linux-386-n{}.gz",
     "darwin-arm64": "clash-darwin-arm64-n{}.gz",
     "darwin-x64": "clash-darwin-amd64-n{}.gz",
   };


### PR DESCRIPTION
## What

Removes the 32-bit x86 (**i686**) build targets end to end:

- `i686-unknown-linux-gnu` → Linux **i386** (`.deb` / `.rpm`)
- `i686-pc-windows-msvc` → Windows **x86** (NSIS installer / portable)

This mirrors the earlier armv7 removal (#4904) and consolidates the distributed matrix onto targets that guarantee hardware AES.

## Why

The backend is adopting hardware-accelerated crates that require the `+aes` target-feature (`+sse2` on x86-64) at **compile time** with **no scalar fallback** (e.g. [`gxhash`](https://github.com/libnyanpasu/clash-nyanpasu/pull/4903)). i686 does not guarantee SSE2+AES-NI, so it cannot support them.

Dropping only the build jobs would leave the core/updater manifest advertising i686 artifacts that are no longer produced, so this drops the whole plumbing.

## Changes (pure removal — 8 files, −94/+0)

- **`.github/workflows/target-dev-build.yaml`**: drop `windows_i686_build` / `linux_i686_build` jobs + their `update_tag` deps.
- **`.github/workflows/deps-build-linux.yaml`**: drop the `i686` arch option and its cross-toolchain / sidecar / GTK-icon / cross-build case branches.
- **`.github/workflows/deps-build-windows-nsis.yaml`**: drop the `i686` arch option, both Tauri build steps and the fixed-webview arch switch cases.
- **`backend/Cross.toml`**: drop the i686 cross-build image.
- **`scripts/manifest.ts`, `scripts/check.ts`**: drop `windows-i386` / `linux-i386` from `SupportedArch` and every arch mapping.
- **`manifest/version.json`**: drop the i386 core mappings from every template.
- **`backend/tauri/src/core/updater/shared.rs`**: drop the i686 platform-detection arms.

## Breaking change ⚠️

Users on 32-bit x86 (Linux i386 / Windows x86) will no longer receive builds and must move to x86_64. No behavior change for any remaining target.

## Relation to #4903

Prerequisite for #4903 (introduce gxhash). Once this merges, #4903 rebases onto `main` so its per-target AES coverage spans exactly the remaining distributed targets (x86_64 + aarch64), with no non-AES target left behind.