### PR TITLE
fix(proxy): resolve provider-owned proxies and delay tests

### DIFF
--- a/backend/tauri/src/core/clash/api.rs
+++ b/backend/tauri/src/core/clash/api.rs
@@ -386,11 +386,23 @@ pub struct DelayRes {
     delay: u64,
 }
 
-/// GET /proxies/{name}/delay
+fn proxy_delay_path(name: &str, provider: Option<&str>) -> String {
+    match provider {
+        Some(provider) => format!("/providers/proxies/{provider}/{name}/healthcheck"),
+        None => format!("/proxies/{name}/delay"),
+    }
+}
+
+/// GET /proxies/{name}/delay or
+/// GET /providers/proxies/{provider}/{name}/healthcheck
 /// 获取代理延迟
 #[instrument]
-pub async fn get_proxy_delay(name: String, test_url: Option<String>) -> Result<DelayRes> {
-    let path = format!("/proxies/{name}/delay");
+pub async fn get_proxy_delay(
+    name: String,
+    provider: Option<String>,
+    test_url: Option<String>,
+) -> Result<DelayRes> {
+    let path = proxy_delay_path(&name, provider.as_deref());
     let default_url = "http://www.gstatic.com/generate_204";
     let test_url = test_url
         .map(|s| if s.is_empty() { default_url.into() } else { s })
@@ -602,6 +614,15 @@ pub fn parse_check_output(log: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn proxy_delay_path_selects_endpoint_by_provider() {
+        assert_eq!(proxy_delay_path("node", None), "/proxies/node/delay");
+        assert_eq!(
+            proxy_delay_path("node", Some("subscription")),
+            "/providers/proxies/subscription/node/healthcheck"
+        );
+    }
 
     #[test]
     fn subscription_info_deserializes_pascal_case() {

--- a/backend/tauri/src/core/clash/proxies.rs
+++ b/backend/tauri/src/core/clash/proxies.rs
@@ -70,6 +70,38 @@ async fn fetch_proxies() -> Result<(api::ProxiesRes, api::ProvidersProxiesRes)> 
     try_join!(api::get_proxies(), api::get_providers_proxies())
 }
 
+fn provider_proxy_map(
+    providers: &IndexMap<String, api::ProxyProviderItem>,
+) -> IndexMap<String, api::ProxyItem> {
+    let mut proxies = IndexMap::new();
+    for (provider, record) in providers {
+        for proxy in &record.proxies {
+            let mut proxy = proxy.clone();
+            proxy.provider = Some(provider.clone());
+            proxies.insert(proxy.name.clone(), proxy);
+        }
+    }
+    proxies
+}
+
+fn resolve_proxy(
+    name: &str,
+    inner_proxies: &IndexMap<String, api::ProxyItem>,
+    provider_proxies: &IndexMap<String, api::ProxyItem>,
+) -> api::ProxyItem {
+    inner_proxies
+        .get(name)
+        .or_else(|| provider_proxies.get(name))
+        .cloned()
+        .unwrap_or_else(|| api::ProxyItem {
+            name: name.to_string(),
+            r#type: "Unknown".to_string(),
+            udp: false,
+            history: vec![],
+            ..Default::default()
+        })
+}
+
 impl Proxies {
     #[instrument]
     pub async fn fetch() -> Result<Self> {
@@ -91,29 +123,11 @@ impl Proxies {
                 .collect()
         };
 
-        // 2. mapping provider => providerProxiesItem to name => ProxyItem
-        let mut provider_map = IndexMap::<String, api::ProxyItem>::new();
-        for (provider, record) in providers_proxies.iter() {
-            let name = record.name.clone();
-            let mut record: api::ProxyItem = record.clone().into();
-            record.provider = Some(provider.clone());
-            provider_map.insert(name, record);
-        }
-        let generate_item = |name: &str| {
-            if let Some(r) = inner_proxies.get(name) {
-                r.clone()
-            } else if let Some(r) = provider_map.get(name) {
-                r.clone()
-            } else {
-                api::ProxyItem {
-                    name: name.to_string(),
-                    r#type: "Unknown".to_string(),
-                    udp: false,
-                    history: vec![],
-                    ..Default::default()
-                }
-            }
-        };
+        // 2. Map every provider-owned proxy by name. Mihomo 1.19.28 no longer
+        // includes these nodes in /proxies, so their metadata must come from
+        // /providers/proxies.
+        let provider_map = provider_proxy_map(&providers_proxies);
+        let generate_item = |name: &str| resolve_proxy(name, &inner_proxies, &provider_map);
 
         let global = inner_proxies.get("GLOBAL");
         let direct = inner_proxies
@@ -278,5 +292,40 @@ impl ProxiesGuardExt for ProxiesGuardSingleton {
         api::update_proxy(group, name).await?;
         self.update().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_provider_owned_proxy_with_metadata() {
+        let node = api::ProxyItem {
+            name: "provider-node".into(),
+            r#type: "Vless".into(),
+            udp: true,
+            ..Default::default()
+        };
+        let providers = IndexMap::from([(
+            "subscription".into(),
+            api::ProxyProviderItem {
+                name: "subscription".into(),
+                r#type: api::ProviderType::Proxy,
+                proxies: vec![node],
+                vehicle_type: api::VehicleType::Http,
+                updated_at: None,
+                subscription_info: None,
+                test_url: None,
+                expected_status: None,
+            },
+        )]);
+
+        let provider_proxies = provider_proxy_map(&providers);
+        let resolved = resolve_proxy("provider-node", &IndexMap::new(), &provider_proxies);
+
+        assert_eq!(resolved.r#type, "Vless");
+        assert!(resolved.udp);
+        assert_eq!(resolved.provider.as_deref(), Some("subscription"));
     }
 }

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -648,9 +648,10 @@ pub async fn inspect_updater(updater_id: usize) -> Result<updater::UpdaterSummar
 #[specta::specta]
 pub async fn clash_api_get_proxy_delay(
     name: String,
+    provider: Option<String>,
     url: Option<String>,
 ) -> Result<clash::api::DelayRes> {
-    match clash::api::get_proxy_delay(name, url).await {
+    match clash::api::get_proxy_delay(name, provider, url).await {
         Ok(res) => Ok(res),
         Err(err) => Err(err.into()),
     }

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -56,9 +56,13 @@ export const commands = {
     typedError<PostProcessingOutput, string>(
       __TAURI_INVOKE('get_postprocessing_output'),
     ),
-  clashApiGetProxyDelay: (name: string, url: string | null) =>
+  clashApiGetProxyDelay: (
+    name: string,
+    provider: string | null,
+    url: string | null,
+  ) =>
     typedError<DelayRes, string>(
-      __TAURI_INVOKE('clash_api_get_proxy_delay', { name, url }),
+      __TAURI_INVOKE('clash_api_get_proxy_delay', { name, provider, url }),
     ),
   clashApiGetConfigs: () =>
     typedError<ClashConfig, string>(__TAURI_INVOKE('clash_api_get_configs')),

--- a/frontend/interface/src/ipc/use-clash-proxies.ts
+++ b/frontend/interface/src/ipc/use-clash-proxies.ts
@@ -67,7 +67,11 @@ export const useClashProxies = () => {
       ): ClashProxiesQueryProxyItem => ({
         ...proxy,
         mutateDelay: async (options?: ClashDelayOptions) => {
-          await updateProxiesDelay.mutateAsync([proxy.name, options])
+          await updateProxiesDelay.mutateAsync([
+            proxy.name,
+            proxy.provider,
+            options,
+          ])
         },
         mutateSelect: async () => {
           await commands.selectProxy(groupName, proxy.name)
@@ -115,10 +119,14 @@ export const useClashProxies = () => {
   }
 
   const updateProxiesDelay = useMutation({
-    mutationFn: async (args: [string, ClashDelayOptions?]) => {
-      const [name, options] = args
+    mutationFn: async (args: [string, string | null, ClashDelayOptions?]) => {
+      const [name, provider, options] = args
       const res = unwrapResult(
-        await commands.clashApiGetProxyDelay(name, options?.url ?? null),
+        await commands.clashApiGetProxyDelay(
+          name,
+          provider,
+          options?.url ?? null,
+        ),
       )
       return {
         name,


### PR DESCRIPTION
## Summary

- Resolve provider-owned proxy metadata from each provider's `proxies` list.
- Preserve the provider name for provider-owned proxies.
- Use `/providers/proxies/{provider}/{proxy}/healthcheck` for provider proxy delay tests.
- Preserve `/proxies/{proxy}/delay` for proxies returned by the root `/proxies` endpoint.

## Background

Mihomo 1.19.28 restored the original Clash `/proxies` behavior and no longer includes proxy-provider nodes in the response:

https://github.com/MetaCubeX/mihomo/commit/85c1798

Nyanpasu previously resolved policy-group members mainly from `/proxies`. When a group referenced nodes through `use`, those nodes could no longer be resolved after upgrading to Mihomo 1.19.28. As a result:

- provider nodes were displayed as `UNKNOWN`;
- protocol and UDP metadata were missing;
- `/proxies/{proxy}/delay` returned 404 for provider-only nodes;
- clicking the delay test button produced no result.

This change resolves provider-owned nodes from `/providers/proxies`, records their provider name, and selects the appropriate delay endpoint.

Root proxies still take precedence over provider records, preserving the existing behavior for Mihomo 1.19.27 and earlier versions.

## Compatibility

The provider proxy healthcheck endpoint was verified with:

- Mihomo 1.19.28
- Mihomo Alpha
- Clash-rs 0.10.7
- Clash-rs Alpha
- Clash Premium n2023-09-05

Older cores that continue returning provider nodes through `/proxies` still use the original delay endpoint.

## Tests

- Added a regression test for resolving provider-owned proxy metadata.
- Added coverage for root and provider proxy delay endpoint selection.
- Passed the relevant Rust unit tests.
- Passed Rust formatting and diff checks.
- Passed frontend TypeScript checks.
- Passed the frontend production build.

Fixes #4950