### PR TITLE
fix(window): preserve state when exiting from tray while minimized

### DIFF
--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -1234,7 +1234,7 @@ pub async fn save_window_size_state(
         .run_legacy_verge_mutation(|| async move {
             match label.as_str() {
                 crate::consts::MAIN_WINDOW_LABEL => {
-                    resolve::save_main_window_state(&app_handle, true)?;
+                    resolve::save_main_window_state_async(&app_handle, true).await?;
                 }
                 _ => log::warn!("Unknown window label: {}", label),
             }

--- a/backend/tauri/src/utils/resolve.rs
+++ b/backend/tauri/src/utils/resolve.rs
@@ -442,8 +442,47 @@ pub fn is_main_window_open(app_handle: &AppHandle) -> bool {
     MainWindow.is_open(app_handle)
 }
 
+fn save_main_window_state_snapshot(
+    app_handle: &AppHandle,
+    save_to_file: bool,
+) -> Result<Option<nyanpasu_config::state::PersistentState>> {
+    MainWindow.save_state(app_handle, save_to_file)?;
+
+    if !save_to_file {
+        return Ok(None);
+    }
+
+    let legacy = Config::verge().data().clone();
+    Ok(Some(crate::bridge::window::persistent_state_from_legacy(
+        &legacy,
+    )?))
+}
+
 pub fn save_main_window_state(app_handle: &AppHandle, save_to_file: bool) -> Result<()> {
-    MainWindow.save_state(app_handle, save_to_file)
+    if let Some(session_state) = save_main_window_state_snapshot(app_handle, save_to_file)? {
+        let client = app_handle
+            .state::<crate::client::NyanpasuClient>()
+            .inner()
+            .clone();
+        block_on(client.replace_session_state(session_state))?;
+    }
+
+    Ok(())
+}
+
+pub async fn save_main_window_state_async(
+    app_handle: &AppHandle,
+    save_to_file: bool,
+) -> Result<()> {
+    if let Some(session_state) = save_main_window_state_snapshot(app_handle, save_to_file)? {
+        let client = app_handle
+            .state::<crate::client::NyanpasuClient>()
+            .inner()
+            .clone();
+        client.replace_session_state(session_state).await?;
+    }
+
+    Ok(())
 }
 
 /// Create window based on window_type config

--- a/backend/tauri/src/window.rs
+++ b/backend/tauri/src/window.rs
@@ -805,19 +805,23 @@ pub trait AppWindow {
         let win = app_handle
             .get_webview_window(self.label())
             .ok_or(anyhow::anyhow!("failed to get window"))?;
-        let current_monitor = win.current_monitor()?;
+        if win.is_minimized()? {
+            if save_to_file {
+                Config::verge().data().save_file()?;
+            }
+            return Ok(());
+        }
 
-        let state = match current_monitor {
+        let state = match win.current_monitor()? {
             Some(_) => {
                 let maximized = win.is_maximized()?;
                 let fullscreen = win.is_fullscreen()?;
-                let is_minimized = win.is_minimized()?;
                 let size = win.inner_size()?;
 
                 // During system shutdown, Windows sends resize events with 0x0 dimensions.
                 // Skip saving in this case to preserve the last valid window state.
                 if size.width == 0 || size.height == 0 {
-                    if !maximized && !fullscreen && !is_minimized {
+                    if !maximized && !fullscreen {
                         tracing::debug!(
                             "skipping window state save: invalid size {}x{} in normal state",
                             size.width,
@@ -833,12 +837,12 @@ pub trait AppWindow {
                     ..WindowState::default()
                 };
 
-                if size.width > 0 && size.height > 0 && !state.maximized && !is_minimized {
+                if size.width > 0 && size.height > 0 && !state.maximized {
                     state.width = size.width;
                     state.height = size.height;
                 }
                 let position = win.outer_position()?;
-                if !state.maximized && !is_minimized {
+                if !state.maximized {
                     state.x = position.x;
                     state.y = position.y;
                 }


### PR DESCRIPTION
## Summary

- Preserve the last valid main-window size and position when the application exits while minimized.
- Avoid overwriting persisted geometry with values observed from a minimized window.
- Synchronize the saved legacy window state into the typed session state used during startup restoration.
- Use the async state-saving path from the async IPC handler.

## Root cause

When the main window was minimized, the exit path attempted to read and save its current geometry. On Windows, the minimized geometry could contain invalid or default values, overwriting the last valid window state.

Additionally, the exit path persisted the legacy window configuration, while startup restoration reads from the typed session state. This allowed the two persisted states to become inconsistent.

## Testing

- Ran `cargo check --manifest-path backend/Cargo.toml -p clash-nyanpasu --lib`.
- Built and tested the Windows release executable.
- Moved and resized the main window to a non-default position and size.
- Minimized the window and exited through the system tray.
- Relaunched the application and confirmed that the previous size and position were restored.

Fixes #4336