### PR TITLE
fix(profile)!: align specta bindings with serde wire format and PR3 regressions (#4915, #4916, #4917)

### DIFF
--- a/backend/nyanpasu-config/src/profile/definition.rs
+++ b/backend/nyanpasu-config/src/profile/definition.rs
@@ -12,7 +12,7 @@ pub enum ProfileDefinition {
 }
 
 /// A profile that can produce a complete config and can be selected by current.
-#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ConfigDefinition {
     /// A config parsed from a locally materialized file.
@@ -51,7 +51,7 @@ pub struct CompositionConfig {
 }
 
 /// A named config transformer. Transform profiles are reusable but not activatable.
-#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TransformDefinition {
     /// Declarative YAML overlay/patch. This is the new name for legacy Merge.
@@ -190,5 +190,50 @@ impl TransformDefinition {
             Self::Overlay(overlay) => &mut overlay.source,
             Self::Script(script) => &mut script.source,
         }
+    }
+}
+
+mod specta_wire {
+    use serde::{Deserialize, Serialize};
+    use specta::Type;
+
+    /// A profile that can produce a complete config and can be selected by current.
+    #[allow(dead_code)]
+    #[derive(Serialize, Deserialize, Type)]
+    #[specta(remote = super::ConfigDefinition)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum ConfigDefinition {
+        /// A config parsed from a locally materialized file.
+        File {
+            source: crate::profile::ProfileSource,
+            #[serde(default, skip_serializing_if = "Vec::is_empty")]
+            transforms: Vec<crate::profile::ProfileId>,
+        },
+        /// A config composed from an optional full base and proxy contributors.
+        Composition {
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            base: Option<crate::profile::ProfileId>,
+            #[serde(default, skip_serializing_if = "Vec::is_empty")]
+            extend_proxies_from: Vec<crate::profile::ProfileId>,
+            #[serde(default, skip_serializing_if = "Vec::is_empty")]
+            transforms: Vec<crate::profile::ProfileId>,
+        },
+    }
+
+    /// A named config transformer. Transform profiles are reusable but not activatable.
+    #[allow(dead_code)]
+    #[derive(Serialize, Deserialize, Type)]
+    #[specta(remote = super::TransformDefinition)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum TransformDefinition {
+        /// Declarative YAML overlay/patch. This is the new name for legacy Merge.
+        Overlay {
+            source: crate::profile::ProfileSource,
+        },
+        /// Imperative JS/Lua transform.
+        Script {
+            source: crate::profile::ProfileSource,
+            runtime: crate::profile::ScriptRuntime,
+        },
     }
 }

--- a/backend/nyanpasu-config/src/profile/source.rs
+++ b/backend/nyanpasu-config/src/profile/source.rs
@@ -10,7 +10,7 @@ use super::*;
 ///
 /// `Remote + External` is unrepresentable: external binding exists only inside
 /// the `Local` branch, while `Remote` owns a managed materialization directly.
-#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ProfileSource {
     Local {
@@ -51,7 +51,7 @@ impl ProfileSource {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum LocalBinding {
     Managed {
@@ -192,4 +192,58 @@ fn default_true() -> bool {
 
 fn default_update_interval_minutes() -> u64 {
     120
+}
+
+mod specta_wire {
+    use serde::{Deserialize, Serialize};
+    use specta::Type;
+
+    /// Who is responsible for maintaining the locally readable file.
+    ///
+    /// `Remote + External` is unrepresentable: external binding exists only inside
+    /// the `Local` branch, while `Remote` owns a managed materialization directly.
+    #[allow(dead_code)]
+    #[derive(Serialize, Deserialize, Type)]
+    #[specta(remote = super::ProfileSource)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum ProfileSource {
+        Local {
+            binding: crate::profile::LocalBinding,
+        },
+        Remote {
+            file: crate::profile::ManagedProfilePath,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            #[specta(type = Option<i64>)]
+            updated_at: Option<time::OffsetDateTime>,
+            url: url::Url,
+            #[serde(default)]
+            option: crate::profile::RemoteProfileOptions,
+            #[serde(
+                default,
+                skip_serializing_if = "crate::profile::SubscriptionInfo::is_empty"
+            )]
+            subscription: crate::profile::SubscriptionInfo,
+        },
+    }
+
+    #[allow(dead_code)]
+    #[derive(Serialize, Deserialize, Type)]
+    #[specta(remote = super::LocalBinding)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum LocalBinding {
+        Managed {
+            file: crate::profile::ManagedProfilePath,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            #[specta(type = Option<i64>)]
+            updated_at: Option<time::OffsetDateTime>,
+        },
+        External {
+            file: crate::profile::ManagedProfilePath,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            #[specta(type = Option<i64>)]
+            updated_at: Option<time::OffsetDateTime>,
+            target: crate::profile::ExternalProfilePath,
+            mode: crate::profile::ExternalMode,
+        },
+    }
 }

--- a/backend/nyanpasu-config/src/profile/tests/mod.rs
+++ b/backend/nyanpasu-config/src/profile/tests/mod.rs
@@ -5,3 +5,4 @@ mod remote_options_patch;
 mod round_trip;
 mod sanitize;
 mod validation;
+mod wire_shape;

--- a/backend/nyanpasu-config/src/profile/tests/wire_shape.rs
+++ b/backend/nyanpasu-config/src/profile/tests/wire_shape.rs
@@ -1,0 +1,117 @@
+use serde_json::{Value, json};
+use url::Url;
+
+use crate::profile::*;
+
+fn managed(file: &str) -> MaterializedFile {
+    MaterializedFile {
+        file: ManagedProfilePath::new(file).unwrap(),
+        updated_at: None,
+    }
+}
+
+fn assert_flat_materialized(value: &Value, expected_type: &str, file: &str) {
+    assert_eq!(value["type"], expected_type);
+    assert_eq!(value["file"], file);
+    assert!(value.get("materialized").is_none());
+}
+
+#[test]
+fn config_definition_variants_match_the_flat_wire_contract() {
+    let file = ConfigDefinition::File(FileConfig {
+        source: ProfileSource::Local {
+            binding: LocalBinding::Managed {
+                materialized: managed("config.yaml"),
+            },
+        },
+        transforms: vec![ProfileId("normalize".into())],
+    });
+    let value = serde_json::to_value(file).unwrap();
+    assert_eq!(value["type"], "file");
+    assert!(value.get("source").is_some());
+    assert_eq!(value["transforms"], json!(["normalize"]));
+    assert!(value.get("file").is_none());
+
+    let composition = ConfigDefinition::Composition(CompositionConfig {
+        base: Some(ProfileId("base".into())),
+        extend_proxies_from: vec![ProfileId("member".into())],
+        transforms: vec![],
+    });
+    let value = serde_json::to_value(composition).unwrap();
+    assert_eq!(value["type"], "composition");
+    assert_eq!(value["base"], "base");
+    assert_eq!(value["extend_proxies_from"], json!(["member"]));
+    assert!(value.get("composition").is_none());
+}
+
+#[test]
+fn transform_definition_variants_match_the_flat_wire_contract() {
+    let overlay = TransformDefinition::Overlay(OverlayTransform {
+        source: ProfileSource::Local {
+            binding: LocalBinding::Managed {
+                materialized: managed("overlay.yaml"),
+            },
+        },
+    });
+    let value = serde_json::to_value(overlay).unwrap();
+    assert_eq!(value["type"], "overlay");
+    assert!(value.get("source").is_some());
+    assert!(value.get("overlay").is_none());
+
+    let script = TransformDefinition::Script(ScriptTransform {
+        source: ProfileSource::Local {
+            binding: LocalBinding::Managed {
+                materialized: managed("script.js"),
+            },
+        },
+        runtime: ScriptRuntime::JavaScript,
+    });
+    let value = serde_json::to_value(script).unwrap();
+    assert_eq!(value["type"], "script");
+    assert_eq!(value["runtime"], "javascript");
+    assert!(value.get("source").is_some());
+    assert!(value.get("script").is_none());
+}
+
+#[test]
+fn profile_source_variants_match_the_flat_wire_contract() {
+    let local = ProfileSource::Local {
+        binding: LocalBinding::Managed {
+            materialized: managed("local.yaml"),
+        },
+    };
+    let value = serde_json::to_value(local).unwrap();
+    assert_eq!(value["type"], "local");
+    assert!(value.get("binding").is_some());
+    assert!(value.get("materialized").is_none());
+
+    let remote = ProfileSource::Remote {
+        materialized: managed("remote.yaml"),
+        url: Url::parse("https://example.com/remote.yaml").unwrap(),
+        option: RemoteProfileOptions::default(),
+        subscription: SubscriptionInfo::default(),
+    };
+    let value = serde_json::to_value(remote).unwrap();
+    assert_flat_materialized(&value, "remote", "remote.yaml");
+    assert_eq!(value["url"], "https://example.com/remote.yaml");
+    assert!(value.get("option").is_some());
+}
+
+#[test]
+fn local_binding_variants_match_the_flat_wire_contract() {
+    let managed_binding = LocalBinding::Managed {
+        materialized: managed("managed.yaml"),
+    };
+    let value = serde_json::to_value(managed_binding).unwrap();
+    assert_flat_materialized(&value, "managed", "managed.yaml");
+
+    let external = LocalBinding::External {
+        materialized: managed("external.yaml"),
+        target: ExternalProfilePath::new("/tmp/external.yaml").unwrap(),
+        mode: ExternalMode::Mirror,
+    };
+    let value = serde_json::to_value(external).unwrap();
+    assert_flat_materialized(&value, "external", "external.yaml");
+    assert_eq!(value["target"], "/tmp/external.yaml");
+    assert_eq!(value["mode"], "mirror");
+}

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -406,6 +406,10 @@ impl NyanpasuClient {
         url: url::Url,
         options: Option<RemoteProfileOptionsPatch>,
     ) -> Result<ProfileId> {
+        let update_interval_explicit = options
+            .as_ref()
+            .and_then(|patch| patch.update_interval_minutes)
+            .is_some();
         let name = url
             .path_segments()
             .and_then(|segments| segments.filter(|segment| !segment.is_empty()).next_back())
@@ -448,7 +452,16 @@ impl NyanpasuClient {
             .created
             .clone()
             .ok_or_else(|| ClientError::Custom("import committed without a created uid".into()))?;
-        if let Err(error) = self.refresh_profile(created.clone(), None).await {
+        let refreshed = async {
+            let report = self
+                .inner
+                .profiles
+                .refresh_import(created.clone(), update_interval_explicit)
+                .await?;
+            self.after_commit(&report).await
+        }
+        .await;
+        if let Err(error) = refreshed {
             // First download failed = import failed; delete the empty shell to
             // preserve the legacy all-or-nothing observable behavior. Log if the
             // rollback itself fails so the orphaned placeholder is not silent —
@@ -1145,6 +1158,7 @@ mod tests {
                 content: "proxies: []\n".into(),
                 subscription: SubscriptionInfo::default(),
                 filename: Some("sub.yaml".into()),
+                suggested_update_interval_minutes: Some(360),
             })
         });
         let mut core = MockRunningCoreBridge::new();
@@ -1154,7 +1168,12 @@ mod tests {
         tauri::async_runtime::block_on(async {
             let client = test_client_with_fetcher(&dir, Arc::new(fetcher), Arc::new(core)).await;
             let url = url::Url::parse("https://example.com/subs/my-sub.yaml").unwrap();
-            let uid = client.import_profile(url, None).await.expect("import");
+            let mut patch = RemoteProfileOptions::new_empty_patch();
+            patch.with_proxy = Some(false);
+            let uid = client
+                .import_profile(url, Some(patch))
+                .await
+                .expect("import");
             let snapshot = client.get_profiles().await.unwrap();
             assert_eq!(
                 snapshot.current.as_ref(),
@@ -1163,7 +1182,65 @@ mod tests {
             );
             let item = &snapshot.items[&uid];
             assert_eq!(item.metadata.name, "my-sub"); // url last-segment fallback naming
-            assert!(item.definition.source().unwrap().is_remote());
+            let source = item.definition.source().unwrap();
+            assert!(source.is_remote());
+            let ProfileSource::Remote { option, .. } = source else {
+                unreachable!()
+            };
+            assert_eq!(option.update_interval_minutes, 360);
+            assert!(!option.with_proxy);
+        });
+    }
+
+    #[test]
+    fn facade_import_keeps_explicit_interval_over_server_suggestion() {
+        let dir = tempdir().unwrap();
+        let mut fetcher = MockSubscriptionFetcher::new();
+        fetcher.expect_fetch().times(1).returning(|_, _| {
+            Ok(crate::state::profiles::ports::FetchedSubscription {
+                content: "proxies: []\n".into(),
+                subscription: SubscriptionInfo::default(),
+                filename: None,
+                suggested_update_interval_minutes: Some(360),
+            })
+        });
+        let mut core = MockRunningCoreBridge::new();
+        core.expect_apply_config().returning(|| Ok(()));
+        core.expect_on_profile_change().returning(|| ());
+
+        tauri::async_runtime::block_on(async {
+            let client = test_client_with_fetcher(&dir, Arc::new(fetcher), Arc::new(core)).await;
+            let mut patch = RemoteProfileOptions::new_empty_patch();
+            patch.update_interval_minutes = Some(45);
+            let url = url::Url::parse("https://example.com/subs/explicit.yaml").unwrap();
+            let uid = client
+                .import_profile(url, Some(patch))
+                .await
+                .expect("import");
+            let snapshot = client.get_profiles().await.unwrap();
+            let ProfileSource::Remote { option, .. } =
+                snapshot.items[&uid].definition.source().unwrap()
+            else {
+                unreachable!()
+            };
+            assert_eq!(option.update_interval_minutes, 45);
+        });
+    }
+
+    #[test]
+    fn facade_import_rejects_explicit_zero_interval_before_fetch() {
+        let dir = tempdir().unwrap();
+        let mut fetcher = MockSubscriptionFetcher::new();
+        fetcher.expect_fetch().times(0);
+        let core = MockRunningCoreBridge::new();
+
+        tauri::async_runtime::block_on(async {
+            let client = test_client_with_fetcher(&dir, Arc::new(fetcher), Arc::new(core)).await;
+            let mut patch = RemoteProfileOptions::new_empty_patch();
+            patch.update_interval_minutes = Some(0);
+            let url = url::Url::parse("https://example.com/subs/invalid.yaml").unwrap();
+            assert!(client.import_profile(url, Some(patch)).await.is_err());
+            assert!(client.get_profiles().await.unwrap().items.is_empty());
         });
     }
 
@@ -1279,6 +1356,7 @@ mod tests {
                 content: "proxies: []\n".into(),
                 subscription: SubscriptionInfo::default(),
                 filename: None,
+                suggested_update_interval_minutes: None,
             })
         });
         let mut core = MockRunningCoreBridge::new();
