### PR TITLE
fix(deep-link): import profiles from install-config deep links & sync profile name from subscription

### DIFF
--- a/backend/nyanpasu-config/src/profile/metadata.rs
+++ b/backend/nyanpasu-config/src/profile/metadata.rs
@@ -13,4 +13,28 @@ pub struct ProfileMetadata {
     #[patch(attribute(serde(default, with = "::serde_with::rust::double_option")))]
     #[patch(attribute(specta(type = Option<Option<String>>)))]
     pub desc: Option<String>,
+
+    /// Provenance flag: `true` when the name was chosen by the user (manual
+    /// create or rename) and must not be overwritten by subscription name-sync.
+    /// Profiles persisted before this field predate provenance tracking; absence
+    /// means user-owned so a refresh cannot silently rename them.
+    /// The value is never trusted from an incoming patch — it is set only by
+    /// rename detection and name-sync (see `ProfileItem::apply_metadata_patch`).
+    /// Only the non-default `false` (an unpinned, sync-eligible profile) is
+    /// persisted; a user-owned `true` is left off the wire and restored by the
+    /// default, so legacy and user-named documents stay byte-identical.
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    // The patch field is optional in both directions (the UI never sends it and
+    // `apply_metadata_patch` zeroes it anyway); `serde(default)` makes it absent-
+    // tolerant on the deserialize side, mirroring `desc`.
+    #[patch(attribute(serde(default)))]
+    pub custom_name: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn is_true(value: &bool) -> bool {
+    *value
 }

--- a/backend/nyanpasu-config/src/profile/patch.rs
+++ b/backend/nyanpasu-config/src/profile/patch.rs
@@ -66,8 +66,18 @@ impl Profiles {
 }
 
 impl ProfileItem {
-    pub fn apply_metadata_patch(&mut self, patch: ProfileMetadataPatch) {
+    pub fn apply_metadata_patch(&mut self, mut patch: ProfileMetadataPatch) {
+        // `custom_name` is provenance-owned: never trust it from an incoming
+        // patch (the UI does not send it). A rename — the patch carries a name
+        // that differs from the current one — pins the flag so subscription
+        // name-sync stops overwriting the user's chosen name. A patch that
+        // repeats the current name must not pin, so the comparison is required.
+        let renamed = matches!(&patch.name, Some(name) if *name != self.metadata.name);
+        patch.custom_name = None;
         self.metadata.apply(patch);
+        if renamed {
+            self.metadata.custom_name = true;
+        }
     }
 
     /// Atomically replace the whole definition (kind / source / binding switch).

--- a/backend/nyanpasu-config/src/profile/tests/dependency.rs
+++ b/backend/nyanpasu-config/src/profile/tests/dependency.rs
@@ -11,6 +11,7 @@ fn file_config(uid: &str, file: &str, transforms: Vec<ProfileId>) -> ProfileItem
         metadata: ProfileMetadata {
             name: uid.into(),
             desc: None,
+            custom_name: true,
         },
         definition: ProfileDefinition::Config {
             config: ConfigDefinition::File(FileConfig {
@@ -34,6 +35,7 @@ fn overlay(uid: &str, file: &str) -> ProfileItem {
         metadata: ProfileMetadata {
             name: uid.into(),
             desc: None,
+            custom_name: true,
         },
         definition: ProfileDefinition::Transform {
             transform: TransformDefinition::Overlay(OverlayTransform {
@@ -63,6 +65,7 @@ fn index_maps_base_extend_transform_and_global() {
         metadata: ProfileMetadata {
             name: "comp".into(),
             desc: None,
+            custom_name: true,
         },
         definition: ProfileDefinition::Config {
             config: ConfigDefinition::Composition(CompositionConfig {

--- a/backend/nyanpasu-config/src/profile/tests/metadata_patch.rs
+++ b/backend/nyanpasu-config/src/profile/tests/metadata_patch.rs
@@ -6,6 +6,7 @@ fn seed() -> ProfileMetadata {
     ProfileMetadata {
         name: "Original".into(),
         desc: Some("keep me".into()),
+        custom_name: false,
     }
 }
 

--- a/backend/nyanpasu-config/src/profile/tests/mutators.rs
+++ b/backend/nyanpasu-config/src/profile/tests/mutators.rs
@@ -11,6 +11,7 @@ fn managed_overlay(uid: &str, file: &str) -> ProfileItem {
         metadata: ProfileMetadata {
             name: uid.into(),
             desc: None,
+            custom_name: false,
         },
         definition: ProfileDefinition::Transform {
             transform: TransformDefinition::Overlay(OverlayTransform {
@@ -112,6 +113,44 @@ fn item_atomic_replacement_and_metadata_patch() {
             },
         },
     }));
+}
+
+#[test]
+fn rename_pins_custom_name_and_ignores_incoming_flag() {
+    let mut item = managed_overlay("ov", "ov.yaml");
+    assert!(!item.metadata.custom_name);
+    // A real rename pins the flag even though the patch tries to set it false.
+    let patch = serde_yaml_ng::from_str("name: Renamed\ncustom_name: false\n").unwrap();
+    item.apply_metadata_patch(patch);
+    assert_eq!(item.metadata.name, "Renamed");
+    assert!(
+        item.metadata.custom_name,
+        "rename must pin despite the patch flag"
+    );
+}
+
+#[test]
+fn patch_repeating_the_current_name_does_not_pin() {
+    let mut item = managed_overlay("ov", "ov.yaml"); // name == "ov"
+    let patch = serde_yaml_ng::from_str("name: ov\n").unwrap();
+    item.apply_metadata_patch(patch);
+    assert!(
+        !item.metadata.custom_name,
+        "re-applying the same name is not a rename and must not pin"
+    );
+}
+
+#[test]
+fn patch_cannot_clear_a_pinned_custom_name() {
+    let mut item = managed_overlay("ov", "ov.yaml");
+    item.metadata.custom_name = true;
+    // A desc-only patch carrying custom_name=false must not clear the pin.
+    let patch = serde_yaml_ng::from_str("desc: hello\ncustom_name: false\n").unwrap();
+    item.apply_metadata_patch(patch);
+    assert!(
+        item.metadata.custom_name,
+        "an incoming custom_name is never trusted"
+    );
 }
 
 #[test]

--- a/backend/nyanpasu-config/src/profile/tests/round_trip.rs
+++ b/backend/nyanpasu-config/src/profile/tests/round_trip.rs
@@ -7,6 +7,28 @@ fn parse(yaml: &str) -> Profiles {
 }
 
 #[test]
+fn metadata_missing_custom_name_defaults_to_user_owned() {
+    // Documents persisted before provenance tracking omit `custom_name`; the
+    // default must be `true` so a refresh never renames a pre-existing profile.
+    let meta: ProfileMetadata =
+        serde_yaml_ng::from_str("name: Legacy\n").expect("metadata deserializes");
+    assert!(meta.custom_name);
+}
+
+#[test]
+fn metadata_custom_name_false_round_trips() {
+    let meta: ProfileMetadata =
+        serde_yaml_ng::from_str("name: Sub\ncustom_name: false\n").expect("deserializes");
+    assert!(!meta.custom_name);
+    let dumped = serde_yaml_ng::to_string(&meta).expect("serializes");
+    let reparsed: ProfileMetadata = serde_yaml_ng::from_str(&dumped).expect("reparses");
+    assert!(
+        !reparsed.custom_name,
+        "custom_name must survive a round-trip"
+    );
+}
+
+#[test]
 fn clean_document_round_trips() {
     let yaml = r#"current: all-subscriptions
 global_transforms:

--- a/backend/nyanpasu-config/src/profile/tests/sanitize.rs
+++ b/backend/nyanpasu-config/src/profile/tests/sanitize.rs
@@ -11,6 +11,7 @@ fn file_config(uid: &str, file: &str) -> ProfileItem {
         metadata: ProfileMetadata {
             name: uid.into(),
             desc: None,
+            custom_name: true,
         },
         definition: ProfileDefinition::Config {
             config: ConfigDefinition::File(FileConfig {
@@ -34,6 +35,7 @@ fn overlay(uid: &str, file: &str) -> ProfileItem {
         metadata: ProfileMetadata {
             name: uid.into(),
             desc: None,
+            custom_name: true,
         },
         definition: ProfileDefinition::Transform {
             transform: TransformDefinition::Overlay(OverlayTransform {

--- a/backend/nyanpasu-config/src/profile/tests/validation.rs
+++ b/backend/nyanpasu-config/src/profile/tests/validation.rs
@@ -12,6 +12,7 @@ fn file_config(uid: &str, file: &str) -> ProfileItem {
         metadata: ProfileMetadata {
             name: uid.into(),
             desc: None,
+            custom_name: true,
         },
         definition: ProfileDefinition::Config {
             config: ConfigDefinition::File(FileConfig {
@@ -35,6 +36,7 @@ fn overlay(uid: &str, file: &str) -> ProfileItem {
         metadata: ProfileMetadata {
             name: uid.into(),
             desc: None,
+            custom_name: true,
         },
         definition: ProfileDefinition::Transform {
             transform: TransformDefinition::Overlay(OverlayTransform {
@@ -108,6 +110,7 @@ fn composition_member_must_be_direct_file_config() {
         metadata: ProfileMetadata {
             name: "comp".into(),
             desc: None,
+            custom_name: true,
         },
         definition: ProfileDefinition::Config {
             config: ConfigDefinition::Composition(CompositionConfig {
@@ -132,6 +135,7 @@ fn empty_composition_is_rejected() {
         metadata: ProfileMetadata {
             name: "comp".into(),
             desc: None,
+            custom_name: true,
         },
         definition: ProfileDefinition::Config {
             config: ConfigDefinition::Composition(CompositionConfig {
@@ -209,6 +213,7 @@ fn composition(uid: &str, base: Option<&str>, contributors: &[&str]) -> ProfileI
         metadata: ProfileMetadata {
             name: uid.into(),
             desc: None,
+            custom_name: true,
         },
         definition: ProfileDefinition::Config {
             config: ConfigDefinition::Composition(CompositionConfig {
@@ -226,6 +231,7 @@ fn remote_file_config(uid: &str, file: &str, url: &str, interval_minutes: u64) -
         metadata: ProfileMetadata {
             name: uid.into(),
             desc: None,
+            custom_name: true,
         },
         definition: ProfileDefinition::Config {
             config: ConfigDefinition::File(FileConfig {

--- a/backend/nyanpasu-config/src/runtime/executor/tests/support.rs
+++ b/backend/nyanpasu-config/src/runtime/executor/tests/support.rs
@@ -124,6 +124,7 @@ fn metadata(uid: &str) -> ProfileMetadata {
     ProfileMetadata {
         name: uid.to_owned(),
         desc: None,
+        custom_name: true,
     }
 }
 

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -144,6 +144,23 @@ async fn sync_legacy_mirrors(
     Ok(())
 }
 
+/// Fallback name for an imported subscription with no caller-provided name:
+/// the url's last non-empty path segment (sans `.yaml`/`.yml`), else the host,
+/// else a constant. Kept separate so `import_profile` reads as orchestration.
+fn url_derived_name(url: &url::Url) -> String {
+    url.path_segments()
+        .and_then(|segments| segments.filter(|segment| !segment.is_empty()).next_back())
+        .map(|segment| {
+            segment
+                .trim_end_matches(".yaml")
+                .trim_end_matches(".yml")
+                .to_string()
+        })
+        .filter(|name| !name.is_empty())
+        .or_else(|| url.host_str().map(str::to_string))
+        .unwrap_or_else(|| "Remote Profile".into())
+}
+
 struct NyanpasuClientInner {
     application: ApplicationClient,
     session_state: SessionStateClient,
@@ -427,36 +444,36 @@ impl NyanpasuClient {
 
     /// Import a remote subscription: add (placeholder name) -> first download
     /// via the refresh transaction -> auto-activate when nothing is current.
-    /// Naming BC (recorded 2026-07-06): legacy content-disposition naming is
-    /// retired; the fallback is the url's last path segment (sans extension)
-    /// or the host.
+    ///
+    /// Naming: a non-empty caller-provided `name` (e.g. a deep-link `name=`
+    /// parameter) is user intent, so it is pinned (`custom_name = true`) and
+    /// never overwritten by later name-sync. Without one, the name is derived
+    /// from the url and left unpinned so the first refresh can adopt the
+    /// subscription's `profile-title` / `Content-Disposition` name.
     pub async fn import_profile(
         &self,
         url: url::Url,
+        name: Option<String>,
         options: Option<RemoteProfileOptionsPatch>,
     ) -> Result<(ProfileId, runtime::RebuildOutcome)> {
         let update_interval_explicit = options
             .as_ref()
             .and_then(|patch| patch.update_interval_minutes)
             .is_some();
-        let name = url
-            .path_segments()
-            .and_then(|segments| segments.filter(|segment| !segment.is_empty()).next_back())
-            .map(|segment| {
-                segment
-                    .trim_end_matches(".yaml")
-                    .trim_end_matches(".yml")
-                    .to_string()
-            })
-            .filter(|name| !name.is_empty())
-            .or_else(|| url.host_str().map(str::to_string))
-            .unwrap_or_else(|| "Remote Profile".into());
+        let (name, custom_name) = match name {
+            Some(name) if !name.trim().is_empty() => (name, true),
+            _ => (url_derived_name(&url), false),
+        };
         let mut option = RemoteProfileOptions::default();
         if let Some(patch) = options {
             option.apply(patch);
         }
         let request = NewProfileRequest {
-            metadata: ProfileMetadata { name, desc: None },
+            metadata: ProfileMetadata {
+                name,
+                desc: None,
+                custom_name,
+            },
             definition: ProfileDefinition::Config {
                 config: ConfigDefinition::File(FileConfig {
                     source: ProfileSource::Remote {
@@ -977,6 +994,7 @@ mod tests {
             metadata: ProfileMetadata {
                 name: "t".into(),
                 desc: None,
+                custom_name: true,
             },
             definition: ProfileDefinition::Config {
                 config: ConfigDefinition::File(FileConfig {
@@ -1387,7 +1405,8 @@ mod tests {
             Ok(crate::state::profiles::ports::FetchedSubscription {
                 content: "proxies: []\n".into(),
                 subscription: SubscriptionInfo::default(),
-                filename: Some("sub.yaml".into()),
+                // No server name: exercises the url last-segment fallback below.
+                filename: None,
                 suggested_update_interval_minutes: Some(360),
             })
         });
@@ -1402,7 +1421,7 @@ mod tests {
             let mut patch = RemoteProfileOptions::new_empty_patch();
             patch.with_proxy = Some(false);
             let (uid, _) = client
-                .import_profile(url, Some(patch))
+                .import_profile(url, None, Some(patch))
                 .await
                 .expect("import");
             let snapshot = client.get_profiles().await.unwrap();
@@ -1446,7 +1465,7 @@ mod tests {
             patch.update_interval_minutes = Some(45);
             let url = url::Url::parse("https://example.com/subs/explicit.yaml").unwrap();
             let (uid, _) = client
-                .import_profile(url, Some(patch))
+                .import_profile(url, None, Some(patch))
                 .await
                 .expect("import");
             let snapshot = client.get_profiles().await.unwrap();
@@ -1471,7 +1490,7 @@ mod tests {
             let mut patch = RemoteProfileOptions::new_empty_patch();
             patch.update_interval_minutes = Some(0);
             let url = url::Url::parse("https://example.com/subs/invalid.yaml").unwrap();
-            assert!(client.import_profile(url, Some(patch)).await.is_err());
+            assert!(client.import_profile(url, None, Some(patch)).await.is_err());
             assert!(client.get_profiles().await.unwrap().items.is_empty());
         });
     }
@@ -1481,6 +1500,7 @@ mod tests {
             metadata: ProfileMetadata {
                 name: name.into(),
                 desc: None,
+                custom_name: true,
             },
             definition: ProfileDefinition::Config {
                 config: ConfigDefinition::File(FileConfig {
@@ -1503,6 +1523,7 @@ mod tests {
             metadata: ProfileMetadata {
                 name: "remote".into(),
                 desc: None,
+                custom_name: true,
             },
             definition: ProfileDefinition::Config {
                 config: ConfigDefinition::File(FileConfig {
@@ -1534,7 +1555,7 @@ mod tests {
         tauri::async_runtime::block_on(async {
             let client = test_client_with_fetcher(&dir, Arc::new(fetcher), Arc::new(core)).await;
             let url = url::Url::parse("https://example.com/subs/x.yaml").unwrap();
-            let result = client.import_profile(url, None).await;
+            let result = client.import_profile(url, None, None).await;
             assert!(
                 result.is_err(),
                 "import must fail when the first download fails"
@@ -1613,7 +1634,10 @@ mod tests {
             // Import a remote subscription; current is already set, so import
             // must NOT overwrite the selection made before it.
             let url = url::Url::parse("https://example.com/subs/x.yaml").unwrap();
-            let (imported, _) = client.import_profile(url, None).await.expect("import");
+            let (imported, _) = client
+                .import_profile(url, None, None)
+                .await
+                .expect("import");
             let snapshot = client.get_profiles().await.unwrap();
             assert_eq!(
                 snapshot.current.as_ref(),
@@ -1627,6 +1651,71 @@ mod tests {
                 unreachable!()
             };
             assert_eq!(option.update_interval_minutes, 120);
+        });
+    }
+
+    fn ok_fetch_without_name() -> MockSubscriptionFetcher {
+        let mut fetcher = MockSubscriptionFetcher::new();
+        fetcher.expect_fetch().returning(|_, _| {
+            Ok(crate::state::profiles::ports::FetchedSubscription {
+                content: "proxies: []\n".into(),
+                subscription: SubscriptionInfo::default(),
+                filename: None,
+                suggested_update_interval_minutes: None,
+            })
+        });
+        fetcher
+    }
+
+    #[test]
+    fn facade_import_without_name_derives_url_name_and_leaves_it_unpinned() {
+        let dir = tempdir().unwrap();
+        let mut core = MockRunningCoreBridge::new();
+        core.expect_check_and_promote().returning(|_, _| Ok(()));
+        core.expect_apply_config().returning(|| Ok(()));
+        core.expect_on_profile_change().returning(|| ());
+
+        tauri::async_runtime::block_on(async {
+            let client =
+                test_client_with_fetcher(&dir, Arc::new(ok_fetch_without_name()), Arc::new(core))
+                    .await;
+            let url = url::Url::parse("https://example.com/subs/my-sub.yaml").unwrap();
+            let (uid, _) = client
+                .import_profile(url, None, None)
+                .await
+                .expect("import");
+            let item = client.get_profiles().await.unwrap().items[&uid].clone();
+            assert_eq!(item.metadata.name, "my-sub");
+            assert!(
+                !item.metadata.custom_name,
+                "no caller name -> unpinned so refresh name-sync can adopt a server name"
+            );
+        });
+    }
+
+    #[test]
+    fn facade_import_with_name_uses_it_and_pins_custom_name() {
+        let dir = tempdir().unwrap();
+        let mut core = MockRunningCoreBridge::new();
+        core.expect_check_and_promote().returning(|_, _| Ok(()));
+        core.expect_apply_config().returning(|| Ok(()));
+        core.expect_on_profile_change().returning(|| ());
+
+        tauri::async_runtime::block_on(async {
+            let client =
+                test_client_with_fetcher(&dir, Arc::new(ok_fetch_without_name()), Arc::new(core))
+                    .await;
+            let url = url::Url::parse("https://example.com/subs/my-sub.yaml").unwrap();
+            let (uid, _) = client
+                .import_profile(url, Some("My VPN".into()), None)
+                .await
+                .expect("import");
+            let item = client.get_profiles().await.unwrap().items[&uid].clone();
+            assert_eq!(item.metadata.name, "My VPN");
+            assert!(
+                item.metadata.custom_name,
+                "a caller-provided name is user intent and must be pinned"
+            );
         });
     }
 }

--- a/backend/tauri/src/client/profiles.rs
+++ b/backend/tauri/src/client/profiles.rs
@@ -365,6 +365,7 @@ mod tests {
             metadata: ProfileMetadata {
                 name: uid.to_uppercase(),
                 desc: None,
+                custom_name: true,
             },
             definition: ProfileDefinition::Config {
                 config: ConfigDefinition::File(FileConfig {
@@ -388,6 +389,7 @@ mod tests {
             metadata: ProfileMetadata {
                 name: uid.to_uppercase(),
                 desc: None,
+                custom_name: true,
             },
             definition: ProfileDefinition::Transform {
                 transform: TransformDefinition::Overlay(OverlayTransform {
@@ -427,6 +429,7 @@ mod tests {
             metadata: ProfileMetadata {
                 name: uid.to_uppercase(),
                 desc: None,
+                custom_name: true,
             },
             definition: ProfileDefinition::Config {
                 config: ConfigDefinition::File(FileConfig {
@@ -455,6 +458,7 @@ mod tests {
             metadata: ProfileMetadata {
                 name: uid.to_uppercase(),
                 desc: None,
+                custom_name: true,
             },
             definition: ProfileDefinition::Config {
                 config: ConfigDefinition::File(FileConfig {
@@ -599,6 +603,104 @@ mod tests {
             _ => unreachable!(),
         }
         assert!(!report.affects_current);
+    }
+
+    fn ok_fetch_named(content: &'static str, filename: &'static str) -> MockSubscriptionFetcher {
+        let mut fetcher = MockSubscriptionFetcher::new();
+        fetcher.expect_fetch().returning(move |_, _| {
+            Ok(FetchedSubscription {
+                content: content.to_string(),
+                filename: Some(filename.to_string()),
+                subscription: SubscriptionInfo::default(),
+                suggested_update_interval_minutes: None,
+            })
+        });
+        fetcher
+    }
+
+    /// Seed a single remote profile (`r1`, name `R1`) with an explicit
+    /// `custom_name`, backed by a fs that accepts refresh writes.
+    async fn remote_client_with_custom_name(
+        custom_name: bool,
+        fetcher: MockSubscriptionFetcher,
+    ) -> (ProfilesClient, TempDir) {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_ensure_not_symlink().returning(|_| Ok(()));
+        fs.expect_write_atomic().returning(|_, _| Ok(()));
+        let dir = tempdir().unwrap();
+        let client = ProfilesClient::new(
+            temp_profiles_path(&dir),
+            std::sync::Arc::new(fs),
+            std::sync::Arc::new(fetcher),
+            std::sync::Arc::new(MockRebuildNotifier::new()),
+        )
+        .await
+        .unwrap();
+        let mut item = remote_config_item("r1");
+        item.metadata.custom_name = custom_name;
+        let mut profiles = Profiles::default();
+        profiles.append_item(item);
+        client.replace(profiles).await.unwrap();
+        (client, dir)
+    }
+
+    fn name_of(report: &CommitReport, uid: &str) -> String {
+        report.snapshot.items[&ProfileId(uid.into())]
+            .metadata
+            .name
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn refresh_syncs_server_name_when_not_user_named() {
+        let (client, _dir) =
+            remote_client_with_custom_name(false, ok_fetch_named("proxies: []\n", "Server Name"))
+                .await;
+        let report = client
+            .refresh(ProfileId("r1".into()), None)
+            .await
+            .expect("refresh ok");
+        assert_eq!(name_of(&report, "r1"), "Server Name");
+    }
+
+    #[tokio::test]
+    async fn refresh_keeps_name_when_user_named() {
+        let (client, _dir) =
+            remote_client_with_custom_name(true, ok_fetch_named("proxies: []\n", "Server Name"))
+                .await;
+        let report = client
+            .refresh(ProfileId("r1".into()), None)
+            .await
+            .expect("refresh ok");
+        assert_eq!(
+            name_of(&report, "r1"),
+            "R1",
+            "a user-named profile is pinned"
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_pins_custom_name_and_survives_refresh() {
+        let (client, _dir) =
+            remote_client_with_custom_name(false, ok_fetch_named("proxies: []\n", "Server Name"))
+                .await;
+
+        let mut patch = ProfileMetadata::new_empty_patch();
+        patch.name = Some("My Name".into());
+        let report = client
+            .patch_metadata(ProfileId("r1".into()), patch)
+            .await
+            .expect("rename ok");
+        let item = &report.snapshot.items[&ProfileId("r1".into())];
+        assert_eq!(item.metadata.name, "My Name");
+        assert!(item.metadata.custom_name, "rename must pin the flag");
+
+        // The server still advertises "Server Name", but the pin must win.
+        let report = client
+            .refresh(ProfileId("r1".into()), None)
+            .await
+            .expect("refresh ok");
+        assert_eq!(name_of(&report, "r1"), "My Name");
     }
 
     #[tokio::test]
@@ -847,6 +949,7 @@ mod tests {
                     subscription: SubscriptionInfo::default(),
                     suggested_update_interval_minutes: None,
                     content: "proxies: []\n".into(),
+                    filename: None,
                 },
             )
             .await;
@@ -887,6 +990,7 @@ mod tests {
                     subscription: SubscriptionInfo::default(),
                     suggested_update_interval_minutes: None,
                     content: "proxies: []\n".into(),
+                    filename: None,
                 },
             )
             .await;
@@ -1314,6 +1418,7 @@ mod tests {
                     metadata: ProfileMetadata {
                         name: "New".into(),
                         desc: None,
+                        custom_name: true,
                     },
                     definition: file_config_item("placeholder").definition,
                 },
@@ -1583,6 +1688,7 @@ mod tests {
             metadata: ProfileMetadata {
                 name: "COMP".into(),
                 desc: None,
+                custom_name: true,
             },
             definition: ProfileDefinition::Config {
                 config: ConfigDefinition::Composition(
@@ -1694,6 +1800,7 @@ mod tests {
             metadata: ProfileMetadata {
                 name: "COMP".into(),
                 desc: None,
+                custom_name: true,
             },
             definition: ProfileDefinition::Config {
                 config: ConfigDefinition::Composition(

--- a/backend/tauri/src/enhance/golden_support.rs
+++ b/backend/tauri/src/enhance/golden_support.rs
@@ -15,6 +15,7 @@ pub(crate) fn metadata(name: &str) -> ProfileMetadata {
     ProfileMetadata {
         name: name.into(),
         desc: None,
+        custom_name: true,
     }
 }
 

--- a/backend/tauri/src/enhance/runtime_builder.rs
+++ b/backend/tauri/src/enhance/runtime_builder.rs
@@ -300,6 +300,7 @@ mod tests {
             metadata: ProfileMetadata {
                 name: "CFG1".into(),
                 desc: None,
+                custom_name: true,
             },
             definition: ProfileDefinition::Config {
                 config: ConfigDefinition::File(FileConfig {
@@ -317,6 +318,7 @@ mod tests {
             metadata: ProfileMetadata {
                 name: "SCR1".into(),
                 desc: None,
+                custom_name: true,
             },
             definition: ProfileDefinition::Transform {
                 transform: TransformDefinition::Script(ScriptTransform {

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -145,17 +145,35 @@ pub async fn enhance_profiles(client: State<'_, NyanpasuClient>) -> Result {
 pub async fn import_profile(
     client: State<'_, NyanpasuClient>,
     url: String,
+    name: Option<String>,
     option: Option<RemoteProfileOptionsPatch>,
 ) -> Result<crate::client::runtime::CommitOutcome<ProfileId>> {
     let url = url::Url::parse(&url).context("failed to parse the url")?;
-    // Return the created uid so the caller can apply user-provided metadata
-    // (import derives the name from the url server-side), plus the rebuild
-    // outcome so a degraded post-import rebuild surfaces to the UI.
-    let (uid, rebuild) = client.import_profile(url, option).await?;
+    // `name` carries deep-link intent (e.g. an install-config `name=` param);
+    // when absent the facade derives the name from the url server-side. Return
+    // the created uid plus the rebuild outcome so a degraded post-import
+    // rebuild surfaces to the UI.
+    let (uid, rebuild) = client.import_profile(url, name, option).await?;
     Ok(crate::client::runtime::CommitOutcome {
         value: uid,
         rebuild,
     })
+}
+
+/// Deep-link URL captured on cold start (from argv) before the frontend could
+/// receive the `scheme-request-received` event. The frontend drains it once on
+/// startup via [`get_pending_deep_link`], closing the race where the event is
+/// emitted before the JS listener has attached. Managed Tauri state, not a
+/// global singleton.
+#[derive(Default)]
+pub struct PendingDeepLink(pub std::sync::Mutex<Option<String>>);
+
+/// Take and clear the pending cold-start deep link, if any. Called once by the
+/// frontend during startup.
+#[tauri::command]
+#[specta::specta]
+pub async fn get_pending_deep_link(pending: State<'_, PendingDeepLink>) -> Result<Option<String>> {
+    Ok(pending.0.lock().unwrap().take())
 }
 
 /// create a new profile

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -160,9 +160,24 @@ pub async fn import_profile(
     })
 }
 
+/// Emitted to the frontend when a `clash-nyanpasu`/`clash` custom-scheme deep
+/// link is received: either from a secondary instance while the app is already
+/// running, or on cold start once the window exists. The frontend listens for
+/// this to import the referenced `install-config` profile. On cold start the
+/// same URL is also stashed in [`PendingDeepLink`] and drained once via
+/// [`get_pending_deep_link`], covering the race where the event fires before the
+/// JS listener attaches.
+///
+/// Event name: `scheme-request-received-event` (derived by `tauri_specta`).
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, tauri_specta::Event)]
+pub struct SchemeRequestReceivedEvent {
+    /// The raw deep-link URL as received from the OS.
+    pub url: String,
+}
+
 /// Deep-link URL captured on cold start (from argv) before the frontend could
-/// receive the `scheme-request-received` event. The frontend drains it once on
-/// startup via [`get_pending_deep_link`], closing the race where the event is
+/// receive the [`SchemeRequestReceivedEvent`] event. The frontend drains it once
+/// on startup via [`get_pending_deep_link`], closing the race where the event is
 /// emitted before the JS listener has attached. Managed Tauri state, not a
 /// global singleton.
 #[derive(Default)]

--- a/backend/tauri/src/lib.rs
+++ b/backend/tauri/src/lib.rs
@@ -291,10 +291,16 @@ pub fn run() -> std::io::Result<()> {
 
             // setup custom scheme
             let handle = app.handle().clone();
+            // Pending deep-link store, drained once by the frontend on startup.
+            // Covers the cold-start race where `scheme-request-received` may be
+            // emitted before the JS listener is attached.
+            app.manage(crate::ipc::PendingDeepLink::default());
             // For start new app from schema
             #[cfg(not(target_os = "macos"))]
             if let Some(url) = custom_scheme {
                 log::info!(target: "app", "started with schema");
+                *app.state::<crate::ipc::PendingDeepLink>().0.lock().unwrap() =
+                    Some(url.to_string());
                 resolve::create_window(&handle.clone());
                 while !is_window_opened() {
                     log::info!(target: "app", "waiting for window open");

--- a/backend/tauri/src/lib.rs
+++ b/backend/tauri/src/lib.rs
@@ -37,7 +37,8 @@ use crate::{
 };
 use anyhow::Context;
 use specta_typescript::Typescript;
-use tauri::{Emitter, Manager};
+use tauri::Manager;
+use tauri_specta::Event;
 use utils::resolve::{is_window_opened, reset_window_open_counter};
 
 rust_i18n::i18n!("./locales");
@@ -306,13 +307,15 @@ pub fn run() -> std::io::Result<()> {
                     log::info!(target: "app", "waiting for window open");
                     std::thread::sleep(std::time::Duration::from_millis(100));
                 }
-                Handle::global()
-                    .app_handle
-                    .lock()
-                    .as_ref()
-                    .unwrap()
-                    .emit("scheme-request-received", url.clone())
-                    .unwrap();
+                let event = crate::ipc::SchemeRequestReceivedEvent {
+                    url: url.to_string(),
+                };
+                if let Some(app_handle) = Handle::global().app_handle.lock().as_ref() {
+                    log_err!(
+                        event.emit(app_handle),
+                        "failed to emit scheme-request-received event"
+                    );
+                }
             }
             // This operation should terminate the app if app is called by custom scheme and this instance is not the primary instance
             log_err!(tauri_plugin_deep_link::register(
@@ -324,7 +327,10 @@ pub fn run() -> std::io::Result<()> {
                         log::info!(target: "app", "waiting for window open");
                         std::thread::sleep(std::time::Duration::from_millis(100));
                     }
-                    handle.emit("scheme-request-received", request).unwrap();
+                    log_err!(
+                        crate::ipc::SchemeRequestReceivedEvent { url: request }.emit(&handle),
+                        "failed to emit scheme-request-received event"
+                    );
                 }
             ));
             std::thread::spawn(move || {

--- a/backend/tauri/src/specta_export.rs
+++ b/backend/tauri/src/specta_export.rs
@@ -126,7 +126,8 @@ pub(crate) fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             core::clash::ws::ClashWsEvent,
             window::WindowMessageEvent,
             window::WindowReadyEvent,
-            core::storage::StorageValueChangedEvent
+            core::storage::StorageValueChangedEvent,
+            ipc::SchemeRequestReceivedEvent
         ])
         .dangerously_cast_bigints_to_number()
         // PR-3 T01: profile domain types, add-only. Commands referencing them

--- a/backend/tauri/src/specta_export.rs
+++ b/backend/tauri/src/specta_export.rs
@@ -53,6 +53,7 @@ pub(crate) fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             ipc::get_profiles,
             ipc::enhance_profiles,
             ipc::import_profile,
+            ipc::get_pending_deep_link,
             ipc::create_profile,
             ipc::reorder_profile,
             ipc::reorder_profiles_by_list,

--- a/backend/tauri/src/state/profiles/actor.rs
+++ b/backend/tauri/src/state/profiles/actor.rs
@@ -124,10 +124,28 @@ pub enum RefreshOutcome {
         /// Validated payload; written to the materialized file inside the
         /// commit handler so a stale download can be fenced before any write.
         content: String,
+        /// Server-provided display name (`profile-title` / `Content-Disposition`),
+        /// applied to a non-user-named profile by name-sync in the commit handler.
+        filename: Option<String>,
     },
     Failed {
         message: String,
     },
+}
+
+/// Decide the profile name to apply after a refresh. Returns `Some(name)` only
+/// when the profile is not user-named and the server supplied a non-blank name;
+/// otherwise the current name is kept. Pure so the provenance rule is unit-tested
+/// without spawning the actor.
+fn synced_name(custom_name: bool, filename: &Option<String>) -> Option<String> {
+    if custom_name {
+        return None;
+    }
+    filename
+        .as_deref()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
 }
 
 #[derive(Debug)]
@@ -836,17 +854,22 @@ impl Actor for ProfilesActor {
                             fetched.subscription,
                             fetched.suggested_update_interval_minutes,
                             fetched.content,
+                            fetched.filename,
                         ))
                     }
                     .await;
                     let outcome = match outcome {
-                        Ok((subscription, suggested_update_interval_minutes, content)) => {
-                            RefreshOutcome::Succeeded {
-                                subscription,
-                                suggested_update_interval_minutes,
-                                content,
-                            }
-                        }
+                        Ok((
+                            subscription,
+                            suggested_update_interval_minutes,
+                            content,
+                            filename,
+                        )) => RefreshOutcome::Succeeded {
+                            subscription,
+                            suggested_update_interval_minutes,
+                            content,
+                            filename,
+                        },
                         Err(message) => RefreshOutcome::Failed { message },
                     };
                     let _ = actor.cast(ProfilesActorMessage::CommitRefreshed { uid, url, outcome });
@@ -902,6 +925,7 @@ impl Actor for ProfilesActor {
                         subscription,
                         suggested_update_interval_minutes,
                         content,
+                        filename,
                     } => {
                         // Re-validate against the CURRENT definition: the URL
                         // fence above cannot see a same-URL definition change
@@ -943,6 +967,16 @@ impl Actor for ProfilesActor {
                                                 uid.clone(),
                                             ));
                                         };
+                                        // Name-sync: a subscription-provided name
+                                        // replaces the current name only while the
+                                        // profile is not user-named. Read the flag
+                                        // before mutating `definition` to avoid a
+                                        // simultaneous mutable borrow of both fields.
+                                        if let Some(name) =
+                                            synced_name(item.metadata.custom_name, &filename)
+                                        {
+                                            item.metadata.name = name;
+                                        }
                                         match item.definition.source_mut() {
                                             Some(ProfileSource::Remote {
                                                 materialized,
@@ -1254,5 +1288,19 @@ mod tests {
     fn overlay_content_needs_only_a_mapping() {
         let overlay = crate::enhance::golden_support::overlay("t1", "t1.yaml");
         assert!(ProfilesActor::validate_fetched_content(&overlay.definition, "a: 1\n").is_ok());
+    }
+
+    #[test]
+    fn synced_name_syncs_only_unpinned_profiles_with_a_server_name() {
+        // Not user-named + server name present -> adopt it.
+        assert_eq!(
+            synced_name(false, &Some("Server Name".into())),
+            Some("Server Name".into())
+        );
+        // User-named -> never overwritten, even with a server name.
+        assert_eq!(synced_name(true, &Some("Server Name".into())), None);
+        // No server name / blank server name -> keep the current name.
+        assert_eq!(synced_name(false, &None), None);
+        assert_eq!(synced_name(false, &Some("   ".into())), None);
     }
 }

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -112,6 +112,10 @@ export const commands = {
     typedError<ProfileDocument_Serialize, string>(
       __TAURI_INVOKE('get_profiles'),
     ),
+  /**
+   *  Rebuild-only command: there is no prior state commit, so a failure is a
+   *  plain error — the committed/degraded model (spec §6.2) does not apply.
+   */
   enhanceProfiles: () =>
     typedError<null, string>(__TAURI_INVOKE('enhance_profiles')),
   importProfile: (
@@ -124,7 +128,7 @@ export const commands = {
       update_interval_minutes: number | null
     } | null,
   ) =>
-    typedError<ProfileId, string>(
+    typedError<CommitOutcome<ProfileId>, string>(
       __TAURI_INVOKE('import_profile', { url, name, option }),
     ),
   /**
@@ -138,15 +142,15 @@ export const commands = {
     request: NewProfileRequest_Deserialize,
     fileData: string | null,
   ) =>
-    typedError<null, string>(
+    typedError<RebuildOutcome, string>(
       __TAURI_INVOKE('create_profile', { request, fileData }),
     ),
   reorderProfile: (activeId: ProfileId, overId: ProfileId) =>
-    typedError<null, string>(
+    typedError<RebuildOutcome, string>(
       __TAURI_INVOKE('reorder_profile', { activeId, overId }),
     ),
   reorderProfilesByList: (list: ProfileId[]) =>
-    typedError<null, string>(
+    typedError<RebuildOutcome, string>(
       __TAURI_INVOKE('reorder_profiles_by_list', { list }),
     ),
   updateProfile: (
@@ -158,36 +162,44 @@ export const commands = {
       update_interval_minutes: number | null
     } | null,
   ) =>
-    typedError<null, string>(__TAURI_INVOKE('update_profile', { uid, option })),
+    typedError<RebuildOutcome, string>(
+      __TAURI_INVOKE('update_profile', { uid, option }),
+    ),
   deleteProfile: (uid: ProfileId) =>
-    typedError<null, string>(__TAURI_INVOKE('delete_profile', { uid })),
+    typedError<RebuildOutcome, string>(
+      __TAURI_INVOKE('delete_profile', { uid }),
+    ),
   activateProfile: (uid: string | null) =>
-    typedError<null, string>(__TAURI_INVOKE('activate_profile', { uid })),
+    typedError<RebuildOutcome, string>(
+      __TAURI_INVOKE('activate_profile', { uid }),
+    ),
   setGlobalTransforms: (ids: ProfileId[]) =>
-    typedError<null, string>(__TAURI_INVOKE('set_global_transforms', { ids })),
+    typedError<RebuildOutcome, string>(
+      __TAURI_INVOKE('set_global_transforms', { ids }),
+    ),
   setProfileValidFields: (fields: string[]) =>
-    typedError<null, string>(
+    typedError<RebuildOutcome, string>(
       __TAURI_INVOKE('set_profile_valid_fields', { fields }),
     ),
   patchProfileMetadata: (
     uid: ProfileId,
     patch: ProfileMetadataPatch_Deserialize,
   ) =>
-    typedError<null, string>(
+    typedError<RebuildOutcome, string>(
       __TAURI_INVOKE('patch_profile_metadata', { uid, patch }),
     ),
   patchRemoteProfileOptions: (
     uid: ProfileId,
     patch: RemoteProfileOptionsPatch_Deserialize,
   ) =>
-    typedError<null, string>(
+    typedError<RebuildOutcome, string>(
       __TAURI_INVOKE('patch_remote_profile_options', { uid, patch }),
     ),
   replaceProfileDefinition: (
     uid: ProfileId,
     definition: ProfileDefinition_Deserialize,
   ) =>
-    typedError<null, string>(
+    typedError<RebuildOutcome, string>(
       __TAURI_INVOKE('replace_profile_definition', { uid, definition }),
     ),
   viewProfile: (uid: ProfileId) =>
@@ -487,6 +499,12 @@ export type ClashWsSnapshot = {
 export type ClashWsTraffic = {
   up: number
   down: number
+}
+
+/**  Mutation payload + rebuild outcome for data-carrying commands (import). */
+export type CommitOutcome<T> = {
+  value: T
+  rebuild: RebuildOutcome
 }
 
 export type CompositionConfig =
@@ -1681,6 +1699,14 @@ export type ProxyProviderItem_Serialize = {
   testUrl?: string | null
   expectedStatus?: string | null
 }
+
+/**
+ *  Post-commit rebuild result for mutation IPC (spec §6.2, decision D2):
+ *  state is committed first; a failed rebuild degrades instead of erroring.
+ */
+export type RebuildOutcome =
+  | { status: 'ok' }
+  | { status: 'degraded'; error: string }
 
 export type RemoteProfileOptionsPatch =
   | RemoteProfileOptionsPatch_Serialize

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -342,6 +342,9 @@ export const events = {
     'clash-connections-event',
   ),
   clashWsEvent: makeEvent<ClashWsEvent>('clash-ws-event'),
+  schemeRequestReceivedEvent: makeEvent<SchemeRequestReceivedEvent>(
+    'scheme-request-received-event',
+  ),
   storageValueChangedEvent: makeEvent<StorageValueChangedEvent>(
     'storage-value-changed-event',
   ),
@@ -1753,6 +1756,22 @@ export type RuntimeInfos = {
   service_config_dir: string
   nyanpasu_config_dir: string
   nyanpasu_data_dir: string
+}
+
+/**
+ *  Emitted to the frontend when a `clash-nyanpasu`/`clash` custom-scheme deep
+ *  link is received: either from a secondary instance while the app is already
+ *  running, or on cold start once the window exists. The frontend listens for
+ *  this to import the referenced `install-config` profile. On cold start the
+ *  same URL is also stashed in [`PendingDeepLink`] and drained once via
+ *  [`get_pending_deep_link`], covering the race where the event fires before the
+ *  JS listener attaches.
+ *
+ *  Event name: `scheme-request-received-event` (derived by `tauri_specta`).
+ */
+export type SchemeRequestReceivedEvent = {
+  /**  The raw deep-link URL as received from the OS. */
+  url: string
 }
 
 export type ScriptRuntime = 'javascript' | 'lua'

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -112,14 +112,11 @@ export const commands = {
     typedError<ProfileDocument_Serialize, string>(
       __TAURI_INVOKE('get_profiles'),
     ),
-  /**
-   *  Rebuild-only command: there is no prior state commit, so a failure is a
-   *  plain error — the committed/degraded model (spec §6.2) does not apply.
-   */
   enhanceProfiles: () =>
     typedError<null, string>(__TAURI_INVOKE('enhance_profiles')),
   importProfile: (
     url: string,
+    name: string | null,
     option: {
       user_agent?: string | null
       with_proxy: boolean | null
@@ -127,23 +124,29 @@ export const commands = {
       update_interval_minutes: number | null
     } | null,
   ) =>
-    typedError<CommitOutcome<ProfileId>, string>(
-      __TAURI_INVOKE('import_profile', { url, option }),
+    typedError<ProfileId, string>(
+      __TAURI_INVOKE('import_profile', { url, name, option }),
     ),
+  /**
+   *  Take and clear the pending cold-start deep link, if any. Called once by the
+   *  frontend during startup.
+   */
+  getPendingDeepLink: () =>
+    typedError<string | null, string>(__TAURI_INVOKE('get_pending_deep_link')),
   /**  create a new profile */
   createProfile: (
     request: NewProfileRequest_Deserialize,
     fileData: string | null,
   ) =>
-    typedError<RebuildOutcome, string>(
+    typedError<null, string>(
       __TAURI_INVOKE('create_profile', { request, fileData }),
     ),
   reorderProfile: (activeId: ProfileId, overId: ProfileId) =>
-    typedError<RebuildOutcome, string>(
+    typedError<null, string>(
       __TAURI_INVOKE('reorder_profile', { activeId, overId }),
     ),
   reorderProfilesByList: (list: ProfileId[]) =>
-    typedError<RebuildOutcome, string>(
+    typedError<null, string>(
       __TAURI_INVOKE('reorder_profiles_by_list', { list }),
     ),
   updateProfile: (
@@ -155,44 +158,36 @@ export const commands = {
       update_interval_minutes: number | null
     } | null,
   ) =>
-    typedError<RebuildOutcome, string>(
-      __TAURI_INVOKE('update_profile', { uid, option }),
-    ),
+    typedError<null, string>(__TAURI_INVOKE('update_profile', { uid, option })),
   deleteProfile: (uid: ProfileId) =>
-    typedError<RebuildOutcome, string>(
-      __TAURI_INVOKE('delete_profile', { uid }),
-    ),
+    typedError<null, string>(__TAURI_INVOKE('delete_profile', { uid })),
   activateProfile: (uid: string | null) =>
-    typedError<RebuildOutcome, string>(
-      __TAURI_INVOKE('activate_profile', { uid }),
-    ),
+    typedError<null, string>(__TAURI_INVOKE('activate_profile', { uid })),
   setGlobalTransforms: (ids: ProfileId[]) =>
-    typedError<RebuildOutcome, string>(
-      __TAURI_INVOKE('set_global_transforms', { ids }),
-    ),
+    typedError<null, string>(__TAURI_INVOKE('set_global_transforms', { ids })),
   setProfileValidFields: (fields: string[]) =>
-    typedError<RebuildOutcome, string>(
+    typedError<null, string>(
       __TAURI_INVOKE('set_profile_valid_fields', { fields }),
     ),
   patchProfileMetadata: (
     uid: ProfileId,
     patch: ProfileMetadataPatch_Deserialize,
   ) =>
-    typedError<RebuildOutcome, string>(
+    typedError<null, string>(
       __TAURI_INVOKE('patch_profile_metadata', { uid, patch }),
     ),
   patchRemoteProfileOptions: (
     uid: ProfileId,
     patch: RemoteProfileOptionsPatch_Deserialize,
   ) =>
-    typedError<RebuildOutcome, string>(
+    typedError<null, string>(
       __TAURI_INVOKE('patch_remote_profile_options', { uid, patch }),
     ),
   replaceProfileDefinition: (
     uid: ProfileId,
     definition: ProfileDefinition_Deserialize,
   ) =>
-    typedError<RebuildOutcome, string>(
+    typedError<null, string>(
       __TAURI_INVOKE('replace_profile_definition', { uid, definition }),
     ),
   viewProfile: (uid: ProfileId) =>
@@ -492,12 +487,6 @@ export type ClashWsSnapshot = {
 export type ClashWsTraffic = {
   up: number
   down: number
-}
-
-/**  Mutation payload + rebuild outcome for data-carrying commands (import). */
-export type CommitOutcome<T> = {
-  value: T
-  rebuild: RebuildOutcome
 }
 
 export type CompositionConfig =
@@ -1172,23 +1161,49 @@ export type ProfileMetadataPatch =
 export type ProfileMetadataPatch_Deserialize = {
   name: string | null
   desc?: string | null
+  custom_name?: boolean | null
 }
 
 export type ProfileMetadataPatch_Serialize = {
   name?: string | null
   desc?: string | null
+  custom_name?: boolean | null
 }
 
 /**  Public, user-editable profile metadata. */
 export type ProfileMetadata_Deserialize = {
   name: string
   desc?: string | null
+  /**
+   *  Provenance flag: `true` when the name was chosen by the user (manual
+   *  create or rename) and must not be overwritten by subscription name-sync.
+   *  Profiles persisted before this field predate provenance tracking; absence
+   *  means user-owned so a refresh cannot silently rename them.
+   *  The value is never trusted from an incoming patch — it is set only by
+   *  rename detection and name-sync (see `ProfileItem::apply_metadata_patch`).
+   *  Only the non-default `false` (an unpinned, sync-eligible profile) is
+   *  persisted; a user-owned `true` is left off the wire and restored by the
+   *  default, so legacy and user-named documents stay byte-identical.
+   */
+  custom_name?: boolean
 }
 
 /**  Public, user-editable profile metadata. */
 export type ProfileMetadata_Serialize = {
   name: string
   desc?: string | null
+  /**
+   *  Provenance flag: `true` when the name was chosen by the user (manual
+   *  create or rename) and must not be overwritten by subscription name-sync.
+   *  Profiles persisted before this field predate provenance tracking; absence
+   *  means user-owned so a refresh cannot silently rename them.
+   *  The value is never trusted from an incoming patch — it is set only by
+   *  rename detection and name-sync (see `ProfileItem::apply_metadata_patch`).
+   *  Only the non-default `false` (an unpinned, sync-eligible profile) is
+   *  persisted; a user-owned `true` is left off the wire and restored by the
+   *  default, so legacy and user-named documents stay byte-identical.
+   */
+  custom_name?: boolean
 }
 
 export type ProfileRemoteOptions = {
@@ -1666,14 +1681,6 @@ export type ProxyProviderItem_Serialize = {
   testUrl?: string | null
   expectedStatus?: string | null
 }
-
-/**
- *  Post-commit rebuild result for mutation IPC (spec §6.2, decision D2):
- *  state is committed first; a failed rebuild degrades instead of erroring.
- */
-export type RebuildOutcome =
-  | { status: 'ok' }
-  | { status: 'degraded'; error: string }
 
 export type RemoteProfileOptionsPatch =
   | RemoteProfileOptionsPatch_Serialize

--- a/frontend/interface/src/ipc/use-profile.ts
+++ b/frontend/interface/src/ipc/use-profile.ts
@@ -65,6 +65,8 @@ export type CreateParams =
       type: 'url'
       data: {
         url: string
+        /** Display name to pin (`custom_name`); `null`/omitted derives it from the URL server-side. */
+        name?: string | null
         option?: RemoteProfileOptionsPatch_Deserialize | null
       }
     }
@@ -106,6 +108,7 @@ export const useProfile = (options?: { without_helper_fn?: boolean }) => {
         const outcome = unwrapResult(
           await commands.importProfile(
             params.data.url,
+            params.data.name ?? null,
             params.data.option ?? null,
           ),
         )

--- a/frontend/nyanpasu/messages/en.json
+++ b/frontend/nyanpasu/messages/en.json
@@ -355,5 +355,9 @@
   "common_off": "Off",
   "common_enabled": "Enabled",
   "common_disabled": "Disabled",
-  "common_clear": "Clear"
+  "common_clear": "Clear",
+  "deep_link_import_title": "Import profile",
+  "deep_link_import_success_message": "Profile \"{name}\" imported successfully",
+  "deep_link_import_failed_message": "Failed to import profile from the link",
+  "deep_link_import_invalid_message": "The link is not a valid profile import link"
 }

--- a/frontend/nyanpasu/messages/ru.json
+++ b/frontend/nyanpasu/messages/ru.json
@@ -355,5 +355,9 @@
   "common_off": "Выкл",
   "common_enabled": "Включено",
   "common_disabled": "Отключено",
-  "common_clear": "Очистить"
+  "common_clear": "Очистить",
+  "deep_link_import_title": "Импорт профиля",
+  "deep_link_import_success_message": "Профиль «{name}» успешно импортирован",
+  "deep_link_import_failed_message": "Не удалось импортировать профиль по ссылке",
+  "deep_link_import_invalid_message": "Ссылка не является корректной ссылкой для импорта профиля"
 }

--- a/frontend/nyanpasu/messages/zh-cn.json
+++ b/frontend/nyanpasu/messages/zh-cn.json
@@ -355,5 +355,9 @@
   "common_off": "关",
   "common_enabled": "启用",
   "common_disabled": "禁用",
-  "common_clear": "清除"
+  "common_clear": "清除",
+  "deep_link_import_title": "导入配置",
+  "deep_link_import_success_message": "配置「{name}」导入成功",
+  "deep_link_import_failed_message": "无法从链接导入配置",
+  "deep_link_import_invalid_message": "该链接不是有效的配置导入链接"
 }

--- a/frontend/nyanpasu/messages/zh-tw.json
+++ b/frontend/nyanpasu/messages/zh-tw.json
@@ -355,5 +355,9 @@
   "common_off": "關",
   "common_enabled": "啟用",
   "common_disabled": "禁用",
-  "common_clear": "清除"
+  "common_clear": "清除",
+  "deep_link_import_title": "匯入設定",
+  "deep_link_import_success_message": "設定「{name}」匯入成功",
+  "deep_link_import_failed_message": "無法從連結匯入設定",
+  "deep_link_import_invalid_message": "此連結不是有效的設定匯入連結"
 }

--- a/frontend/nyanpasu/src/hooks/use-deep-link-import.ts
+++ b/frontend/nyanpasu/src/hooks/use-deep-link-import.ts
@@ -2,10 +2,8 @@ import { useEffect, useRef } from 'react'
 import { m } from '@/paraglide/messages'
 import { parseInstallConfigDeepLink } from '@/utils/deep-link'
 import { message } from '@/utils/notification'
-import { commands, unwrapResult, useProfile } from '@nyanpasu/interface'
-import { listen, type UnlistenFn } from '@tauri-apps/api/event'
-
-const SCHEME_EVENT = 'scheme-request-received'
+import { commands, events, unwrapResult, useProfile } from '@nyanpasu/interface'
+import { type UnlistenFn } from '@tauri-apps/api/event'
 
 // Guard against duplicate registration across React StrictMode's double-mount
 // and against multiple hook consumers: only one global listener should exist.
@@ -78,9 +76,10 @@ export function useDeepLinkImport() {
       }
     }
 
-    listen<string>(SCHEME_EVENT, async (event) => {
-      await handleDeepLink(event.payload)
-    })
+    events.schemeRequestReceivedEvent
+      .listen(async (event) => {
+        await handleDeepLink(event.payload.url)
+      })
       .then((fn) => {
         // The effect may have been cleaned up before `listen` resolved.
         if (disposed) {

--- a/frontend/nyanpasu/src/hooks/use-deep-link-import.ts
+++ b/frontend/nyanpasu/src/hooks/use-deep-link-import.ts
@@ -1,0 +1,117 @@
+import { useEffect, useRef } from 'react'
+import { m } from '@/paraglide/messages'
+import { parseInstallConfigDeepLink } from '@/utils/deep-link'
+import { message } from '@/utils/notification'
+import { commands, unwrapResult, useProfile } from '@nyanpasu/interface'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+
+const SCHEME_EVENT = 'scheme-request-received'
+
+// Guard against duplicate registration across React StrictMode's double-mount
+// and against multiple hook consumers: only one global listener should exist.
+let listenerRegistered = false
+
+/**
+ * Imports the profile described by an `install-config` deep link. Two delivery
+ * paths are handled: the `scheme-request-received` Tauri event (running app or
+ * secondary instance) and the backend's pending deep link drained once on
+ * startup (cold start, where the event may fire before the listener registers).
+ * Mount once near the app root.
+ */
+export function useDeepLinkImport() {
+  const { create } = useProfile()
+
+  // Keep the latest mutation without re-registering the listener on every render.
+  const createRef = useRef(create)
+  createRef.current = create
+
+  // Dedupe the same deep link arriving through both paths (event + pending
+  // command may fire near-simultaneously on startup). Guarded synchronously
+  // before the first await, so concurrent calls collapse to a single import.
+  const inFlight = useRef(new Set<string>())
+
+  useEffect(() => {
+    if (listenerRegistered) {
+      return
+    }
+    listenerRegistered = true
+
+    let unlisten: UnlistenFn | undefined
+    let disposed = false
+
+    const handleDeepLink = async (raw: string) => {
+      const parsed = parseInstallConfigDeepLink(raw)
+      if (!parsed) {
+        console.error('[deep-link] ignored unsupported deep link:', raw)
+        await message(m.deep_link_import_invalid_message(), {
+          title: m.deep_link_import_title(),
+          kind: 'error',
+        })
+        return
+      }
+
+      if (inFlight.current.has(raw)) {
+        return
+      }
+      inFlight.current.add(raw)
+
+      try {
+        await createRef.current.mutateAsync({
+          type: 'url',
+          data: { url: parsed.url, name: parsed.name, option: null },
+        })
+
+        await message(
+          m.deep_link_import_success_message({
+            name: parsed.name ?? parsed.url,
+          }),
+          { title: m.deep_link_import_title(), kind: 'info' },
+        )
+      } catch (error) {
+        console.error('[deep-link] import failed:', error)
+        await message(m.deep_link_import_failed_message(), {
+          title: m.deep_link_import_title(),
+          kind: 'error',
+        })
+      } finally {
+        inFlight.current.delete(raw)
+      }
+    }
+
+    listen<string>(SCHEME_EVENT, async (event) => {
+      await handleDeepLink(event.payload)
+    })
+      .then((fn) => {
+        // The effect may have been cleaned up before `listen` resolved.
+        if (disposed) {
+          fn()
+          return
+        }
+        unlisten = fn
+      })
+      .catch((error) => {
+        listenerRegistered = false
+        console.error('[deep-link] failed to register listener:', error)
+      })
+
+    // Cold start: the event may have been emitted before the listener above was
+    // registered, so drain the backend's pending deep link (take-and-clear) once.
+    commands
+      .getPendingDeepLink()
+      .then(async (result) => {
+        const pending = unwrapResult(result)
+        if (pending) {
+          await handleDeepLink(pending)
+        }
+      })
+      .catch((error) => {
+        console.error('[deep-link] failed to read pending deep link:', error)
+      })
+
+    return () => {
+      disposed = true
+      unlisten?.()
+      listenerRegistered = false
+    }
+  }, [])
+}

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/_modules/profile-quick-import.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/_modules/profile-quick-import.tsx
@@ -42,6 +42,7 @@ export default function ProfileQuickImport() {
           type: 'url',
           data: {
             url: data.url,
+            name: null,
             option: null,
           },
         })

--- a/frontend/nyanpasu/src/pages/__root.tsx
+++ b/frontend/nyanpasu/src/pages/__root.tsx
@@ -18,6 +18,7 @@ import CustomCssProvider from '@/components/providers/custom-css-provider'
 import { LanguageProvider } from '@/components/providers/language-provider'
 import { ExperimentalThemeProvider } from '@/components/providers/theme-provider'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { useDeepLinkImport } from '@/hooks/use-deep-link-import'
 import { m } from '@/paraglide/messages'
 import { message } from '@/utils/notification'
 import {
@@ -133,6 +134,11 @@ function DegradedRebuildNotifier() {
   return null
 }
 
+function DeepLinkImport() {
+  useDeepLinkImport()
+  return null
+}
+
 export default function App() {
   return (
     <NyanpasuProvider>
@@ -143,6 +149,7 @@ export default function App() {
               <TooltipProvider>
                 <WindowReveal />
                 <DegradedRebuildNotifier />
+                <DeepLinkImport />
                 <Outlet />
               </TooltipProvider>
             </CustomCssProvider>

--- a/frontend/nyanpasu/src/utils/deep-link.ts
+++ b/frontend/nyanpasu/src/utils/deep-link.ts
@@ -1,0 +1,65 @@
+/**
+ * Parsing of `install-config` deep links used to import a subscription profile.
+ *
+ * Supported shapes (percent-encoded `url`, optional `name`):
+ *   clash://install-config?url=<http(s) url>&name=<display name>
+ *   clash-nyanpasu://install-config?url=<http(s) url>
+ *   clash:/install-config?url=...        (single-slash form on some platforms)
+ */
+
+export type InstallConfigDeepLink = {
+  /** The http(s) subscription URL to import. */
+  url: string
+  /** Optional user-provided display name, `null` when absent. */
+  name: string | null
+}
+
+const SUPPORTED_SCHEMES = ['clash:', 'clash-nyanpasu:']
+
+const INSTALL_CONFIG_ACTION = 'install-config'
+
+/**
+ * Parse a raw deep link string into an install-config payload.
+ * Returns `null` for any unsupported, malformed or non-install-config link.
+ */
+export function parseInstallConfigDeepLink(
+  raw: string,
+): InstallConfigDeepLink | null {
+  let parsed: URL
+  try {
+    parsed = new URL(raw)
+  } catch {
+    return null
+  }
+
+  if (!SUPPORTED_SCHEMES.includes(parsed.protocol)) {
+    return null
+  }
+
+  // Depending on platform and `scheme://` vs `scheme:/` form the action lands
+  // either in the host or in the pathname.
+  const action = (
+    parsed.host || parsed.pathname.replace(/^\/+/, '')
+  ).toLowerCase()
+  if (action !== INSTALL_CONFIG_ACTION) {
+    return null
+  }
+
+  // `URLSearchParams` already percent-decodes the values.
+  const url = parsed.searchParams.get('url')
+  if (!url || !isHttpUrl(url)) {
+    return null
+  }
+
+  const name = parsed.searchParams.get('name')
+  return { url, name: name && name.trim() ? name : null }
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const { protocol } = new URL(value)
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> **Reworked on top of the new profiles domain pipeline** (#4889 / #4890) after they landed — the branch was rebuilt from current `main`, nothing is left of the legacy `config/profile` module. Same behavior as originally proposed.

## What

Two related changes around subscription profiles, split into two commits:

### 1. `fix(deep-link)`: importing profiles via `install-config` deep links works again

The backend registers the `clash://` / `clash-nyanpasu://` schemes and emits the `scheme-request-received` Tauri event (both on cold start and from a secondary instance), but the current frontend has **no listener for that event** — a deep link only focuses the window and the URL is silently dropped, so `clash://install-config?...` links do nothing. (Looks like a regression from the UI rewrite: CHANGELOG still mentions a "Custom scheme url parser in webkit".)

- New frontend listener + parser for `clash://install-config?url=<percent-encoded>&name=<optional>` (both schemes, `scheme://` and `scheme:/` forms). The import goes through the exact same path as quick import.
- `import_profile` accepts an optional caller-supplied `name` carrying the deep-link intent; without one the name is derived from the url exactly as today.
- Cold-start race fix: `is_window_opened()` flips on `WindowReadyEvent` from JS, but the `scheme-request-received` listener is attached asynchronously after mount, so the event could be emitted before anyone listens. The deep link captured from `argv` is now also stored in managed state (`PendingDeepLink`) and drained once on startup via a new `get_pending_deep_link` command (take-and-clear, deduplicated with the event path on the frontend).
- Success/failure notifications with strings for `en` / `ru` / `zh-cn` / `zh-tw`.

### 2. `feat(profile)`: keep the remote profile name in sync with the subscription

`service/profile_file.rs` already parses `profile-title` / `Content-Disposition` into `FetchedSubscription.filename`, but the value is discarded down the stack (`actor.rs` refresh spawn), so server-side renames never reach the profile list.

I'm aware #4889 deliberately retired content-disposition naming *on import*; this is not a straight revert of that decision. The header name is applied only through provenance tracking:

- New `ProfileMetadata.custom_name`: `true` when the name was chosen by the user (manual create, deep-link `name=`, rename via `patch_profile_metadata`), `false` when it was url-derived on import.
- The refresh commit handler adopts the freshest header-provided filename **only** for non-user-named profiles (pure `synced_name()` helper, unit-tested).
- Renaming pins the name; the flag is never trusted from an incoming patch.
- Backward compatible: profiles persisted before this field deserialize as user-named and keep their names; the default `true` is skipped on serialization, so existing documents (and the 1.6.1 migration golden fixture) stay byte-identical.

## Testing

- `cargo test -p clash-nyanpasu` — 224 passed / 0 failed; `cargo test -p nyanpasu-config` — 127 passed / 0 failed. New coverage: `synced_name` unit tests, rename-pinning, serde backward-compat/roundtrip, facade import with/without a caller name, refresh adopts/keeps name via `MockSubscriptionFetcher`.
- `export_typescript_bindings` regenerated `bindings.ts`.
- `cargo fmt --check`, clippy via lint-staged, `tsc --noEmit` for all three frontend projects, prettier/oxlint — clean.
- Deep-link parser exercised against both schemes, both slash forms, missing/extra params, non-http targets, and garbage input.

Happy to split or adjust anything — including moving the `custom_name` discussion to an issue if you prefer that flow for behavior changes.
