### PR TITLE
fix(fake-core): prevent macOS ConnectionReset in HTTP protocol tests

### DIFF
--- a/backend/fake-core/src/main.rs
+++ b/backend/fake-core/src/main.rs
@@ -29,7 +29,7 @@ use fake_core::{
 use std::{
     env,
     io::{Read, Write},
-    net::{TcpListener, TcpStream},
+    net::{Shutdown, TcpListener, TcpStream},
     process::ExitCode,
     sync::{
         Arc,
@@ -328,6 +328,11 @@ fn handle_http_client(mut stream: TcpStream, status: u16, body: &str) -> std::io
     );
     stream.write_all(response.as_bytes())?;
     stream.flush()?;
+    // Shutdown write half so the client sees a clean FIN (EOF) on its read
+    // side before the socket is dropped.  Without this, macOS may send a
+    // RST when the drop closes the socket, which races with read_to_string
+    // and causes ConnectionReset (error 54).
+    stream.shutdown(Shutdown::Write)?;
     Ok(())
 }
 


### PR DESCRIPTION
Add explicit stream.shutdown(Shutdown::Write) after flushing the HTTP response in handle_http_client. On macOS, dropping the TcpStream without shutting down the write half can cause the kernel to send a RST before the client reads the full response, resulting in ConnectionReset (error 54) in read_to_string.