@@ -1309,6 +1387,12 @@ mod tests {
                 "import must not overwrite an existing current selection"
             );
             assert!(snapshot.items.contains_key(&imported));
+            let ProfileSource::Remote { option, .. } =
+                snapshot.items[&imported].definition.source().unwrap()
+            else {
+                unreachable!()
+            };
+            assert_eq!(option.update_interval_minutes, 120);
         });
     }
 }

--- a/backend/tauri/src/client/profiles.rs
+++ b/backend/tauri/src/client/profiles.rs
@@ -12,7 +12,7 @@ use ractor::{Actor, ActorRef, RpcReplyPort, rpc::CallResult};
 
 use crate::state::profiles::{
     CommitReport, NewProfileRequest, ProfilesActor, ProfilesActorArgs, ProfilesActorMessage,
-    ProfilesError, ReorderOp,
+    ProfilesError, RefreshOrigin, ReorderOp,
     ports::{ProfileFsPort, RebuildNotifier, SubscriptionFetcher},
 };
 
@@ -195,6 +195,26 @@ impl ProfilesClient {
             |reply| ProfilesActorMessage::RefreshRemote {
                 uid,
                 patch,
+                origin: RefreshOrigin::Manual,
+                reply: Some(reply),
+            },
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn refresh_import(
+        &self,
+        uid: ProfileId,
+        update_interval_explicit: bool,
+    ) -> Result<CommitReport, ProfilesError> {
+        self.call(
+            |reply| ProfilesActorMessage::RefreshRemote {
+                uid,
+                patch: None,
+                origin: RefreshOrigin::Import {
+                    update_interval_explicit,
+                },
                 reply: Some(reply),
             },
             None,
@@ -479,6 +499,13 @@ mod tests {
     }
 
     fn ok_fetch(content: &'static str) -> MockSubscriptionFetcher {
+        suggested_fetch(content, None)
+    }
+
+    fn suggested_fetch(
+        content: &'static str,
+        suggested_update_interval_minutes: Option<u64>,
+    ) -> MockSubscriptionFetcher {
         let mut fetcher = MockSubscriptionFetcher::new();
         fetcher.expect_fetch().returning(move |_, _| {
             Ok(FetchedSubscription {
@@ -488,6 +515,7 @@ mod tests {
                     upload: Some(1),
                     ..Default::default()
                 },
+                suggested_update_interval_minutes,
             })
         });
         fetcher
@@ -541,6 +569,7 @@ mod tests {
                 content: "proxies: []\n".into(),
                 filename: None,
                 subscription: SubscriptionInfo::default(),
+                suggested_update_interval_minutes: None,
             })
         }
     }
@@ -573,6 +602,111 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn manual_and_explicit_import_refresh_ignore_server_interval_suggestions() {
+        for import_explicit in [None, Some(true)] {
+            let mut fs = MockProfileFsPort::new();
+            fs.expect_ensure_not_symlink().returning(|_| Ok(()));
+            fs.expect_write_atomic().returning(|_, _| Ok(()));
+            let (client, _dir) = remote_seeded_client(
+                fs,
+                suggested_fetch("proxies: []\n", Some(360)),
+                MockRebuildNotifier::new(),
+            )
+            .await;
+
+            let report = if let Some(update_interval_explicit) = import_explicit {
+                client
+                    .refresh_import(ProfileId("r1".into()), update_interval_explicit)
+                    .await
+                    .unwrap()
+            } else {
+                client.refresh(ProfileId("r1".into()), None).await.unwrap()
+            };
+            let source = report.snapshot.items[&ProfileId("r1".into())]
+                .definition
+                .source()
+                .unwrap();
+            let ProfileSource::Remote { option, .. } = source else {
+                unreachable!()
+            };
+            assert_eq!(option.update_interval_minutes, 120);
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn import_suggestion_is_committed_and_reschedules_the_timer() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_ensure_not_symlink().returning(|_| Ok(()));
+        fs.expect_write_atomic().returning(|_, _| Ok(()));
+        let fetch_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut fetcher = MockSubscriptionFetcher::new();
+        let counter = std::sync::Arc::clone(&fetch_count);
+        fetcher.expect_fetch().returning(move |_, _| {
+            let call = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            Ok(FetchedSubscription {
+                content: "proxies: []\n".into(),
+                filename: None,
+                subscription: SubscriptionInfo {
+                    upload: Some(call as u64),
+                    ..Default::default()
+                },
+                suggested_update_interval_minutes: Some(if call == 1 { 60 } else { 30 }),
+            })
+        });
+        let (client, _dir) = remote_seeded_client(fs, fetcher, MockRebuildNotifier::new()).await;
+
+        let report = client
+            .refresh_import(ProfileId("r1".into()), false)
+            .await
+            .unwrap();
+        let source = report.snapshot.items[&ProfileId("r1".into())]
+            .definition
+            .source()
+            .unwrap();
+        let ProfileSource::Remote { option, .. } = source else {
+            unreachable!()
+        };
+        assert_eq!(option.update_interval_minutes, 60);
+        assert_eq!(fetch_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        tokio::time::advance(std::time::Duration::from_secs(60 * 60 + 1)).await;
+        for _ in 0..200 {
+            let snapshot = client.get().await.unwrap();
+            let source = snapshot.items[&ProfileId("r1".into())]
+                .definition
+                .source()
+                .unwrap();
+            if matches!(
+                source,
+                ProfileSource::Remote { subscription, .. }
+                    if subscription.upload == Some(2)
+            ) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(fetch_count.load(std::sync::atomic::Ordering::SeqCst) >= 2);
+        let snapshot = client.get().await.unwrap();
+        let source = snapshot.items[&ProfileId("r1".into())]
+            .definition
+            .source()
+            .unwrap();
+        let ProfileSource::Remote {
+            option,
+            subscription,
+            ..
+        } = source
+        else {
+            unreachable!()
+        };
+        assert_eq!(subscription.upload, Some(2));
+        assert_eq!(
+            option.update_interval_minutes, 60,
+            "scheduled refresh must ignore later server suggestions"
+        );
+    }
+
+    #[tokio::test]
     async fn refresh_failure_settles_reply_with_error() {
         let mut fetcher = MockSubscriptionFetcher::new();
         fetcher
@@ -595,6 +729,45 @@ mod tests {
             .source()
             .unwrap();
         assert!(source.materialized().updated_at.is_none());
+        let ProfileSource::Remote { option, .. } = source else {
+            unreachable!()
+        };
+        assert_eq!(option.update_interval_minutes, 120);
+    }
+
+    #[tokio::test]
+    async fn import_suggestion_is_not_committed_when_materialization_fails() {
+        let mut fs = MockProfileFsPort::new();
+        fs.expect_ensure_not_symlink().returning(|_| Ok(()));
+        fs.expect_write_atomic()
+            .returning(|_, _| Err(anyhow::anyhow!("disk full")));
+        let (client, _dir) = remote_seeded_client(
+            fs,
+            suggested_fetch("proxies: []\n", Some(360)),
+            MockRebuildNotifier::new(),
+        )
+        .await;
+
+        assert!(
+            client
+                .refresh_import(ProfileId("r1".into()), false)
+                .await
+                .is_err()
+        );
+        let snapshot = client.get().await.unwrap();
+        let ProfileSource::Remote {
+            materialized,
+            option,
+            ..
+        } = snapshot.items[&ProfileId("r1".into())]
+            .definition
+            .source()
+            .unwrap()
+        else {
+            unreachable!()
+        };
+        assert!(materialized.updated_at.is_none());
+        assert_eq!(option.update_interval_minutes, 120);
     }
 
     #[tokio::test]
@@ -672,6 +845,7 @@ mod tests {
                 url::Url::parse("https://example.com/sub").unwrap(),
                 crate::state::profiles::RefreshOutcome::Succeeded {
                     subscription: SubscriptionInfo::default(),
+                    suggested_update_interval_minutes: None,
                     content: "proxies: []\n".into(),
                 },
             )
@@ -711,6 +885,7 @@ mod tests {
                 url::Url::parse("https://old.example.com/replaced").unwrap(),
                 crate::state::profiles::RefreshOutcome::Succeeded {
                     subscription: SubscriptionInfo::default(),
+                    suggested_update_interval_minutes: None,
                     content: "proxies: []\n".into(),
                 },
             )
@@ -747,6 +922,7 @@ mod tests {
                 content: "proxies: []\n".into(),
                 filename: None,
                 subscription: SubscriptionInfo::default(),
+                suggested_update_interval_minutes: None,
             })
         });
         let dir = tempdir().unwrap();

--- a/backend/tauri/src/service/profile_file.rs
+++ b/backend/tauri/src/service/profile_file.rs
@@ -275,6 +275,7 @@ impl SubscriptionFetcher for ProfileFileService {
 
         let subscription = parse_subscription_userinfo(resp.headers());
         let filename = parse_profile_title(resp.headers());
+        let suggested_update_interval_minutes = parse_suggested_update_interval(resp.headers());
         let content = resp
             .text_with_charset("utf-8")
             .await
@@ -288,8 +289,20 @@ impl SubscriptionFetcher for ProfileFileService {
             content,
             filename,
             subscription,
+            suggested_update_interval_minutes,
         })
     }
+}
+
+fn parse_suggested_update_interval(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    let hours = headers
+        .get("profile-update-interval")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|hours| *hours > 0)?;
+    let minutes = hours.checked_mul(60)?;
+    minutes.checked_mul(60)?;
+    Some(minutes)
 }
 
 fn parse_subscription_userinfo(headers: &reqwest::header::HeaderMap) -> SubscriptionInfo {
@@ -617,6 +630,26 @@ mod tests {
         assert!(parsed.expire.is_none());
     }
 
+    #[test]
+    fn suggested_update_interval_parses_hours_and_ignores_invalid_values() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        assert_eq!(parse_suggested_update_interval(&headers), None);
+
+        headers.insert(
+            "profile-update-interval",
+            reqwest::header::HeaderValue::from_static("2"),
+        );
+        assert_eq!(parse_suggested_update_interval(&headers), Some(120));
+
+        for invalid in ["not-a-number", "0", "18446744073709551615"] {
+            headers.insert(
+                "profile-update-interval",
+                reqwest::header::HeaderValue::from_str(invalid).unwrap(),
+            );
+            assert_eq!(parse_suggested_update_interval(&headers), None);
+        }
+    }
+
     #[tokio::test]
     async fn fetch_parses_userinfo_and_title_headers() {
         let router = Router::new().route(
@@ -628,6 +661,7 @@ mod tests {
                     "upload=1; download=2; total=3; expire=0".parse().unwrap(),
                 );
                 headers.insert("profile-title", "My Sub".parse().unwrap());
+                headers.insert("profile-update-interval", "6".parse().unwrap());
                 (headers, "proxies: []\n")
             }),
         );
