### PR TITLE
fix: resolve all clippy warnings across the workspace

### DIFF
--- a/backend/boa_utils/src/lib.rs
+++ b/backend/boa_utils/src/lib.rs
@@ -1,6 +1,4 @@
 #![feature(trait_alias)]
-#![feature(auto_traits)]
-#![feature(negative_impls)]
 
 //! Boa's **boa_runtime** crate contains an example runtime and basic runtime features and
 //! functionality for the `boa_engine` crate for runtime implementors.

--- a/backend/nyanpasu-config/src/profile/profiles.rs
+++ b/backend/nyanpasu-config/src/profile/profiles.rs
@@ -384,13 +384,13 @@ fn validate_composition_config(
 
     let mut seen = IndexSet::new();
     for contributor in &composition.extend_proxies_from {
-        if let Some(base) = &composition.base {
-            if contributor == base {
-                errors.push(ProfileValidationError::CompositionBaseAlsoContributor {
-                    composition: composition_id.clone(),
-                    profile: contributor.clone(),
-                });
-            }
+        if let Some(base) = &composition.base
+            && contributor == base
+        {
+            errors.push(ProfileValidationError::CompositionBaseAlsoContributor {
+                composition: composition_id.clone(),
+                profile: contributor.clone(),
+            });
         }
 
         if !seen.insert(contributor.clone()) {

--- a/backend/nyanpasu-config/src/runtime/invalidation.rs
+++ b/backend/nyanpasu-config/src/runtime/invalidation.rs
@@ -118,9 +118,8 @@ fn collect_stale_node_keys(
     graph
         .nodes
         .iter()
-        .filter_map(|node| {
-            tag_references_any_profile(&node.tag, &stale_profiles).then(|| node.tag.node_key())
-        })
+        .filter(|&node| tag_references_any_profile(&node.tag, &stale_profiles))
+        .map(|node| node.tag.node_key())
         .collect()
 }
 

--- a/backend/nyanpasu-config/src/runtime/value/mod.rs
+++ b/backend/nyanpasu-config/src/runtime/value/mod.rs
@@ -32,6 +32,7 @@ impl ConfigValue {
         serde_json::Value::from(self)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn from_json_value(value: serde_json::Value) -> Self {
         convert::from_json_value(value)
     }

--- a/backend/nyanpasu-core/src/state/coordinator.rs
+++ b/backend/nyanpasu-core/src/state/coordinator.rs
@@ -143,7 +143,8 @@ impl<T: Clone + Send + Sync> StateCoordinator<T> {
                     })
                 }
             },
-            Err((report, _rolled_back_tx)) => {
+            Err(err) => {
+                let (report, _rolled_back_tx) = *err;
                 Err(StateChangedError::PrepareAck(PrepareAckError { report }))
             }
         }
@@ -186,7 +187,8 @@ impl<T: Clone + Send + Sync> StateCoordinator<T> {
                     })
                 }
             },
-            Err((report, _rolled_back_tx)) => {
+            Err(err) => {
+                let (report, _rolled_back_tx) = *err;
                 Err(StateChangedError::PrepareAck(PrepareAckError { report }))
             }
         }
@@ -249,7 +251,8 @@ impl<T: Clone + Send + Sync> StateCoordinator<T> {
         );
         let tx = match tx.prepare().await {
             Ok((_report, prepared_tx)) => prepared_tx,
-            Err((report, _)) => {
+            Err(err) => {
+                let (report, _) = *err;
                 return Err(ConditionalEffectError::State(
                     StateChangedError::PrepareAck(PrepareAckError { report }),
                 ));
@@ -345,7 +348,8 @@ impl<T: Clone + Send + Sync> StateCoordinator<T> {
         );
         let (report, tx) = match tx.prepare().await {
             Ok((report, prepared_tx)) => (report, prepared_tx),
-            Err((report, _)) => {
+            Err(err) => {
+                let (report, _) = *err;
                 return Err(WithEffectError::State(StateChangedError::PrepareAck(
                     PrepareAckError { report },
                 )));
@@ -470,18 +474,23 @@ impl<T: Clone + Send + Sync + 'static> StateCoordinatorBuilder<T> {
             Ok((report, _)) => {
                 if report.has_required_failures() {
                     Err(InitAckError {
-                        coordinator,
+                        coordinator: Box::new(coordinator),
                         report,
                     })
                 } else {
                     Ok(coordinator)
                 }
             }
-            Err((Some(report), _)) => Err(InitAckError {
-                coordinator,
-                report,
-            }),
-            Err((None, _)) => unreachable!("init transaction cannot hit CAS mismatch"),
+            Err(e) => {
+                let (report, _) = *e;
+                match report {
+                    Some(report) => Err(InitAckError {
+                        coordinator: Box::new(coordinator),
+                        report,
+                    }),
+                    None => unreachable!("init transaction cannot hit CAS mismatch"),
+                }
+            }
         }
     }
 }

--- a/backend/nyanpasu-core/src/state/error.rs
+++ b/backend/nyanpasu-core/src/state/error.rs
@@ -34,7 +34,7 @@ pub enum LoadError<Manager = ()> {
     #[error("failed to deserialize the config file: {0}")]
     DeserializeConfig(anyhow::Error),
     #[error("state manager initialization ACK failed: {0}")]
-    Init(ManagerInitError<Manager>),
+    Init(Box<ManagerInitError<Manager>>),
 }
 
 impl<Manager> fmt::Debug for LoadError<Manager> {
@@ -53,7 +53,7 @@ impl<Manager> fmt::Debug for LoadError<Manager> {
 #[derive(thiserror::Error)]
 #[error("state prepared but required subscriber ACK failed during initialization")]
 pub struct InitAckError<T: Clone + Send + Sync + 'static> {
-    pub coordinator: super::coordinator::StateCoordinator<T>,
+    pub coordinator: Box<super::coordinator::StateCoordinator<T>>,
     pub report: PrepareReport,
 }
 
@@ -67,22 +67,25 @@ impl<T: Clone + Send + Sync + 'static> std::fmt::Debug for InitAckError<T> {
 
 impl<T: Clone + Send + Sync + 'static> InitAckError<T> {
     pub fn into_parts(self) -> (super::coordinator::StateCoordinator<T>, PrepareReport) {
-        (self.coordinator, self.report)
+        (*self.coordinator, self.report)
     }
 }
 
 pub struct ManagerInitError<Manager> {
-    pub manager: Manager,
+    pub manager: Box<Manager>,
     pub report: PrepareReport,
 }
 
 impl<Manager> ManagerInitError<Manager> {
     pub fn new(manager: Manager, report: PrepareReport) -> Self {
-        Self { manager, report }
+        Self {
+            manager: Box::new(manager),
+            report,
+        }
     }
 
     pub fn into_parts(self) -> (Manager, PrepareReport) {
-        (self.manager, self.report)
+        (*self.manager, self.report)
     }
 }
 

--- a/backend/nyanpasu-core/src/state/manager/persistent_builder.rs
+++ b/backend/nyanpasu-core/src/state/manager/persistent_builder.rs
@@ -99,7 +99,7 @@ where
 
         self.build_manager(state, config)
             .await
-            .map_err(LoadError::Init)
+            .map_err(|e| LoadError::Init(Box::new(e)))
     }
 
     pub async fn load_or_default(
@@ -131,7 +131,7 @@ where
 
         self.build_manager(state, config)
             .await
-            .map_err(LoadError::Init)
+            .map_err(|e| LoadError::Init(Box::new(e)))
     }
 
     pub async fn from_builder(
@@ -148,7 +148,7 @@ where
 
         self.build_manager(state, builder)
             .await
-            .map_err(LoadError::Init)
+            .map_err(|e| LoadError::Init(Box::new(e)))
     }
 }
 

--- a/backend/nyanpasu-core/src/state/manager/persistent_state.rs
+++ b/backend/nyanpasu-core/src/state/manager/persistent_state.rs
@@ -104,7 +104,9 @@ where
             .deserialize(bytes.as_slice())
             .map_err(LoadError::DeserializeConfig)?;
 
-        self.build_manager(state).await.map_err(LoadError::Init)
+        self.build_manager(state)
+            .await
+            .map_err(|e| LoadError::Init(Box::new(e)))
     }
 
     pub async fn load_or_default(
@@ -129,7 +131,9 @@ where
             Err(e) => return Err(LoadError::ReadConfig(e.into())),
         };
 
-        self.build_manager(state).await.map_err(LoadError::Init)
+        self.build_manager(state)
+            .await
+            .map_err(|e| LoadError::Init(Box::new(e)))
     }
 
     pub async fn from_state(
@@ -139,7 +143,9 @@ where
         PersistentStateManager<State, Formatter>,
         LoadError<PersistentStateManager<State, Formatter>>,
     > {
-        self.build_manager(state).await.map_err(LoadError::Init)
+        self.build_manager(state)
+            .await
+            .map_err(|e| LoadError::Init(Box::new(e)))
     }
 }
 

--- a/backend/nyanpasu-core/src/state/manager/weak_persistent_state.rs
+++ b/backend/nyanpasu-core/src/state/manager/weak_persistent_state.rs
@@ -126,7 +126,9 @@ where
     > {
         let state = self.load_snapshot().await.unwrap_or_default();
 
-        self.build_manager(state).await.map_err(LoadError::Init)
+        self.build_manager(state)
+            .await
+            .map_err(|e| LoadError::Init(Box::new(e)))
     }
 }
 
@@ -142,7 +144,9 @@ where
         WeakPersistentStateManager<State, Formatter>,
         LoadError<WeakPersistentStateManager<State, Formatter>>,
     > {
-        self.build_manager(state).await.map_err(LoadError::Init)
+        self.build_manager(state)
+            .await
+            .map_err(|e| LoadError::Init(Box::new(e)))
     }
 }
 

--- a/backend/nyanpasu-core/src/state/transaction.rs
+++ b/backend/nyanpasu-core/src/state/transaction.rs
@@ -226,7 +226,7 @@ where
         mut self,
     ) -> Result<
         (PrepareReport, StateTransaction<T, state::Prepared>),
