### PR TITLE
chore(backend): align nyanpasu dependencies with upstream (monorepo migration P1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,21 @@ jobs:
           sudo docker image prune --all --force
           df -h
 
+      - name: Build nyanpasu-service IPC smoke test
+        run: >-
+          cargo build --locked
+          --manifest-path backend/Cargo.toml
+          --package nyanpasu-core
+          --example nyanpasu_service_ipc_smoke
+
+      - name: Run nyanpasu-service IPC smoke test (Unix)
+        if: startsWith(matrix.os, 'windows-') == false
+        run: sudo ./backend/target/debug/examples/nyanpasu_service_ipc_smoke
+
+      - name: Run nyanpasu-service IPC smoke test (Windows)
+        if: startsWith(matrix.os, 'windows-')
+        run: .\backend\target\debug\examples\nyanpasu_service_ipc_smoke.exe
+
       - name: Test
         run: pnpm test
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1888,7 +1888,7 @@ dependencies = [
  "specta-typescript",
  "struct-patch",
  "strum",
- "sysinfo 0.39.6",
+ "sysinfo",
  "sysproxy",
  "tauri",
  "tauri-build",
@@ -1988,7 +1988,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2739,18 +2739,18 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "dirs-utils"
 version = "0.1.0"
-source = "git+https://github.com/libnyanpasu/nyanpasu-utils.git#4165ebfecccc5606f4a1abc0bbe847cd018123dd"
+source = "git+https://github.com/LibNyanpasu/nyanpasu-utils.git?rev=607ad2a30388dc53f5f3eae9e75de8769ec7a162#607ad2a30388dc53f5f3eae9e75de8769ec7a162"
 dependencies = [
  "dirs 6.0.0",
  "thiserror 2.0.18",
  "tracing",
- "windows 0.61.3",
+ "windows 0.62.0",
 ]
 
 [[package]]
@@ -2809,7 +2809,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.8",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -3310,7 +3310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4345,11 +4345,11 @@ dependencies = [
 
 [[package]]
 name = "halfbrown"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2c385c6df70fd180bbb673d93039dbd2cd34e41d782600bdf6e1ca7bce39aa"
+checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "serde",
 ]
 
@@ -5004,23 +5004,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b00d05442c2106c75b7410f820b152f61ec0edc7befcb9b381b673a20314753"
-dependencies = [
- "doctest-file",
- "futures-core",
- "libc",
- "recvmsg",
- "tokio",
- "widestring 1.2.0",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "interprocess"
-version = "2.3.0"
-source = "git+https://github.com/libnyanpasu/interprocess.git?branch=fix/linux-32bit-build#33b6a835833ca7fe5276c7dd8a13bfbdac7a80a2"
+checksum = "53bf2b0e0785c5394a7392f66d7c4fb9c653633c29b27a932280da3cb344c66a"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -5877,7 +5863,7 @@ dependencies = [
  "png 0.18.0",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5948,7 +5934,7 @@ dependencies = [
 [[package]]
 name = "network-utils"
 version = "0.1.0"
-source = "git+https://github.com/libnyanpasu/nyanpasu-utils.git#4165ebfecccc5606f4a1abc0bbe847cd018123dd"
+source = "git+https://github.com/LibNyanpasu/nyanpasu-utils.git?rev=607ad2a30388dc53f5f3eae9e75de8769ec7a162#607ad2a30388dc53f5f3eae9e75de8769ec7a162"
 dependencies = [
  "log",
  "tempfile",
@@ -6291,6 +6277,7 @@ dependencies = [
  "fs-err",
  "gxhash",
  "indexmap 2.14.0",
+ "nyanpasu-ipc",
  "nyanpasu-utils",
  "serde",
  "serde_yaml_ng",
@@ -6333,8 +6320,8 @@ dependencies = [
 
 [[package]]
 name = "nyanpasu-ipc"
-version = "1.4.2"
-source = "git+https://github.com/libnyanpasu/nyanpasu-service.git#3742aaaebc475f90d8ed7774aa7b6c6ff263b90e"
+version = "1.4.4"
+source = "git+https://github.com/LibNyanpasu/nyanpasu-service.git?rev=b244da295f9893d7f3a34433c2b35f377a55a466#b244da295f9893d7f3a34433c2b35f377a55a466"
 dependencies = [
  "anyhow",
  "axum",
@@ -6345,7 +6332,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "indexmap 2.14.0",
- "interprocess 2.3.0 (git+https://github.com/libnyanpasu/interprocess.git?branch=fix/linux-32bit-build)",
+ "interprocess",
  "nyanpasu-utils",
  "pin-project-lite",
  "serde",
@@ -6357,7 +6344,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-attributes",
- "windows 0.61.3",
+ "windows 0.62.0",
 ]
 
 [[package]]
@@ -6372,7 +6359,7 @@ dependencies = [
 [[package]]
 name = "nyanpasu-utils"
 version = "0.1.0"
-source = "git+https://github.com/libnyanpasu/nyanpasu-utils.git#4165ebfecccc5606f4a1abc0bbe847cd018123dd"
+source = "git+https://github.com/LibNyanpasu/nyanpasu-utils.git?rev=607ad2a30388dc53f5f3eae9e75de8769ec7a162#607ad2a30388dc53f5f3eae9e75de8769ec7a162"
 dependencies = [
  "camino",
  "constcat",
@@ -6388,7 +6375,7 @@ dependencies = [
  "serde",
  "shared_child",
  "specta",
- "sysinfo 0.37.2",
+ "sysinfo",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6963,11 +6950,11 @@ dependencies = [
 [[package]]
 name = "os-utils"
 version = "0.1.0"
-source = "git+https://github.com/libnyanpasu/nyanpasu-utils.git#4165ebfecccc5606f4a1abc0bbe847cd018123dd"
+source = "git+https://github.com/LibNyanpasu/nyanpasu-utils.git?rev=607ad2a30388dc53f5f3eae9e75de8769ec7a162#607ad2a30388dc53f5f3eae9e75de8769ec7a162"
 dependencies = [
- "nix 0.30.1",
+ "nix 0.31.3",
  "shared_child",
- "windows 0.61.3",
+ "windows 0.62.0",
 ]
 
 [[package]]
@@ -8070,7 +8057,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9461,9 +9448,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simd-json"
-version = "0.16.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90daf33666402178ddbb5d595e6d5e6d7d372da948e23ea26762f5a23e02a04e"
+checksum = "e32d7ab2678282d21e53374fbead7119b7eacbede73685dcaac472870a29a11c"
 dependencies = [
  "halfbrown",
  "ref-cast",
@@ -9686,7 +9673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10036,20 +10023,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.61.3",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
@@ -10344,7 +10317,7 @@ name = "tauri-plugin-deep-link"
 version = "0.1.2"
 dependencies = [
  "dirs 6.0.0",
- "interprocess 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interprocess",
  "log",
  "objc2 0.6.4",
  "once_cell",
@@ -10685,7 +10658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.52.0",
@@ -11411,7 +11384,7 @@ dependencies = [
  "png 0.18.0",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11797,9 +11770,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-trait"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0508fce11ad19e0aab49ce20b6bec7f8f82902ded31df1c9fc61b90f0eb396b8"
+checksum = "f3f4b4a98dfe54bc9ed3641af7ffcb837240269627dbd5cb047d13daa39736cc"
 dependencies = [
  "float-cmp 0.10.0",
  "halfbrown",
@@ -12554,7 +12527,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13327,7 +13300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -20,15 +20,13 @@ authors = ["zzzgydi", "keiko233"]
 
 [workspace.dependencies]
 # --- nyanpasu ---
-# Deliberately not pinned with `rev`: nyanpasu-ipc depends on nyanpasu-utils via
-# the same git URL on its default branch. A `rev` here would give the two
-# references different source ids, duplicating every crate in the nyanpasu-utils
-# workspace (nyanpasu-utils/dirs-utils/network-utils/os-utils). Cargo.lock pins
-# the exact commit for both.
-nyanpasu-utils = { git = "https://github.com/libnyanpasu/nyanpasu-utils.git", features = [
+# TODO(monorepo-p2): replace these frozen git dependencies with in-tree paths.
+# The utils URL and rev deliberately match nyanpasu-service's upstream manifest
+# byte-for-byte so Cargo resolves one source identity for all four utils crates.
+nyanpasu-utils = { git = "https://github.com/LibNyanpasu/nyanpasu-utils.git", rev = "607ad2a30388dc53f5f3eae9e75de8769ec7a162", features = [
   "specta",
 ] }
-nyanpasu-ipc = { git = "https://github.com/libnyanpasu/nyanpasu-service.git", features = [
+nyanpasu-ipc = { git = "https://github.com/LibNyanpasu/nyanpasu-service.git", rev = "b244da295f9893d7f3a34433c2b35f377a55a466", features = [
   "client",
   "specta",
 ] } # IPC bridge between the UI process and service process

--- a/backend/nyanpasu-core/Cargo.toml
+++ b/backend/nyanpasu-core/Cargo.toml
@@ -23,6 +23,7 @@ fs-err = { workspace = true }
 serde_yaml_ng = { workspace = true }
 
 [dev-dependencies]
+nyanpasu-ipc = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tempfile = "3"
 # Currently exercised only by the gxhash smoke test below. Every distributed

--- a/backend/nyanpasu-core/examples/nyanpasu_service_ipc_smoke.rs
+++ b/backend/nyanpasu-core/examples/nyanpasu_service_ipc_smoke.rs
@@ -1,0 +1,268 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
+
+use anyhow::{Context, Result, bail};
+use nyanpasu_ipc::client::{ClientError, shortcuts::Client};
+use tempfile::TempDir;
+use tokio::{process::Child, time::Instant};
+
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(20);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+struct ServiceProcess {
+    child: Child,
+}
+
+impl ServiceProcess {
+    async fn shutdown(mut self) -> Result<()> {
+        if self
+            .child
+            .try_wait()
+            .context("failed to inspect nyanpasu-service during shutdown")?
+            .is_none()
+        {
+            self.child
+                .kill()
+                .await
+                .context("failed to terminate nyanpasu-service")?;
+        }
+        self.child
+            .wait()
+            .await
+            .context("failed to reap nyanpasu-service")?;
+        cleanup_global_runtime_files();
+        Ok(())
+    }
+}
+
+impl Drop for ServiceProcess {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+        cleanup_global_runtime_files();
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    ensure_no_service_is_running().await?;
+
+    let binary = service_binary()?;
+    let dirs = SmokeDirs::new()?;
+    let daemon_log = fs::File::create(&dirs.output)
+        .with_context(|| format!("failed to create {}", dirs.output.display()))?;
+    let daemon_stderr = daemon_log
+        .try_clone()
+        .context("failed to clone the daemon log handle")?;
+    let child = tokio::process::Command::new(&binary)
+        .arg("server")
+        .arg("--nyanpasu-config-dir")
+        .arg(&dirs.config)
+        .arg("--nyanpasu-data-dir")
+        .arg(&dirs.data)
+        .arg("--nyanpasu-app-dir")
+        .arg(&dirs.app)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(daemon_log))
+        .stderr(Stdio::from(daemon_stderr))
+        .kill_on_drop(true)
+        .spawn()
+        .with_context(|| format!("failed to start {}", binary.display()))?;
+    let mut service = ServiceProcess { child };
+
+    let result = async {
+        let status = wait_for_status(&mut service.child).await?;
+        let logs = Client::service_default()
+            .inspect_logs()
+            .await
+            .context("read-only inspect_logs request failed")?;
+        Result::<_>::Ok((
+            status.version.into_owned(),
+            status.core_infos.state,
+            logs.logs.len(),
+        ))
+    }
+    .await;
+    let shutdown_result = service.shutdown().await;
+
+    let (version, core_state, log_count) = match result {
+        Ok(summary) => summary,
+        Err(error) => {
+            let output = fs::read_to_string(&dirs.output)
+                .unwrap_or_else(|read_error| format!("<failed to read daemon log: {read_error}>"));
+            shutdown_result.context("failed to stop daemon after smoke-test failure")?;
+            bail!("{error:#}\nnyanpasu-service output:\n{output}");
+        }
+    };
+    shutdown_result?;
+
+    println!(
+        "IPC smoke test passed: service_version={}, core_state={:?}, logs={}",
+        version, core_state, log_count
+    );
+    Ok(())
+}
+
+async fn ensure_no_service_is_running() -> Result<()> {
+    match tokio::time::timeout(CONNECT_TIMEOUT, Client::service_default().status()).await {
+        Ok(Ok(_)) => bail!(
+            "another nyanpasu-service is already reachable; stop it before running the smoke test"
+        ),
+        Ok(Err(error)) if is_endpoint_not_ready(&error) => Ok(()),
+        Ok(Err(error)) => Err(error.into()),
+        Err(error) => Err(error).context("timed out probing the global nyanpasu-service endpoint"),
+    }
+}
+
+async fn wait_for_status(
+    child: &mut Child,
+) -> Result<nyanpasu_ipc::api::status::StatusResBody<'static>> {
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .context("failed to inspect nyanpasu-service")?
+        {
+            bail!("nyanpasu-service exited before IPC was ready: {status}");
+        }
+
+        match tokio::time::timeout(CONNECT_TIMEOUT, Client::service_default().status()).await {
+            Ok(Ok(status)) => return Ok(status),
+            Ok(Err(error)) if is_endpoint_not_ready(&error) => {}
+            Ok(Err(error)) => return Err(error.into()),
+            Err(error) => {
+                return Err(error).context("nyanpasu-service status request timed out");
+            }
+        }
+
+        if Instant::now() >= deadline {
+            bail!("timed out waiting for nyanpasu-service IPC");
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+fn is_endpoint_not_ready(error: &ClientError<'_>) -> bool {
+    // ClientError::Io does not retain whether an I/O failure happened while connecting or while
+    // reading a response. Only these endpoint-absence errors are safe to classify as startup races;
+    // all other I/O, HTTP, server-response, and decode errors fail the smoke test immediately.
+    matches!(
+        error,
+        ClientError::Io(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
+            )
+    )
+}
+
+struct SmokeDirs {
+    _root: TempDir,
+    config: PathBuf,
+    data: PathBuf,
+    app: PathBuf,
+    output: PathBuf,
+}
+
+impl SmokeDirs {
+    fn new() -> Result<Self> {
+        let root = tempfile::tempdir().context("failed to create smoke-test directory")?;
+        let config = root.path().join("config");
+        let data = root.path().join("data");
+        let app = root.path().join("app");
+        let output = root.path().join("nyanpasu-service.log");
+        for dir in [&config, &data, &app] {
+            fs::create_dir_all(dir)
+                .with_context(|| format!("failed to create {}", dir.display()))?;
+        }
+        Ok(Self {
+            _root: root,
+            config,
+            data,
+            app,
+            output,
+        })
+    }
+}
+
+fn service_binary() -> Result<PathBuf> {
+    if let Some(path) = env::var_os("NYANPASU_SERVICE_SMOKE_BINARY") {
+        return existing_binary(path.into());
+    }
+
+    let filename = format!(
+        "nyanpasu-service-{}{}",
+        sidecar_host(),
+        env::consts::EXE_SUFFIX
+    );
+    existing_binary(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../tauri/sidecar")
+            .join(filename),
+    )
+}
+
+fn existing_binary(path: PathBuf) -> Result<PathBuf> {
+    if !path.is_file() {
+        bail!(
+            "nyanpasu-service smoke binary not found: {}",
+            path.display()
+        );
+    }
+    path.canonicalize()
+        .with_context(|| format!("failed to canonicalize {}", path.display()))
+}
+
+fn cleanup_global_runtime_files() {
+    // The frozen daemon does not derive these paths from --nyanpasu-data-dir: service.pid lives in
+    // suggest_service_data_dir("nyanpasu-service"), and IPC is the fixed nyanpasu_ipc pipe/socket.
+    // The smoke process therefore owns global runtime paths while it runs. This is why
+    // ensure_no_service_is_running() is mandatory and a local installed service must be stopped.
+    let data_dir = nyanpasu_utils::dirs::suggest_service_data_dir("nyanpasu-service");
+    let _ = fs::remove_file(data_dir.join("service.pid"));
+    #[cfg(unix)]
+    let _ = fs::remove_file("/var/run/nyanpasu_ipc.sock");
+}
+
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
+fn sidecar_host() -> &'static str {
+    "x86_64-pc-windows-msvc"
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "windows"))]
+fn sidecar_host() -> &'static str {
+    "aarch64-pc-windows-msvc"
+}
+
+#[cfg(all(target_arch = "x86_64", target_os = "macos"))]
+fn sidecar_host() -> &'static str {
+    "x86_64-apple-darwin"
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+fn sidecar_host() -> &'static str {
+    "aarch64-apple-darwin"
+}
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+fn sidecar_host() -> &'static str {
+    "x86_64-unknown-linux-gnu"
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+fn sidecar_host() -> &'static str {
+    "aarch64-unknown-linux-gnu"
+}
+
+#[cfg(not(any(
+    all(target_arch = "x86_64", target_os = "windows"),
+    all(target_arch = "aarch64", target_os = "windows"),
+    all(target_arch = "x86_64", target_os = "macos"),
+    all(target_arch = "aarch64", target_os = "macos"),
+    all(target_arch = "x86_64", target_os = "linux"),
+    all(target_arch = "aarch64", target_os = "linux"),
+)))]
+compile_error!("the nyanpasu-service smoke test supports only distributed desktop targets");


### PR DESCRIPTION
P1 of the monorepo migration: align this repo's nyanpasu dependencies with the exact upstream snapshots that P2 will import via `git subtree`, so that P2 is a pure structural change with no dependency drift mixed in.

This is a stacked PR. P2 (subtree import + workspace dissolution + path switch) follows and depends on this.

## Frozen upstream snapshots

| Repo | Rev |
|---|---|
| `nyanpasu-utils` | `607ad2a30388dc53f5f3eae9e75de8769ec7a162` |
| `nyanpasu-service` | `b244da295f9893d7f3a34433c2b35f377a55a466` |

Upstream `main` is frozen for the duration of this stack.

## Why the utils dep is now pinned with `rev` (reversing the old comment)

The removed comment said a `rev` pin was deliberately avoided, because `nyanpasu-ipc` referenced `nyanpasu-utils` via the same git URL on its default branch, so pinning would split the source identity and duplicate all four utils crates.

That reasoning held for the old service commit `3742aaae`. It no longer does: `nyanpasu-service` at `b244da29` pins utils itself:

```toml
nyanpasu-utils = { git = "https://github.com/LibNyanpasu/nyanpasu-utils.git", default-features = false, rev = "607ad2a30388dc53f5f3eae9e75de8769ec7a162" }
```

So the situation is now inverted — staying rev-less is what would split the source identity. This PR matches that declaration's URL **and** rev byte-for-byte. Note the URL casing (`LibNyanpasu`): Cargo derives source identity from the literal string, so lowercase `libnyanpasu` would resolve to a second, distinct source and duplicate `nyanpasu-utils` / `dirs-utils` / `network-utils` / `os-utils`.

## Verification

Package counts are from `cargo metadata`, not `cargo tree -d` — the latter only prints duplicates and so cannot distinguish "exactly one" from "absent".

| Package | Count | Source |
|---|---|---|
| `nyanpasu-utils` | 1 | `git+…/LibNyanpasu/nyanpasu-utils.git?rev=607ad2a3…` |
| `dirs-utils` | 1 | same |
| `network-utils` | 1 | same |
| `os-utils` | 1 | same |
| `nyanpasu-ipc` | 1 | `git+…/LibNyanpasu/nyanpasu-service.git?rev=b244da29…` |

- `pnpm lint:clippy` (the repo gate): pass
- `cargo fmt --check`: pass
- `cargo test --all-features`: pass — tauri 250, config 133, core 94
- `actionlint`: pass
- Lock updated only via `cargo update --precise`; no bare `cargo update` was run.

## Resolution changes inherited from upstream

Aligning to the frozen snapshot changes more than the two pinned crates. These are upstream's decisions, not local ones:

- **The `interprocess` fork is gone.** `main` carried both registry `interprocess 2.3.0` and `git+https://github.com/libnyanpasu/interprocess.git?branch=fix/linux-32bit-build`. The frozen service uses registry `interprocess 2.3.1`, collapsing both to one registry package.
- `sysinfo` 0.37.2 / 0.39.6 → 0.39.6
- `simd-json` 0.16.0 → 0.17.3, `halfbrown` 0.3.0 → 0.4.0, `value-trait` 0.11.0 → 0.12.2

**Reviewer note:** the dropped fork's branch was `fix/linux-32bit-build`. Worth a sanity check that 2.3.1 carries that fix, though with i686 and armv7 already dropped from the target matrix the exposure is likely nil.

## IPC smoke test

Semver ordering cannot prove wire-protocol compatibility, so this adds a real end-to-end check instead: it downloads the daemon that `scripts/check.ts` currently selects, starts it against isolated config/data/app dirs, issues `status` plus a read-only `inspect_logs`, and shuts it down. Wired into the existing 3-platform unit-test matrix.

The startup poll retries **only** `ClientError::Io(NotFound | ConnectionRefused)` — the genuine endpoint-not-bound-yet race. Decode, HTTP, and server-response errors fail immediately with the original error, so a wire break surfaces as itself rather than as a generic timeout.

Known limitations, recorded in the code:

- The daemon's PID file and IPC endpoint are **global**, not derived from the passed dirs — `service_pid_file()` resolves via `suggest_service_data_dir()`, and the endpoints are hardcoded `\\.\pipe\nyanpasu_ipc` / `/var/run/nyanpasu_ipc.sock`. So the test cannot run alongside an installed daemon; `ensure_no_service_is_running()` enforces this, and running it locally requires stopping the installed service first.
- Upstream's `ClientError::Io` does not record whether the I/O error occurred while connecting or while reading the response, which is why the retry set is restricted to those two kinds.

## Caveats

- **Linux and macOS smoke legs are wired but were never executed locally** — this PR's CI run is their first execution.
- `cargo clippy -- -D warnings` is red on this branch, but it is **equally red on unmodified `main`** (`tauri-plugin-deep-link`: `redundant reference in format! argument`). The repo's actual gate is `pnpm lint:clippy` without `-D warnings`, which passes. No unrelated pre-existing warnings were fixed here.

## Deliberately left to P2

Empty `[patch.crates-io]`, workspace membership, the subtree imports and nested-workspace dissolution, and the path switch that removes the temporary `nyanpasu-ipc` rev pin. `rust-toolchain.toml`, `Cross.toml`, `.cargo/config.toml`, and the release matrices are untouched.