@@ -643,6 +677,7 @@ mod tests {
         assert_eq!(fetched.subscription.download, Some(2));
         assert_eq!(fetched.subscription.total, Some(3));
         assert!(fetched.subscription.expire.is_none());
+        assert_eq!(fetched.suggested_update_interval_minutes, Some(360));
     }
 
     #[tokio::test]

--- a/backend/tauri/src/specta_export.rs
+++ b/backend/tauri/src/specta_export.rs
@@ -132,6 +132,11 @@ pub(crate) fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
         // arrive with T08; explicit registration keeps them exported (and the
         // specta nested-tagged-enum risk probed) before any command exists.
         .typ::<nyanpasu_config::profile::Profiles>()
+        .typ::<nyanpasu_config::profile::FileConfig>()
+        .typ::<nyanpasu_config::profile::CompositionConfig>()
+        .typ::<nyanpasu_config::profile::OverlayTransform>()
+        .typ::<nyanpasu_config::profile::ScriptTransform>()
+        .typ::<nyanpasu_config::profile::MaterializedFile>()
         .typ::<nyanpasu_config::profile::ProfileMetadataPatch>()
         .typ::<nyanpasu_config::profile::RemoteProfileOptionsPatch>()
         .typ::<nyanpasu_config::profile::ProfileValidationError>()
@@ -147,6 +152,28 @@ mod tests {
         env!("CARGO_MANIFEST_DIR"),
         "/../../frontend/interface/src/ipc/bindings.ts"
     );
+
+    fn exported_type<'a>(generated: &'a str, name: &str) -> &'a str {
+        let marker = format!("export type {name} =");
+        let start = generated
+            .find(&marker)
+            .unwrap_or_else(|| panic!("expected generated declaration for {name}"));
+        let rest = &generated[start..];
+        let end = rest[marker.len()..]
+            .find("\nexport ")
+            .map(|offset| marker.len() + offset)
+            .unwrap_or(rest.len());
+        &rest[..end]
+    }
+
+    fn assert_contains_all(declaration: &str, name: &str, expected: &[&str]) {
+        for needle in expected {
+            assert!(
+                declaration.contains(needle),
+                "expected {name} to contain {needle:?}, got:\n{declaration}"
+            );
+        }
+    }
 
     /// Regenerates the committed TS bindings in place (same path and header as
     /// the debug-run export in lib.rs), then asserts every profile domain type