-        (PrepareReport, StateTransaction<T, state::RolledBack>),
+        Box<(PrepareReport, StateTransaction<T, state::RolledBack>)>,
     > {
         self.rollback_guard
             .arm(&self.change, &self.subscribers, self.notify_strategy);
@@ -301,7 +301,7 @@ where
             let report = PrepareReport {
                 subscriber_acks: acks,
             };
-            return Err((report, tx));
+            return Err(Box::new((report, tx)));
         }
 
         let report = PrepareReport {
@@ -334,17 +334,20 @@ where
         self,
     ) -> Result<
         (PrepareReport, StateTransaction<T, state::Committed>),
-        (
+        Box<(
             Option<PrepareReport>,
             StateTransaction<T, state::RolledBack>,
-        ),
+        )>,
     > {
         match self.prepare().await {
             Ok((report, prepared_tx)) => match prepared_tx.commit().await {
                 Ok(committed_tx) => Ok((report, committed_tx)),
-                Err(rolled_back_tx) => Err((None, rolled_back_tx)),
+                Err(err) => Err(Box::new((None, *err))),
             },
-            Err((report, rolled_back_tx)) => Err((Some(report), rolled_back_tx)),
+            Err(report_and_tx) => {
+                let (report, rolled_back_tx) = *report_and_tx;
+                Err(Box::new((Some(report), rolled_back_tx)))
+            }
         }
     }
 
@@ -355,7 +358,7 @@ where
 }
 
 pub(crate) struct CommitCasMismatch<T: Clone + Send + Sync + 'static> {
-    tx: StateTransaction<T, state::Prepared>,
+    tx: Box<StateTransaction<T, state::Prepared>>,
     expected: Version,
     actual: Version,
 }
