### PR TITLE
chore(i18n): clean up and synchronize i18n configurations

### DIFF
--- a/backend/nyanpasu-config/src/application/i18n.rs
+++ b/backend/nyanpasu-config/src/application/i18n.rs
@@ -4,25 +4,45 @@ use specta::Type;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Type)]
 pub enum I18nLanguage {
-    #[serde(rename = "zh-CN")]
-    SimplifiedChinese,
     #[serde(rename = "en-US")]
     English,
+    #[serde(rename = "ko")]
+    Korean,
     #[serde(rename = "ru")]
     Russian,
+    #[serde(rename = "zh-CN")]
+    SimplifiedChinese,
+    #[serde(rename = "zh-TW")]
+    TraditionalChinese,
 }
 
 pub fn default_i18n_language() -> I18nLanguage {
     let system_locale = nyanpasu_helper::locale::get_system_locale();
-    if is_simplified_chinese(&system_locale) {
-        I18nLanguage::SimplifiedChinese
-    } else if is_english(&system_locale) {
+    if is_english(&system_locale) {
         I18nLanguage::English
+    } else if is_korean(&system_locale) {
+        I18nLanguage::Korean
     } else if is_russian(&system_locale) {
         I18nLanguage::Russian
+    } else if is_simplified_chinese(&system_locale) {
+        I18nLanguage::SimplifiedChinese
+    } else if is_traditional_chinese(&system_locale) {
+        I18nLanguage::TraditionalChinese
     } else {
         I18nLanguage::English
     }
+}
+
+fn is_english(lang: &LanguageTag) -> bool {
+    lang.primary_language().eq_ignore_ascii_case("en")
+}
+
+fn is_korean(lang: &LanguageTag) -> bool {
+    lang.primary_language().eq_ignore_ascii_case("ko")
+}
+
+fn is_russian(lang: &LanguageTag) -> bool {
+    lang.primary_language().eq_ignore_ascii_case("ru")
 }
 
 fn is_simplified_chinese(lang: &LanguageTag) -> bool {
@@ -43,12 +63,22 @@ fn is_simplified_chinese(lang: &LanguageTag) -> bool {
     }
 }
 
-fn is_english(lang: &LanguageTag) -> bool {
-    lang.primary_language().eq_ignore_ascii_case("en")
-}
-
-fn is_russian(lang: &LanguageTag) -> bool {
-    lang.primary_language().eq_ignore_ascii_case("ru")
+fn is_traditional_chinese(lang: &LanguageTag) -> bool {
+    if !lang.primary_language().eq_ignore_ascii_case("zh") {
+        return false;
+    }
+    // Prefer the explicit script subtag when present.
+    match lang.script() {
+        Some(script) if script.eq_ignore_ascii_case("Hant") => return true,
+        Some(script) if script.eq_ignore_ascii_case("Hans") => return false,
+        _ => {}
+    }
+    // Fall back to the region: only TW/HK/MO are Traditional Chinese.
+    // Bare `zh` and Simplified regions (CN/SG/MY) default to Simplified.
+    match lang.region() {
+        Some(region) => matches!(region.to_ascii_uppercase().as_str(), "TW" | "HK" | "MO"),
+        None => false,
+    }
 }
 
 #[cfg(test)]
@@ -69,6 +99,15 @@ mod tests {
     }
 
     #[test]
+    fn detects_traditional_chinese() {
+        assert!(is_traditional_chinese(&tag("zh-TW")));
+        assert!(is_traditional_chinese(&tag("zh-HK")));
+        assert!(is_traditional_chinese(&tag("zh-MO")));
+        assert!(is_traditional_chinese(&tag("zh-Hant")));
+        assert!(is_traditional_chinese(&tag("zh-Hant-TW")));
+    }
+
+    #[test]
     fn rejects_traditional_chinese() {
         assert!(!is_simplified_chinese(&tag("zh-TW")));
         assert!(!is_simplified_chinese(&tag("zh-HK")));
@@ -78,10 +117,12 @@ mod tests {
     }
 
     #[test]
-    fn detects_english_and_russian() {
+    fn detects_english_korean_and_russian() {
         assert!(is_english(&tag("en")));
         assert!(is_english(&tag("en-US")));
         assert!(is_english(&tag("en-GB")));
+        assert!(is_korean(&tag("ko")));
+        assert!(is_korean(&tag("ko-KR")));
         assert!(is_russian(&tag("ru")));
         assert!(is_russian(&tag("ru-RU")));
         assert!(!is_english(&tag("zh-CN")));

--- a/backend/tauri/tauri.conf.json
+++ b/backend/tauri/tauri.conf.json
@@ -12,14 +12,20 @@
         "type": "embedBootstrapper"
       },
       "wix": {
-        "language": ["en-US", "ru-RU", "zh-CN", "zh-TW"],
+        "language": ["en-US", "ko-KR", "ru-RU", "zh-CN", "zh-TW"],
         "template": "./templates/installer.wxs",
         "fragmentPaths": ["./templates/cleanup.wxs"]
       },
       "nsis": {
         "displayLanguageSelector": true,
         "installerIcon": "icons/icon.ico",
-        "languages": ["English", "Russian", "SimpChinese", "TradChinese"],
+        "languages": [
+          "English",
+          "Korean",
+          "Russian",
+          "SimpChinese",
+          "TradChinese"
+        ],
         "template": "./templates/installer.nsi",
         "installMode": "both"
       }

--- a/frontend/nyanpasu/project.inlang/settings.json
+++ b/frontend/nyanpasu/project.inlang/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://inlang.com/schema/project-settings",
   "baseLocale": "en",
-  "locales": ["en", "zh-cn", "zh-tw", "ru", "ko"],
+  "locales": ["en", "ko", "ru", "zh-cn", "zh-tw"],
   "modules": [
     "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4/dist/index.js",
     "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2/dist/index.js"


### PR DESCRIPTION
- add missing tradchinese and korean language detection to backend
- reorder language list in frontend to match backend implementation
- add korean language support to nsis installer

cc @keiko233 @greenhat616 @4o3F @moduvoice 