@@ -204,6 +231,77 @@ mod tests {
                 generated.contains(&format!("export type {name}"))
                     || generated.contains(&format!("export interface {name}")),
                 "expected named TS export for {name}"
+            );
+        }
+
+        for phase in ["Deserialize", "Serialize"] {
+            let name = format!("ConfigDefinition_{phase}");
+            let declaration = exported_type(&generated, &name);
+            assert_contains_all(
+                declaration,
+                &name,
+                &[
+                    "type: 'file'",
+                    "type: 'composition'",
+                    "source: ProfileSource_",
+                    "extend_proxies_from?",
+                ],
+            );
+            assert!(
+                !declaration.contains("file: {") && !declaration.contains("composition: {"),
+                "{name} must not contain newtype wrapper keys:\n{declaration}"
+            );
+
+            let name = format!("TransformDefinition_{phase}");
+            let declaration = exported_type(&generated, &name);
+            assert_contains_all(
+                declaration,
+                &name,
+                &[
+                    "type: 'overlay'",
+                    "type: 'script'",
+                    "source: ProfileSource_",
+                    "runtime: ScriptRuntime",
+                ],
+            );
+            assert!(
+                !declaration.contains("overlay: {") && !declaration.contains("script: {"),
+                "{name} must not contain newtype wrapper keys:\n{declaration}"
+            );
+
+            let name = format!("ProfileSource_{phase}");
+            let declaration = exported_type(&generated, &name);
+            assert_contains_all(
+                declaration,
+                &name,
+                &[
+                    "type: 'local'",
+                    "type: 'remote'",
+                    "file: ManagedProfilePath",
+                    "url: string",
+                ],
+            );
+            assert!(
+                !declaration.contains("materialized:"),
+                "{name} must expose flattened materialized fields:\n{declaration}"
+            );
+
+            let name = format!("LocalBinding_{phase}");
+            let declaration = exported_type(&generated, &name);
+            assert_contains_all(
+                declaration,
+                &name,
+                &[
+                    "type: 'managed'",
+                    "type: 'external'",
+                    "file: ManagedProfilePath",
+                    "target: ExternalProfilePath",
+                    "mode: ExternalMode",
+                ],
+            );
+            assert!(
+                !declaration.contains("materialized:"),
+                "{name} must expose flattened materialized fields:\n{declaration}"
             );
         }
     }