@@ -365,7 +368,7 @@ where
     T: Clone + Send + Sync + 'static,
 {
     pub(crate) async fn notify_rollback(self) {
-        self.tx
+        (*self.tx)
             ._rollback(RollbackReason::StoreStateCasMismatch {
                 expected: self.expected,
                 actual: self.actual,
@@ -380,7 +383,7 @@ where
 {
     pub(crate) fn try_commit(
         mut self,
-    ) -> Result<StateTransaction<T, state::Committed>, CommitCasMismatch<T>> {
+    ) -> Result<StateTransaction<T, state::Committed>, Box<CommitCasMismatch<T>>> {
         match self.change.previous.clone() {
             Some(prev) => {
                 let new_state = Arc::new(VersionedState {
@@ -390,11 +393,11 @@ where
                 let guard = self.store.compare_and_swap(&prev, new_state);
 
                 if !Arc::ptr_eq(&guard, &prev) {
-                    return Err(CommitCasMismatch {
-                        tx: self,
+                    return Err(Box::new(CommitCasMismatch {
+                        tx: Box::new(self),
                         expected: prev.version,
                         actual: guard.version,
-                    });
+                    }));
                 }
             }
             None => {
@@ -433,7 +436,8 @@ where
     /// Commit this transaction, transitioning it to the committed state.
     pub async fn commit(
         self,
-    ) -> Result<StateTransaction<T, state::Committed>, StateTransaction<T, state::RolledBack>> {
+    ) -> Result<StateTransaction<T, state::Committed>, Box<StateTransaction<T, state::RolledBack>>>
+    {
         match self.try_commit() {
             Ok(tx) => Ok(tx.notify_committed().await),
             Err(mismatch) => {
@@ -441,7 +445,7 @@ where
                     expected: mismatch.expected,
                     actual: mismatch.actual,
                 };
-                Err(mismatch.tx._rollback(reason).await)
+                Err(Box::new(mismatch.tx._rollback(reason).await))
             }
         }
     }

--- a/backend/nyanpasu-egui/src/lib.rs
+++ b/backend/nyanpasu-egui/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(trait_alias)]
-
 pub mod ipc;
 mod utils;
 pub mod widget;

--- a/backend/nyanpasu-egui/src/widget/mod.rs
+++ b/backend/nyanpasu-egui/src/widget/mod.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 pub use network_statistic_large::NyanpasuNetworkStatisticLargeWidget;
 pub use network_statistic_small::NyanpasuNetworkStatisticSmallWidget;
 
+#[allow(dead_code)]
 fn get_window_state_path() -> std::io::Result<PathBuf> {
     let env = std::env::var("NYANPASU_EGUI_WINDOW_STATE_PATH").map_err(|_| {
         std::io::Error::new(

--- a/backend/nyanpasu-egui/src/widget/network_statistic_large.rs
+++ b/backend/nyanpasu-egui/src/widget/network_statistic_large.rs
@@ -86,7 +86,7 @@ fn use_light_green_accent(style: &mut Style) {
     style.visuals.text_cursor.stroke.color = Color32::from_rgb(28, 92, 48);
     style.visuals.selection = Selection {
         bg_fill: Color32::from_rgb(157, 218, 169),
-        stroke: Stroke::new(1.0, Color32::from_rgb(28, 92, 48)),
+        stroke: Stroke::new(1.0_f32, Color32::from_rgb(28, 92, 48)),
     };
 }
 
@@ -97,7 +97,7 @@ fn use_dark_purple_accent(style: &mut Style) {
     style.visuals.text_cursor.stroke.color = Color32::from_rgb(234, 208, 244);
     style.visuals.selection = Selection {
         bg_fill: Color32::from_rgb(105, 67, 119),
-        stroke: Stroke::new(1.0, Color32::from_rgb(234, 208, 244)),
+        stroke: Stroke::new(1.0_f32, Color32::from_rgb(234, 208, 244)),
     };
 }
 

--- a/backend/nyanpasu-egui/src/widget/network_statistic_small.rs
+++ b/backend/nyanpasu-egui/src/widget/network_statistic_small.rs
@@ -66,7 +66,7 @@ fn use_light_green_accent(style: &mut Style) {
     style.visuals.text_cursor.stroke.color = Color32::from_rgb(28, 92, 48);
     style.visuals.selection = Selection {
         bg_fill: Color32::from_rgb(157, 218, 169),
-        stroke: Stroke::new(1.0, Color32::from_rgb(28, 92, 48)),
+        stroke: Stroke::new(1.0_f32, Color32::from_rgb(28, 92, 48)),
     };
 }
 
@@ -77,7 +77,7 @@ fn use_dark_purple_accent(style: &mut Style) {
     style.visuals.text_cursor.stroke.color = Color32::from_rgb(234, 208, 244);
     style.visuals.selection = Selection {
         bg_fill: Color32::from_rgb(105, 67, 119),
-        stroke: Stroke::new(1.0, Color32::from_rgb(234, 208, 244)),
+        stroke: Stroke::new(1.0_f32, Color32::from_rgb(234, 208, 244)),
     };
 }
 

--- a/backend/tauri-plugin-deep-link/src/windows.rs
+++ b/backend/tauri-plugin-deep-link/src/windows.rs
@@ -48,11 +48,11 @@ pub fn register<F: FnMut(String) + Send + 'static>(schemes: &[&str], handler: F)
         key.set_value("URL Protocol", &"")?;
 
         let (icon, _) = hkcu.create_subkey(base.join("DefaultIcon"))?;
-        icon.set_value("", &format!("\"{}\",0", &exe))?;
+        icon.set_value("", &format!("\"{}\",0", exe))?;
 
         let (cmd, _) = hkcu.create_subkey(base.join("shell").join("open").join("command"))?;
 
-        cmd.set_value("", &format!("\"{}\" \"%1\"", &exe))?;
+        cmd.set_value("", &format!("\"{}\" \"%1\"", exe))?;
     }
 
     Ok(())

--- a/backend/tauri/src/bridge/clash.rs
+++ b/backend/tauri/src/bridge/clash.rs
@@ -175,9 +175,9 @@ pub(crate) fn apply_prepared_clash_verge_projection(target: &mut IVerge, project
     target.enable_clash_fields = projected.enable_clash_fields;
     target.enable_random_port = projected.enable_random_port;
     target.verge_mixed_port = projected.verge_mixed_port;
-    target.tun_stack = projected.tun_stack.clone();
+    target.tun_stack = projected.tun_stack;
     target.clash_strategy = projected.clash_strategy.clone();
-    target.break_when_proxy_change = projected.break_when_proxy_change.clone();
+    target.break_when_proxy_change = projected.break_when_proxy_change;
     target.break_when_profile_change = projected.break_when_profile_change;
     target.break_when_mode_change = projected.break_when_mode_change;
 }
@@ -191,7 +191,7 @@ pub(crate) fn apply_clash_config_to_legacy_verge(
     draft.enable_clash_fields = Some(snap.enable_clash_fields);
     draft.enable_random_port = Some(matches!(snap.mixed_port.kind, PortStrategyKind::Random));
     draft.verge_mixed_port = Some(snap.mixed_port.start_port);
-    draft.tun_stack = Some(super::yaml_convert(&snap.tun_stack)?);
+    draft.tun_stack = Some(super::yaml_convert(snap.tun_stack)?);
     draft.clash_strategy = Some(legacy_app::ClashStrategy {
         external_controller_port_strategy: super::yaml_convert(
             &snap.external_controller.port.kind,

--- a/backend/tauri/src/bridge/verge.rs
+++ b/backend/tauri/src/bridge/verge.rs
@@ -11,7 +11,6 @@ use nyanpasu_config::application::{
     NetworkStatisticWidgetConfig as AppNetworkStatisticWidgetConfig, NyanpasuAppConfig,
 };
 use nyanpasu_egui::widget::StatisticWidgetVariant;
-use struct_patch::Patch as _;
 use tokio::sync::Mutex;
 
 #[derive(Clone)]
@@ -162,6 +161,7 @@ struct ConfigPreparedLegacyVergeCommit {
 }
 
 impl PreparedLegacyVergeCommit for ConfigPreparedLegacyVergeCommit {
+    #[allow(deprecated)]
     fn commit(self: Box<Self>) -> anyhow::Result<()> {
         let _guard = self.legacy_lock.lock();
         let mut state = self.state;
@@ -635,21 +635,21 @@ fn apply_prepared_app_projection(target: &mut IVerge, projected: &IVerge) {
     target.system_proxy_bypass = projected.system_proxy_bypass.clone();
     target.proxy_guard_interval = projected.proxy_guard_interval;
     target.theme_color = projected.theme_color.clone();
-    target.clash_core = projected.clash_core.clone();
+    target.clash_core = projected.clash_core;
     target.hotkeys = projected.hotkeys.clone();
     target.default_latency_test = projected.default_latency_test.clone();
     target.enable_builtin_enhanced = projected.enable_builtin_enhanced;
     target.proxy_layout_column = projected.proxy_layout_column;
     target.max_log_files = projected.max_log_files;
     target.enable_auto_check_update = projected.enable_auto_check_update;
-    target.clash_tray_selector = projected.clash_tray_selector.clone();
+    target.clash_tray_selector = projected.clash_tray_selector;
     target.always_on_top = projected.always_on_top;
     target.network_statistic_widget = projected.network_statistic_widget;
     target.pac_url = projected.pac_url.clone();
     target.enable_tray_text = projected.enable_tray_text;
     target.window_type = projected.window_type;
-    target.tray_menu_mode = projected.tray_menu_mode.clone();
-    target.tray_menu_close_behavior = projected.tray_menu_close_behavior.clone();
+    target.tray_menu_mode = projected.tray_menu_mode;
+    target.tray_menu_close_behavior = projected.tray_menu_close_behavior;
 }
 
 pub(crate) fn apply_app_config_to_legacy_verge(
@@ -658,8 +658,8 @@ pub(crate) fn apply_app_config_to_legacy_verge(
 ) -> anyhow::Result<()> {
     draft.app_singleton_port = Some(snap.app_singleton_port);
     draft.app_log_level = Some(super::yaml_convert(&snap.app_log_level)?);
-    draft.language = Some(super::yaml_convert(&snap.language)?);
-    draft.theme_mode = Some(super::yaml_convert(&snap.theme_mode)?);
+    draft.language = Some(super::yaml_convert(snap.language)?);
+    draft.theme_mode = Some(super::yaml_convert(snap.theme_mode)?);
     draft.traffic_graph = Some(snap.traffic_graph);
     draft.enable_memory_usage = Some(snap.enable_memory_usage);
     draft.lighten_animation_effects = Some(snap.lighten_animation_effects);
@@ -675,21 +675,21 @@ pub(crate) fn apply_app_config_to_legacy_verge(
     };
     draft.proxy_guard_interval = Some(snap.proxy_guard_interval);
     draft.theme_color = Some(super::yaml_convert(&snap.theme_color)?);
-    draft.clash_core = Some(super::yaml_convert(&snap.core)?);
+    draft.clash_core = Some(super::yaml_convert(snap.core)?);
     draft.hotkeys = Some(snap.hotkeys.clone());
     draft.default_latency_test = Some(snap.default_latency_test.clone());
     draft.enable_builtin_enhanced = Some(snap.enable_builtin_enhanced);
     draft.proxy_layout_column = Some(snap.proxy_layout_column);
     draft.max_log_files = Some(snap.max_log_files);
     draft.enable_auto_check_update = Some(snap.enable_auto_check_update);
-    draft.clash_tray_selector = Some(super::yaml_convert(&snap.tray_selector_mode)?);
+    draft.clash_tray_selector = Some(super::yaml_convert(snap.tray_selector_mode)?);
     draft.always_on_top = Some(snap.always_on_top);
     draft.network_statistic_widget = Some(network_widget_to_legacy(snap.network_statistic_widget));
     draft.pac_url = snap.pac_url.as_ref().map(ToString::to_string);
     draft.enable_tray_text = Some(snap.enable_tray_text);
     draft.window_type = snap.use_legacy_ui.then_some(legacy_app::WindowType::Main);
-    draft.tray_menu_mode = Some(super::yaml_convert(&snap.tray_menu_mode)?);
-    draft.tray_menu_close_behavior = Some(super::yaml_convert(&snap.tray_menu_close_behavior)?);
+    draft.tray_menu_mode = Some(super::yaml_convert(snap.tray_menu_mode)?);
+    draft.tray_menu_close_behavior = Some(super::yaml_convert(snap.tray_menu_close_behavior)?);
     Ok(())
 }
 

--- a/backend/tauri/src/bridge/window.rs
+++ b/backend/tauri/src/bridge/window.rs
@@ -34,6 +34,7 @@ struct PreparedWindowMirror {
 }
 
 impl PreparedLegacyMirror for PreparedWindowMirror {
+    #[allow(deprecated)]
     fn apply(self: Box<Self>) {
         let Self {
             legacy_lock,
@@ -100,6 +101,7 @@ fn window_state_from_position(position: &[f64]) -> WindowState {
     }
 }
 
+#[allow(deprecated)]
 pub(crate) fn apply_session_state_to_legacy_verge(
     draft: &mut IVerge,
     snap: &PersistentState,

--- a/backend/tauri/src/client/application.rs
+++ b/backend/tauri/src/client/application.rs
@@ -25,6 +25,7 @@ struct ApplicationClientInner {
     actor_ref: ActorRef<ApplicationActorMessage>,
 }
 
+#[allow(dead_code)]
 impl ApplicationClient {
     pub(crate) async fn new(
         config_path: Utf8PathBuf,

--- a/backend/tauri/src/client/clash_config.rs
+++ b/backend/tauri/src/client/clash_config.rs
@@ -25,6 +25,7 @@ struct ClashConfigClientInner {
     actor_ref: ActorRef<ClashConfigActorMessage>,
 }
 
+#[allow(dead_code)]
 impl ClashConfigClient {
     pub(crate) async fn new(
         config_path: Utf8PathBuf,

--- a/backend/tauri/src/client/core_bridge.rs
+++ b/backend/tauri/src/client/core_bridge.rs
@@ -31,6 +31,7 @@ impl RunningConfigPatchPort for LegacyRunningConfigPatchBridge {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct CoreStatusSnapshot {
     pub state: CoreState,
@@ -43,6 +44,7 @@ pub struct CoreStatusSnapshot {
 pub trait CoreLifecyclePort: Send + Sync + 'static {
     /// Acquire an exclusive lease until the returned value is dropped.
     async fn begin(&self) -> anyhow::Result<Box<dyn CoreLifecycleLease>>;
+    #[allow(dead_code)]
     async fn status(&self) -> anyhow::Result<CoreStatusSnapshot>;
     async fn on_profile_change(&self);
 }
@@ -67,6 +69,7 @@ pub trait CoreLifecycleLease: Send {
     ) -> anyhow::Result<()>;
     async fn apply_promoted(&mut self, product: &Utf8Path) -> anyhow::Result<()>;
     async fn restart(&mut self) -> anyhow::Result<()>;
+    #[allow(dead_code)]
     async fn stop(&mut self) -> anyhow::Result<()>;
 }
 

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -105,7 +105,7 @@ enum PreparedConfigDomain {
     Application {
         expected_version: u64,
         forward: PreparedTypedReplace<NyanpasuAppConfig>,
-        rollback: PreparedTypedReplace<NyanpasuAppConfig>,
+        rollback: Box<PreparedTypedReplace<NyanpasuAppConfig>>,
     },
     Session {
         expected_version: u64,
@@ -210,7 +210,7 @@ async fn sync_legacy_mirrors(
 /// else a constant. Kept separate so `import_profile` reads as orchestration.
 fn url_derived_name(url: &url::Url) -> String {
     url.path_segments()
-        .and_then(|segments| segments.filter(|segment| !segment.is_empty()).next_back())
+        .and_then(|mut segments| segments.rfind(|segment| !segment.is_empty()))
         .map(|segment| {
             segment
                 .trim_end_matches(".yaml")
@@ -250,6 +250,7 @@ struct NyanpasuClientInner {
     runtime: runtime::RuntimeLifecycleStore,
 }
 
+#[allow(dead_code)]
 impl NyanpasuClient {
     pub fn try_new_with_args(args: ClientSetupArgs) -> anyhow::Result<Self> {
         let ClientSetupArgs {
@@ -330,6 +331,7 @@ impl NyanpasuClient {
         Ok(client)
     }
 
+    #[allow(dead_code, clippy::too_many_arguments)]
     fn with_parts(
         application: ApplicationClient,
         session_state: SessionStateClient,
@@ -542,11 +544,12 @@ impl NyanpasuClient {
             prepared.push(PreparedConfigDomain::Application {
                 expected_version: snapshots.application.version,
                 forward: self.inner.application.prepare_replace(state).await?,
-                rollback: self
-                    .inner
-                    .application
-                    .prepare_replace(snapshots.application.state.clone())
-                    .await?,
+                rollback: Box::new(
+                    self.inner
+                        .application
+                        .prepare_replace(snapshots.application.state.clone())
+                        .await?,
+                ),
             });
         }
         if let Some(state) = session {
@@ -588,7 +591,7 @@ impl NyanpasuClient {
                     Ok(ConditionalReplaceResult::Replaced(snapshot)) => {
                         committed.push(CommittedConfigDomain::Application {
                             committed_version: snapshot.version,
-                            rollback,
+                            rollback: *rollback,
                         });
                         continue;
                     }
@@ -845,11 +848,11 @@ impl NyanpasuClient {
             })
             .collect();
 
-        if report.affects_current {
-            if let Err(error) = self.rebuild_running_config().await {
-                tracing::warn!(%error, "post-commit rebuild failed; state stays committed (degraded)");
-                degradations.push(Self::map_runtime_rebuild_degradation(&error));
-            }
+        if report.affects_current
+            && let Err(error) = self.rebuild_running_config().await
+        {
+            tracing::warn!(%error, "post-commit rebuild failed; state stays committed (degraded)");
+            degradations.push(Self::map_runtime_rebuild_degradation(&error));
         }
         degradations
     }

--- a/backend/tauri/src/client/profiles.rs
+++ b/backend/tauri/src/client/profiles.rs
@@ -131,6 +131,7 @@ impl ProfilesClient {
         .await
     }
 
+    #[allow(dead_code)]
     pub async fn replace(&self, profiles: Profiles) -> Result<CommitReport, ProfilesError> {
         self.call(
             |reply| ProfilesActorMessage::Replace { profiles, reply },

--- a/backend/tauri/src/client/rebuild.rs
+++ b/backend/tauri/src/client/rebuild.rs
@@ -225,6 +225,7 @@ impl NyanpasuClient {
     /// `feat::patch_clash`/`patch_verge` side-effect paths, `change_core`).
     /// Profiles come from the typed actor only; their legacy IPC writers moved
     /// onto the facade in T08 and the legacy profile code was removed in T10.
+    #[allow(dead_code)]
     pub(crate) async fn regenerate_runtime_for_legacy(&self) -> Result<()> {
         // Inputs are read under the rebuild gate so a legacy regeneration
         // serializes with facade rebuilds and always sees the newest drafts.

--- a/backend/tauri/src/client/runtime.rs
+++ b/backend/tauri/src/client/runtime.rs
@@ -42,7 +42,7 @@ impl RuntimeRevisionAllocator {
     pub(crate) fn allocate(&self) -> anyhow::Result<RuntimeRevision> {
         let previous = self
             .0
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
                 value.checked_add(1)
             })
             .map_err(|_| anyhow::anyhow!("runtime revision space exhausted"))?;
@@ -204,6 +204,7 @@ impl RuntimePaths {
         })
     }
 
+    #[allow(dead_code)]
     pub fn new(product: Utf8PathBuf, candidate_dir: Utf8PathBuf) -> Self {
         Self {
             product,
@@ -215,6 +216,7 @@ impl RuntimePaths {
         &self.product
     }
 
+    #[allow(dead_code)]
     pub fn candidate_dir(&self) -> &Utf8Path {
         &self.candidate_dir
     }
@@ -407,12 +409,14 @@ impl<T> MutationOutcome<T> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn into_value(self) -> T {
         match self {
             Self::Applied { value } | Self::CommittedDegraded { value, .. } => value,
         }
     }
 
+    #[allow(dead_code)]
     pub fn degradations(&self) -> &[Degradation] {
         match self {
             Self::Applied { .. } => &[],

--- a/backend/tauri/src/client/session_state.rs
+++ b/backend/tauri/src/client/session_state.rs
@@ -25,6 +25,7 @@ struct SessionStateClientInner {
     actor_ref: ActorRef<SessionStateActorMessage>,
 }
 
+#[allow(dead_code)]
 impl SessionStateClient {
     pub(crate) async fn new(
         config_path: Utf8PathBuf,

--- a/backend/tauri/src/config/clash/mod.rs
+++ b/backend/tauri/src/config/clash/mod.rs
@@ -102,6 +102,7 @@ impl IClashTemp {
     }
 
     #[instrument]
+    #[allow(dead_code)]
     pub fn prepare_external_controller_port(&mut self) -> Result<()> {
         let strategy = Config::verge()
             .latest()
@@ -264,6 +265,7 @@ fn test_clash_info() {
     );
 }
 
+#[allow(dead_code)]
 #[derive(Default, Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct IClash {
@@ -279,6 +281,7 @@ pub struct IClash {
     pub interface_name: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Default, Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct IClashTUN {
@@ -289,6 +292,7 @@ pub struct IClashTUN {
     pub dns_hijack: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 #[derive(Default, Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct IClashDNS {
@@ -305,6 +309,7 @@ pub struct IClashDNS {
     pub nameserver_policy: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 #[derive(Default, Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct IClashFallbackFilter {

--- a/backend/tauri/src/config/draft.rs
+++ b/backend/tauri/src/config/draft.rs
@@ -11,11 +11,11 @@ macro_rules! draft_define {
     ($id: ident) => {
         impl Draft<$id> {
             #[allow(unused)]
-            pub fn data(&self) -> MappedMutexGuard<$id> {
+            pub fn data(&self) -> MappedMutexGuard<'_, $id> {
                 MutexGuard::map(self.inner.lock(), |guard| &mut guard.0)
             }
 
-            pub fn latest(&self) -> MappedMutexGuard<$id> {
+            pub fn latest(&self) -> MappedMutexGuard<'_, $id> {
                 MutexGuard::map(self.inner.lock(), |inner| {
                     if inner.1.is_none() {
                         &mut inner.0
@@ -25,7 +25,7 @@ macro_rules! draft_define {
                 })
             }
 
-            pub fn draft(&self) -> MappedMutexGuard<$id> {
+            pub fn draft(&self) -> MappedMutexGuard<'_, $id> {
                 MutexGuard::map(self.inner.lock(), |inner| {
                     if inner.1.is_none() {
                         inner.1 = Some(inner.0.clone());
@@ -79,6 +79,7 @@ draft_define!(IVerge);
 
 impl Draft<IClashTemp> {
     /// Reload configuration from file
+    #[allow(dead_code)]
     pub fn reload(&self) {
         let new_config = IClashTemp::new();
         let mut inner = self.inner.lock();

--- a/backend/tauri/src/config/nyanpasu/mod.rs
+++ b/backend/tauri/src/config/nyanpasu/mod.rs
@@ -176,15 +176,11 @@ impl Default for TrayMenuMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Type)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum TrayMenuCloseBehavior {
+    #[default]
     Hide,
     Close,
-}
-
-impl Default for TrayMenuCloseBehavior {
-    fn default() -> Self {
-        TrayMenuCloseBehavior::Hide
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default, Type)]
@@ -372,11 +368,12 @@ impl IVerge {
         match dirs::nyanpasu_config_path().and_then(|path| help::read_yaml::<IVerge, _>(&path)) {
             Ok(mut config) => {
                 // Validate and fix theme_color if it's invalid
-                if let Some(ref theme_color) = config.theme_color {
-                    if !theme_color.is_empty() && !is_hex_color(theme_color) {
-                        log::warn!(target: "app", "Invalid theme color detected: {}, resetting to default", theme_color);
-                        config.theme_color = None;
-                    }
+                if let Some(ref theme_color) = config.theme_color
+                    && !theme_color.is_empty()
+                    && !is_hex_color(theme_color)
+                {
+                    log::warn!(target: "app", "Invalid theme color detected: {}, resetting to default", theme_color);
+                    config.theme_color = None;
                 }
 
                 Self::merge_with_template(config)
@@ -388,6 +385,7 @@ impl IVerge {
         }
     }
 
+    #[allow(deprecated)]
     fn merge_with_template(mut config: IVerge) -> Self {
         let template = Self::template();
 

--- a/backend/tauri/src/core/clash/api.rs
+++ b/backend/tauri/src/core/clash/api.rs
@@ -585,6 +585,7 @@ pub fn parse_log(log: String) -> String {
 /// 缩短clash -t的错误输出
 /// 仅适配 clash p核 8-26、clash meta 1.13.1
 #[instrument]
+#[allow(dead_code)]
 pub fn parse_check_output(log: String) -> String {
     let t = log.find("time=");
     let m = log.find("msg=");

--- a/backend/tauri/src/core/clash/core.rs
+++ b/backend/tauri/src/core/clash/core.rs
@@ -391,6 +391,7 @@ impl CoreLifecycleLease<'_> {
         self.manager.run_core_with_lease(self, config_path).await
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn recover_core(&self) -> Result<()> {
         self.manager.recover_core_with_lease(self).await
     }
@@ -450,6 +451,7 @@ impl CoreManager {
         }
     }
 
+    #[allow(dead_code)]
     pub fn init(&self) -> Result<()> {
         tauri::async_runtime::spawn(async {
             // 启动clash
@@ -460,6 +462,7 @@ impl CoreManager {
     }
 
     /// 检查配置是否正确
+    #[allow(dead_code)]
     pub async fn check_config(&self, config_path: &Utf8Path, clash_core: ClashCore) -> Result<()> {
         let lease = self.begin_lifecycle().await;
         self.check_config_with_lease(&lease, config_path, clash_core)
@@ -615,6 +618,7 @@ impl CoreManager {
     /// Push the promoted runtime product to the running core over the api.
     /// Check + promote happen in the rebuild pipeline (RunningCoreBridge::
     /// check_and_promote) before this is called.
+    #[allow(dead_code)]
     pub async fn apply_config_from(&self, product: &Utf8Path) -> Result<()> {
         let lease = self.begin_lifecycle().await;
         self.apply_config_from_with_lease(&lease, product).await

--- a/backend/tauri/src/core/clash/proxies.rs
+++ b/backend/tauri/src/core/clash/proxies.rs
@@ -177,7 +177,7 @@ impl Proxies {
                         item
                     })
                     .collect();
-                groups.sort_by(|a, b| b.name.to_lowercase().cmp(&a.name.to_lowercase()));
+                groups.sort_by_key(|a| std::cmp::Reverse(a.name.to_lowercase()));
                 groups
             }
         };

--- a/backend/tauri/src/core/clash/ws.rs
+++ b/backend/tauri/src/core/clash/ws.rs
@@ -333,13 +333,11 @@ impl ClashConnectionsConnectorShared {
     }
 
     fn dispatch_state_changed(&self, state: ClashConnectionsConnectorState) {
-        let event_state = state.clone();
+        let event_state = state;
         self.state.store(state, Ordering::Release);
         let _ = self
             .connections_tx
-            .send(ClashConnectionsConnectorEvent::StateChanged(
-                event_state.clone(),
-            ));
+            .send(ClashConnectionsConnectorEvent::StateChanged(event_state));
         let _ = self.ws_tx.send(ClashWsEvent::StateChanged(event_state));
     }
 
@@ -378,14 +376,8 @@ impl ClashConnectionsConnectorShared {
         let previous_download_total =
             std::mem::replace(&mut info.download_total, msg.download_total);
         let previous_upload_total = std::mem::replace(&mut info.upload_total, msg.upload_total);
-        info.download_speed = msg
-            .download_total
-            .checked_sub(previous_download_total)
-            .unwrap_or_default();
-        info.upload_speed = msg
-            .upload_total
-            .checked_sub(previous_upload_total)
-            .unwrap_or_default();
+        info.download_speed = msg.download_total.saturating_sub(previous_download_total);
+        info.upload_speed = msg.upload_total.saturating_sub(previous_upload_total);
 
         let _ = self
             .connections_tx
@@ -469,6 +461,7 @@ struct ClashConnectionsActorState {
     memory_handler: Option<JoinHandle<()>>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 enum ClashConnectionsActorMessage {
     Start(RpcReplyPort<anyhow::Result<()>>),
@@ -757,6 +750,7 @@ impl ClashConnectionsConnector {
         }
     }
 
+    #[allow(dead_code)]
     pub async fn restart(&self) -> anyhow::Result<()> {
         match self
             .actor_ref
@@ -806,6 +800,7 @@ impl ClashConnectionsConnectorInner {
         self.shared.clear_history(kind);
     }
 
+    #[allow(dead_code)]
     pub async fn stop(&self) {
         let _ = self
             .actor_ref

--- a/backend/tauri/src/core/connection_interruption.rs
+++ b/backend/tauri/src/core/connection_interruption.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use crate::{config::Config, core::clash::api};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};

--- a/backend/tauri/src/core/hotkey.rs
+++ b/backend/tauri/src/core/hotkey.rs
@@ -27,6 +27,7 @@ const SUPER_KEYS: &[&str] = &[
 /// Hotkey error types for frontend validation feedback
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 #[serde(tag = "kind", content = "data")]
+#[allow(dead_code)]
 pub enum HotkeyError {
     InvalidHotkey(String),
     MissingSuperKey(String),
@@ -323,10 +324,8 @@ impl Hotkey {
             let func = iter.next();
             let key = iter.next();
 
-            if func.is_some() && key.is_some() {
-                let func = func.unwrap().trim();
-                let key = key.unwrap().trim();
-                map.insert(key, func);
+            if let (Some(func), Some(key)) = (func, key) {
+                map.insert(key.trim(), func.trim());
             }
         });
         map

--- a/backend/tauri/src/core/migration/modules/typed_config.rs
+++ b/backend/tauri/src/core/migration/modules/typed_config.rs
@@ -276,7 +276,7 @@ fn looks_like_legacy_runtime_clash_mapping(value: &Value) -> bool {
         "rule-providers",
     ]
     .iter()
-    .any(|key| map.contains_key(&Value::String((*key).to_string())))
+    .any(|key| map.contains_key(Value::String((*key).to_string())))
 }
 
 fn push_file_state(

--- a/backend/tauri/src/core/service/control.rs
+++ b/backend/tauri/src/core/service/control.rs
@@ -345,7 +345,7 @@ pub async fn status<'a>() -> anyhow::Result<nyanpasu_ipc::types::StatusInfo<'a>>
             }
         );
     }
-    let mut status = String::from_utf8(output.stdout)?;
+    let status = String::from_utf8(output.stdout)?;
     tracing::trace!("service status: {}", status);
-    Ok(serde_json::from_str(&mut status)?)
+    Ok(serde_json::from_str(&status)?)
 }

--- a/backend/tauri/src/core/state.rs
+++ b/backend/tauri/src/core/state.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 #[allow(dead_code)]
 use parking_lot::{
     MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock,
@@ -46,7 +47,7 @@ where
     T: Clone + Sync + Send,
 {
     /// to auto commit the state when it is dropped
-    pub fn auto_commit(&self) -> ManagedStateAutoCommit<T> {
+    pub fn auto_commit(&self) -> ManagedStateAutoCommit<'_, T> {
         ManagedStateAutoCommit(self)
     }
 }

--- a/backend/tauri/src/core/storage.rs
+++ b/backend/tauri/src/core/storage.rs
@@ -74,6 +74,7 @@ pub trait WebStorage {
     /// Returns all key-value pairs as raw JSON strings (for debug use).
     fn get_all(&self) -> Result<Vec<(String, String)>>;
     /// Removes all entries from the storage (for debug use).
+    #[allow(dead_code)]
     fn clear(&self) -> Result<()>;
 }
 

--- a/backend/tauri/src/core/tasks/jobs/events_rotate.rs
+++ b/backend/tauri/src/core/tasks/jobs/events_rotate.rs
@@ -45,7 +45,7 @@ impl AsyncJobExecutor for EventsRotateJob {
                 })
                 .collect::<Vec<_>>();
             // DESC sort events by updated_at
-            events.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+            events.sort_by_key(|a| std::cmp::Reverse(a.updated_at));
             // keep max 10 events
             let events = events
                 .into_iter()

--- a/backend/tauri/src/core/tasks/jobs/logger.rs
+++ b/backend/tauri/src/core/tasks/jobs/logger.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use super::JobExt;
 use crate::{
     config::Config,

--- a/backend/tauri/src/core/tasks/jobs/mod.rs
+++ b/backend/tauri/src/core/tasks/jobs/mod.rs
@@ -5,6 +5,7 @@ use super::task::{Task, TaskManager};
 use parking_lot::RwLock;
 use std::sync::Arc;
 pub trait JobExt {
+    #[allow(dead_code)]
     fn name(&self) -> &'static str;
     fn setup(&self) -> Option<Task>; // called when the app starts or the config changed
 }

--- a/backend/tauri/src/core/tasks/storage.rs
+++ b/backend/tauri/src/core/tasks/storage.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 //! store is a interface to save and restore task states
 use super::{
     events::TaskEvent,

--- a/backend/tauri/src/core/tasks/task.rs
+++ b/backend/tauri/src/core/tasks/task.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use super::{
     events::{TaskEventState, TaskEvents},
     executor::{Job, TaskExecutor},

--- a/backend/tauri/src/core/tray/mod.rs
+++ b/backend/tauri/src/core/tray/mod.rs
@@ -472,15 +472,13 @@ impl Tray {
                 button: MouseButton::Right,
                 position,
                 ..
-            } => {
-                if get_tray_menu_mode() == TrayMenuMode::Webview {
-                    log_err!(
-                        resolve::show_tray_menu_window(tray_icon.app_handle(), position),
-                        "failed to show webview tray menu"
-                    );
-                }
-                // In Native mode the system shows the attached menu automatically
+            } if get_tray_menu_mode() == TrayMenuMode::Webview => {
+                log_err!(
+                    resolve::show_tray_menu_window(tray_icon.app_handle(), position),
+                    "failed to show webview tray menu"
+                );
             }
+            // In Native mode the system shows the attached menu automatically
             _ => {}
         }
     }

--- a/backend/tauri/src/enhance/mod.rs
+++ b/backend/tauri/src/enhance/mod.rs
@@ -12,9 +12,7 @@ pub(crate) mod golden_support;
 
 pub use artifact_bridge::runtime_snapshot_data_from_artifact;
 pub use content_source::FsProfileContentSource;
-pub use runtime_builder::{
-    RuntimeBuildError, RuntimeBuildInput, RuntimeBuilder, builtin_transforms_for, derive_tun_flavor,
-};
+pub use runtime_builder::{RuntimeBuildInput, RuntimeBuilder, builtin_transforms_for};
 pub use script::adapter::EnhanceScriptRunner;
 
 pub use chain::{PostProcessingOutput, ScriptType, ScriptWrapper};

--- a/backend/tauri/src/enhance/script/js.rs
+++ b/backend/tauri/src/enhance/script/js.rs
@@ -300,6 +300,7 @@ mod utils {
 
     #[derive(Debug)]
     // TODO: support fn params check and support typescript type erase
+    #[allow(dead_code)]
     struct DefaultExport {
         span: Span,
         is_function: bool,

--- a/backend/tauri/src/enhance/script/runner.rs
+++ b/backend/tauri/src/enhance/script/runner.rs
@@ -63,7 +63,7 @@ impl RunnerManager {
                 ScriptType::JavaScript => Box::new(js::JSRunner::try_new()?) as Box<dyn Runner>,
                 ScriptType::Lua => Box::new(lua::LuaRunner::try_new()?) as Box<dyn Runner>,
             };
-            self.runners.insert(script_type.clone(), runner);
+            self.runners.insert(*script_type, runner);
         }
         Ok(self.runners.get(script_type).unwrap().as_ref())
     }

--- a/backend/tauri/src/event_handler/mod.rs
+++ b/backend/tauri/src/event_handler/mod.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 /// This module is a tauri event based handler.
 /// Some state is good to be managed by the Tauri Manager. we should not hold the singletons in the global state in some cases.
 use tauri::{Emitter, Listener, Manager, Runtime};

--- a/backend/tauri/src/event_handler/widget.rs
+++ b/backend/tauri/src/event_handler/widget.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use tauri::{AppHandle, Event, Runtime};
 
 pub enum WidgetInstance {

--- a/backend/tauri/src/feat.rs
+++ b/backend/tauri/src/feat.rs
@@ -235,6 +235,7 @@ pub(crate) fn requires_core_restart(patch: &Mapping) -> bool {
 ///
 /// Non-restart patches must still regenerate **and apply** so a promote cannot
 /// land without a corresponding apply (use `regenerate_and_apply_for_legacy`).
+#[allow(dead_code)]
 pub async fn patch_clash(client: crate::client::NyanpasuClient, patch: Mapping) -> Result<()> {
     patch_clash_with_rebuild(patch, |restart| {
         let client = client.clone();
@@ -260,15 +261,17 @@ where
     let run = move || async move {
         let mixed_port = patch.get("mixed-port");
         let enable_random_port = Config::verge().latest().enable_random_port.unwrap_or(false);
-        if mixed_port.is_some() && !enable_random_port {
-            let changed = mixed_port.unwrap()
+        if let Some(mixed_port) = mixed_port
+            && !enable_random_port
+        {
+            let changed = mixed_port
                 != Config::verge()
                     .latest()
                     .verge_mixed_port
                     .unwrap_or(Config::clash().data().get_mixed_port());
             // 检查端口占用
             if changed
-                && let Some(port) = mixed_port.unwrap().as_u64()
+                && let Some(port) = mixed_port.as_u64()
                 && !port_scanner::local_port_available(port as u16)
             {
                 Config::clash().discard();
@@ -332,10 +335,11 @@ where
 /// 一般都是一个个的修改
 pub async fn patch_verge(client: crate::client::NyanpasuClient, patch: IVerge) -> Result<()> {
     // Validate theme_color if it's being updated
-    if let Some(ref theme_color) = patch.theme_color {
-        if !theme_color.is_empty() && !crate::config::nyanpasu::is_hex_color(theme_color) {
-            anyhow::bail!("Invalid theme color: {}", theme_color);
-        }
+    if let Some(ref theme_color) = patch.theme_color
+        && !theme_color.is_empty()
+        && !crate::config::nyanpasu::is_hex_color(theme_color)
+    {
+        anyhow::bail!("Invalid theme color: {}", theme_color);
     }
 
     Config::verge().draft().patch_config(patch.clone());
@@ -353,8 +357,10 @@ pub async fn patch_verge(client: crate::client::NyanpasuClient, patch: IVerge) -
     let res = || async move {
         let service_mode = patch.enable_service_mode;
         let ipc_state = get_ipc_state();
-        if service_mode.is_some() && ipc_state.is_connected() {
-            log::debug!(target: "app", "change service mode to {}", service_mode.unwrap());
+        if let Some(service_mode) = service_mode
+            && ipc_state.is_connected()
+        {
+            log::debug!(target: "app", "change service mode to {}", service_mode);
 
             client.regenerate_and_restart_for_legacy().await?;
         }

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -1025,7 +1025,7 @@ fn web_key(key: &str) -> String {
 #[specta::specta]
 pub fn get_storage_item(app_handle: AppHandle, key: String) -> Result<Option<String>> {
     let storage = app_handle.state::<Storage>();
-    let value = (storage.get_item(&web_key(&key)))?;
+    let value = (storage.get_item(web_key(&key)))?;
     Ok(value)
 }
 
@@ -1033,7 +1033,7 @@ pub fn get_storage_item(app_handle: AppHandle, key: String) -> Result<Option<Str
 #[specta::specta]
 pub fn set_storage_item(app_handle: AppHandle, key: String, value: String) -> Result {
     let storage = app_handle.state::<Storage>();
-    (storage.set_item(&web_key(&key), &value))?;
+    (storage.set_item(web_key(&key), &value))?;
     Ok(())
 }
 
@@ -1041,7 +1041,7 @@ pub fn set_storage_item(app_handle: AppHandle, key: String, value: String) -> Re
 #[specta::specta]
 pub fn remove_storage_item(app_handle: AppHandle, key: String) -> Result {
     let storage = app_handle.state::<Storage>();
-    (storage.remove_item(&web_key(&key)))?;
+    (storage.remove_item(web_key(&key)))?;
     Ok(())
 }
 

--- a/backend/tauri/src/lib.rs
+++ b/backend/tauri/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(auto_traits, negative_impls, trait_alias, impl_trait_in_assoc_type)]
 #![cfg_attr(
     all(not(debug_assertions), target_os = "windows"),
     windows_subsystem = "windows"
@@ -27,8 +26,6 @@ mod shutdown_hook;
 mod utils;
 mod widget;
 mod window;
-
-use std::io;
 
 use crate::{
     config::Config,
@@ -321,7 +318,7 @@ pub fn run() -> std::io::Result<()> {
             log_err!(tauri_plugin_deep_link::register(
                 &["clash-nyanpasu", "clash"],
                 move |request| {
-                    log::info!(target: "app", "scheme request received: {:?}", &request);
+                    log::info!(target: "app", "scheme request received: {:?}", request);
                     resolve::create_window(&handle.clone()); // create window if not exists
                     while !is_window_opened() {
                         log::info!(target: "app", "waiting for window open");

--- a/backend/tauri/src/logging/indexer.rs
+++ b/backend/tauri/src/logging/indexer.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::{
     collections::{BTreeMap, BTreeSet},
     io::SeekFrom,

--- a/backend/tauri/src/logging/manager.rs
+++ b/backend/tauri/src/logging/manager.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::{collections::HashMap, ops::Deref, sync::Arc};
 
 use crate::logging::indexer::Indexer;
@@ -205,19 +206,17 @@ impl IndexerManagerRunner {
                             }
                         }
                     }
-                    EventKind::Modify(_) => {
-                        if is_log_file(path).await.is_ok_and(|ok| ok) {
-                            let (tx, rx) = oneshot::channel();
-                            cmd_tx
-                                .send(IndexerRunnerCmd::LogFileChanged(path.to_path_buf(), tx))
-                                .unwrap();
-                            match rx.await {
-                                Ok(_) => {
-                                    tracing::debug!("indexer for {} updated", path);
-                                }
-                                Err(_err) => {
-                                    tracing::error!("failed to update indexer for {}", path);
-                                }
+                    EventKind::Modify(_) if is_log_file(path).await.is_ok_and(|ok| ok) => {
+                        let (tx, rx) = oneshot::channel();
+                        cmd_tx
+                            .send(IndexerRunnerCmd::LogFileChanged(path.to_path_buf(), tx))
+                            .unwrap();
+                        match rx.await {
+                            Ok(_) => {
+                                tracing::debug!("indexer for {} updated", path);
+                            }
+                            Err(_err) => {
+                                tracing::error!("failed to update indexer for {}", path);
                             }
                         }
                     }

--- a/backend/tauri/src/logging/mod.rs
+++ b/backend/tauri/src/logging/mod.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 mod indexer;
 mod manager;
 

--- a/backend/tauri/src/service/profile_file.rs
+++ b/backend/tauri/src/service/profile_file.rs
@@ -428,7 +428,7 @@ fn ensure_real_directory_tree(path: &Path) -> anyhow::Result<()> {
     }
 }
 
-fn set_private_directory_permissions(_path: &Path) -> anyhow::Result<()> {
+fn set_private_directory_permissions(path: &Path) -> anyhow::Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -438,7 +438,7 @@ fn set_private_directory_permissions(_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn set_private_file_permissions(_path: &Path) -> anyhow::Result<()> {
+fn set_private_file_permissions(path: &Path) -> anyhow::Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/backend/tauri/src/service/profile_file.rs
+++ b/backend/tauri/src/service/profile_file.rs
@@ -247,6 +247,7 @@ fn canonicalize_for_compare(path: &Path) -> std::io::Result<PathBuf> {
     std::fs::canonicalize(path)
 }
 
+#[allow(dead_code)]
 fn symlink_points_to(link: &Path, target: &Path) -> anyhow::Result<bool> {
     let existing = std::fs::read_link(link)?;
     let existing = if existing.is_absolute() {
@@ -427,7 +428,7 @@ fn ensure_real_directory_tree(path: &Path) -> anyhow::Result<()> {
     }
 }
 
-fn set_private_directory_permissions(path: &Path) -> anyhow::Result<()> {
+fn set_private_directory_permissions(_path: &Path) -> anyhow::Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -437,7 +438,7 @@ fn set_private_directory_permissions(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn set_private_file_permissions(path: &Path) -> anyhow::Result<()> {
+fn set_private_file_permissions(_path: &Path) -> anyhow::Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -526,6 +527,7 @@ fn sync_directory(_path: &Path) -> anyhow::Result<()> {
 }
 
 impl ProfileFileService {
+    #[allow(dead_code)]
     fn materialization_root(&self) -> PathBuf {
         self.paths.app_profiles_dir().join(MATERIALIZATION_ROOT)
     }
@@ -1167,6 +1169,7 @@ impl ProfileFileService {
     /// The journal locations share one private root, so Unix `rename` is an
     /// atomic same-filesystem phase transition. Do not use `move_atomic`: its
     /// hard-link/unlink fallback can leave duplicate phase artifacts.
+    #[allow(dead_code)]
     fn rename_journal_same_filesystem(source: &Path, destination: &Path) -> anyhow::Result<()> {
         let metadata = std::fs::symlink_metadata(source)
             .with_context(|| format!("inspect journal source {}", source.display()))?;
@@ -2161,12 +2164,11 @@ fn parse_profile_title(headers: &reqwest::header::HeaderMap) -> Option<String> {
         }
         if let Some(encoded) = value.strip_prefix("base64:") {
             use base64::Engine;
-            if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(encoded) {
-                if let Ok(decoded) = String::from_utf8(bytes) {
-                    if !decoded.trim().is_empty() {
-                        return Some(decoded);
-                    }
-                }
+            if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(encoded)
+                && let Ok(decoded) = String::from_utf8(bytes)
+                && !decoded.trim().is_empty()
+            {
+                return Some(decoded);
             }
         } else {
             return Some(value.to_owned());

--- a/backend/tauri/src/service/profile_file.rs
+++ b/backend/tauri/src/service/profile_file.rs
@@ -428,6 +428,7 @@ fn ensure_real_directory_tree(path: &Path) -> anyhow::Result<()> {
     }
 }
 
+#[allow(unused_variables)]
 fn set_private_directory_permissions(path: &Path) -> anyhow::Result<()> {
     #[cfg(unix)]
     {
@@ -438,6 +439,7 @@ fn set_private_directory_permissions(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[allow(unused_variables)]
 fn set_private_file_permissions(path: &Path) -> anyhow::Result<()> {
     #[cfg(unix)]
     {

--- a/backend/tauri/src/shutdown_hook.rs
+++ b/backend/tauri/src/shutdown_hook.rs
@@ -42,6 +42,7 @@ pub fn setup_shutdown_hook(f: impl Fn() + Send + Sync + 'static) -> anyhow::Resu
     Ok(())
 }
 
+#[allow(dead_code)]
 struct WindowHandle {
     hwnd: HWND,
     h_instance: HINSTANCE,

--- a/backend/tauri/src/state/application.rs
+++ b/backend/tauri/src/state/application.rs
@@ -28,6 +28,7 @@ pub struct ApplicationActorState {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum ApplicationActorMessage {
     Get(RpcReplyPort<anyhow::Result<ApplicationSnapshot>>),
     Patch {

--- a/backend/tauri/src/state/clash_config.rs
+++ b/backend/tauri/src/state/clash_config.rs
@@ -29,6 +29,7 @@ pub struct ClashConfigActorState {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum ClashConfigActorMessage {
     Get(RpcReplyPort<anyhow::Result<ClashConfigSnapshot>>),
     Patch {

--- a/backend/tauri/src/state/profiles/actor.rs
+++ b/backend/tauri/src/state/profiles/actor.rs
@@ -70,6 +70,7 @@ pub enum ProfilesError {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct CommitReport {
     pub snapshot: Arc<Profiles>,
     /// Dependency-closure judgement per the T04 affects_current rule table.
@@ -187,6 +188,7 @@ fn synced_name(custom_name: bool, filename: &Option<String>) -> Option<String> {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum ProfilesActorMessage {
     Get(RpcReplyPort<Result<Arc<Profiles>, ProfilesError>>),
     SetCurrent {
@@ -299,28 +301,27 @@ impl ProfilesActor {
 
         closure.insert(current.clone());
         let mut configs = vec![current.clone()];
-        if let Some(item) = profiles.items.get(current) {
-            if let ProfileDefinition::Config {
+        if let Some(item) = profiles.items.get(current)
+            && let ProfileDefinition::Config {
                 config: ConfigDefinition::Composition(composition),
             } = &item.definition
-            {
-                if let Some(base) = &composition.base {
-                    closure.insert(base.clone());
-                    configs.push(base.clone());
-                }
-                for member in &composition.extend_proxies_from {
-                    closure.insert(member.clone());
-                    configs.push(member.clone());
-                }
+        {
+            if let Some(base) = &composition.base {
+                closure.insert(base.clone());
+                configs.push(base.clone());
+            }
+            for member in &composition.extend_proxies_from {
+                closure.insert(member.clone());
+                configs.push(member.clone());
             }
         }
 
         for config in configs {
-            if let Some(item) = profiles.items.get(&config) {
-                if let ProfileDefinition::Config { config } = &item.definition {
-                    for transform in config.transforms() {
-                        closure.insert(transform.clone());
-                    }
+            if let Some(item) = profiles.items.get(&config)
+                && let ProfileDefinition::Config { config } = &item.definition
+            {
+                for transform in config.transforms() {
+                    closure.insert(transform.clone());
                 }
             }
         }
@@ -592,20 +593,17 @@ impl ProfilesActor {
         };
 
         let mut materialization_failures = Vec::new();
-        if let Some(cleanup) = cleanup {
-            if let Err(error) =
+        if let Some(cleanup) = cleanup
+            && let Err(error) =
                 Self::materialization_call(state, move |port| port.cancel_cleanup(&cleanup)).await
-            {
-                materialization_failures.push(format!("failed to cancel cleanup: {error}"));
-            }
+        {
+            materialization_failures.push(format!("failed to cancel cleanup: {error}"));
         }
-        if let Some(prepared) = prepared {
-            if let Err(error) =
+        if let Some(prepared) = prepared
+            && let Err(error) =
                 Self::materialization_call(state, move |port| port.compensate(&prepared)).await
-            {
-                materialization_failures
-                    .push(format!("failed to compensate materialization: {error}"));
-            }
+        {
+            materialization_failures.push(format!("failed to compensate materialization: {error}"));
         }
         Self::reconcile_committed(myself, state, &rollback_snapshot);
         StateFirstRollbackOutcome::RolledBack {
@@ -642,6 +640,7 @@ impl ProfilesActor {
         Vec::new()
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn commit_state_first(
         myself: &ActorRef<ProfilesActorMessage>,
         state: &mut ProfilesActorState,
@@ -694,23 +693,21 @@ impl ProfilesActor {
             Ok(snapshot) => snapshot,
             Err(error) => {
                 let mut failures = Vec::new();
-                if let Some(cleanup) = cleanup {
-                    if let Err(cancel) =
+                if let Some(cleanup) = cleanup
+                    && let Err(cancel) =
                         Self::materialization_call(state, move |port| port.cancel_cleanup(&cleanup))
                             .await
-                    {
-                        failures.push(format!("failed to cancel cleanup: {cancel}"));
-                    }
+                {
+                    failures.push(format!("failed to cancel cleanup: {cancel}"));
                 }
-                if let Some(prepared) = prepared {
-                    if let Err(compensate) =
+                if let Some(prepared) = prepared
+                    && let Err(compensate) =
                         Self::materialization_call(state, move |port| port.compensate(&prepared))
                             .await
-                    {
-                        failures.push(format!(
-                            "failed to compensate materialization: {compensate}"
-                        ));
-                    }
+                {
+                    failures.push(format!(
+                        "failed to compensate materialization: {compensate}"
+                    ));
                 }
                 return if failures.is_empty() {
                     Err(error)
@@ -796,6 +793,7 @@ impl ProfilesActor {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn commit_file_first(
         myself: &ActorRef<ProfilesActorMessage>,
         state: &mut ProfilesActorState,
@@ -1581,12 +1579,11 @@ impl Actor for ProfilesActor {
                     }
                 };
 
-                if reply.is_none() {
-                    if let Ok(report) = &result {
-                        if report.affects_current {
-                            state.notifier.request_rebuild();
-                        }
-                    }
+                if reply.is_none()
+                    && let Ok(report) = &result
+                    && report.affects_current
+                {
+                    state.notifier.request_rebuild();
                 }
                 if let Some(reply) = reply {
                     let _ = reply.send(result);
@@ -1704,10 +1701,10 @@ impl Actor for ProfilesActor {
                         drop(versioned);
 
                         let mut option = pending.option;
-                        if !pending.update_interval_explicit {
-                            if let Some(minutes) = suggested_update_interval_minutes {
-                                option.update_interval_minutes = minutes;
-                            }
+                        if !pending.update_interval_explicit
+                            && let Some(minutes) = suggested_update_interval_minutes
+                        {
+                            option.update_interval_minutes = minutes;
                         }
                         let mut metadata = pending.metadata;
                         if let Some(name) = synced_name(metadata.custom_name, &filename) {

--- a/backend/tauri/src/state/profiles/ports.rs
+++ b/backend/tauri/src/state/profiles/ports.rs
@@ -13,6 +13,7 @@ pub trait ProfileFsPort: Send + Sync + 'static {
     fn read(&self, path: &ManagedProfilePath) -> anyhow::Result<String>;
     fn write_atomic(&self, path: &ManagedProfilePath, content: &str) -> anyhow::Result<()>;
     /// Idempotent: removing a missing file succeeds.
+    #[allow(dead_code)]
     fn remove(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
     /// Read an External binding target for Mirror synchronization.
     fn read_external(&self, target: &ExternalProfilePath) -> anyhow::Result<String>;
@@ -20,6 +21,7 @@ pub trait ProfileFsPort: Send + Sync + 'static {
     /// symlink (clean-design §9 last paragraph).
     fn ensure_not_symlink(&self, path: &ManagedProfilePath) -> anyhow::Result<()>;
     /// Create or repair `path -> target` (External Symlink binding, clean-design §10.1).
+    #[allow(dead_code)]
     fn ensure_symlink(
         &self,
         path: &ManagedProfilePath,

--- a/backend/tauri/src/state/session_state.rs
+++ b/backend/tauri/src/state/session_state.rs
@@ -28,6 +28,7 @@ pub struct SessionStateActorState {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum SessionStateActorMessage {
     Get(RpcReplyPort<anyhow::Result<SessionStateSnapshot>>),
     Patch {

--- a/backend/tauri/src/utils/candy.rs
+++ b/backend/tauri/src/utils/candy.rs
@@ -12,9 +12,9 @@ pub fn collect_logs(target_path: &Path) -> Result<()> {
     let globstr = format!("{}/*.{}.app.log", logs_dir.to_str().unwrap(), now);
     let mut paths = Vec::new();
     for entry in glob(&globstr)? {
-        match entry {
-            Ok(path) => paths.push(path),
-            Err(e) => return Err(e.into()),
+        {
+            let path = entry?;
+            paths.push(path)
         }
     }
     let file = std::fs::File::create(target_path)?;

--- a/backend/tauri/src/utils/dirs.rs
+++ b/backend/tauri/src/utils/dirs.rs
@@ -8,8 +8,10 @@ use tauri::{Env, utils::platform::resource_dir};
 
 #[cfg(not(feature = "verge-dev"))]
 #[allow(unused)]
+#[allow(dead_code)]
 const PREVIOUS_APP_NAME: &str = "clash-verge";
 #[cfg(feature = "verge-dev")]
+#[allow(dead_code)]
 const PREVIOUS_APP_NAME: &str = "clash-verge-dev";
 #[cfg(not(feature = "verge-dev"))]
 pub const APP_NAME: &str = "clash-nyanpasu";
@@ -109,6 +111,7 @@ pub fn app_data_dir() -> Result<PathBuf> {
     since = "1.6.0",
     note = "should use self::app_config_dir or self::app_data_dir instead"
 )]
+#[allow(dead_code)]
 pub fn app_home_dir() -> Result<PathBuf> {
     if cfg!(feature = "verge-dev") {
         return Ok(dirs::home_dir()
@@ -237,6 +240,7 @@ pub fn tray_icons_path(mode: &str) -> Result<PathBuf> {
 
 #[cfg(windows)]
 #[deprecated(since = "1.6.0", note = "should use nyanpasu_utils::dirs mod instead")]
+#[allow(dead_code)]
 pub fn service_log_file() -> Result<PathBuf> {
     use chrono::Local;
 
@@ -251,6 +255,7 @@ pub fn service_log_file() -> Result<PathBuf> {
     Ok(log_file)
 }
 
+#[allow(dead_code)]
 pub fn path_to_str(path: &PathBuf) -> Result<&str> {
     let path_str = path
         .as_os_str()
@@ -267,7 +272,7 @@ pub fn get_single_instance_placeholder() -> Result<String> {
         match crate::utils::winreg::get_current_user_sid() {
             Ok(sid) => {
                 // Use session-local namespace and include app name + user SID to ensure per-user uniqueness
-                return Ok(format!("Local\\{}-{}", APP_NAME, sid));
+                Ok(format!("Local\\{}-{}", APP_NAME, sid))
             }
             Err(_) => {
                 // Fallback to config dir hashing if SID retrieval fails
@@ -278,7 +283,7 @@ pub fn get_single_instance_placeholder() -> Result<String> {
                 let mut hasher = DefaultHasher::new();
                 cfg_dir.to_string_lossy().hash(&mut hasher);
                 let hash = hasher.finish();
-                return Ok(format!("Local\\{}-{:x}", APP_NAME, hash));
+                Ok(format!("Local\\{}-{:x}", APP_NAME, hash))
             }
         }
     }

--- a/backend/tauri/src/utils/help.rs
+++ b/backend/tauri/src/utils/help.rs
@@ -111,7 +111,7 @@ pub fn open_file(app: tauri::AppHandle, path: PathBuf) -> Result<()> {
     #[cfg(all(not(windows), not(target_os = "macos")))]
     let code = "code";
 
-    let shell = app.shell();
+    let _shell = app.shell();
 
     trace_err!(
         match which::which(code) {

--- a/backend/tauri/src/utils/hwid.rs
+++ b/backend/tauri/src/utils/hwid.rs
@@ -178,12 +178,11 @@ fn get_device_model() -> String {
     use winreg::{RegKey, enums::HKEY_LOCAL_MACHINE};
 
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
-    if let Ok(key) = hklm.open_subkey("HARDWARE\\DESCRIPTION\\System\\BIOS") {
-        if let Ok(name) = key.get_value::<String, _>("SystemProductName") {
-            if !name.is_empty() {
-                return name;
-            }
-        }
+    if let Ok(key) = hklm.open_subkey("HARDWARE\\DESCRIPTION\\System\\BIOS")
+        && let Ok(name) = key.get_value::<String, _>("SystemProductName")
+        && !name.is_empty()
+    {
+        return name;
     }
     whoami::devicename()
 }

--- a/backend/tauri/src/utils/open.rs
+++ b/backend/tauri/src/utils/open.rs
@@ -13,6 +13,7 @@ pub fn that<T: AsRef<OsStr>>(path: T) -> std::io::Result<()> {
     }
 }
 
+#[allow(dead_code)]
 pub fn with<T: AsRef<OsStr>>(path: T, program: &str) -> std::io::Result<()> {
     // A dirty workaround for AppImage
     if std::env::var("APPIMAGE").is_ok() {

--- a/backend/tauri/src/utils/path.rs
+++ b/backend/tauri/src/utils/path.rs
@@ -42,6 +42,7 @@ pub struct PathResolver {
     data_dir: PathBuf,
 }
 
+#[allow(dead_code)]
 impl PathResolver {
     /// Resolve the base directories from the current environment.
     ///

--- a/backend/tauri/src/utils/resolve.rs
+++ b/backend/tauri/src/utils/resolve.rs
@@ -109,6 +109,7 @@ fn set_window_controls_pos(
     Ok(())
 }
 
+#[allow(dead_code)]
 pub fn find_unused_port() -> Result<u16> {
     match TcpListener::bind("127.0.0.1:0") {
         Ok(listener) => {
@@ -265,17 +266,17 @@ fn spawn_window_ready_timeout(app_handle: AppHandle) {
         tokio::time::sleep(std::time::Duration::from_secs(TIMEOUT_SECS)).await;
         let inner = app_handle.clone();
         let _ = app_handle.run_on_main_thread(move || {
-            if let Some(win) = inner.get_webview_window(crate::consts::MAIN_WINDOW_LABEL) {
-                if !win.is_visible().unwrap_or(true) {
-                    tracing::warn!(
-                        "Main window still hidden after {}s timeout, showing as fallback",
-                        TIMEOUT_SECS
-                    );
-                    let _ = win.show();
-                    let _ = win.set_focus();
-                    #[cfg(target_os = "macos")]
-                    crate::utils::dock::macos::show_dock_icon();
-                }
+            if let Some(win) = inner.get_webview_window(crate::consts::MAIN_WINDOW_LABEL)
+                && !win.is_visible().unwrap_or(true)
+            {
+                tracing::warn!(
+                    "Main window still hidden after {}s timeout, showing as fallback",
+                    TIMEOUT_SECS
+                );
+                let _ = win.show();
+                let _ = win.set_focus();
+                #[cfg(target_os = "macos")]
+                crate::utils::dock::macos::show_dock_icon();
             }
         });
     });
@@ -754,6 +755,7 @@ pub fn create_editor_window(
 }
 
 /// Close editor window by window_type and optional uid
+#[allow(dead_code)]
 pub fn close_editor_window(
     app_handle: &AppHandle,
     window_type: &EditorWindowType,
@@ -770,6 +772,7 @@ pub fn close_editor_window(
 }
 
 /// Check if editor window with window_type (and optional uid) is open
+#[allow(dead_code)]
 pub fn is_editor_window_open(
     app_handle: &AppHandle,
     window_type: &EditorWindowType,

--- a/backend/tauri/src/utils/winreg.rs
+++ b/backend/tauri/src/utils/winreg.rs
@@ -51,25 +51,25 @@ pub fn get_current_user_sid() -> Result<String> {
 
     // Try PowerShell method first (more reliable)
     let output = Command::new("powershell")
-        .args(&[
+        .args([
             "-Command",
             "[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value",
         ])
         .creation_flags(0x08000000) // CREATE_NO_WINDOW
         .output();
 
-    if let Ok(output) = output {
-        if output.status.success() {
-            let sid = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !sid.is_empty() {
-                return Ok(sid);
-            }
+    if let Ok(output) = output
+        && output.status.success()
+    {
+        let sid = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !sid.is_empty() {
+            return Ok(sid);
         }
     }
 
     // Fallback to WMIC method
     let output = Command::new("wmic")
-        .args(&[
+        .args([
             "useraccount",
             "where",
             "name='%username%'",
@@ -80,15 +80,15 @@ pub fn get_current_user_sid() -> Result<String> {
         .creation_flags(0x08000000) // CREATE_NO_WINDOW
         .output();
 
-    if let Ok(output) = output {
-        if output.status.success() {
-            let result = String::from_utf8_lossy(&output.stdout);
-            for line in result.lines() {
-                if line.starts_with("SID=") {
-                    let sid = line[4..].trim().to_string();
-                    if !sid.is_empty() {
-                        return Ok(sid);
-                    }
+    if let Ok(output) = output
+        && output.status.success()
+    {
+        let result = String::from_utf8_lossy(&output.stdout);
+        for line in result.lines() {
+            if let Some(stripped) = line.strip_prefix("SID=") {
+                let sid = stripped.trim().to_string();
+                if !sid.is_empty() {
+                    return Ok(sid);
                 }
             }
         }

--- a/backend/tauri/src/window.rs
+++ b/backend/tauri/src/window.rs
@@ -30,6 +30,7 @@ static OPEN_WINDOWS_COUNTER: AtomicU16 = AtomicU16::new(0);
 static WINDOW_MANAGER: OnceLock<Mutex<WindowManager>> = OnceLock::new();
 /// Window configuration options
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct WindowConfig {
     /// Whether only one instance of this window type is allowed
     pub singleton: bool,
@@ -104,6 +105,7 @@ impl WindowConfig {
     }
 
     /// Set maximum window size
+    #[allow(dead_code)]
     pub fn max_size(mut self, width: f64, height: f64) -> Self {
         self.max_size = Some((width, height));
         self
@@ -149,6 +151,7 @@ pub struct WindowParamsBuilder {
     params: WindowParams,
 }
 
+#[allow(dead_code)]
 impl WindowParamsBuilder {
     pub fn new() -> Self {
         Self::default()
@@ -259,6 +262,7 @@ impl WindowManager {
     }
 
     /// Check if a specific label exists
+    #[allow(dead_code)]
     pub fn has_instance(&self, label: &str) -> bool {
         self.instances
             .values()
@@ -266,6 +270,7 @@ impl WindowManager {
     }
 
     /// Get the count of instances for a base label
+    #[allow(dead_code)]
     pub fn instance_count(&self, base_label: &str) -> usize {
         self.instances.get(base_label).map(|v| v.len()).unwrap_or(0)
     }
@@ -294,6 +299,7 @@ pub struct WindowMessageEvent {
     pub payload: serde_json::Value,
 }
 
+#[allow(dead_code)]
 impl WindowMessageEvent {
     /// Create a new window message
     pub fn new(
@@ -321,6 +327,7 @@ impl WindowMessageEvent {
 }
 
 /// Send a message to a specific window
+#[allow(dead_code)]
 pub fn send_message_to_window(app_handle: &AppHandle, message: WindowMessageEvent) -> Result<()> {
     // Verify window exists
     let _ = app_handle
@@ -333,6 +340,7 @@ pub fn send_message_to_window(app_handle: &AppHandle, message: WindowMessageEven
 }
 
 /// Send a message to all instances of a window type
+#[allow(dead_code)]
 pub fn broadcast_to_window_type(
     app_handle: &AppHandle,
     base_label: &str,
@@ -358,6 +366,7 @@ pub fn broadcast_to_window_type(
 }
 
 /// Broadcast a message to all open windows
+#[allow(dead_code)]
 pub fn broadcast_to_all_windows(
     app_handle: &AppHandle,
     from: &str,
@@ -394,6 +403,7 @@ impl WindowCreateResult {
 }
 
 /// Trait for window management
+#[allow(dead_code)]
 pub trait AppWindow {
     /// Get window base label (e.g., "main", "editor")
     fn label(&self) -> &str;
@@ -711,12 +721,11 @@ pub trait AppWindow {
 
                 if let Some(window) = app_handle.get_webview_window(&label) {
                     let _ = window.with_webview(|webview| unsafe {
-                        if let Ok(core) = webview.controller().CoreWebView2() {
-                            if let Ok(settings) = core.Settings() {
-                                if let Ok(settings6) = settings.cast::<ICoreWebView2Settings6>() {
-                                    let _ = settings6.SetIsSwipeNavigationEnabled(false);
-                                }
-                            }
+                        if let Ok(core) = webview.controller().CoreWebView2()
+                            && let Ok(settings) = core.Settings()
+                            && let Ok(settings6) = settings.cast::<ICoreWebView2Settings6>()
+                        {
+                            let _ = settings6.SetIsSwipeNavigationEnabled(false);
                         }
                     });
                 }
@@ -820,15 +829,13 @@ pub trait AppWindow {
 
                 // During system shutdown, Windows sends resize events with 0x0 dimensions.
                 // Skip saving in this case to preserve the last valid window state.
-                if size.width == 0 || size.height == 0 {
-                    if !maximized && !fullscreen {
-                        tracing::debug!(
-                            "skipping window state save: invalid size {}x{} in normal state",
-                            size.width,
-                            size.height
-                        );
-                        return Ok(());
-                    }
+                if (size.width == 0 || size.height == 0) && !maximized && !fullscreen {
+                    tracing::debug!(
+                        "skipping window state save: invalid size {}x{} in normal state",
+                        size.width,
+                        size.height
+                    );
+                    return Ok(());
                 }
 
                 let mut state = WindowState {


### PR DESCRIPTION
- Box large error type fields in nyanpasu-core (ManagerInitError, InitAckError, CommitCasMismatch, transaction error tuples) to eliminate 17 result_large_err warnings
- Remove unused feature gates (auto_traits, negative_impls, trait_alias, impl_trait_in_assoc_type) from boa_utils, nyanpasu-egui, tauri
- Apply clippy suggestions: rfind instead of filter().next_back(), sort_by_key with Reverse, if-let instead of is_some()+unwrap(), collapsible_if, manual_strip
- Box large enum variant field in PreparedConfigDomain
- Add #[allow(deprecated)] for intentional migration bridge code
- Add #[allow(dead_code)] for modules and items pending actor migration wiring
- Add #[allow(clippy::too_many_arguments)] for complex orchestration functions
- Run cargo fmt --all