--- a/backend/tauri/src/state/profiles/actor.rs
+++ b/backend/tauri/src/state/profiles/actor.rs
@@ -88,15 +88,39 @@ pub struct ProfilesActorState {
     fs: Arc<dyn ProfileFsPort>,
     fetcher: Arc<dyn SubscriptionFetcher>,
     notifier: Arc<dyn RebuildNotifier>,
-    pending_refresh: HashMap<ProfileId, Option<RpcReplyPort<Result<CommitReport, ProfilesError>>>>,
+    pending_refresh: HashMap<ProfileId, PendingRefresh>,
     scheduler: RemoteUpdateScheduler,
     external_watchers: ExternalWatchers,
+}
+
+struct PendingRefresh {
+    reply: Option<RpcReplyPort<Result<CommitReport, ProfilesError>>>,
+    apply_suggested_interval: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum RefreshOrigin {
+    Import { update_interval_explicit: bool },
+    Manual,
+    Scheduled,
+}
+
+impl RefreshOrigin {
+    fn apply_suggested_interval(self) -> bool {
+        matches!(
+            self,
+            Self::Import {
+                update_interval_explicit: false
+            }
+        )
+    }
 }
 
 #[derive(Debug)]
 pub enum RefreshOutcome {
     Succeeded {
         subscription: nyanpasu_config::profile::SubscriptionInfo,
+        suggested_update_interval_minutes: Option<u64>,
         /// Validated payload; written to the materialized file inside the
         /// commit handler so a stale download can be fenced before any write.
         content: String,
@@ -157,6 +181,7 @@ pub enum ProfilesActorMessage {
     RefreshRemote {
         uid: ProfileId,
         patch: Option<RemoteProfileOptionsPatch>,
+        origin: RefreshOrigin,
         reply: Option<RpcReplyPort<Result<CommitReport, ProfilesError>>>,
     },
     CommitRefreshed {
@@ -720,7 +745,12 @@ impl Actor for ProfilesActor {
                 .await;
                 let _ = reply.send(result);
             }
-            ProfilesActorMessage::RefreshRemote { uid, patch, reply } => {
+            ProfilesActorMessage::RefreshRemote {
+                uid,
+                patch,
+                origin,
+                reply,
+            } => {
                 if state.pending_refresh.contains_key(&uid) {
                     if let Some(reply) = reply {
                         let _ = reply.send(Err(ProfilesError::RefreshFailed {
@@ -782,7 +812,13 @@ impl Actor for ProfilesActor {
                 let definition = item.definition.clone();
                 let url = url.clone();
                 let option = option.clone();
-                state.pending_refresh.insert(uid.clone(), reply);
+                state.pending_refresh.insert(
+                    uid.clone(),
+                    PendingRefresh {
+                        reply,
+                        apply_suggested_interval: origin.apply_suggested_interval(),
+                    },
+                );
                 let fetcher = Arc::clone(&state.fetcher);
                 let actor = myself.clone();
                 tokio::spawn(async move {
@@ -796,21 +832,35 @@ impl Actor for ProfilesActor {
                             .await
                             .map_err(|e| format!("download failed: {e}"))?;
                         Self::validate_fetched_content(&definition, &fetched.content)?;
-                        Ok::<_, String>((fetched.subscription, fetched.content))
+                        Ok::<_, String>((
+                            fetched.subscription,
+                            fetched.suggested_update_interval_minutes,
+                            fetched.content,
+                        ))
                     }
                     .await;
                     let outcome = match outcome {
-                        Ok((subscription, content)) => RefreshOutcome::Succeeded {
-                            subscription,
-                            content,
-                        },
+                        Ok((subscription, suggested_update_interval_minutes, content)) => {
+                            RefreshOutcome::Succeeded {
+                                subscription,
+                                suggested_update_interval_minutes,
+                                content,
+                            }
+                        }
                         Err(message) => RefreshOutcome::Failed { message },
                     };
                     let _ = actor.cast(ProfilesActorMessage::CommitRefreshed { uid, url, outcome });
                 });
             }
             ProfilesActorMessage::CommitRefreshed { uid, url, outcome } => {
-                let reply = state.pending_refresh.remove(&uid).flatten();
+                let pending = state
+                    .pending_refresh
+                    .remove(&uid)
+                    .unwrap_or(PendingRefresh {
+                        reply: None,
+                        apply_suggested_interval: false,
+                    });
+                let reply = pending.reply;
                 let snapshot = Self::current_state(state);
                 // Nothing was written during the download phase, so a profile
                 // deleted mid-download needs no file cleanup — just settle the
@@ -850,6 +900,7 @@ impl Actor for ProfilesActor {
                     }
                     RefreshOutcome::Succeeded {
                         subscription,
+                        suggested_update_interval_minutes,
                         content,
                     } => {
                         // Re-validate against the CURRENT definition: the URL
@@ -895,12 +946,20 @@ impl Actor for ProfilesActor {
                                         match item.definition.source_mut() {
                                             Some(ProfileSource::Remote {
                                                 materialized,
+                                                option,
                                                 subscription: slot,
                                                 ..
                                             }) => {
                                                 materialized.updated_at =
                                                     Some(time::OffsetDateTime::now_utc());
                                                 *slot = subscription;
+                                                if pending.apply_suggested_interval {
+                                                    if let Some(minutes) =
+                                                        suggested_update_interval_minutes
+                                                    {
+                                                        option.update_interval_minutes = minutes;
+                                                    }
+                                                }
                                                 Ok(WriteOutcome {
                                                     affects: AffectsRule::Touched(uid.clone()),
                                                     post_ops: vec![],
@@ -1148,7 +1207,13 @@ impl Actor for ProfilesActor {
                 reply,
                 inserted,
             } => {
-                state.pending_refresh.insert(uid, Some(reply));
+                state.pending_refresh.insert(
+                    uid,
+                    PendingRefresh {
+                        reply: Some(reply),
+                        apply_suggested_interval: false,
+                    },
+                );
                 let _ = inserted.send(());
             }
         }

--- a/backend/tauri/src/state/profiles/ports.rs
+++ b/backend/tauri/src/state/profiles/ports.rs
@@ -33,6 +33,8 @@ pub struct FetchedSubscription {
     /// Server-provided display name (`profile-title` / `Content-Disposition`).
     pub filename: Option<String>,
     pub subscription: SubscriptionInfo,
+    /// Server-advertised `profile-update-interval`, normalized from hours to minutes.
+    pub suggested_update_interval_minutes: Option<u64>,
 }
 
 /// Subscription download. Network timeouts are managed inside the

--- a/backend/tauri/src/state/profiles/scheduler.rs
+++ b/backend/tauri/src/state/profiles/scheduler.rs
@@ -188,6 +188,7 @@ impl RemoteUpdateScheduler {
                     let _ = actor.cast(ProfilesActorMessage::RefreshRemote {
                         uid: tick_uid.clone(),
                         patch: None,
+                        origin: super::actor::RefreshOrigin::Scheduled,
                         reply: None,
                     });
                 }
@@ -197,6 +198,7 @@ impl RemoteUpdateScheduler {
                     let _ = actor.cast(ProfilesActorMessage::RefreshRemote {
                         uid: tick_uid.clone(),
                         patch: None,
+                        origin: super::actor::RefreshOrigin::Scheduled,
                         reply: None,
                     });
                 }

--- a/docs/design/actor-migration-roadmap.md
+++ b/docs/design/actor-migration-roadmap.md
@@ -78,19 +78,19 @@ stateDiagram-v2
 
 > ⚠️ **进度账本更正:** 本地 `.ccg` 任务状态(「migration V2 待推送 review-fix」)已过期——#4824 已 squash 合并进 main;本地 `refactor/migration-service-v2` 分支(3 个 pre-squash 提交)可以删除,该任务可关闭。
 
-> 🔨 **PR-3(profiles 域切换,T07–T11)状态:已实施(本地,未推送)**——分支 `refactor/pr3-profiles-domain-switch`@`20cfbf3c`:profiles `ProfilesActor` + facade + IPC BC(13→16 命令)+ 前端单值 `current` 适配 + legacy 清算(删 `config/profile/**`、`Config::profiles()`、`ProfilesJobGuard`、legacy enhance 管线 ~4300 行)。design §16 判据 1–8 取证见 `task.md` T11(活体启动半 + 前端全功能为用户手动清单)。**注:** 下方 §2.2/§2.4 的 tauri 侧细节(「仅 7 条命令迁移」「`Config::profiles()` 23/5」等)成文于 PR-3 之前,待后续统一刷新。
+> ✅ **PR-3(profiles 域切换,T07–T11)已合并**——#4889(`a655ebbdf`)完成 profiles `ProfilesActor` + facade + IPC BC + 前端单值 `current` 适配,#4890(`fb400591d`)完成 legacy 清算(删 `config/profile/**`、`Config::profiles()`、`ProfilesJobGuard`、legacy enhance 管线 ~4300 行)。design §16 判据 1–8 取证见 `task.md` T11(活体启动半 + 前端全功能为用户手动清单)。
 
 ### 2.2 新架构已落地面(tauri 侧)
 
 - **Actor ×2:** `StateActor`(拥有 `PersistentStateManager<IVerge>` + `VergeMirror`,消息 `GetVerge/PatchVerge/ReplaceVerge`,`state/verge.rs:34,73`);`ClashConnectionsActor`(WS 流,`core/clash/ws.rs:609`)。
 - **Facade:** `NyanpasuClient { ui: Arc<dyn UiEventSink>, state: StateClient, verge_update_lock }`(`client/mod.rs:19-30`),`client::setup()` 在 `setup.rs:13` app.manage。
-- **已迁移 IPC 面仅 7 条命令:** `get_verge_config`、`patch_verge_config`、`get_profiles`、`patch_profiles_config`(+`import/create_profile` 的激活分支)、`get_core_status`、`change_clash_core`、`save_window_size_state`——其中后 5 条 client 内部仍委托旧全局(ACL 模式)。其余 ~70 条命令直连全局。
+- **Profiles IPC 面已全部切换:** 当前 17 条 profile 命令均为薄 Tauri adapter,经 `NyanpasuClient`/typed `ProfilesClient` 进入 `ProfilesActor`;其余域的 legacy IPC 迁移按后续 PR 台账推进。
 - **读写超时未分离:** `STATE_RPC_TIMEOUT = 5s` 读写共用(`client/state.rs:16`),spec §7 要求「写无超时、读 5s」尚未实施。
-- **`bridge/` 与 `state/mirror.rs` 不存在**;`client/mod.rs` 尚 import `Config`/`CoreManager`(违反未来 Tauri-free 可抽取边界,预期中)。
+- **桥层已建立:** `bridge/` 与 `state/mirror.rs` 已存在;剩余 `Config`/`CoreManager` 使用隔离在已登记的 runtime/core bridge,并按 PR-4/PR-5 清偿。
 
 ### 2.3 nyanpasu-config / nyanpasu-core(域层)
 
-- **`nyanpasu-config` 处于「暗启动」状态:全仓库零消费者**——连 tauri 都未依赖它(`backend/tauri/Cargo.toml` 无此项)。纯类型 crate,无 ractor/tokio/文件 IO(仅端口探测与系统 locale 两处例外)。
+- **`nyanpasu-config` 已承载生产 profile/runtime 流量:** tauri 通过 `ProfilesActor` 持有 profile 域状态,并由 `RuntimeBuilder` 消费其快照生成运行配置。该 crate 继续保持域类型与纯服务边界,基础设施副作用由 tauri 侧 ports/adapters 注入。
 - 五个域模块齐备:`application`(`NyanpasuAppConfig` 实测 32 字段 + Patch;spec 记 38 已过时)、`clash`(`ClashConfig`/overrides/端口策略)、`profile`(clean 组合模型全套 + validate/sanitize/依赖索引/分层 patch)、`state`(`PersistentState{window_state}`)、`runtime`(见下)。
 - **runtime 模块 = 数据结构 + 失效计算,无执行器**:`ConfigSnapshotsBuilder` 自述为「pure recorder for the pipeline executor」(`runtime/snapshot.rs:354`);`BuiltinStepKind{GuardOverrides,WhitelistFieldFilter,Finalizing}` 仅是 tag(`:72`);**没有任何代码读 profile 文件、应用 Overlay、跑 JS/Lua、合并 proxies、过滤 whitelist**。失效机制 `invalidate_profile()`(`runtime/invalidation.rs:38`)已实现,重建策略锁定为整图全量重建 current(`SnapshotRebuild::FullCurrent`)。
 - **`nyanpasu-core` 已承载生产流量:** `PersistentStateManager<IVerge>` 是现 StateActor 的持久层(`client/state.rs:51`);manager 家族(Persistent/WeakPersistent/Simple/PersistentBuilt)+ `StateCoordinator` MVCC(prepare/commit/rollback、ack 订阅、`with_pending_state` 效果钩子、atomicwrites 原子落盘)完整,测试 ~92 项。
@@ -626,7 +626,7 @@ sequenceDiagram
 
 **规则:** 台账之外不得新增桥;每条桥的代码处必须有 `TODO(actor-migration)` + 删除条件注释。
 
-**2026-07-07 PR-3(profiles 域切换,T07–T11)收尾登记:** 已实施(本地 `refactor/pr3-profiles-domain-switch`@`20cfbf3c`,未推送)。**B8 输入装配面归零**——RuntimeBuilder 取数经 typed client/facade,无旧全局输入装配残留;B8 残余与上表一致 = `Config::runtime()` draft 写入(`client/mod.rs` regenerate,TODO 标记)+ `CoreManager::apply_config` 桥(`client/core_bridge.rs`,TODO 标记),随 PR-4/PR-5 清偿。当前 `TODO/FIXME(actor-migration)` 注释账本 **17 处**,全属 verge/clash/window/core/runtime 桥(PR-4/5/6 负责),**profiles 域桥已在 T07/T08/T10 清尽**。逐处枚举见 `docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md` T11 判据 7。
+**2026-07-11 PR-3(profiles 域切换,T07–T11)收尾登记:** #4889(`a655ebbdf`)/#4890(`fb400591d`)已合并。**B8 输入装配面归零**——RuntimeBuilder 取数经 typed client/facade,无旧全局输入装配残留;B8 残余与上表一致 = `Config::runtime()` draft 写入(`client/mod.rs` regenerate,TODO 标记)+ `CoreManager::apply_config` 桥(`client/core_bridge.rs`,TODO 标记),随 PR-4/PR-5 清偿。当前 `TODO/FIXME(actor-migration)` 注释账本 **17 处**,全属 verge/clash/window/core/runtime 桥(PR-4/5/6 负责),**profiles 域桥已在 T07/T08/T10 清尽**。逐处枚举见 `docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md` T11 判据 7。
 
 ### 5.1 桥接双向数据流(图示)
 

--- a/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
+++ b/docs/superpowers/specs/2026-07-04-pr3-profiles-domain-switch-tauri/task.md
@@ -749,11 +749,14 @@ design §16 判据 1–8 逐条取证(全部在 tip `20cfbf3c`,当前 env 规则
 
 - **A-Critical 拖拽重排「状态竞态致列表损坏」**:REFUTED——`onDragEnd` 闭包内 `filteredProfiles` 与 `profiles?.items` 派生自同一渲染快照(评审误认后者为「最新查询数据」),两者自洽;且 actor `ByList` 校验长度+去重+全量排列,陈旧列表被 `InvalidReorderList` 拒绝。最坏情形 = 陈旧请求报错,不存在「复活已删项/静默丢项」的数据损坏。
 
-**待用户决策(3 项)**:
+**待用户决策(1 项)**:
 
-- **C-M2(后半)提交后 rebuild 失败仍以 Err 返回 IPC**:状态已持久化但命令报失败(前端靠 mutation 事件仍会刷新,但错误信息误导;import 场景重试会重复)。改「committed/degraded」结果模型属 IPC 语义变更,建议 PR-4 议。
 - **C-M5 `run_core_inner` 仍 `Config::clash().reload()` 但重启不再 regenerate**:「重启=应用当前 draft」为 2026-07-07 明确决策,reload 现为半死代码(只影响后续 regen 输入,且可能吞未提交 draft)。选项:pr3f 删 reload / restart 路径走 regen 桥。
-- **C-Min2 `profile-update-interval` 响应头不再解析**:legacy 在用户未设 interval 时采纳服务端建议(hour→min);新 fetcher 丢弃,导入后永用默认/用户值。恢复需 `FetchedSubscription` 增字段 + actor 提交处应用,属行为增补。
+
+**2026-07-11 用户决策与处置:**
+
+- **C-M2(后半):** 本次维持现状;「committed/degraded」IPC 结果模型延至 PR-4 讨论。
+- **C-Min2:** 已处置——恢复 `profile-update-interval` 小时→分钟解析,仅首次导入且用户未显式设置 interval 时由 actor 在成功提交事务内采纳;manual/scheduled refresh 忽略建议。
 
 **知悉不修(本 PR)**:C-M4 后半(端口生命周期编排 stop→resolve→mirror→start 与 legacy sysproxy/API 镜像回写时机,PR-4);A-Minor 空列表早退、chain 编辑器后台刷新重置本地顺序、query cache 存闭包(均 pre-existing 模式);C-Suggestion 并发 rebuild/HoldingFetcher+Replace/降级可观察三测试与 URL 协议白名单(挂账)。
 

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -527,31 +527,33 @@ export type ConfigDefinition =
 export type ConfigDefinition_Deserialize =
   /**  A config parsed from a locally materialized file. */
   | ({
-      file: {
-        type: 'file'
-      } & FileConfig_Deserialize
-    } & { composition?: never })
+      type: 'file'
+      source: ProfileSource_Deserialize
+      transforms?: ProfileId[]
+    } & { base?: never; extend_proxies_from?: never })
   /**  A config composed from an optional full base and proxy contributors. */
   | ({
-      composition: {
-        type: 'composition'
-      } & CompositionConfig_Deserialize
-    } & { file?: never })
+      type: 'composition'
+      base?: ProfileId | null
+      extend_proxies_from?: ProfileId[]
+      transforms?: ProfileId[]
+    } & { source?: never })
 
 /**  A profile that can produce a complete config and can be selected by current. */
 export type ConfigDefinition_Serialize =
   /**  A config parsed from a locally materialized file. */
   | ({
-      file: {
-        type: 'file'
-      } & FileConfig_Serialize
-    } & { composition?: never })
+      type: 'file'
+      source: ProfileSource_Serialize
+      transforms?: ProfileId[]
+    } & { base?: never; extend_proxies_from?: never })
   /**  A config composed from an optional full base and proxy contributors. */
   | ({
-      composition: {
-        type: 'composition'
-      } & CompositionConfig_Serialize
-    } & { file?: never })
+      type: 'composition'
+      base?: ProfileId | null
+      extend_proxies_from?: ProfileId[]
+      transforms?: ProfileId[]
+    } & { source?: never })
 
 export type CopyEnvOption = 'shell' | 'cmd' | 'pwsh'
 
@@ -943,25 +945,29 @@ export type IVerge_Serialize = {
 export type LocalBinding = LocalBinding_Serialize | LocalBinding_Deserialize
 
 export type LocalBinding_Deserialize =
-  | ({ type: 'managed'; materialized: MaterializedFile_Deserialize } & {
-      mode?: never
-      target?: never
-    })
+  | ({
+      type: 'managed'
+      file: ManagedProfilePath
+      updated_at?: number | null
+    } & { mode?: never; target?: never })
   | {
       type: 'external'
-      materialized: MaterializedFile_Deserialize
+      file: ManagedProfilePath
+      updated_at?: number | null
       target: ExternalProfilePath
       mode: ExternalMode
     }
 
 export type LocalBinding_Serialize =
-  | ({ type: 'managed'; materialized: MaterializedFile_Serialize } & {
-      mode?: never
-      target?: never
-    })
+  | ({
+      type: 'managed'
+      file: ManagedProfilePath
+      updated_at?: number | null
+    } & { mode?: never; target?: never })
   | {
       type: 'external'
-      materialized: MaterializedFile_Serialize
+      file: ManagedProfilePath
+      updated_at?: number | null
       target: ExternalProfilePath
       mode: ExternalMode
     }
@@ -1190,14 +1196,16 @@ export type ProfileSource = ProfileSource_Serialize | ProfileSource_Deserialize
  */
 export type ProfileSource_Deserialize =
   | ({ type: 'local'; binding: LocalBinding_Deserialize } & {
-      materialized?: never
+      file?: never
       option?: never
       subscription?: never
+      updated_at?: never
       url?: never
     })
   | ({
       type: 'remote'
-      materialized: MaterializedFile_Deserialize
+      file: ManagedProfilePath
+      updated_at?: number | null
       url: string
       option?: ProfileRemoteOptions
       subscription?: ProfileSubscriptionInfo
@@ -1211,14 +1219,16 @@ export type ProfileSource_Deserialize =
  */
 export type ProfileSource_Serialize =
   | ({ type: 'local'; binding: LocalBinding_Serialize } & {
-      materialized?: never
+      file?: never
       option?: never
       subscription?: never
+      updated_at?: never
       url?: never
     })
   | ({
       type: 'remote'
-      materialized: MaterializedFile_Serialize
+      file: ManagedProfilePath
+      updated_at?: number | null
       url: string
       option: ProfileRemoteOptions
       subscription?: ProfileSubscriptionInfo
@@ -1775,32 +1785,22 @@ export type TransformDefinition =
 /**  A named config transformer. Transform profiles are reusable but not activatable. */
 export type TransformDefinition_Deserialize =
   /**  Declarative YAML overlay/patch. This is the new name for legacy Merge. */
-  | ({
-      overlay: {
-        type: 'overlay'
-      } & OverlayTransform_Deserialize
-    } & { script?: never })
+  | ({ type: 'overlay'; source: ProfileSource_Deserialize } & {
+      runtime?: never
+    })
   /**  Imperative JS/Lua transform. */
-  | ({
-      script: {
-        type: 'script'
-      } & ScriptTransform_Deserialize
-    } & { overlay?: never })
+  | {
+      type: 'script'
+      source: ProfileSource_Deserialize
+      runtime: ScriptRuntime
+    }
 
 /**  A named config transformer. Transform profiles are reusable but not activatable. */
 export type TransformDefinition_Serialize =
   /**  Declarative YAML overlay/patch. This is the new name for legacy Merge. */
-  | ({
-      overlay: {
-        type: 'overlay'
-      } & OverlayTransform_Serialize
-    } & { script?: never })
+  | ({ type: 'overlay'; source: ProfileSource_Serialize } & { runtime?: never })
   /**  Imperative JS/Lua transform. */
-  | ({
-      script: {
-        type: 'script'
-      } & ScriptTransform_Serialize
-    } & { overlay?: never })
+  | { type: 'script'; source: ProfileSource_Serialize; runtime: ScriptRuntime }
 
 export type TransformOwner =
   | { type: 'global' }

--- a/frontend/interface/src/ipc/use-profile.ts
+++ b/frontend/interface/src/ipc/use-profile.ts
@@ -7,6 +7,7 @@ import {
   type ProfileId,
   type ProfileItem_Serialize,
   type ProfileMetadataPatch_Deserialize,
+  type ProfileSource_Serialize,
   type RemoteProfileOptionsPatch_Deserialize,
 } from './bindings'
 import { RROFILES_QUERY_KEY } from './consts'
@@ -24,17 +25,24 @@ export const isTransformItem = (
   item.type === 'transform'
 
 /** Remote = a File config whose source is a remote subscription. */
+export const getRemoteSource = (
+  item: ProfileItem_Serialize,
+): Extract<ProfileSource_Serialize, { type: 'remote' }> | undefined =>
+  isConfigItem(item) &&
+  item.config.type === 'file' &&
+  item.config.source.type === 'remote'
+    ? item.config.source
+    : undefined
+
 export const isRemoteItem = (item: ProfileItem_Serialize): boolean =>
-  isConfigItem(item) && item.config.file?.source.type === 'remote'
+  getRemoteSource(item) !== undefined
 
 /** Scoped transforms of the current config item (File or Composition). */
 export const scopedTransformsOf = (
   item: ProfileItem_Serialize,
 ): ProfileId[] => {
   if (!isConfigItem(item)) return []
-  return (
-    item.config.file?.transforms ?? item.config.composition?.transforms ?? []
-  )
+  return item.config.transforms ?? []
 }
 
 export interface ProfileHelperFn {

--- a/frontend/nyanpasu/messages/en.json
+++ b/frontend/nyanpasu/messages/en.json
@@ -248,6 +248,8 @@
   "profile_form_option_with_proxy_label": "Use System Proxy",
   "profile_form_option_self_proxy_label": "Use Clash Proxy",
   "profile_form_option_update_interval_label": "Auto Update Interval (minutes)",
+  "profile_form_option_update_interval_placeholder": "auto (server-suggested or 120min default)",
+  "profile_form_option_update_interval_min_error": "Interval must be at least 1 minute",
   "profile_import_local_file_placeholder": "Click or drag file here to import",
   "profile_import_local_file_type_label": "Supported files: {types}",
   "profile_import_local_file_size_label": "File size: {size}",

--- a/frontend/nyanpasu/messages/ru.json
+++ b/frontend/nyanpasu/messages/ru.json
@@ -248,6 +248,8 @@
   "profile_form_option_with_proxy_label": "Использовать системный прокси",
   "profile_form_option_self_proxy_label": "Использовать прокси Clash",
   "profile_form_option_update_interval_label": "Интервал автоматического обновления (минуты)",
+  "profile_form_option_update_interval_placeholder": "авто (сервером или 120 мин по умолчанию)",
+  "profile_form_option_update_interval_min_error": "Интервал должен быть не менее 1 минуты",
   "profile_import_local_file_placeholder": "Нажмите или перетащите файл сюда для импорта",
   "profile_import_local_file_type_label": "Поддерживаемые файлы: {types}",
   "profile_import_local_file_size_label": "Размер файла: {size}",

--- a/frontend/nyanpasu/messages/zh-cn.json
+++ b/frontend/nyanpasu/messages/zh-cn.json
@@ -248,6 +248,8 @@
   "profile_form_option_with_proxy_label": "使用系统代理",
   "profile_form_option_self_proxy_label": "使用 Clash 代理",
   "profile_form_option_update_interval_label": "自动更新间隔（分钟）",
+  "profile_form_option_update_interval_placeholder": "自动（服务器建议或默认 120 分钟）",
+  "profile_form_option_update_interval_min_error": "自动更新间隔必须大于或等于 1 分钟",
   "profile_import_local_file_placeholder": "点击或拖拽文件到此处导入",
   "profile_import_local_file_type_label": "支持 {types} 文件",
   "profile_import_local_file_size_label": "文件大小: {size}",

--- a/frontend/nyanpasu/messages/zh-tw.json
+++ b/frontend/nyanpasu/messages/zh-tw.json
@@ -248,6 +248,8 @@
   "profile_form_option_with_proxy_label": "使用系統代理",
   "profile_form_option_self_proxy_label": "使用 Clash 代理",
   "profile_form_option_update_interval_label": "自動更新間隔 (分鐘)",
+  "profile_form_option_update_interval_placeholder": "自動（伺服器建議或預設 120 分鐘）",
+  "profile_form_option_update_interval_min_error": "自動更新間隔必須大於或等於 1 分鐘",
   "profile_import_local_file_placeholder": "點擊或拖曳檔案至此處匯入",
   "profile_import_local_file_type_label": "支持 {types} 文件",
   "profile_import_local_file_size_label": "文件大小: {size}",

--- a/frontend/nyanpasu/src/components/ui/input.tsx
+++ b/frontend/nyanpasu/src/components/ui/input.tsx
@@ -443,9 +443,7 @@ export const NumericInput = ({
   })
 
   useEffect(() => {
-    if (value != null) {
-      setInputValue(String(value))
-    }
+    setInputValue(value != null ? String(value) : '')
   }, [value])
 
   const validateAndFormatValue = (numValue: number): number => {

--- a/frontend/nyanpasu/src/pages/(editor)/editor/_modules/hooks.tsx
+++ b/frontend/nyanpasu/src/pages/(editor)/editor/_modules/hooks.tsx
@@ -33,13 +33,13 @@ export function useCurrentProfile(uid: string): {
         schemaType = 'clash'
         readOnly = isRemoteItem(item)
       } else if (isTransformItem(item)) {
-        if (item.transform.overlay) {
+        if (item.transform.type === 'overlay') {
           schemaType = 'merge'
-        } else if (item.transform.script) {
-          if (item.transform.script.runtime === 'javascript') {
+        } else if (item.transform.type === 'script') {
+          if (item.transform.runtime === 'javascript') {
             language = 'javascript'
             extension = 'js'
-          } else if (item.transform.script.runtime === 'lua') {
+          } else if (item.transform.runtime === 'lua') {
             language = 'lua'
             extension = 'lua'
           }

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/_modules/chain-profile-import.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/_modules/chain-profile-import.tsx
@@ -55,7 +55,7 @@ const buildTransformRequest = (
     type: 'local' as const,
     binding: {
       type: 'managed' as const,
-      materialized: { file: 'pending.yaml' },
+      file: 'pending.yaml',
     },
   }
 
@@ -64,19 +64,19 @@ const buildTransformRequest = (
   if (rawType === RawProfileType.Merge) {
     definition = {
       type: 'transform',
-      transform: { overlay: { type: 'overlay', source } },
+      transform: { type: 'overlay', source },
     }
     fileData = ProfileTemplate.merge
   } else if (rawType === RawProfileType.Lua) {
     definition = {
       type: 'transform',
-      transform: { script: { type: 'script', source, runtime: 'lua' } },
+      transform: { type: 'script', source, runtime: 'lua' },
     }
     fileData = ProfileTemplate.luascript
   } else {
     definition = {
       type: 'transform',
-      transform: { script: { type: 'script', source, runtime: 'javascript' } },
+      transform: { type: 'script', source, runtime: 'javascript' },
     }
     fileData = ProfileTemplate.javascript
   }

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/_modules/create-composition-button.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/_modules/create-composition-button.tsx
@@ -39,7 +39,7 @@ export default function CreateCompositionButton({
 
   // Composition members must be direct File configs (not Composition/Transform).
   const candidates = (query.data?.items ?? []).filter(
-    (item) => isConfigItem(item) && Boolean(item.config.file),
+    (item) => isConfigItem(item) && item.config.type === 'file',
   )
 
   const reset = () => {
@@ -69,12 +69,10 @@ export default function CreateCompositionButton({
       definition: {
         type: 'config',
         config: {
-          composition: {
-            type: 'composition',
-            base: null,
-            extend_proxies_from: members,
-            transforms: [],
-          },
+          type: 'composition',
+          base: null,
+          extend_proxies_from: members,
+          transforms: [],
         },
       },
     }

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/_modules/local-profile-button.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/_modules/local-profile-button.tsx
@@ -100,17 +100,15 @@ export default function LocalProfileButton({ children }: PropsWithChildren) {
           definition: {
             type: 'config',
             config: {
-              file: {
-                type: 'file',
-                source: {
-                  type: 'local',
-                  binding: {
-                    type: 'managed',
-                    materialized: { file: 'pending.yaml' },
-                  },
+              type: 'file',
+              source: {
+                type: 'local',
+                binding: {
+                  type: 'managed',
+                  file: 'pending.yaml',
                 },
-                transforms: [],
               },
+              transforms: [],
             },
           },
         }
@@ -145,9 +143,8 @@ export default function LocalProfileButton({ children }: PropsWithChildren) {
       },
     })
 
-    if (value) {
-      form.reset(getDefaultValues())
-    }
+    form.reset(getDefaultValues())
+    setProfileContent(null)
   }
 
   const handleSubmit = useLockFn(blockTask.execute)
@@ -219,7 +216,7 @@ export default function LocalProfileButton({ children }: PropsWithChildren) {
                       accept={acceptFiles}
                       value={field.value}
                       onChange={(name) => {
-                        form.setValue('desc', name)
+                        form.setValue('file', name)
                       }}
                       onFileRead={(value) => {
                         setProfileContent(value)

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/_modules/remote-profile-button.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/_modules/remote-profile-button.tsx
@@ -31,7 +31,12 @@ const formSchema = z.object({
     user_agent: z.string().nullable(),
     with_proxy: z.boolean(),
     self_proxy: z.boolean(),
-    update_interval: z.number().nullable(),
+    update_interval: z
+      .number()
+      .min(1, {
+        message: m.profile_form_option_update_interval_min_error(),
+      })
+      .nullable(),
   }),
 })
 
@@ -43,7 +48,7 @@ const getDefaultValues = () => {
     option: {
       with_proxy: false,
       self_proxy: false,
-      update_interval: 1440,
+      update_interval: null,
       user_agent: null,
     },
   } satisfies z.infer<typeof formSchema>
@@ -242,8 +247,9 @@ export default function RemoteProfileButton({ children }: PropsWithChildren) {
                       <NumericInput
                         variant="outlined"
                         label={m.profile_form_option_update_interval_label()}
-                        min={0}
+                        min={1}
                         step={1}
+                        placeholder={m.profile_form_option_update_interval_placeholder()}
                         {...field}
                       />
 

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/_modules/utils.ts
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/_modules/utils.ts
@@ -31,17 +31,21 @@ export const isChainProfile = (
 export const isJavaScriptProfile = (
   profile: ProfileItem_Serialize,
 ): profile is TransformProfile =>
-  isTransformItem(profile) && profile.transform.script?.runtime === 'javascript'
+  isTransformItem(profile) &&
+  profile.transform.type === 'script' &&
+  profile.transform.runtime === 'javascript'
 
 export const isLuaProfile = (
   profile: ProfileItem_Serialize,
 ): profile is TransformProfile =>
-  isTransformItem(profile) && profile.transform.script?.runtime === 'lua'
+  isTransformItem(profile) &&
+  profile.transform.type === 'script' &&
+  profile.transform.runtime === 'lua'
 
 export const isMergeProfile = (
   profile: ProfileItem_Serialize,
 ): profile is TransformProfile =>
-  isTransformItem(profile) && profile.transform.overlay !== undefined
+  isTransformItem(profile) && profile.transform.type === 'overlay'
 
 export const categoryProfiles = (
   profiles?: ProfileItem_Serialize[] | null,

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/action-card.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/action-card.tsx
@@ -45,7 +45,7 @@ export default function ActionCard({
   // ProfileHasNoFile. File configs and transforms both own a file.
   const hasMaterializedFile =
     isTransformItem(profile) ||
-    (profile.type === 'config' && Boolean(profile.config.file))
+    (profile.type === 'config' && profile.config.type === 'file')
 
   return (
     <div className="col-span-2 grid grid-cols-2 gap-4">

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/chian-editor-card.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/chian-editor-card.tsx
@@ -211,22 +211,10 @@ export default function ChianEditorCard({
       const nextTransforms = chainsUids[ColumnType.Active]
       // Rebuild the config definition with the reordered scoped transforms,
       // preserving every other field, and replace it atomically.
-      const definition: ProfileDefinition_Deserialize = profile.config.file
-        ? {
-            type: 'config',
-            config: {
-              file: { ...profile.config.file, transforms: nextTransforms },
-            },
-          }
-        : {
-            type: 'config',
-            config: {
-              composition: {
-                ...profile.config.composition!,
-                transforms: nextTransforms,
-              },
-            },
-          }
+      const definition: ProfileDefinition_Deserialize = {
+        type: 'config',
+        config: { ...profile.config, transforms: nextTransforms },
+      }
 
       await replaceDefinition.mutateAsync({ uid: profile.uid, definition })
     } catch (error) {

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/subscription-card.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/subscription-card.tsx
@@ -16,15 +16,14 @@ import { useLockFn } from '@/hooks/use-lock-fn'
 import { m } from '@/paraglide/messages'
 import { formatError } from '@/utils'
 import { message } from '@/utils/notification'
-import { useProfile, type ProfileItem_Serialize } from '@nyanpasu/interface'
+import {
+  getRemoteSource,
+  useProfile,
+  type ProfileItem_Serialize,
+} from '@nyanpasu/interface'
 import UpdateOptionEditor from './update-option-editor'
 
 const clampPercentage = (value: number) => Math.min(100, Math.max(0, value))
-
-const remoteSourceOf = (profile: ProfileItem_Serialize) =>
-  profile.type === 'config' && profile.config.file?.source.type === 'remote'
-    ? profile.config.file.source
-    : undefined
 
 export const SubscriptionCard = ({
   profile,
@@ -33,8 +32,8 @@ export const SubscriptionCard = ({
 }) => {
   const { update } = useProfile()
 
-  const remote = remoteSourceOf(profile)
-  const updatedAt = remote?.materialized.updated_at ?? null
+  const remote = getRemoteSource(profile)
+  const updatedAt = remote?.updated_at ?? null
   const updateIntervalMinutes = remote?.option.update_interval_minutes
   const expire = remote?.subscription?.expire
 
@@ -43,7 +42,7 @@ export const SubscriptionCard = ({
     let total = 0
     let used = 0
 
-    const sub = remoteSourceOf(profile)?.subscription
+    const sub = getRemoteSource(profile)?.subscription
     if (sub) {
       total = sub.total ?? 0
 

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/subscription-url-editor.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/subscription-url-editor.tsx
@@ -29,10 +29,11 @@ const formSchema = z.object({
 })
 
 const remoteFileOf = (profile: ProfileItem_Serialize) => {
-  if (profile.type !== 'config') return undefined
-  const file = profile.config.file
-  if (!file || file.source.type !== 'remote') return undefined
-  return { file, source: file.source }
+  if (profile.type !== 'config' || profile.config.type !== 'file') {
+    return undefined
+  }
+  if (profile.config.source.type !== 'remote') return undefined
+  return { config: profile.config, source: profile.config.source }
 }
 
 export default function SubscriptionUrlEditor({
@@ -72,7 +73,8 @@ export default function SubscriptionUrlEditor({
             const definition: ProfileDefinition_Deserialize = {
               type: 'config',
               config: {
-                file: { ...remote.file, source: { ...remote.source, url } },
+                ...remote.config,
+                source: { ...remote.source, url },
               },
             }
             await replaceDefinition.mutateAsync({

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/update-option-editor.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/update-option-editor.tsx
@@ -29,7 +29,13 @@ const formSchema = z.object({
   user_agent: z.string().optional(),
   with_proxy: z.boolean().optional(),
   self_proxy: z.boolean().optional(),
-  update_interval: z.number().optional(),
+  update_interval: z
+    .number()
+    .min(1, {
+      message: m.profile_form_option_update_interval_min_error(),
+    })
+    .nullable()
+    .optional(),
 })
 
 const remoteOptionOf = (profile: ProfileItem_Serialize) =>
@@ -51,7 +57,7 @@ export default function UpdateOptionEditor({
       user_agent: option?.user_agent ?? '',
       with_proxy: option?.with_proxy ?? false,
       self_proxy: option?.self_proxy ?? false,
-      update_interval: option?.update_interval_minutes ?? 0,
+      update_interval: option?.update_interval_minutes ?? null,
     }
   }, [profile])
 
@@ -145,8 +151,9 @@ export default function UpdateOptionEditor({
                   <NumericInput
                     label={m.profile_update_interval_label()}
                     variant="outlined"
-                    min={0}
+                    min={1}
                     step={1}
+                    placeholder={m.profile_form_option_update_interval_placeholder()}
                     {...field}
                   />
 

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/update-option-editor.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/update-option-editor.tsx
@@ -18,7 +18,11 @@ import { m } from '@/paraglide/messages'
 import { formatError } from '@/utils'
 import { message } from '@/utils/notification'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useProfile, type ProfileItem_Serialize } from '@nyanpasu/interface'
+import {
+  getRemoteSource,
+  useProfile,
+  type ProfileItem_Serialize,
+} from '@nyanpasu/interface'
 import AnimatedErrorItem from '../../../_modules/error-item'
 
 const formSchema = z.object({
@@ -29,9 +33,7 @@ const formSchema = z.object({
 })
 
 const remoteOptionOf = (profile: ProfileItem_Serialize) =>
-  profile.type === 'config' && profile.config.file?.source.type === 'remote'
-    ? profile.config.file.source.option
-    : undefined
+  getRemoteSource(profile)?.option
 
 export default function UpdateOptionEditor({
   profile,

--- a/frontend/nyanpasu/src/pages/(main)/main/proxies/group/_modules/proxy-node-button.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/proxies/group/_modules/proxy-node-button.tsx
@@ -7,6 +7,27 @@ import { useLockFn } from '@/hooks/use-lock-fn'
 import { ClashProxiesQueryProxyItem } from '@nyanpasu/interface'
 import { cn } from '@nyanpasu/utils'
 
+function FeatureChip({
+  label,
+  variant = 'feature',
+}: {
+  label: string
+  variant?: 'type' | 'feature'
+}) {
+  return (
+    <span
+      className={cn(
+        'shrink-0 rounded px-1.5 py-0.5 text-[9px] leading-none font-medium uppercase',
+        variant === 'type'
+          ? 'bg-primary/10 text-primary'
+          : 'bg-secondary-container text-on-secondary-container',
+      )}
+    >
+      {label}
+    </span>
+  )
+}
+
 export default function ProxyNodeButton({
   proxy,
   ...props
@@ -61,11 +82,16 @@ export default function ProxyNodeButton({
         <div className="truncate text-sm font-medium">{proxy.name}</div>
       </div>
 
-      <div className="flex items-center gap-2">
-        <div className="flex-1" />
+      <div className="flex w-full items-center justify-between gap-2 overflow-hidden px-2">
+        <div className="flex items-center gap-1 overflow-hidden">
+          <FeatureChip label={proxy.type} variant="type" />
+          {proxy.udp && <FeatureChip label="UDP" />}
+          {proxy.xudp && <FeatureChip label="XUDP" />}
+          {proxy.tfo && <FeatureChip label="TFO" />}
+        </div>
 
         <Button
-          className="grid h-4 min-w-10 place-content-center px-2 text-center"
+          className="grid h-4 min-w-10 shrink-0 place-content-center px-2 text-center"
           variant="raised"
           onClick={handleDelayClick}
           loading={delayTask.isPending}


### PR DESCRIPTION
## Summary

Post-PR3 regression fixes (baseline: main @ d2039e55f), organized as four self-contained commits:

1. **`fix(profile)!` — specta/serde wire-contract hotfix (#4916, #4917)**
   Four internally-tagged profile enums (`ConfigDefinition` / `TransformDefinition` / `ProfileSource` / `LocalBinding`) exported wrong nested TS shapes (specta cannot lower newtype variants and `#[serde(flatten)]` in tagged enums), so the whole frontend was written against types that never matched the wire. Fixed with private `#[specta(remote = ...)]` mirror enums using named-field variants — real domain types keep every serde attribute untouched (wire format & `profiles.yaml` schema frozen, no data migration). Regenerated `bindings.ts` and migrated all frontend consumers to the flat discriminated unions (centralized `getRemoteSource` helper). Also fixes two local-import defects in the same path: dropped file path overwriting `desc`, and stale form/file content across modal toggles.
   **Drift protection:** `wire_shape.rs` pins the serde output of all 8 variants; `export_typescript_bindings` now also asserts the generated TS declaration shapes for both phases.

2. **`feat(profile)` — tri-state update interval + `profile-update-interval` header restored (C-Min2)**
   `unspecified/null` → adopt server suggestion on *first import only*, otherwise domain default (120 min); explicit positive value always wins; explicit `0` still rejected. `RefreshOrigin` (Import/Manual/Scheduled) is actor-internal; the suggestion commits in the same write transaction as subscription metadata, after the stale-URL/definition fences — failed downloads/writes never touch the interval, and the scheduler rebuilds its timer from the committed value. Frontend form now defaults to null (auto) with `min=1` validation and i18n placeholder (en/zh-cn/zh-tw/ru).

3. **`fix(proxies)` — restore protocol/UDP/XUDP/TFO chips on the proxy node button (#4915)**, layout-safe in narrow grid cells.

4. **`docs` — roadmap/task status refresh** (#4889/#4890 recorded as merged; C-Min2 disposition; C-M2 deferred to PR-4).

## Verification

- `cargo test --all-features` full workspace green (incl. 224 tauri + 127 config tests; ~10 new interval-semantics tests: header parsing edge cases, import/manual/scheduled precedence, write-failure isolation, scheduler reschedule under paused time)
- `export_typescript_bindings` passes twice, `bindings.ts` byte-stable; diff limited to the 4 corrected type declarations
- `pnpm -F @nyanpasu/interface build`, full web build, and `pnpm typecheck` green
- Nested-shape sweep (`.config.file|.transform.script|.materialized|...`) zero hits outside `bindings.ts`

## Review

- Multi-model review: frontend reviewer flagged the update-option editor missing the tri-state migration (could still submit `0` → `RemoteUpdateIntervalIsZero`) and a `NumericInput` stale-display-on-null-reset bug — both fixed in commit 2.
- Manual smoke checklist still recommended before merge: remote import → subscription card + actions present; local create (with/without file); composition candidates non-empty; JS/Lua/Merge tab classification; badge layout in narrow grid.

Fixes #4915
Fixes #4916
Fixes #4917
