### PR TITLE
PR-5-pre: switch to the nyanpasu-runtime submodule and add a fail-closed daemon compat gate

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2398,6 +2398,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -2427,6 +2437,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -2463,6 +2486,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.119",
 ]
@@ -3247,6 +3281,28 @@ version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "enumset"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc5801fd11762e24d1e420d01d2ac518f2a2ca4329d4fbb6639f2412b6204e0"
+dependencies = [
+ "enumset_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
+dependencies = [
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4644,7 +4700,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6322,6 +6378,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nyanpasu-core-metadata"
+version = "1.0.0-rc.1"
+dependencies = [
+ "constcat",
+ "enumset",
+ "schemars 1.2.1",
+ "semver 1.0.28",
+ "serde",
+ "specta",
+]
+
+[[package]]
 name = "nyanpasu-egui"
 version = "0.1.0"
 dependencies = [
@@ -6354,14 +6422,15 @@ dependencies = [
 
 [[package]]
 name = "nyanpasu-ipc"
-version = "1.4.5"
-source = "git+https://github.com/libnyanpasu/nyanpasu-service.git?tag=v1.4.5#eb9a3f950e462810eeba2e436aa4ab2fcf315257"
+version = "2.0.0-rc.1"
 dependencies = [
  "anyhow",
  "derive_builder",
  "futures-util",
+ "http",
  "indexmap 2.14.1",
  "interprocess",
+ "nyanpasu-core-metadata",
  "nyanpasu-utils",
  "reqwest 0.13.4",
  "reqwest-websocket",
@@ -6387,7 +6456,6 @@ dependencies = [
 [[package]]
 name = "nyanpasu-utils"
 version = "0.1.0"
-source = "git+https://github.com/libnyanpasu/nyanpasu-utils.git#4110eafacd0d72487b0c83be402bec5c323fbd34"
 dependencies = [
  "camino",
  "constcat",
@@ -8895,7 +8963,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -8922,6 +8990,7 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -8931,6 +9000,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9078,7 +9159,7 @@ checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.21.7",
+ "base64 0.22.1",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
@@ -10631,7 +10712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -319,7 +319,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -330,7 +330,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1384,7 +1384,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2030,7 +2030,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2400,6 +2400,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -2424,6 +2434,19 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
@@ -2442,6 +2465,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.119",
 ]
@@ -2708,7 +2742,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3190,6 +3224,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumset"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc5801fd11762e24d1e420d01d2ac518f2a2ca4329d4fbb6639f2412b6204e0"
+dependencies = [
+ "enumset_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "env_filter"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3279,7 +3335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5769,7 +5825,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6026,7 +6082,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6196,6 +6252,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nyanpasu-core-metadata"
+version = "1.0.0-rc.1"
+dependencies = [
+ "constcat",
+ "enumset",
+ "schemars 1.2.1",
+ "semver 1.0.28",
+ "serde",
+ "specta",
+]
+
+[[package]]
 name = "nyanpasu-egui"
 version = "0.1.0"
 dependencies = [
@@ -6228,14 +6296,15 @@ dependencies = [
 
 [[package]]
 name = "nyanpasu-ipc"
-version = "1.4.5"
-source = "git+https://github.com/libnyanpasu/nyanpasu-service.git?tag=v1.4.5#eb9a3f950e462810eeba2e436aa4ab2fcf315257"
+version = "2.0.0-rc.1"
 dependencies = [
  "anyhow",
  "derive_builder",
  "futures-util",
+ "http",
  "indexmap 2.14.0",
  "interprocess",
+ "nyanpasu-core-metadata",
  "nyanpasu-utils",
  "reqwest 0.13.4",
  "reqwest-websocket",
@@ -6261,7 +6330,6 @@ dependencies = [
 [[package]]
 name = "nyanpasu-utils"
 version = "0.1.0"
-source = "git+https://github.com/libnyanpasu/nyanpasu-utils.git#4110eafacd0d72487b0c83be402bec5c323fbd34"
 dependencies = [
  "camino",
  "constcat",
@@ -6876,7 +6944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7896,7 +7964,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8617,7 +8685,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8676,7 +8744,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8759,7 +8827,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -8786,6 +8854,7 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -8795,6 +8864,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9513,7 +9594,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9526,7 +9607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10497,7 +10578,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11210,7 +11291,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11324,7 +11405,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12279,7 +12360,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13044,7 +13125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,11 +12,13 @@ members = [
   # sidecar/resource (see tauri.conf.json externalBin / resources).
   "fake-core",
 ]
+# `nyanpasu-runtime` is a submodule with its own workspace root. Without this
+# exclude, cargo pulls its member crates into this workspace and their
+# `workspace = true` inheritance resolves against this root, which has no
+# `anyhow` entry — surfacing as `dependency.anyhow was not found`.
+exclude = ["nyanpasu-runtime"]
 
 [patch.crates-io]
-
-[patch."https://github.com/libnyanpasu/nyanpasu-service.git"]
-nyanpasu-utils = { git = "https://github.com/libnyanpasu/nyanpasu-utils.git" }
 
 [workspace.package]
 repository = "https://github.com/keiko233/clash-nyanpasu.git"
@@ -26,20 +28,16 @@ authors = ["zzzgydi", "keiko233"]
 
 [workspace.dependencies]
 # --- nyanpasu ---
-# Deliberately not pinned with `rev`: nyanpasu-ipc depends on nyanpasu-utils via
-# the same git URL on its default branch. A `rev` here would give the two
-# references different source ids, duplicating every crate in the nyanpasu-utils
-# workspace (nyanpasu-utils/dirs-utils/network-utils/os-utils). Cargo.lock pins
-# the exact commit for both.
-nyanpasu-utils = { git = "https://github.com/libnyanpasu/nyanpasu-utils.git", features = [
+# These crates come from the `backend/nyanpasu-runtime` submodule; the gitlink is
+# the pin. `scripts/check.ts` derives the sidecar version from that submodule's
+# `nyanpasu_service/Cargo.toml` and downloads the release tagged with it, so the
+# IPC client and the `nyanpasu-service` binary follow one pin -- but only as far
+# as that crate version has been bumped. A gitlink ahead of the last version bump
+# downloads a daemon older than the protocol these crates speak.
+nyanpasu-utils = { path = "nyanpasu-runtime/crates/nyanpasu-utils", features = [
   "specta",
 ] }
-# TODO: temporarily pinned to the v1.4.5 release tag instead of the default
-# branch, so the IPC client stays on the same released version as the
-# nyanpasu-service sidecar pinned in `scripts/check.ts`. Unlike the `rev` case
-# above this is safe: nyanpasu-service.git is referenced exactly once, and the
-# `[patch]` entry keys on the bare URL. Unpin when both sides move together.
-nyanpasu-ipc = { git = "https://github.com/libnyanpasu/nyanpasu-service.git", tag = "v1.4.5", features = [
+nyanpasu-ipc = { path = "nyanpasu-runtime/nyanpasu_ipc", features = [
   "client",
   "specta",
 ] } # IPC bridge between the UI process and service process

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,11 +12,13 @@ members = [
   # sidecar/resource (see tauri.conf.json externalBin / resources).
   "fake-core",
 ]
+# `nyanpasu-runtime` is a submodule with its own workspace root. Without this
+# exclude, cargo pulls its member crates into this workspace and their
+# `workspace = true` inheritance resolves against this root, which has no
+# `anyhow` entry — surfacing as `dependency.anyhow was not found`.
+exclude = ["nyanpasu-runtime"]
 
 [patch.crates-io]
-
-[patch."https://github.com/libnyanpasu/nyanpasu-service.git"]
-nyanpasu-utils = { git = "https://github.com/libnyanpasu/nyanpasu-utils.git" }
 
 [workspace.package]
 repository = "https://github.com/keiko233/clash-nyanpasu.git"
@@ -26,20 +28,14 @@ authors = ["zzzgydi", "keiko233"]
 
 [workspace.dependencies]
 # --- nyanpasu ---
-# Deliberately not pinned with `rev`: nyanpasu-ipc depends on nyanpasu-utils via
-# the same git URL on its default branch. A `rev` here would give the two
-# references different source ids, duplicating every crate in the nyanpasu-utils
-# workspace (nyanpasu-utils/dirs-utils/network-utils/os-utils). Cargo.lock pins
-# the exact commit for both.
-nyanpasu-utils = { git = "https://github.com/libnyanpasu/nyanpasu-utils.git", features = [
+# Both crates come from the `backend/nyanpasu-runtime` submodule, pinned to the
+# `v2.0.0-rc.1` tag. `scripts/check.ts` reads the sidecar version out of the same
+# submodule, so the IPC client and the `nyanpasu-service` binary always move
+# together.
+nyanpasu-utils = { path = "nyanpasu-runtime/crates/nyanpasu-utils", features = [
   "specta",
 ] }
-# TODO: temporarily pinned to the v1.4.5 release tag instead of the default
-# branch, so the IPC client stays on the same released version as the
-# nyanpasu-service sidecar pinned in `scripts/check.ts`. Unlike the `rev` case
-# above this is safe: nyanpasu-service.git is referenced exactly once, and the
-# `[patch]` entry keys on the bare URL. Unpin when both sides move together.
-nyanpasu-ipc = { git = "https://github.com/libnyanpasu/nyanpasu-service.git", tag = "v1.4.5", features = [
+nyanpasu-ipc = { path = "nyanpasu-runtime/nyanpasu_ipc", features = [
   "client",
   "specta",
 ] } # IPC bridge between the UI process and service process

--- a/backend/tauri/src/core/clash/core.rs
+++ b/backend/tauri/src/core/clash/core.rs
@@ -47,6 +47,20 @@ pub enum RunType {
     Elevated,
 }
 
+impl RunType {
+    /// 纯分类：Service backend 的唯一判据。
+    /// `IpcState::Connected` 只可能由通过 `ServiceCompat` 门禁的 daemon 产生
+    /// （见 `core::service::ipc::target_ipc_state`），因此旧版 daemon 无法到达
+    /// `RunType::Service`，也就无法构造出会发 `/core/*` 的 `Instance::Service`。
+    pub fn classify(enable_service: bool, ipc_state: crate::core::service::ipc::IpcState) -> Self {
+        if enable_service && ipc_state.is_connected() {
+            Self::Service
+        } else {
+            Self::Normal
+        }
+    }
+}
+
 impl Default for RunType {
     fn default() -> Self {
         let enable_service = {
@@ -56,13 +70,13 @@ impl Default for RunType {
                 .as_ref()
                 .unwrap_or(&false)
         };
-        if enable_service && crate::core::service::ipc::get_ipc_state().is_connected() {
+        let run_type = Self::classify(enable_service, crate::core::service::ipc::get_ipc_state());
+        if run_type == Self::Service {
             tracing::info!("run core as service");
-            RunType::Service
         } else {
             tracing::info!("run core as child process");
-            RunType::Normal
         }
+        run_type
     }
 }
 

--- a/backend/tauri/src/core/service/compat.rs
+++ b/backend/tauri/src/core/service/compat.rs
@@ -1,0 +1,179 @@
+//! PR-5-pre: daemon 主版本兼容门。
+//!
+//! v2 的 `StatusResBody` 把所有新增字段都标成了
+//! `#[serde(default, skip_serializing_if = "Option::is_none")]`，所以 v1.4.5 daemon 的
+//! `/status` 负载是 v2 结构的严格子集，**一定**能静默解码成功。因此本门禁必须做
+//! 显式 semver 主版本比较，绝不能依赖解码失败。
+
+use nyanpasu_ipc::types::{ServiceStatus, StatusInfo};
+
+/// PR-5-pre 起，只有主版本等于此值的 daemon 允许承载核心生命周期。
+pub const REQUIRED_SERVICE_MAJOR: u64 = 2;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, specta::Type)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ServiceCompat {
+    /// daemon 未安装 / 未运行 / 未上报 server 信息，没有可判定的版本。
+    Unknown,
+    /// 主版本匹配，允许进入 Service backend。
+    Compatible { server_version: String },
+    /// 主版本不匹配（典型：v1.4.5）。fail-closed。
+    Incompatible {
+        server_version: String,
+        required_major: u64,
+    },
+    /// server 上报的版本不是合法 semver。fail-closed。
+    Unparsable { server_version: String },
+}
+
+impl ServiceCompat {
+    /// 纯函数：无 I/O、无全局状态、无 `Config::*()`。
+    pub fn classify(info: &StatusInfo<'_>) -> Self {
+        if info.status != ServiceStatus::Running {
+            return Self::Unknown;
+        }
+
+        let Some(server) = info.server.as_ref() else {
+            return Self::Unknown;
+        };
+        let server_version = server.version.to_string();
+        let Some(version) = parse_service_version(&server_version) else {
+            return Self::Unparsable { server_version };
+        };
+
+        if version.major != REQUIRED_SERVICE_MAJOR {
+            return Self::Incompatible {
+                server_version,
+                required_major: REQUIRED_SERVICE_MAJOR,
+            };
+        }
+
+        Self::Compatible { server_version }
+    }
+
+    /// 唯一的放行判据。
+    pub fn allows_service_backend(&self) -> bool {
+        matches!(self, Self::Compatible { .. })
+    }
+}
+
+/// 供 `ServiceCompat` 与启动时自动升级检查复用的唯一版本解析入口。
+pub fn parse_service_version(raw: &str) -> Option<semver::Version> {
+    semver::Version::parse(raw).ok()
+}
+
+/// Source: nyanpasu-runtime @ tag v1.4.5 —
+/// `nyanpasu_ipc/src/{types,api}/status.rs`.
+/// 用途：证明 v1 daemon 的 `/status` 会静默解码成 v2 结构，因此兼容门必须做显式
+/// semver 比较。
+#[cfg(test)]
+pub(super) const STATUS_V1_4_5_FIXTURE: &str = include_str!("fixtures/status_v1_4_5.json");
+
+#[cfg(test)]
+pub(super) const STATUS_V2_0_0_RC1_FIXTURE: &str = include_str!("fixtures/status_v2_0_0_rc1.json");
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use nyanpasu_ipc::types::{ServiceStatus, StatusInfo};
+
+    use super::{
+        REQUIRED_SERVICE_MAJOR, STATUS_V1_4_5_FIXTURE, STATUS_V2_0_0_RC1_FIXTURE, ServiceCompat,
+        parse_service_version,
+    };
+
+    fn parse_fixture(fixture: &'static str) -> StatusInfo<'static> {
+        serde_json::from_str(fixture).expect("status fixture must decode")
+    }
+
+    #[test]
+    fn v1_fixture_is_really_v1_shaped() {
+        for key in ["controller", "health", "revision", "detail", "logs"] {
+            assert!(
+                !STATUS_V1_4_5_FIXTURE.contains(&format!("\"{key}\"")),
+                "v1 fixture must not contain v2-only key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn v1_payload_still_decodes_into_v2_struct() {
+        let info = parse_fixture(STATUS_V1_4_5_FIXTURE);
+
+        assert_eq!(
+            info.server.as_ref().map(|server| server.version.as_ref()),
+            Some("1.4.5")
+        );
+    }
+
+    #[test]
+    fn v1_daemon_is_incompatible() {
+        let info = parse_fixture(STATUS_V1_4_5_FIXTURE);
+        let compat = ServiceCompat::classify(&info);
+
+        assert_eq!(
+            compat,
+            ServiceCompat::Incompatible {
+                server_version: "1.4.5".to_owned(),
+                required_major: REQUIRED_SERVICE_MAJOR,
+            }
+        );
+        assert!(!compat.allows_service_backend());
+    }
+
+    #[test]
+    fn v2_daemon_is_compatible() {
+        let info = parse_fixture(STATUS_V2_0_0_RC1_FIXTURE);
+        let compat = ServiceCompat::classify(&info);
+
+        assert_eq!(
+            compat,
+            ServiceCompat::Compatible {
+                server_version: "2.0.0-rc.1".to_owned(),
+            }
+        );
+        assert!(compat.allows_service_backend());
+    }
+
+    #[test]
+    fn unparsable_version_is_fail_closed() {
+        let mut info = parse_fixture(STATUS_V2_0_0_RC1_FIXTURE);
+        info.server
+            .as_mut()
+            .expect("running fixture must include server info")
+            .version = Cow::Borrowed("nightly");
+        let compat = ServiceCompat::classify(&info);
+
+        assert_eq!(
+            compat,
+            ServiceCompat::Unparsable {
+                server_version: "nightly".to_owned(),
+            }
+        );
+        assert!(!compat.allows_service_backend());
+    }
+
+    #[test]
+    fn stopped_or_not_installed_is_unknown() {
+        let mut info = parse_fixture(STATUS_V2_0_0_RC1_FIXTURE);
+
+        info.status = ServiceStatus::Stopped;
+        let stopped = ServiceCompat::classify(&info);
+        assert_eq!(stopped, ServiceCompat::Unknown);
+        assert!(!stopped.allows_service_backend());
+
+        info.status = ServiceStatus::NotInstalled;
+        let not_installed = ServiceCompat::classify(&info);
+        assert_eq!(not_installed, ServiceCompat::Unknown);
+        assert!(!not_installed.allows_service_backend());
+    }
+
+    #[test]
+    fn rc_prerelease_still_outranks_v1() {
+        let rc = parse_service_version("2.0.0-rc.1").expect("rc version must parse");
+        let v1 = parse_service_version("1.4.5").expect("v1 version must parse");
+
+        assert!(rc > v1);
+    }
+}

--- a/backend/tauri/src/core/service/fixtures/status_v1_4_5.json
+++ b/backend/tauri/src/core/service/fixtures/status_v1_4_5.json
@@ -1,0 +1,20 @@
+{
+  "name": "nyanpasu-service",
+  "version": "2.0.0-rc.1",
+  "status": "running",
+  "server": {
+    "version": "1.4.5",
+    "core_infos": {
+      "type": { "clash": "mihomo" },
+      "state": { "Stopped": null },
+      "state_changed_at": 1753900000000,
+      "config_path": null
+    },
+    "runtime_infos": {
+      "service_data_dir": "/nonexistent/service/data",
+      "service_config_dir": "/nonexistent/service/config",
+      "nyanpasu_config_dir": "/nonexistent/nyanpasu/config",
+      "nyanpasu_data_dir": "/nonexistent/nyanpasu/data"
+    }
+  }
+}

--- a/backend/tauri/src/core/service/fixtures/status_v2_0_0_rc1.json
+++ b/backend/tauri/src/core/service/fixtures/status_v2_0_0_rc1.json
@@ -1,0 +1,23 @@
+{
+  "name": "nyanpasu-service",
+  "version": "2.0.0-rc.1",
+  "status": "running",
+  "server": {
+    "version": "2.0.0-rc.1",
+    "core_infos": {
+      "type": { "clash": "mihomo" },
+      "state": { "Stopped": null },
+      "state_changed_at": 1753900000000,
+      "config_path": null
+    },
+    "runtime_infos": {
+      "service_data_dir": "/nonexistent/service/data",
+      "service_config_dir": "/nonexistent/service/config",
+      "nyanpasu_config_dir": "/nonexistent/nyanpasu/config",
+      "nyanpasu_data_dir": "/nonexistent/nyanpasu/data"
+    },
+    "logs": {
+      "service_dir": "/nonexistent/logs"
+    }
+  }
+}

--- a/backend/tauri/src/core/service/ipc.rs
+++ b/backend/tauri/src/core/service/ipc.rs
@@ -2,12 +2,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use atomic_enum::atomic_enum;
 
-use nyanpasu_ipc::types::ServiceStatus;
+use nyanpasu_ipc::types::{ServiceStatus, StatusInfo};
 use nyanpasu_utils::runtime::block_on;
 use serde::Serialize;
 use tracing::instrument;
 
 use crate::log_err;
+
+use super::compat::ServiceCompat;
 
 #[derive(PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -37,8 +39,11 @@ pub(super) fn set_ipc_state(state: IpcState) {
 }
 
 fn dispatch_disconnected() {
+    // Strong CAS on purpose: a spurious `compare_exchange_weak` failure here
+    // would leave a stale `Connected` past the accepted poll window and weaken
+    // the fail-closed compat gate riding on this transition.
     if IPC_STATE
-        .compare_exchange_weak(
+        .compare_exchange(
             IpcState::Connected,
             IpcState::Disconnected,
             Ordering::SeqCst,
@@ -52,7 +57,7 @@ fn dispatch_disconnected() {
 
 fn dispatch_connected() {
     if IPC_STATE
-        .compare_exchange_weak(
+        .compare_exchange(
             IpcState::Disconnected,
             IpcState::Connected,
             Ordering::SeqCst,
@@ -97,33 +102,201 @@ pub(super) fn spawn_health_check() {
     std::thread::spawn(|| {
         HEALTH_CHECK_RUNNING.store(true, Ordering::Release);
         block_on(async {
+            // Latched in the poll loop rather than in a static: entering the
+            // incompatible state is worth one line, staying in it is not, and
+            // the loop is the only thing that lives as long as the state does.
+            let mut warned_incompatible = false;
             loop {
                 if KILL_FLAG.load(Ordering::Acquire) {
                     set_ipc_state(IpcState::Disconnected);
                     HEALTH_CHECK_RUNNING.store(false, Ordering::Release);
                     break;
                 }
-                health_check().await;
+                warned_incompatible = health_check(warned_incompatible).await;
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
             }
         })
     });
 }
 
+/// What level (if any) `health_check` should log the "daemon incompatible"
+/// message at this poll.
+#[derive(Debug, PartialEq, Eq)]
+enum WarnLevel {
+    Warn,
+    Debug,
+    Silent,
+}
+
+/// Pure decision behind the warning latch: given the latch carried from the
+/// previous poll and whether this poll found the daemon incompatible-but-
+/// running, decide the log level for this poll and the latch to carry into
+/// the next one. A probe that can't reach the daemon at all is fed `false`
+/// here, the same as a compatible daemon would be: it stays silent and clears
+/// the latch, so a later recurrence of the incompatible state warns again.
+fn next_incompatible_warning_state(
+    warned: bool,
+    incompatible_but_running: bool,
+) -> (WarnLevel, bool) {
+    match (incompatible_but_running, warned) {
+        (true, false) => (WarnLevel::Warn, true),
+        (true, true) => (WarnLevel::Debug, true),
+        (false, _) => (WarnLevel::Silent, false),
+    }
+}
+
+/// `warned` says whether the previous poll already reported an incompatible
+/// daemon; the return value carries that forward. Without it a permanently
+/// incompatible daemon warns once per 5s poll for as long as the app runs,
+/// which buries every other warning in the log.
 #[instrument]
-async fn health_check() {
+async fn health_check(warned: bool) -> bool {
     match super::control::status().await {
-        Ok(info) => match info.status {
-            ServiceStatus::Running => {
-                dispatch_connected();
+        Ok(info) => {
+            let (state, compat) = target_ipc_state(&info);
+            let incompatible_but_running =
+                info.status == ServiceStatus::Running && !compat.allows_service_backend();
+            let (level, next_warned) =
+                next_incompatible_warning_state(warned, incompatible_but_running);
+            match level {
+                WarnLevel::Warn => tracing::warn!(
+                    ?compat,
+                    "service daemon is incompatible; core will continue running on Local backend"
+                ),
+                WarnLevel::Debug => tracing::debug!(
+                    ?compat,
+                    "service daemon is incompatible; core will continue running on Local backend"
+                ),
+                WarnLevel::Silent => {}
             }
-            ServiceStatus::Stopped | ServiceStatus::NotInstalled => {
-                dispatch_disconnected();
+            match state {
+                IpcState::Connected => dispatch_connected(),
+                IpcState::Disconnected => dispatch_disconnected(),
             }
-        },
+            next_warned
+        }
         Err(e) => {
             tracing::error!("IPC health check failed: {}", e);
             dispatch_disconnected();
+            // The daemon stopped answering, so route it through the same
+            // decision as a compatible probe: the latch clears, and a
+            // recurring incompatible reading warns again.
+            let (_, next_warned) = next_incompatible_warning_state(warned, false);
+            next_warned
         }
+    }
+}
+
+// TODO(actor-migration): compat gate lives on the legacy IpcState seam.
+// Reason: CoreActor / CoreBackend do not exist until PR-5a.
+// Remove when: PR-5c moves run-mode selection onto CoreClient::set_mode.
+/// 纯函数：把一次 status 查询结果映射为目标 IpcState。
+/// fail-closed —— 只有 daemon 在跑**且**通过兼容门禁才允许 Connected。
+pub(super) fn target_ipc_state(info: &StatusInfo<'_>) -> (IpcState, ServiceCompat) {
+    let compat = ServiceCompat::classify(info);
+    let state = match info.status {
+        ServiceStatus::Running if compat.allows_service_backend() => IpcState::Connected,
+        _ => IpcState::Disconnected,
+    };
+    (state, compat)
+}
+
+#[cfg(test)]
+mod tests {
+    use nyanpasu_ipc::types::StatusInfo;
+
+    use crate::core::{
+        RunType,
+        service::compat::{
+            REQUIRED_SERVICE_MAJOR, STATUS_V1_4_5_FIXTURE, STATUS_V2_0_0_RC1_FIXTURE, ServiceCompat,
+        },
+    };
+
+    use super::{IpcState, WarnLevel, next_incompatible_warning_state, target_ipc_state};
+
+    fn parse_fixture(fixture: &'static str) -> StatusInfo<'static> {
+        serde_json::from_str(fixture).expect("status fixture must decode")
+    }
+
+    #[test]
+    fn v1_daemon_never_reaches_service_backend() {
+        let info = parse_fixture(STATUS_V1_4_5_FIXTURE);
+        let (state, compat) = target_ipc_state(&info);
+
+        assert!(state == IpcState::Disconnected);
+        assert_eq!(
+            compat,
+            ServiceCompat::Incompatible {
+                server_version: "1.4.5".to_owned(),
+                required_major: REQUIRED_SERVICE_MAJOR,
+            }
+        );
+        assert_eq!(RunType::classify(true, state), RunType::Normal);
+    }
+
+    #[test]
+    fn v2_daemon_reaches_service_backend() {
+        let info = parse_fixture(STATUS_V2_0_0_RC1_FIXTURE);
+        let (state, compat) = target_ipc_state(&info);
+
+        assert!(state == IpcState::Connected);
+        assert_eq!(
+            compat,
+            ServiceCompat::Compatible {
+                server_version: "2.0.0-rc.1".to_owned(),
+            }
+        );
+        assert_eq!(RunType::classify(true, state), RunType::Service);
+    }
+
+    #[test]
+    fn entering_incompatible_state_warns_once() {
+        let (level, warned) = next_incompatible_warning_state(false, true);
+
+        assert_eq!(level, WarnLevel::Warn);
+        assert!(warned);
+    }
+
+    #[test]
+    fn staying_incompatible_only_debug_logs() {
+        let (level, warned) = next_incompatible_warning_state(true, true);
+
+        assert_eq!(level, WarnLevel::Debug);
+        assert!(warned);
+    }
+
+    #[test]
+    fn leaving_incompatible_state_clears_latch() {
+        let (level, warned) = next_incompatible_warning_state(true, false);
+
+        assert_eq!(level, WarnLevel::Silent);
+        assert!(!warned);
+    }
+
+    #[test]
+    fn unreachable_probe_clears_latch_so_recurrence_warns_again() {
+        // health_check's Err arm feeds `false` regardless of the prior
+        // latch, mirroring an unreachable daemon.
+        let (level, warned) = next_incompatible_warning_state(true, false);
+        assert_eq!(level, WarnLevel::Silent);
+        assert!(!warned);
+
+        // The next poll finding the daemon incompatible again must warn,
+        // not debug-log, because the latch was cleared above.
+        let (level, warned) = next_incompatible_warning_state(warned, true);
+        assert_eq!(level, WarnLevel::Warn);
+        assert!(warned);
+    }
+
+    #[test]
+    fn compatible_daemon_never_warns() {
+        assert_eq!(
+            next_incompatible_warning_state(false, false),
+            (WarnLevel::Silent, false)
+        );
+        assert_eq!(
+            next_incompatible_warning_state(true, false),
+            (WarnLevel::Silent, false)
+        );
     }
 }

--- a/backend/tauri/src/core/service/ipc.rs
+++ b/backend/tauri/src/core/service/ipc.rs
@@ -2,12 +2,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use atomic_enum::atomic_enum;
 
-use nyanpasu_ipc::types::ServiceStatus;
+use nyanpasu_ipc::types::{ServiceStatus, StatusInfo};
 use nyanpasu_utils::runtime::block_on;
 use serde::Serialize;
 use tracing::instrument;
 
 use crate::log_err;
+
+use super::compat::ServiceCompat;
 
 #[derive(PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -37,8 +39,11 @@ pub(super) fn set_ipc_state(state: IpcState) {
 }
 
 fn dispatch_disconnected() {
+    // Strong CAS on purpose: a spurious `compare_exchange_weak` failure here
+    // would leave a stale `Connected` past the accepted poll window and weaken
+    // the fail-closed compat gate riding on this transition.
     if IPC_STATE
-        .compare_exchange_weak(
+        .compare_exchange(
             IpcState::Connected,
             IpcState::Disconnected,
             Ordering::SeqCst,
@@ -52,7 +57,7 @@ fn dispatch_disconnected() {
 
 fn dispatch_connected() {
     if IPC_STATE
-        .compare_exchange_weak(
+        .compare_exchange(
             IpcState::Disconnected,
             IpcState::Connected,
             Ordering::SeqCst,
@@ -113,17 +118,85 @@ pub(super) fn spawn_health_check() {
 #[instrument]
 async fn health_check() {
     match super::control::status().await {
-        Ok(info) => match info.status {
-            ServiceStatus::Running => {
-                dispatch_connected();
+        Ok(info) => {
+            let (state, compat) = target_ipc_state(&info);
+            if info.status == ServiceStatus::Running && !compat.allows_service_backend() {
+                tracing::warn!(
+                    ?compat,
+                    "service daemon is incompatible; core will continue running on Local backend"
+                );
             }
-            ServiceStatus::Stopped | ServiceStatus::NotInstalled => {
-                dispatch_disconnected();
+            match state {
+                IpcState::Connected => dispatch_connected(),
+                IpcState::Disconnected => dispatch_disconnected(),
             }
-        },
+        }
         Err(e) => {
             tracing::error!("IPC health check failed: {}", e);
             dispatch_disconnected();
         }
+    }
+}
+
+// TODO(actor-migration): compat gate lives on the legacy IpcState seam.
+// Reason: CoreActor / CoreBackend do not exist until PR-5a.
+// Remove when: PR-5c moves run-mode selection onto CoreClient::set_mode.
+/// 纯函数：把一次 status 查询结果映射为目标 IpcState。
+/// fail-closed —— 只有 daemon 在跑**且**通过兼容门禁才允许 Connected。
+pub(super) fn target_ipc_state(info: &StatusInfo<'_>) -> (IpcState, ServiceCompat) {
+    let compat = ServiceCompat::classify(info);
+    let state = match info.status {
+        ServiceStatus::Running if compat.allows_service_backend() => IpcState::Connected,
+        _ => IpcState::Disconnected,
+    };
+    (state, compat)
+}
+
+#[cfg(test)]
+mod tests {
+    use nyanpasu_ipc::types::StatusInfo;
+
+    use crate::core::{
+        RunType,
+        service::compat::{
+            REQUIRED_SERVICE_MAJOR, STATUS_V1_4_5_FIXTURE, STATUS_V2_0_0_RC1_FIXTURE, ServiceCompat,
+        },
+    };
+
+    use super::{IpcState, target_ipc_state};
+
+    fn parse_fixture(fixture: &'static str) -> StatusInfo<'static> {
+        serde_json::from_str(fixture).expect("status fixture must decode")
+    }
+
+    #[test]
+    fn v1_daemon_never_reaches_service_backend() {
+        let info = parse_fixture(STATUS_V1_4_5_FIXTURE);
+        let (state, compat) = target_ipc_state(&info);
+
+        assert!(state == IpcState::Disconnected);
+        assert_eq!(
+            compat,
+            ServiceCompat::Incompatible {
+                server_version: "1.4.5".to_owned(),
+                required_major: REQUIRED_SERVICE_MAJOR,
+            }
+        );
+        assert_eq!(RunType::classify(true, state), RunType::Normal);
+    }
+
+    #[test]
+    fn v2_daemon_reaches_service_backend() {
+        let info = parse_fixture(STATUS_V2_0_0_RC1_FIXTURE);
+        let (state, compat) = target_ipc_state(&info);
+
+        assert!(state == IpcState::Connected);
+        assert_eq!(
+            compat,
+            ServiceCompat::Compatible {
+                server_version: "2.0.0-rc.1".to_owned(),
+            }
+        );
+        assert_eq!(RunType::classify(true, state), RunType::Service);
     }
 }

--- a/backend/tauri/src/core/service/mod.rs
+++ b/backend/tauri/src/core/service/mod.rs
@@ -5,6 +5,7 @@ use once_cell::sync::Lazy;
 
 use crate::{config::Config, utils::dirs::app_install_dir};
 
+pub mod compat;
 pub mod control;
 pub mod ipc;
 

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -906,11 +906,30 @@ pub mod service {
     use super::Result;
     use crate::core::service;
 
+    /// `StatusInfo` 的 additive 镜像：字段逐一复制（specta 不支持 `serde(flatten)`，
+    /// 见本文件 `GetSysProxyResponse` 的同款处理），追加 `compat`。
+    /// wire 是原结构的严格超集，前端既有消费点不受影响。
+    #[derive(serde::Serialize, specta::Type)]
+    pub struct ServiceStatusInfo<'a> {
+        pub name: std::borrow::Cow<'a, str>,
+        pub version: std::borrow::Cow<'a, str>,
+        pub status: nyanpasu_ipc::types::ServiceStatus,
+        pub server: Option<nyanpasu_ipc::api::status::StatusResBody<'a>>,
+        pub compat: crate::core::service::compat::ServiceCompat,
+    }
+
     #[tauri::command]
     #[specta::specta]
-    pub async fn status_service<'a>() -> Result<nyanpasu_ipc::types::StatusInfo<'a>> {
-        let res = (service::control::status().await)?;
-        Ok(res)
+    pub async fn status_service<'a>() -> Result<ServiceStatusInfo<'a>> {
+        let info = (service::control::status().await)?;
+        let compat = crate::core::service::compat::ServiceCompat::classify(&info);
+        Ok(ServiceStatusInfo {
+            name: info.name,
+            version: info.version,
+            status: info.status,
+            server: info.server,
+            compat,
+        })
     }
 
     #[tauri::command]

--- a/backend/tauri/src/utils/init/mod.rs
+++ b/backend/tauri/src/utils/init/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::*,
+    core::service::compat,
     utils::{dirs, help},
 };
 use anyhow::{Context, Result, anyhow};
@@ -245,9 +246,12 @@ pub fn init_service() -> Result<()> {
                     tracing::info!(
                         "service mode is enabled and service is running, do a update check"
                     );
-                    if let Some(info) = status.server {
-                        let server_ver = semver::Version::parse(info.version.as_ref()).unwrap();
-                        let app_ver = semver::Version::parse(status.version.as_ref()).unwrap();
+                    if let Some(info) = status.server
+                        && let (Some(server_ver), Some(app_ver)) = (
+                            compat::parse_service_version(info.version.as_ref()),
+                            compat::parse_service_version(status.version.as_ref()),
+                        )
+                    {
                         if app_ver > server_ver {
                             tracing::info!(
                                 "client service ver is newer than exist one, do service update"
@@ -256,6 +260,10 @@ pub fn init_service() -> Result<()> {
                                 log::error!(target: "app", "failed to update service: {e:?}");
                             }
                         }
+                    } else {
+                        tracing::warn!(
+                            "service version not comparable; skipping the auto-update check"
+                        );
                     }
                 }
                 Err(e) => {

--- a/docs/design/actor-migration-roadmap.md
+++ b/docs/design/actor-migration-roadmap.md
@@ -1,8 +1,8 @@
 # Clash Nyanpasu Actor 迁移路线图 v3（稳定化优先）
 
 **日期：** 2026-07-13
-**状态修订：** 2026-07-18
-**状态：** Implementing（**PR-4S / S10 稳定化 COMPLETE**；S01～S10 已完成；手工 smoke `E-01`…`E-11` **PASS**——maintainer attestation 2026-07-18，权威 `smoke-evidence.md`，raw per-field artifacts 未保留；target-tip multi-OS CI PASS @ `10c837cd…` run 29635372676 / Q-09…Q-11；cleanup-tip multi-OS CI PASS @ `8909566c…` run 29638274786 / Q-18…Q-20；review thread-gate 已满足；**PR-5a UNLOCKED**。R-01…R-18 与 PR-5/6/7 仍未完成；**不得**宣告整条 actor migration 完成）
+**状态修订：** 2026-08-02（§6 按**简化设计**整体重写：R0 → PR-5-pre → 5a → 5b → 5c；取代原 engine-first 表述；权威 spec `docs/superpowers/specs/2026-08-01-pr5-core-actor/`）
+**状态：** Implementing（**PR-4S / S10 稳定化 COMPLETE**；S01～S10 已完成；手工 smoke `E-01`…`E-11` **PASS**——maintainer attestation 2026-07-18，权威 `smoke-evidence.md`，raw per-field artifacts 未保留；target-tip multi-OS CI PASS @ `10c837cd…` run 29635372676 / Q-09…Q-11；cleanup-tip multi-OS CI PASS @ `8909566c…` run 29638274786 / Q-18…Q-20；review thread-gate 已满足；**PR-5a UNLOCKED**；**PR-5 简化设计与任务卡就绪（2026-08-01 定稿，2026-08-02 §6 对齐重写；未实施）**。R-01…R-18 与 PR-5/6/7 仍未完成；**不得**宣告整条 actor migration 完成）
 
 **范围基线：** `main @ 9886aacc750b691d6abc893808ddaaf9dfb6a538`（`fix(proxy): resolve provider-owned proxies (#4954)`；已包含 PR-4 `#4932`；S01 `daf872d9`；S02 `807f1733`；S03 工作区已验证；S04 工作区已验证：`CoreLifecycleLease` / 统一 lifecycle mutex / change_core lease span / updater stop-swap-restart；S05 Applied-based patch compensation 工作区已验证；S06 prepared mirrors / three-domain saga 工作区已验证；S07 profile materialization transactions / durable `Profiles.revision` / import fetch-before-commit / startup+periodic reconcile 工作区已验证；S08 `MutationOutcome` wire / Specta / frontend / import 终态协议 工作区已验证；S09 instance-owned `RebuildCoordinator` + test-only `fake-core` process matrix 工作区已验证）
 **取代：** `actor-migration-roadmap.md` v2  
@@ -21,7 +21,9 @@ PR-1～PR-4 已合并
         ↓
 PR-4S 稳定化门（必须完成）
         ↓
-PR-5 CoreActor 三段式迁移
+R0 runtime 协议收敛（上游 submodule，可与下一步并行）
+        ↓
+PR-5 CoreActor 四段式迁移（5-pre → 5a → 5b → 5c）
         ↓
 PR-6 外围 actor / effect adapter
         ↓
@@ -124,7 +126,7 @@ unchecked candidate 必须位于应用私有 candidate 目录，使用不可预�
 | PR-3 profiles 域切换         |       ✅ | ⚠️ 条件通过 | S07 已补齐 profile 文件/状态事务 + import fetch-before-commit；S08 已将 crate-internal degradation 与 post-commit rebuild 合并为公共 `MutationOutcome`；已发生回归的 contract tests 继续固化                                                                                                                                                                                                                                                                                                                          |
 | PR-4 runtime 派生化          |       ✅ | ⚠️ 条件闭环 | S03/S04 已补齐 promoted/applied + 统一 lifecycle lease；S05 已补齐 D6 Applied compensation；S09 已去全局化 dispatcher 并补齐 process-level fake-core matrix；S10 smoke + tip/cleanup CI 已 PASS；PR-5/6 residual globals 仍待后续阶段                                                                                                                                                                                                                                                                                 |
 | **PR-4S 稳定化门**           |       ✅ |     ✅ 完成 | S01～S10 已完成。手工 smoke `E-01`…`E-11` **PASS**（maintainer attestation 2026-07-18；权威 `docs/superpowers/specs/2026-07-13-pr4s-actor-migration-stabilization/smoke-evidence.md`；raw per-field artifacts 未保留）；tip multi-OS CI PASS @ `10c837cd…` run 29635372676（Q-09…Q-11）；cleanup-tip multi-OS CI PASS @ `8909566c0bb759f562d420af4b9672469920fc21` run 29638274786（Q-18…Q-20）；review thread-gate 已满足；`REGEN_BRIDGE`/OnceCell first-install-wins 已删除。**PR-5a UNLOCKED**。R-01…R-18 未清零。 |
-| PR-5 CoreActor               |   未开始 |           — | **已解锁** — 可按 §6 三段式启动；稳定化门已关闭                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| PR-5 CoreActor               |   未开始 |           — | **已解锁**；**简化设计**/任务卡就绪（2026-08-01 定稿，2026-08-02 §6 对齐）；阶段序 R0 → PR-5-pre → 5a → 5b → 5c；权威 spec `docs/superpowers/specs/2026-08-01-pr5-core-actor/`                                                                                                                                                                                                                                                                                                                                        |
 | PR-6 外围 actors/effects     |   未开始 |           — | 必须在 PR-5 生命周期稳定后实施                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | PR-7 清算                    |   未开始 |           — | 只允许删除，不再承载行为迁移                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 
@@ -164,9 +166,12 @@ flowchart LR
   P3["PR-3 profiles/runtime pipeline ✅"] --> S
   P4["PR-4 runtime derivation ✅"] --> S
 
-  S["PR-4S 稳定化门 ✅\nTask R4S COMPLETE"] --> P5A["PR-5a CoreActor\n生命周期所有权\nUNLOCKED"]
-  P5A --> P5B["PR-5b Runtime lifecycle\nChangeCore / Applied revision"]
-  P5B --> P5C["PR-5c Ports + service mode\nLogSink / Core global 清零"]
+  S["PR-4S 稳定化门 ✅\nTask R4S COMPLETE"] --> R0["R0 runtime 协议收敛\nCoreErrorKind\n(上游 submodule PR)"]
+  S --> P5P["PR-5-pre 依赖与兼容门\nruntime v2 path deps\n+ ServiceCompat fail-closed"]
+  R0 --> P5A
+  P5P --> P5A["PR-5a 最小 CoreActor\nOperationId + CoreBackend enum"]
+  P5A --> P5B["PR-5b 单一 runtime apply 管线\nPromoted/Applied 入 actor"]
+  P5B --> P5C["PR-5c 状态/日志/运行模式\nresidual 清理"]
 
   P5C --> P6A["PR-6a SystemProxyActor"]
   P5C --> P6B["PR-6b HotkeyActor"]
@@ -186,7 +191,8 @@ flowchart LR
 ### 并行性
 
 - PR-4S 是单一原子稳定化门，内部允许按 commit lane 并行开发，但只允许一个 PR 整体合并。
-- PR-5a/5b/5c 严格串行。
+- R0 是 `nyanpasu-runtime` **上游 submodule** 的独立 PR，可与 PR-5-pre 并行开发，二者互不阻塞；但 PR-5a 消费 typed `CoreErrorKind` 之前，R0 必须先合并并 bump submodule。R0 在用户授权 push 之前只做 submodule 内本地提交。
+- PR-5-pre/5a/5b/5c 严格串行，各自独立 PR，每个合并后 `main` 保持 shippable。
 - PR-6a～6d 可在 PR-5c 后并行；PR-6e 可在 PR-4S 后预先开发，但最终接线不得早于 PR-5c。
 - PR-7 只能做删除、调用点切换收尾和 denylist，不再引入新行为模型。
 
@@ -240,43 +246,103 @@ flowchart LR
 
 ---
 
-## 6. PR-5 — Core 生命周期迁移（三段式）
+## 6. PR-5 — Core 生命周期迁移（简化设计；R0 + 四段式；2026-08-02 重写）
 
-### 6.1 PR-5a — CoreActor 生命周期所有权
+> **修订说明（2026-08-02）**：本节此前为 "engine-first 四段式"，描述 `CoreEngine` trait / `LocalCoreEngine` / `ServiceCoreEngine`、actor 层延迟 `Recover` 二次恢复、`ChangeCoreReport` 专用 wire，以及 A1–A8 / B1–B5 / C1–C6 编号。该设计已被**简化设计**取代，本节按新 spec 整体重写。
+> 简化依据：`backend/nyanpasu-runtime` submodule（tag `v2.0.0-rc.1`）里的 `nyanpasu-core-manager` / `nyanpasu-service` 已经具备 manager、状态机、有界恢复、配置应用分类与回滚能力。PR-5 因此只新增**一层应用事务协调**，不在 `clash-nyanpasu` 里重做一遍。
+> **语义权威**：`docs/superpowers/specs/2026-08-01-pr5-core-actor/design.md`（设计正文）与同目录 `task.md`（任务清单：R0 / P1–P2 / A1–A3 / B1–B4 / C1–C4）。
+> **release-gate**：dev 渠道接受 rc.1；**stable 渠道发布前 submodule 须 bump 到上游正式 v2.0.0**。
 
-**范围：**
+### 6.总览 — 核心收敛
 
-- `CoreActor` 独占 `Instance::{Child,Service}`、状态、重启退避和生命周期串行；
-- typed `CoreClient` 暴露 `status/start/stop/restart/recover`；
-- `restart_sidecar`、startup 和 health recovery 全部走 facade/client；
-- 禁止 actor 外直接持有 child/process state；
-- `Recover` 使用 actor 内 delayed self-message，不使用裸线程递归。
+PR-5 **只**新增三样东西：
 
-**退出：** 除 legacy adapter 内部外无 `CoreManager::run_core()` 直接调用。
+1. `CoreActor` —— GUI 进程内的核心所有权、运行后端选择、Promoted / Applied 状态、跨步骤事务排他；
+2. 取消安全的 `OperationId` / `CoreOperationGuard` —— 替代 `rebuild_gate`、`clash_patch_gate` 和 legacy lifecycle mutex；
+3. 封闭 `CoreBackend` enum —— `{ Local, Service, #[cfg(test)] Test }`。
 
-### 6.2 PR-5b — Runtime lifecycle 与换核事务
+**明确不新增**：`CoreEngine` trait / `CoreEngineFactory`、`EngineStatus` / `EngineRevision` / `ApplyReport` / `EngineError` 等类型镜像、actor 层第二层自动恢复、actor 持有的 clash-api client、`ChangeCoreReport` 专用 wire。
 
-**范围：**
+### 6.R0 — `nyanpasu-runtime` 协议收敛（上游 submodule PR）
 
-- CoreActor 消费 `RuntimeRevision`；
-- `CheckConfig/ApplyConfig/RestartWith/ChangeCore` 进入同一 mailbox；
-- 成功 apply/start 后发布 Applied revision；
-- `ChangeCoreOutcome` 结构化表达新核错误、rollback 状态和最终运行状态；
-- API-first patch 由 CoreActor 串行，并以 Applied snapshot 补偿；
-- runtime health 事件经 `UiEventSink` 发布。
-
-**退出：** desired/promoted/applied 不再依赖 legacy CoreManager 推断。
-
-### 6.3 PR-5c — 端口、service mode 与日志
+**性质：** 这是 `backend/nyanpasu-runtime` **上游仓库**的独立 PR，不是 `clash-nyanpasu` 的 PR。实施时只在 submodule 内建本地分支并本地提交；**未经用户显式授权不得 push，也不得在本仓库 bump submodule 指针**。
 
 **范围：**
 
-- restart/change-core 固定时序：`stop → resolve ports → mirror consumers → build/check/promote → start`；
-- fixed port 被旧核占用的场景自动化测试；
-- `RunType` 由 typed Application snapshot 参数化；
-- `LogSink` 注入 CoreActor，`get_clash_logs` 走 CoreClient；
-- service-mode IPC 全部走 facade；
-- 删除 `CoreManager::global()` 和 `Logger::global()` 写端。
+- `nyanpasu-core-metadata` 增加 `CoreErrorKind` enum，serde 字符串保持现有 `error_kind` 值；
+- `nyanpasu-core-manager::Error::kind()` 返回该 enum，durability wrapper 递归返回 source kind；
+- service error envelope 与 IPC client 复用同一 enum，v2 wire golden 不变；
+- 不新建 crate，不引入通用 `CoreEngine` trait。
+
+**退出：** manager / service / client 不再各自维护第二份 error-kind match 或字符串表；v2 wire golden 全绿；submodule bump 后 clash app 可直接消费 typed kind。
+
+**依赖关系：** R0 与 PR-5-pre **可并行**，互不阻塞（PR-5-pre 只做依赖切换与兼容门，不消费 typed kind）。PR-5a 若要消费 typed `CoreErrorKind`，必须先合并 R0 并 bump submodule。
+
+### 6.0 PR-5-pre — 依赖与 daemon 兼容门（不引入 CoreActor）
+
+**实施计划：** `docs/superpowers/plans/2026-08-01-pr5-pre.md`
+
+**范围：**
+
+- workspace 依赖 `nyanpasu-utils` / `nyanpasu-ipc` 由 git 切至 submodule path 依赖；`[workspace] exclude = ["nyanpasu-runtime"]`；删除 `[patch."…nyanpasu-service.git"]` 块并清掉失效注释；更新 Cargo.lock；
+- **只切这两个 crate**。`nyanpasu-core-manager` / `nyanpasu-core-metadata` / `clash-api` 的 workspace 条目**推迟到 PR-5a 的首个真实消费者**——leader 裁定 D1=A（2026-08-02），是对 task.md P1 卡"四个 crate"措辞的**有意偏离**：无人引用的 `[workspace.dependencies]` 条目不进入 Cargo.lock 解析图，属死文本；且 `nyanpasu-core-metadata` 本就随 ipc v2 传递进来；保持依赖/体积增量完全可归因于这一次切换；
+- `StatusInfo` specta 面扩宽 + additive compat 字段的 bindings regen；
+- **`ServiceCompat` 主版本 fail-closed 门禁**：v1.4.5 的 `/status` 是 v2 结构的严格子集、必然静默解码成功，所以门禁必须是**显式 semver 主版本比较**，且必须先于任何 `/core/*` 调用存在；旧 v1 daemon 永不进入 Service backend；
+- **保留启动时自动版本对比 + `update_service()` 语义**（`2.0.0-rc.1 > 1.4.5` 会自动触发升级；兼容门只是用户拒绝或升级失败时的 fail-closed 兜底）；
+- 记录发布二进制体积变化。
+
+**退出：**
+
+- `cargo metadata` exit 0；Cargo.lock 零 `nyanpasu-*` git source、`nyanpasu-utils` 单份；
+- workspace tests 绿；bindings fresh；
+- **architecture ledger gate 绿**——允许且仅允许 `migration_markers` +1（兼容门接在 legacy `IpcState` seam 上的那条 `TODO(actor-migration)` 注释），snapshot 相应重写后 gate 必须 exit 0；其余四项指标不得变动；
+- v1.4.5 fixture 下没有 `/core/*` 请求；
+- 本阶段不引入 CoreActor。
+
+### 6.1 PR-5a — 最小 CoreActor + `OperationId` + backend enum（A1–A3）
+
+**范围：**
+
+- **A1 `CoreBackend`**：封闭 enum `{ Local, Service, #[cfg(test)] Test }`，**不定义 `CoreEngine` trait / factory**。`Local` 直接包装 `nyanpasu_core_manager::CoreManager`，构造 `ManagerOptions` 时**显式写出 `LocalIpcPolicy::Disable`**（上游默认值已是 `Disable`，显式化是为了让安全门在 app 侧可见可审）；`Service` 使用实例化的 `nyanpasu_ipc::client::Client`，禁止 `service_default()`。只实现 check / start / apply / stop / restart / recover 与状态、日志订阅所需方法；Local 的 apply 结果转换为现有 `CoreApplyData`，**不定义 `ApplyReport`**；
+- **A2 取消安全 `OperationId`**：ID 由共享的 `CoreClient` 在发送 `AcquireOperation` **之前**预分配，并先构造 pending `CoreOperationGuard`，消除"actor 已登记 active、调用 future 先被取消"的窗口。actor 维护 active operation + FIFO waiters；`ReleaseOperation` 同时承担"释放 active"与"取消 waiter"；mutation 校验 active `OperationId`，不匹配返回 `StaleOperation`；status / log / lifecycle read 不需要 guard；shutdown 拒绝全部 waiters 后关闭 backend。**不实现 TTL、auto-steal、watchdog、续期或心跳**；
+- **A3 接入现有生命周期 seam**：先让 `CoreClient` / `CoreOperationGuard` 实现既有 `CoreLifecyclePort` / `CoreLifecycleLease` 兼容 seam，使 rebuild / change-core 调用点在 5a 暂不重写；旧 trait 名不得扩散到新代码。setup 注入 `CoreClient`，start / stop / restart / status 改走 actor；
+- **恢复策略**：自动恢复完全由 runtime / daemon 负责（manager 已按 `InstanceOptions` 做有界 Supervisor 重启 + 指数退避）。**actor 不配置第二层 `RecoverPolicy`，不发 delayed `Recover{attempt}`**；它只观察最终状态，在 Supervisor / daemon 最终放弃后发布一次 `core_recovery_exhausted` degradation，并在用户显式重试时调用 `recover` / `restart`。删除 legacy `CoreManager::lifecycle_lock` 与裸线程递归 recover。
+
+**退出：** operation 测试覆盖 FIFO、等待取消、刚获批取消、stale `ReleaseOperation`、wrong-id mutation、shutdown drain；Local / Service 基本生命周期 parity 测试；legacy core 生命周期不再被新调用点使用。
+
+### 6.2 PR-5b — 单一 runtime apply 管线（B1–B4）
+
+**范围：**
+
+- **B1 Promoted / Applied 入 actor**：`CheckAndPromote` 在 `CoreOperationGuard` 下校验 candidate hash、dry-run、原子 promote 并推进 Promoted；`ApplyPromoted` / `StartPromoted` 按 backend outcome 推进 Applied。`CoreClient` 通过 watch snapshot 暴露 lifecycle（读状态不发 mailbox RPC），删除 `NyanpasuClient` 侧独立的 `RuntimeLifecycleStore` 与 `publish_promoted` / `publish_applied` / `restore_promoted`；四条 runtime 读 IPC 继续读 Promoted；
+- **B2 `CoreOperationGuard` 替换 app locks**：所有 rebuild / regenerate / start / change-core 在读取 snapshots **之前**取得 guard，事务结束后释放；删除 `rebuild_gate`；保留 rebuild worker 的 capacity-1 coalesce，构建期间发生的新 commit 触发下一次 rebuild；
+- **B3 删除 API-first patch 与补偿层**：所有运行配置变更统一走 runtime 的 full-config `apply_config`，由 runtime 自行决定 `PATCH /configs` / `PUT /configs` / same-epoch restart / core switch / rollback。`patch_running_config` 改为 typed desired commit + 统一 rebuild/apply；删除 `RunningConfigPatchPort`、`LegacyRunningConfigPatchBridge`、`clash_patch_gate`、`ControllerBinding` 与 actor 内 clash-api client cache、`config_patch_from_mapping`、GUI 侧 patch compensation plan/fence。其余 proxies / connections / ws / tray 等直接 clash-api 消费者留给 PR-6；
+- **B4 简化 ChangeCore**：换核降级为**普通 commit-first mutation**——`ApplicationClient::patch(core = new)` 后复用统一 apply 管线。runtime 若返回 `RolledBack`，则保留 desired 新核与 Promoted 新配置、返回 `CommittedDegraded { phase: CoreRollback }`，**不执行第二套应用层回滚事务**。删除 legacy verge draft/discard、rollback rebuild、product bytes restore、old-core 第二次 restart 与 `ChangeCoreReport` 专用 wire；前端复用通用 `RuntimeApplyReport` / `MutationOutcome` 展示 degraded。
+  > 这**取代**了原 OQ-3 关于 `MutationOutcome<ChangeCoreReport>` 五分支映射的裁定——该裁定已被简化设计取代。
+
+**退出：** `rg 'rebuild_gate|clash_patch_gate|RunningConfigPatchPort|LegacyRunningConfigPatchBridge'` 为 0；apply parity 覆盖 Noop / Patched / Reloaded / Restarted / Switched / RolledBack（Warning 是正交标志，不是 outcome）；change-core rollback 测试断言 desired=new、Promoted=new、Applied=old；两个并发 rebuild 不重叠，后一个在 FIFO 后读取最新 snapshot。
+
+### 6.3 PR-5c — 必要清理，不做指标驱动半迁移（C1–C4）
+
+**范围：**
+
+- **C1 状态与日志**：backend status / events 投影到 actor 的 watch snapshot，status read 不走 mailbox RPC；actor 维护 100 条 `LogFrame` 环形缓冲（直接复用 `nyanpasu-core-metadata::LogFrame`，**不定义 `LogSink` trait**，manager 的 JSONL sink 保持原样），`get_clash_logs` 从 raw 渲染、可 additive 暴露 frames；删除 legacy `Logger` global；
+- **C2 运行模式**：`RunType = { Normal, Service }`（`Elevated` 的 `todo!()` 删除）。app config / service control 完成后**显式**调用 `set_mode` / `reconcile_mode`，该操作照常排队取得 `CoreOperationGuard`；删除 `pending_run_type` 设计、`core/service/ipc.rs` 的 statics 与 5 s 轮询线程。service install / update / uninstall 保持独立的具体 `ServiceController`，**不迁入 CoreActor、不引入完整 `ServiceControlPort`**（除非测试确实需要替换 OS command runner）；**保留启动时自动版本对比 + `update_service()` 语义**；
+- **C3 macOS DNS**：actor 内用小型 `MacosDnsGuard` 与 start / stop 保序，Service backend 走 IPC `set_dns`；**非 macOS 不定义空的 `NetworkDnsPort` 抽象**；
+- **C4 residual 与 smoke**：删除真正已失去调用者的 core / service / logger 文件与 globals；**Updater 不增加 `attach_core_port` 半迁移桥**——完整注入仍由 PR-6d 完成，PR-5 允许保留一个有明确 owner 和 remove condition 的 residual；更新 roadmap / ledger，**不以 `CoreManager::global() == 0` 作为牺牲边界的硬指标**。
+
+**退出：** smoke 1 = Local 模式 patch / restart / core-switch rollback；smoke 2 = Windows v1 daemon 自动升级后进入 v2 Service 模式，拒绝升级时 fail-closed 回 Local；smoke 3 = macOS TUN 开关与 DNS 恢复；fixed-port 占用作为**自动化集成测试**，不要求单独手工 smoke；`test_real_dirs == 0`。
+
+### 6.4 阶段规划必答项（2026-08-02 审查遗留）
+
+以下四项在 2026-08-02 的对抗性审查中被记录，**不阻塞本节定稿**，但对应阶段的实施计划**必须**给出明确答案后才能开工：
+
+| ID    | 必答项                                                                                                                                                                                                                                                       | 责任阶段        |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------- |
+| RQ-01 | 完整的 **post-commit failure matrix**：commit **前**失败一律返回 `Err`；commit **后**失败一律映射为 `MutationOutcome` 的 degraded phase。必须逐项覆盖 operation acquire 超时、build 失败、check 失败、promote 失败、revision 冲突、IPC 连接丢失、apply error | PR-5b 计划      |
+| RQ-02 | **engine revision 的 app 侧处理**：Local 的 `RevisionId` 与 Service 的 `RevisionIdInfo` 如何存储、刷新、重连后对账、冲突如何解；以及 `expected_revision` 的 CAS 语义——`None` 表示无条件应用，**仅允许出现在首次 start**                                      | PR-5a / 5b 计划 |
+| RQ-03 | apply parity 矩阵必须包含 **`Noop`**；`Warning` 视为与 outcome **正交的标志位**，不得当成一个 outcome 分支                                                                                                                                                   | PR-5b 计划      |
+| RQ-04 | `begin_operation` 必须有**调用侧有限超时**；等待中的 waiter 经既有 `ReleaseOperation` drop 路径取消。**不引入 TTL、auto-steal 或 watchdog**                                                                                                                  | PR-5a 计划      |
 
 ---
 
@@ -397,7 +463,7 @@ pub struct Degradation {
 | candidate check 失败                     | product/promoted/applied 均保持旧值                 |
 | product promote 成功、store publish 失败 | 明确权威和 recovery；不得静默                       |
 | apply 失败                               | promoted 新、applied 旧，outcome degraded           |
-| change_core 新核 start 失败              | 生命周期 lease 阻止并发 restart                     |
+| change_core 新核 start 失败              | `CoreOperationGuard` 阻止并发 restart               |
 | rollback rebuild 失败                    | 恢复旧 product + promoted + applied                 |
 | rollback old-core restart 失败           | 最终状态结构化为 stopped/degraded                   |
 | actor mirror prepare 失败                | typed state 不提交                                  |

--- a/docs/superpowers/plans/2026-08-01-pr5-pre.md
+++ b/docs/superpowers/plans/2026-08-01-pr5-pre.md
@@ -1,0 +1,650 @@
+# PR-5-pre 实施计划 — 依赖与 daemon 兼容门
+
+**日期：** 2026-08-01
+**分支：** `refactor/core-manager-actor`
+**权威 spec：** `docs/superpowers/specs/2026-08-01-pr5-core-actor/design.md`（§10 保留的安全门）、同目录 `task.md`（`PR-5-pre` 卡）
+**路线图定位：** `docs/design/actor-migration-roadmap.md` §6.0
+**平台：** Windows 11 / PowerShell（验证命令按 PowerShell 书写）
+
+---
+
+## 0. 本阶段的边界
+
+**做：**
+
+1. `nyanpasu-utils` / `nyanpasu-ipc` 从 git 依赖切到 `backend/nyanpasu-runtime` submodule path 依赖（P1）；
+2. `ServiceCompat` 主版本 fail-closed 门禁：旧 v1 daemon 永不进入 Service backend（P2）。
+
+**不做（越界即返工）：**
+
+- 不新增 `CoreActor`、`CoreClient`、`CoreBackend`、`OperationId`、`CoreOperationGuard`；
+- 不改 `core/clash/core.rs` 的生命周期逻辑（只允许加不改变行为的 doc comment，见 S6）；
+- 不删除 `CoreManager::global()`、`Logger::global()`、`rebuild_gate`、`clash_patch_gate`；
+- 不新增 `nyanpasu-core-manager` / `clash-api` 的 workspace 依赖条目（决策点 D1）；
+- 不改 `scripts/check.ts`（已与 submodule 天然 lockstep，见 §1 事实 F6）；
+- 不动 `[patch.crates-io]`（现为空块，属既有代码）。
+
+---
+
+## 1. 已核验事实（2026-08-01 本次会话逐条复核）
+
+| ID  | 事实                                                                                                                                                                                                                                                                                                                                                                 | 锚点                                                                                                                                                                                       |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| F1  | `backend/Cargo.toml` 现以 git 依赖声明两个 crate：`nyanpasu-utils`（默认分支）、`nyanpasu-ipc`（`tag = "v1.4.5"`），并有一个 `[patch."https://github.com/libnyanpasu/nyanpasu-service.git"]` 块把 `nyanpasu-utils` 重定向到 `nyanpasu-utils.git`                                                                                                                     | `backend/Cargo.toml:16-45`                                                                                                                                                                 |
+| F2  | **成员 manifest 全部走 `.workspace = true`，P1 无需改动任何成员 manifest**：`backend/tauri/Cargo.toml:27,31`、`backend/nyanpasu-core/Cargo.toml:18`、`backend/nyanpasu-config/Cargo.toml:17`、`backend/boa_utils/Cargo.toml:18`                                                                                                                                      | 上述四处                                                                                                                                                                                   |
+| F3  | submodule `backend/nyanpasu-runtime` 钉在 tag `v2.0.0-rc.1`（commit `0d2993ab`）；布局 `crates/{clash-api,nyanpasu-core-manager,nyanpasu-core-metadata,nyanpasu-service-runtime,nyanpasu-utils}` + `nyanpasu_ipc` + `nyanpasu_service`；`crates/nyanpasu-utils` 是**嵌套 submodule**（`3cb3af02`），已 checkout 且源码完整                                           | `git submodule status`、`backend/nyanpasu-runtime/.gitmodules`                                                                                                                             |
+| F4  | crate 版本：`nyanpasu_service` = `2.0.0-rc.1`、`nyanpasu_ipc` = `2.0.0-rc.1`、`nyanpasu-core-manager` / `nyanpasu-core-metadata` / `clash-api` = `1.0.0-rc.1`、`nyanpasu-utils` = `0.1.0`                                                                                                                                                                            | 各 `Cargo.toml:3`                                                                                                                                                                          |
+| F5  | `nyanpasu_ipc/Cargo.toml` 用 `workspace = true` 继承 `anyhow/serde/thiserror/tokio/tracing/tracing-attributes/futures-util/windows`。**这正是 `exclude` 必需的原因**：若被外层 workspace 吸入，这些继承会对着 `backend/Cargo.toml`（无 `anyhow` 条目）解析并报 `dependency.anyhow was not found`                                                                     | `backend/nyanpasu-runtime/nyanpasu_ipc/Cargo.toml:24-49`                                                                                                                                   |
+| F6  | `scripts/check.ts` 从 submodule 的 `nyanpasu_service/Cargo.toml` 读版本，并从 `libnyanpasu/nyanpasu-runtime` 的 `v<version>` release 下载 sidecar → **submodule 钉版与 sidecar 天然 lockstep，本阶段无需改脚本**                                                                                                                                                     | `scripts/check.ts:674-712`                                                                                                                                                                 |
+| F7  | **兼容风险确认**：v2 `StatusResBody` 的新增字段全部是 `#[serde(default, skip_serializing_if = "Option::is_none")]`（`CoreInfos.controller/health/revision/detail`、`StatusResBody.logs`），源码注释明写“a payload carrying none of the fields below is byte-identical to the pre-S7 wire format”。→ **v1.4.5 的 `/status` 必然静默解码成功，绝不能用解码失败当门禁** | `backend/nyanpasu-runtime/nyanpasu_ipc/src/api/status.rs:124-197`                                                                                                                          |
+| F8  | 启动自动升级语义在 `init_service()`：`enable_service` 为真 → 查 `control::status()` → `status.version`（本地 sidecar 版本）与 `status.server.version`（在跑的 daemon 版本）比 semver，`app_ver > server_ver` 则 `update_service()`（UAC 提权）。`2.0.0-rc.1 > 1.4.5` 成立（预发布号只在同一 `major.minor.patch` 内降序），升级会自动触发                             | `backend/tauri/src/utils/init/mod.rs:231-269`                                                                                                                                              |
+| F9  | **两处 `semver::Version::parse(...).unwrap()`**，daemon 若上报非 semver 字符串会 panic                                                                                                                                                                                                                                                                               | `backend/tauri/src/utils/init/mod.rs:249,250`                                                                                                                                              |
+| F10 | **Service backend 的唯一开关是 `IpcState`**：`RunType::default()` = `enable_service && get_ipc_state().is_connected()`；`IpcState` 只由 `health_check()` 里的 `dispatch_connected()` / `dispatch_disconnected()` 翻转                                                                                                                                                | `backend/tauri/src/core/clash/core.rs:50-67`、`backend/tauri/src/core/service/ipc.rs:39-65,113-129`                                                                                        |
+| F11 | 发 `/core/*` 的调用点共 5 处 `Client::service_default()`，**全部在 `Instance::Service` 分支或 `RunType::Service` 匹配臂内**，而 `Instance::Service` 只能由 `RunType::Service` 构造                                                                                                                                                                                   | `core/clash/core.rs:256,285,315,352,689` + `:83-124`                                                                                                                                       |
+| F12 | `status_service` 命令直接返回 `nyanpasu_ipc::types::StatusInfo`；前端只读 `.status` / `.name` / `.server?.version`                                                                                                                                                                                                                                                   | `backend/tauri/src/ipc.rs:909-914`；`frontend/nyanpasu/src/pages/(main)/main/settings/system/_modules/system-service-ctrl.tsx:161,164,248,278,283,287`、`.../system-service-switch.tsx:24` |
+| F13 | **specta 不支持 `serde(flatten)`**（仓内既有结论与既有绕法）                                                                                                                                                                                                                                                                                                         | `backend/tauri/src/ipc.rs:87-99`                                                                                                                                                           |
+| F14 | bindings 由 `#[test] export_typescript_bindings` **就地重生成**（内部还会 `npx prettier --write`）；CI 用 `git diff --exit-code -- frontend/interface/src/ipc/bindings.ts` 卡新鲜度                                                                                                                                                                                  | `backend/tauri/src/specta_export.rs:148-207`；`.github/workflows/ci.yml:306-308`                                                                                                           |
+| F15 | “architecture ledger” = `scripts/architecture-ledger.ts`；`pnpm lint:architecture-ledger`（gate 模式，与 `scripts/architecture-ledger.snapshot.json` 精确比对）、`pnpm architecture-ledger`（report）、`pnpm test:architecture-ledger`（脚本自测）。ledger 已把 `nyanpasu-runtime` 列入跳过目录                                                                      | `package.json`；`scripts/architecture-ledger.ts:27-35`                                                                                                                                     |
+| F16 | CI 的 Rust lint 只有 `pnpm run-p lint:clippy lint:rustfmt`（`lint:clippy` **不带** `-D warnings`）                                                                                                                                                                                                                                                                   | `.github/workflows/ci.yml:107-113`；`package.json`                                                                                                                                         |
+
+### 与 leader 交接事实的**订正**（三条）
+
+> **C1（好消息，降低风险）**：`reqwest 0.13.4` 与 `windows 0.62.2` **早已在基线 lock 里**——v1.4.5 的 `nyanpasu-ipc` 就依赖它们（`backend/Cargo.lock:6229-6249`；`reqwest` 0.12.28 与 0.13.4 双份见 `:8267,8312`）。所以本次切换**不会新增 reqwest / windows 重复树**。真正的新增只有 `nyanpasu-core-metadata` 及其小依赖（`enumset`、`schemars 1`）。→ 体积增量预期是**几十 KB 量级**，不是几 MB。
+
+> **C2（好消息）**：submodule 的嵌套 `nyanpasu-utils`（`3cb3af02`）与当前 Cargo.lock 里 git 默认分支的 `4110eafa`，**中间只差一个 `chore: apply linting fixes with rustfmt` 提交**，`git diff` 仅触及 `src/io/atomic_fs.rs` 与 `src/process/pid_file.rs` 的**格式**（两个 `pub async fn` 签名折行合并），无任何语义/API 变化；且这两个模块 app 侧完全不用（app 只用 `runtime` / `dirs` / `io::read_line` / `os` / `core` / `network::macos`）。→ **`nyanpasu-utils` 的 API 漂移风险为零**。注意它在提交序上是**旧**于 lock 里那个 commit（`3cb3af02` 是 `4110eafa` 的祖先），但因差异纯格式，不构成降级风险。
+
+> **C3（需要设计调整）**：`nyanpasu_ipc::client::Client::service_default()` 在 v2 **仍然存在**（`backend/nyanpasu-runtime/nyanpasu_ipc/src/client/mod.rs:93`）。design §4 的“禁止 `service_default()`”是 **PR-5a** 的约束，不是编译期强制。本阶段**不动**这 5 个调用点。
+
+### `LocalIpcPolicy::Disable` 的落点结论
+
+design §10 列了“`LocalIpcPolicy::Disable` 显式设置”。核查结果：
+
+- `LocalIpcPolicy` 是 `nyanpasu-core-manager` 的 `ManagerOptions` 字段（`backend/nyanpasu-runtime/crates/nyanpasu-core-manager/src/spec.rs:67,85`），**默认值已经是 `Disable`**（`spec.rs:114`，并有 `spec.rs:156` 的单测钉住）；
+- 本阶段**不构造 `CoreManager`**（不引入 `nyanpasu-core-manager` 依赖），因此**没有可以“显式设置”的位置**。
+
+**结论：`LocalIpcPolicy::Disable` 属于 PR-5a（A1 卡 `LocalBackend` 构造 `ManagerOptions` 时显式写出），本计划不实施。** 已在 §7 的 out-of-scope 中登记。
+
+---
+
+## 2. 需 leader 裁定的决策点
+
+> 以下四项已给出**推荐选项**。若 leader 未另行裁定，codex 按推荐项执行。
+>
+> **Leader 裁定（2026-08-02）：D1 = A、D2 = A、D3 = A、D4 = Yes。** 下述各节保留论证原文，执行一律按裁定项。D1 对 task.md P1 卡措辞的有意偏离须写入 PR 描述。
+
+### D1 — `nyanpasu-core-manager` / `nyanpasu-core-metadata` / `clash-api` 是否现在就加 workspace 条目？
+
+task.md P1 卡原文：「utils/ipc/core-manager/core-metadata 使用 submodule path」。
+
+- **选项 A（推荐，最小改动）**：本阶段只加 `nyanpasu-utils` 与 `nyanpasu-ipc` 两条 path 依赖。
+  理由：(1) `[workspace.dependencies]` 里**无人引用的条目不会进入 Cargo.lock 解析图**，纯属死文本，违反 CLAUDE.md §2「不写投机代码」；(2) `nyanpasu-core-metadata` 本来就会随 `nyanpasu-ipc` v2 **传递进 lock**，无需显式条目；(3) `nyanpasu-core-manager` / `clash-api` 的首个真实消费者是 PR-5a 的 `CoreBackend::Local`，在那里加才有 review 上下文；(4) 让本阶段的体积/依赖增量**完全可归因于 ipc v2 这一次切换**，是 P1「记录体积变化」这张卡的前提。
+- **选项 B（字面遵守任务卡）**：四条全加。代价：两条死条目 + 体积归因被污染 + PR-5a review 时无法区分“新引入”与“早已声明”。
+
+**推荐 A**，并在 PR 描述里注明这是对 task.md P1 措辞的一处有意偏离。
+
+### D2 — 发布二进制体积如何记录？
+
+- **选项 A（推荐）**：本地只做**依赖图证据**（秒级）：`cargo tree --duplicates` 前后对比 + `Cargo.lock` 的 `[[package]]` 计数差；**权威体积数字取自 CI**——用 PR 分支首次 build 产物大小对比 main 最近一次同 target 产物。本地零编译成本。
+- **选项 B**：本地 `cargo build --release` 前后各一次。代价极高：release profile 是 `lto = true` + `codegen-units = 1` + `opt-level = "s"`，Windows 上 tauri crate 全量重链约 30–60 min×2，且本地数字与 CI 打包产物不可直接比较（feature/env 不同）。
+- **选项 C**：完全推迟到 CI，不做本地证据。
+
+**推荐 A**。结合 C1，预期结论是“依赖重复度不变，新增 `nyanpasu-core-metadata` + `enumset` + `schemars`，体积增量在噪声量级”。
+
+### D3 — `status_service` 的 compat 信息如何 additive 暴露？
+
+因 F13（specta 不支持 `flatten`）+ F12（前端读 `.status`/`.name`/`.server.version`）：
+
+- **选项 A（推荐）**：新增 app 自有 DTO `ServiceStatusInfo`，**逐字段镜像** `StatusInfo` 的 4 个字段再加 `compat`。wire 是原结构的**严格超集**，三处前端消费点零改动，且只需一次 sidecar 进程调用。代价：4 行字段镜像（仓内已有同款先例 `GetSysProxyResponse`，`ipc.rs:87-99`）。
+- **选项 B**：保留 `status_service` 原样，另加独立命令 `get_service_compat()`。最保守，但每次查询要**多 spawn 一次 `nyanpasu-service.exe status --json` 子进程**。
+- **选项 C**：`#[serde(flatten)]` —— **不可行**，specta 不支持。
+
+**推荐 A**。
+
+### D4 — 是否顺手消除 `init/mod.rs` 的两处 `.unwrap()`（F9）？
+
+- **推荐：是**。理由：P2 卡要求 ServiceCompat 对**不可解析版本 fail-closed**；同一批版本字符串在隔壁还留着 panic 路径，是自相矛盾的。改法是让 `init_service()` 复用 `compat::parse_service_version()`，解析失败则 `tracing::warn!` 并跳过升级（与“daemon 状态查询失败则跳过”的既有语义一致）。**升级触发条件本身一字不改**。
+- 若 leader 认为这超出 §3「外科手术式改动」，则跳过 S8 中的该子步骤，只保留 `compat` 模块的解析函数不被 `init` 复用。
+
+---
+
+## 3. 实施步骤
+
+> 每步给出：编辑内容 → 验证命令 → 通过判据。
+> 全程 **不要** 跑 `cargo clippy -- -D warnings`（仓库本就红）；真实门禁见 S10。
+
+### S1 — `backend/Cargo.toml` 切 path 依赖
+
+**唯一被编辑的文件：`backend/Cargo.toml`**（F2：成员 manifest 全部走 `.workspace = true`，不动）。
+
+**编辑 1／在 `[workspace]` 块内、`members` 之后加 `exclude`：**
+
+```toml
+[workspace]
+resolver = "2"
+members = [
+  # ...（保持原样）
+]
+# `nyanpasu-runtime` is a submodule with its own workspace root. Without this
+# exclude, cargo pulls its member crates into this workspace and their
+# `workspace = true` inheritance resolves against this root, which has no
+# `anyhow` entry — surfacing as `dependency.anyhow was not found`.
+exclude = ["nyanpasu-runtime"]
+```
+
+**编辑 2／整块删除 git patch：**
+
+```toml
+# 删除这三行（含标题行与空行处理）：
+[patch."https://github.com/libnyanpasu/nyanpasu-service.git"]
+nyanpasu-utils = { git = "https://github.com/libnyanpasu/nyanpasu-utils.git" }
+```
+
+`[patch.crates-io]` 空块**保留**（既有代码，非本次范围）。
+
+**编辑 3／`[workspace.dependencies]` 的 `# --- nyanpasu ---` 段整体替换。**
+把现有 `backend/Cargo.toml:28-45`（两段过时注释 + 两条 git 依赖）替换为：
+
+```toml
+# --- nyanpasu ---
+# Both crates come from the `backend/nyanpasu-runtime` submodule, pinned to the
+# `v2.0.0-rc.1` tag. `scripts/check.ts` reads the sidecar version out of the same
+# submodule, so the IPC client and the `nyanpasu-service` binary always move
+# together.
+nyanpasu-utils = { path = "nyanpasu-runtime/crates/nyanpasu-utils", features = [
+  "specta",
+] }
+nyanpasu-ipc = { path = "nyanpasu-runtime/nyanpasu_ipc", features = [
+  "client",
+  "specta",
+] } # IPC bridge between the UI process and service process
+```
+
+被删掉的两段注释（`:29-33` 讲 `rev` 会导致 source id 分裂、`:37-41` 讲 v1.4.5 钉版）在 path 依赖下已全部失效，必须删干净，不要保留成“历史注释”。
+
+> path 相对 `backend/Cargo.toml` 所在目录，所以是 `nyanpasu-runtime/...` 而非 `backend/nyanpasu-runtime/...`。
+
+**验证：**
+
+```powershell
+cargo metadata --manifest-path .\backend\Cargo.toml --format-version 1 | Out-Null
+$LASTEXITCODE   # 必须为 0
+```
+
+**通过判据：** exit 0。
+**失败诊断：** 若报 `dependency.anyhow was not found` 或 `current package believes it's in a workspace when it's not` → 编辑 1 的 `exclude` 没生效（拼写／位置错误）。
+
+---
+
+### S2 — 更新 Cargo.lock 并核对 git 残留归零
+
+S1 的 `cargo metadata` 已就地最小重解析并写回 `backend/Cargo.lock`。本步只做核对。
+
+**验证：**
+
+```powershell
+# 1) 不再有 nyanpasu-* 的 git source
+Select-String -Path .\backend\Cargo.lock -Pattern 'nyanpasu-service\.git|nyanpasu-utils\.git'
+# 期望：无输出
+
+# 2) nyanpasu-utils 恰好一份，且是 path 依赖（path 依赖在 lock 中没有 `source =` 行）
+Select-String -Path .\backend\Cargo.lock -Pattern '^name = "nyanpasu-utils"' -Context 0,2
+
+# 3) nyanpasu-ipc 升到 2.0.0-rc.1 且无 source
+Select-String -Path .\backend\Cargo.lock -Pattern '^name = "nyanpasu-ipc"' -Context 0,2
+
+# 4) nyanpasu-core-metadata 作为传递依赖出现
+Select-String -Path .\backend\Cargo.lock -Pattern '^name = "nyanpasu-core-metadata"' -Context 0,2
+
+# 5) libnyanpasu git source 计数：9 -> 7
+(Select-String -Path .\backend\Cargo.lock -Pattern 'libnyanpasu' | Measure-Object).Count
+
+# 6) 改动范围核对
+git diff --stat backend/Cargo.lock
+```
+
+**通过判据：**
+
+- (1) 零输出；
+- (2) 恰好 1 处命中，`version = "0.1.0"`，紧随其后**没有** `source =` 行；
+- (3) 1 处命中，`version = "2.0.0-rc.1"`，**没有** `source =` 行；
+- (4) 存在，`version = "1.0.0-rc.1"`；
+- (5) 计数为 **7**（剩余为 `serde-yaml-ng` / `sysproxy-rs` / `auto-launch` / `delay-timer` / `rust-runas` / `include_url_macro` / `include-compress-bytes`）；
+- (6) diff 只涉及 nyanpasu 系条目与新增的 `enumset` / `schemars` 及其小依赖；若出现大面积无关 crate 版本跳变，说明误跑了 `cargo generate-lockfile` / `cargo update`，**回滚 lock 重来**。
+
+---
+
+### S3 — 依赖重复度与体积证据（按 D2 选项 A）
+
+**动作：** 记录切换后的依赖图证据，写入 PR 描述（**不要**生成新的报告 .md 文件）。
+
+```powershell
+# 重复 crate 清单（对比 main 分支同命令输出）
+cargo tree --manifest-path .\backend\Cargo.toml --duplicates --edges normal | Out-String
+
+# 包总数
+(Select-String -Path .\backend\Cargo.lock -Pattern '^\[\[package\]\]' | Measure-Object).Count
+```
+
+对照基线（切换前，可用 `git stash` 或 `git show HEAD:backend/Cargo.lock` 取）记录：
+
+- `reqwest` 双份（0.12.28 / 0.13.4）**切换前后都存在** —— 见事实 C1，不是本次引入的；
+- 新增包：`nyanpasu-core-metadata`、`enumset`、`schemars`（及其传递项）；
+- 消失包：无（`nyanpasu-utils` 只是换 source）。
+
+**通过判据：** `--duplicates` 输出中**没有新增的重复 crate 组**。若出现新的重复组（尤其 `specta` / `serde` / `tokio` 分裂成两份），**停止并上报 leader**——那意味着 feature 统一失败，不能靠改本计划解决。
+
+**权威体积数字：** PR 开出后从 CI build 产物读取，与 main 最近一次同 target 产物对比，填入 PR 描述。本地**不做** release 构建。
+
+---
+
+### S4 — 新增 `ServiceCompat` 纯模块
+
+**新文件：`backend/tauri/src/core/service/compat.rs`**
+
+**注册：** 在 `backend/tauri/src/core/service/mod.rs` 的 `pub mod control; pub mod ipc;` 旁加 `pub mod compat;`。
+
+**内容契约（codex 按此实现，不要扩大）：**
+
+```rust
+//! PR-5-pre: daemon 主版本兼容门。
+//!
+//! v2 的 `StatusResBody` 把所有新增字段都标成了
+//! `#[serde(default, skip_serializing_if = "Option::is_none")]`，所以 v1.4.5 daemon 的
+//! `/status` 负载是 v2 结构的严格子集，**一定**能静默解码成功。因此本门禁必须做
+//! 显式 semver 主版本比较，绝不能依赖解码失败。
+
+/// PR-5-pre 起，只有主版本等于此值的 daemon 允许承载核心生命周期。
+pub const REQUIRED_SERVICE_MAJOR: u64 = 2;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, specta::Type)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ServiceCompat {
+    /// daemon 未安装 / 未运行 / 未上报 server 信息，没有可判定的版本。
+    Unknown,
+    /// 主版本匹配，允许进入 Service backend。
+    Compatible { server_version: String },
+    /// 主版本不匹配（典型：v1.4.5）。fail-closed。
+    Incompatible { server_version: String, required_major: u64 },
+    /// server 上报的版本不是合法 semver。fail-closed。
+    Unparsable { server_version: String },
+}
+
+impl ServiceCompat {
+    /// 纯函数：无 I/O、无全局状态、无 `Config::*()`。
+    pub fn classify(info: &StatusInfo<'_>) -> Self;
+    /// 唯一的放行判据。
+    pub fn allows_service_backend(&self) -> bool;   // 仅 Compatible 为 true
+}
+
+/// 供 `ServiceCompat` 与启动时自动升级检查复用的唯一版本解析入口。
+pub fn parse_service_version(raw: &str) -> Option<semver::Version>;
+```
+
+`classify` 判定顺序（**必须按此顺序**）：
+
+1. `info.status != ServiceStatus::Running` → `Unknown`；
+2. `info.server` 为 `None` → `Unknown`；
+3. `parse_service_version(&server.version)` 为 `None` → `Unparsable`；
+4. `version.major != REQUIRED_SERVICE_MAJOR` → `Incompatible`；
+5. 其余 → `Compatible`。
+
+**约束：**
+
+- 该模块**不得**调用 `Config::verge()`、`::global()`、文件系统、进程或网络（保持 ledger `config_calls` / `service_globals` 计数不变）；
+- `semver` 已是 `backend/tauri` 的既有 runtime 依赖（`backend/tauri/Cargo.toml:118`，`[dependencies]` 段；`:23` 是 `[build-dependencies]` 里的另一份），不新增依赖。
+
+---
+
+### S5 — `health_check` fail-closed 接入（唯一 choke point）
+
+**编辑：`backend/tauri/src/core/service/ipc.rs`**
+
+依据 F10：`IpcState` 是 Service backend 的唯一开关，`health_check()` 是它唯一的翻转来源。因此**只需在这一处接门禁**。
+
+新增纯函数（便于测试传播链）：
+
+```rust
+/// 纯函数：把一次 status 查询结果映射为目标 IpcState。
+/// fail-closed —— 只有 daemon 在跑**且**通过兼容门禁才允许 Connected。
+pub(super) fn target_ipc_state(info: &StatusInfo<'_>) -> (IpcState, ServiceCompat) {
+    let compat = ServiceCompat::classify(info);
+    let state = match info.status {
+        ServiceStatus::Running if compat.allows_service_backend() => IpcState::Connected,
+        _ => IpcState::Disconnected,
+    };
+    (state, compat)
+}
+```
+
+`health_check()` 改为：`Ok(info)` 分支调用 `target_ipc_state`，`Connected` → `dispatch_connected()`，否则 `dispatch_disconnected()`；当 `info.status == Running` 却被判不兼容时额外打一条 `tracing::warn!`，说明 daemon 版本与“核心继续跑在 Local backend”。`Err(_)` 分支保持原样（已是 fail-closed）。
+
+在该 seam 上加一条迁移标记（会让 ledger `migration_markers` +1，S10 处理）：
+
+```rust
+// TODO(actor-migration): compat gate lives on the legacy IpcState seam.
+// Reason: CoreActor / CoreBackend do not exist until PR-5a.
+// Remove when: PR-5c moves run-mode selection onto CoreClient::set_mode.
+```
+
+**不改动：** `mod.rs::init_service()` 无需改——它按 `status == Running` 决定是否 spawn health check，v1 daemon 仍会 spawn，但 `health_check` 会把状态钉死在 `Disconnected`，结果正确且 fail-closed。
+
+**已知行为后果（预期且可接受，写进 PR 描述）：** 用户在装有 v1 daemon 的机器上切换「服务模式」开关时，`feat.rs:360-366` 因 `ipc_state.is_connected()` 为假而跳过 `regenerate_and_restart_for_legacy()`——与「daemon 未运行」的既有表现完全一致。
+
+**已接受的残留风险（写进 PR 描述，不在本阶段解决）：** 兼容判定挂在既有的 5 s 健康轮询上，因此 `IpcState` 是一份**有滞后的缓存**。如果用户在**同一次会话中途**把已连接的 v2 daemon 换成 v1（降级安装／回滚），最长会存在一个轮询周期的陈旧 `Connected` 窗口，期间 `RunType::default()` 仍可能返回 `Service`。
+
+- 这条路径不在正常升级方向上：v1 → v2 由 `init_service()` 的自动升级覆盖，且升级后首次轮询即判为 `Compatible`；
+- 本阶段**不引入**额外的即时失效机制（那需要事件驱动的 daemon 状态源，属于 PR-5c 的范围）；
+- PR-5c / C2 删除轮询线程、改为 `set_mode` / `reconcile_mode` 显式驱动后，该窗口自然消失；
+- 按 task.md 的 Exit 措辞（「v1.4.5 **fixture** 下没有 `/core/*` 请求」），判据的证明以 fixture 级 T8 为准，**不要求**覆盖这个时序窗口。
+
+---
+
+### S6 — 抽出可测的 `RunType` 分类函数
+
+**编辑：`backend/tauri/src/core/clash/core.rs:50-67`**
+
+把 `Default::default()` 拆成「读配置」+「纯分类」两段，行为逐字等价：
+
+```rust
+impl RunType {
+    /// 纯分类：Service backend 的唯一判据。
+    /// `IpcState::Connected` 只可能由通过 `ServiceCompat` 门禁的 daemon 产生
+    /// （见 `core::service::ipc::target_ipc_state`），因此旧版 daemon 无法到达
+    /// `RunType::Service`，也就无法构造出会发 `/core/*` 的 `Instance::Service`。
+    pub fn classify(enable_service: bool, ipc_state: IpcState) -> Self {
+        if enable_service && ipc_state.is_connected() { Self::Service } else { Self::Normal }
+    }
+}
+
+impl Default for RunType {
+    fn default() -> Self {
+        let enable_service = { /* 原 Config::verge() 读取，一字不改 */ };
+        let run_type = Self::classify(enable_service, crate::core::service::ipc::get_ipc_state());
+        // 原有两条 tracing::info! 保留，按 run_type 分支输出
+        run_type
+    }
+}
+```
+
+**约束：** `Config::verge()` 调用保持在 `default()` 内且**只有一处**（ledger `config_calls` 不变）。`core/clash/core.rs` 其它部分**一律不动**。
+
+---
+
+### S7 — `status_service` additive 暴露 compat（按 D3 选项 A）
+
+**编辑：`backend/tauri/src/ipc.rs` 的 `pub mod service`**
+
+```rust
+/// `StatusInfo` 的 additive 镜像：字段逐一复制（specta 不支持 `serde(flatten)`，
+/// 见本文件 `GetSysProxyResponse` 的同款处理），追加 `compat`。
+/// wire 是原结构的严格超集，前端既有消费点不受影响。
+#[derive(serde::Serialize, specta::Type)]
+pub struct ServiceStatusInfo<'a> {
+    pub name: std::borrow::Cow<'a, str>,
+    pub version: std::borrow::Cow<'a, str>,
+    pub status: nyanpasu_ipc::types::ServiceStatus,
+    pub server: Option<nyanpasu_ipc::api::status::StatusResBody<'a>>,
+    pub compat: crate::core::service::compat::ServiceCompat,
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn status_service<'a>() -> Result<ServiceStatusInfo<'a>> {
+    let info = (service::control::status().await)?;
+    let compat = crate::core::service::compat::ServiceCompat::classify(&info);
+    Ok(ServiceStatusInfo { name: info.name, version: info.version, status: info.status, server: info.server, compat })
+}
+```
+
+**约束：** `specta_export.rs` 的命令注册列表**不改**（`ipc::service::status_service` 名字未变）。前端**不改**——`.status` / `.name` / `.server?.version` 三个读取点在超集下继续有效。
+
+> **Leader 复核注（2026-08-02）：** 上述草图中 `ServiceStatusInfo<'a>` 的生命周期在 `async` command 返回位上大概率无法约束（`info` 是函数内局部量）。实施时若借用形式不编译，直接改用 owned/`'static` 形式（`Cow<'static, str>` 或 `String`），wire 形状不变；属实现细节调整，不算偏离计划。
+
+---
+
+### S8 — 保留启动自动升级语义（+ D4 去 panic）
+
+**编辑：`backend/tauri/src/utils/init/mod.rs:243-264`**
+
+**必须保持不变的部分：** `enable_service` 门槛、`app_ver > server_ver` 的比较方向、`update_service()` 的调用与 UAC 提权路径、失败仅记 error 不中断启动。
+
+**唯一改动（D4 判 Yes 时）：** 两处 `semver::Version::parse(...).unwrap()` 换成 `compat::parse_service_version(...)`，任一为 `None` 则 `tracing::warn!` 并跳过升级检查。
+
+```rust
+if let Some(info) = status.server
+    && let (Some(server_ver), Some(app_ver)) = (
+        compat::parse_service_version(info.version.as_ref()),
+        compat::parse_service_version(status.version.as_ref()),
+    )
+{
+    if app_ver > server_ver { /* 原 update_service() 逻辑，一字不改 */ }
+} else {
+    tracing::warn!("service version not comparable; skipping the auto-update check");
+}
+```
+
+D4 判 No 时：本步只做**不改代码的复核**——确认 `2.0.0-rc.1 > 1.4.5` 成立且升级路径未被 S5 影响（S5 只动 `health_check`，`init_service` 的版本比较与 `IpcState` 无关）。
+
+---
+
+### S9 — 测试
+
+**新增 fixture 目录：`backend/tauri/src/core/service/fixtures/`**（与仓内既有 `core/migration/fixtures`、`enhance/fixtures` 同构）
+
+#### S9.0 — fixture 溯源（先做，不要凭记忆手写）
+
+submodule 是上游改名合并后的同一个仓库，**tag `v1.4.5` 就在里面**（`git -C backend/nyanpasu-runtime tag -l 'v1*'` 可见 `v1.1.3` … `v1.4.5`）。因此 v1 结构定义可以直接取出比对，不需要猜：
+
+```powershell
+# 定位 v1 时代的 status 相关文件
+git -C backend/nyanpasu-runtime ls-tree -r v1.4.5 --name-only | rg 'status'
+
+# 读取 v1.4.5 的两份权威定义
+git -C backend/nyanpasu-runtime show v1.4.5:nyanpasu_ipc/src/api/status.rs
+git -C backend/nyanpasu-runtime show v1.4.5:nyanpasu_ipc/src/types/status.rs
+```
+
+**已核验的 v1.4.5 定义（2026-08-02 取自上述命令，codex 仍须复跑确认）：**
+
+- `types/status.rs`：`ServiceStatus { NotInstalled, Stopped, Running }`（`rename_all = "snake_case"`）、`StatusInfo<'n> { name, version, status, server: Option<StatusResBody<'n>> }` —— **与 v2 完全一致**；
+- `api/status.rs`：`CoreState { Running, Stopped(Option<String>) }`（无 rename，外部标签）、`CoreInfos { r#type, state, state_changed_at, config_path }`、`RuntimeInfos { service_data_dir, service_config_dir, nyanpasu_config_dir, nyanpasu_data_dir }`、`StatusResBody<'a> { version, core_infos, runtime_infos }`。
+
+对照 v2（`backend/nyanpasu-runtime/nyanpasu_ipc/src/api/status.rs:124-197`）可确认：v2 相对 v1 **只增不改**，新增的 `CoreInfos.{controller,health,revision,detail}` 与 `StatusResBody.logs` 全部是 `#[serde(default, skip_serializing_if = "Option::is_none")]`。→ **v1 负载是 v2 的严格子集，必然解码成功**（事实 F7 由此从"源码注释推断"升级为"两版定义直接比对"）。
+
+fixture 文件头部必须写明溯源标签，例如：
+
+```jsonc
+// Source: nyanpasu-runtime @ tag v1.4.5 —— nyanpasu_ipc/src/{types,api}/status.rs
+// 用途：证明 v1 daemon 的 /status 会静默解码成 v2 结构，因此兼容门必须做显式 semver 比较。
+```
+
+> JSON 不支持注释。若 fixture 用纯 `.json`，把溯源信息写在**引用它的 Rust 常量上方的 doc comment** 里；或把 fixture 存为 `.jsonc` 并在测试里剥注释——**推荐前者**（更简单，且 `include_str!` 不需要预处理）。
+
+#### fixture 1：`status_v1_4_5.json`
+
+按 S9.0 取出的 v1.4.5 定义构造（= v2 结构去掉全部 v2-only 可选字段）。形状：
+
+```json
+{
+  "name": "nyanpasu-service",
+  "version": "2.0.0-rc.1",
+  "status": "running",
+  "server": {
+    "version": "1.4.5",
+    "core_infos": {
+      "type": { "clash": "mihomo" },
+      "state": { "Stopped": null },
+      "state_changed_at": 1753900000000,
+      "config_path": null
+    },
+    "runtime_infos": {
+      "service_data_dir": "/nonexistent/service/data",
+      "service_config_dir": "/nonexistent/service/config",
+      "nyanpasu_config_dir": "/nonexistent/nyanpasu/config",
+      "nyanpasu_data_dir": "/nonexistent/nyanpasu/data"
+    }
+  }
+}
+```
+
+`CoreType` 的 serde 形状是外部标签 `{"clash": "mihomo"}`（`backend/nyanpasu-runtime/crates/nyanpasu-utils/src/core/definition.rs:87-92,12-24`）；`CoreState::Stopped(Option<String>)` 无 rename，外部标签为 `{"Stopped": null}`（`nyanpasu_ipc/src/api/status.rs:7-12`）。路径字段用不存在的假路径，**测试不触碰真实目录**（ledger `test_real_dirs` 必须保持 0）。
+
+#### fixture 2：`status_v2_0_0_rc1.json`
+
+同上但 `server.version = "2.0.0-rc.1"`，并**带上** v2-only 字段中的至少一个（如 `"logs": { "service_dir": "/nonexistent/logs" }`），用于正向放行用例。
+
+#### 测试（写在 `compat.rs` 的 `#[cfg(test)] mod tests`）
+
+| #   | 名称                                      | 断言                                                                                                            | 对应 Exit                      |
+| --- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| T1  | `v1_fixture_is_really_v1_shaped`          | fixture 1 的 JSON 文本**不含** `controller` / `health` / `revision` / `detail` / `logs` 任一键                  | 保证 T2 有意义                 |
+| T2  | `v1_payload_still_decodes_into_v2_struct` | `serde_json::from_str::<StatusInfo>(fixture1)` **成功**，且 `server.version == "1.4.5"`                         | 证明「解码失败不可依赖」（F7） |
+| T3  | `v1_daemon_is_incompatible`               | `classify` → `Incompatible { server_version: "1.4.5", required_major: 2 }`；`allows_service_backend() == false` | 「major fail-closed」          |
+| T4  | `v2_daemon_is_compatible`                 | fixture 2 → `Compatible`；`allows_service_backend() == true`                                                    | 门禁不误伤 v2                  |
+| T5  | `unparsable_version_is_fail_closed`       | 把 `server.version` 改成 `"nightly"` → `Unparsable`，不放行                                                     | fail-closed                    |
+| T6  | `stopped_or_not_installed_is_unknown`     | `status` 为 `stopped` / `not_installed` → `Unknown`，不放行                                                     | fail-closed                    |
+| T7  | `rc_prerelease_still_outranks_v1`         | `parse_service_version("2.0.0-rc.1") > parse_service_version("1.4.5")`                                          | 钉住 F8：自动升级仍会触发      |
+
+#### 传播链测试（写在 `ipc.rs` 的 `#[cfg(test)] mod tests`）
+
+| #   | 名称                                      | 断言                                                                                                                                                  | 对应 Exit                                    |
+| --- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| T8  | `v1_daemon_never_reaches_service_backend` | 载入 fixture 1 → `target_ipc_state(&info)` 返回 `(IpcState::Disconnected, Incompatible)` → `RunType::classify(true, Disconnected) == RunType::Normal` | **「v1.4.5 fixture 下没有 `/core/*` 请求」** |
+| T9  | `v2_daemon_reaches_service_backend`       | fixture 2 → `(Connected, Compatible)` → `RunType::classify(true, Connected) == RunType::Service`                                                      | 正向不回归                                   |
+
+**T8 为什么等价于「没有 `/core/*` 请求」：** 依据 F11，5 处 `/core/*` 调用点全部位于 `Instance::Service` 分支或 `RunType::Service` 匹配臂；而 `Instance::try_new` 只在 `RunType::Service` 时构造 `Instance::Service`（`core/clash/core.rs:99-123`）。T8 证明 v1 payload 无法产出 `RunType::Service`，因此 `/core/*` 分支不可达。该不变量已由 S6 的 doc comment 在 `RunType::classify` 上写明。
+
+> **可选加固（leader 可要求）：** 在 `core/clash/core.rs` 加一个 `include_str!(file!())` 的调用点计数钉（断言 `service_default()` 恰好出现 5 次），任何新增调用点强制 review。默认**不做**——PR-5a 会重写该文件，计数钉只会制造 churn。
+
+**测试纪律：** 全部 fixture 驱动，无 TempDir 需求（连临时目录都不用）、无 sleep、无真实 daemon、无 `dirs::*` 调用。
+
+---
+
+### S10 — 门禁、bindings 与 ledger
+
+按顺序执行：
+
+```powershell
+# 1) 格式
+pnpm fmt:backend
+pnpm lint:rustfmt
+
+# 2) clippy（注意：不加 -D warnings，仓库本就有既存 warning）
+pnpm lint:clippy
+
+# 3) 全量后端测试 + bindings 就地重生成
+pnpm test:backend
+
+# 4) bindings 差异审阅（不是 --exit-code，先看内容）
+git diff --stat frontend/interface/src/ipc/bindings.ts
+git diff frontend/interface/src/ipc/bindings.ts
+
+# 5) 前端类型检查（bindings 变了必须过）
+pnpm lint:ts
+
+# 6) ledger：先 report 看当前值
+pnpm architecture-ledger
+```
+
+**bindings 预期差异（两类，都必须出现）：**
+
+- **ipc v2 带来的 `StatusInfo` 面扩宽**：`CoreInfos` 新增 `controller` / `health` / `revision` / `detail`，`StatusResBody` 新增 `logs`，并带出 `CoreControllerInfo` / `CoreHealthInfo` / `CoreHealthState` / `ConfigRevisionInfo` / `CoreStateDetail` / `LogPathsInfo` 等新类型（roadmap §6.0 已预告）；
+- **S7 带来的 `ServiceStatusInfo`**：新类型 + `statusService` 返回类型改为它。
+
+若 diff 里出现**与 service / status 无关**的类型变动，停下核查——那说明改动溢出了范围。
+
+**ledger 处理：**
+
+```powershell
+# 7) gate 先跑一次，确认唯一的差异是预期的 marker +1
+pnpm lint:architecture-ledger
+```
+
+预期唯一偏差：`migration_markers.byKey["TODO(actor-migration)"]` 由 **16 → 17**，`total` 由 **18 → 19**（S5 加的那一条）。
+其余四项**必须原封不动**：`config_calls.total == 120`（`Config::verge()` 93 / `Config::clash()` 27）、`service_globals.total == 80`、`legacy_dto_refs.total == 300`、`test_real_dirs.total == 0`、`bridgeFiles` 8 个文件不变。
+
+确认后再重写 snapshot：
+
+```powershell
+deno run -A scripts/architecture-ledger.ts --write-snapshot
+git diff scripts/architecture-ledger.snapshot.json   # 逐行核对只有上述 +1
+pnpm lint:architecture-ledger                        # 必须 exit 0
+pnpm test:architecture-ledger                        # 脚本自测
+```
+
+> **若 `config_calls` 或 `service_globals` 发生了变化**：说明 S4/S5/S6 里写进了 `Config::*()` 或 `::global()`，违反 §S4 约束。**回头改代码，不要靠改 snapshot 掩盖。**
+
+**最后：`cargo metadata` 复核 + 全绿确认**
+
+```powershell
+cargo metadata --manifest-path .\backend\Cargo.toml --format-version 1 --locked | Out-Null
+$LASTEXITCODE   # 0，且 --locked 通过说明 lock 与 manifest 一致、无待更新
+```
+
+---
+
+## 4. Exit 判据映射
+
+task.md `PR-5-pre` Exit 三条，逐条对应：
+
+| Exit 判据                                | 由哪些步骤交付 | 验证命令／断言                                                                                                                                                                                             |
+| ---------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cargo metadata` 绿                      | S1、S2         | `cargo metadata --manifest-path .\backend\Cargo.toml --format-version 1 --locked`，exit 0                                                                                                                  |
+| workspace tests 绿                       | S9、S10        | `pnpm test:backend` 全绿（含 T1–T9）                                                                                                                                                                       |
+| bindings 绿                              | S7、S10        | `pnpm test:backend` 后 `pnpm lint:ts` 绿；CI 的 `git diff --exit-code -- frontend/interface/src/ipc/bindings.ts` 在提交后为空                                                                              |
+| architecture ledger 绿                   | S10            | snapshot 按**恰好** `migration_markers.byKey["TODO(actor-migration)"]` 16→17、`migration_markers.total` 18→19 重写（其余四项指标与 `bridgeFiles` 一字不变），重写后 `pnpm lint:architecture-ledger` exit 0 |
+| **v1.4.5 fixture 下没有 `/core/*` 请求** | S4、S5、S6、S9 | **T8**（`classify → Incompatible` → `IpcState::Disconnected` → `RunType::Normal`），配合 F11 的不变量：`Instance::Service` 是 `/core/*` 的唯一来源，只能由 `RunType::Service` 构造                         |
+| 本 PR 不引入 CoreActor                   | §0 / §7        | `rg 'CoreActor\|CoreBackend\|CoreOperationGuard\|OperationId' backend/tauri/src` 零命中                                                                                                                    |
+
+roadmap §6.0 附加退出项：
+
+| §6.0 判据                                             | 对应                                                                                                                                                                     |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Cargo.lock 零 `nyanpasu-*` git source                 | S2 验证 (1)                                                                                                                                                              |
+| `nyanpasu-utils` 单份                                 | S2 验证 (2)                                                                                                                                                              |
+| `[patch]` 块删除                                      | S1 编辑 2                                                                                                                                                                |
+| `ServiceCompat` fail-closed 且先于任何 `/core/*` 存在 | S4 + S5（门禁位于 `IpcState` 唯一翻转点，结构上先于所有 `/core/*`）                                                                                                      |
+| ledger gate 绿                                        | S10。roadmap §6.0（2026-08-02 重写）已把该判据从"snapshot 不变"改为"**gate 绿，允许且仅允许 `migration_markers` +1**"；snapshot 按 16→17 / 18→19 重写后 gate 必须 exit 0 |
+
+---
+
+## 5. 风险与回滚
+
+| 风险                                                             | 概率                            | 影响                                          | 缓解／回滚                                                                                                                                                                                                                                                                                                                  |
+| ---------------------------------------------------------------- | ------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `exclude` 遗漏 → `dependency.anyhow was not found`               | 低（已知解法）                  | S1 立即失败                                   | S1 失败诊断已给出；补 `exclude` 即可                                                                                                                                                                                                                                                                                        |
+| lock 被 `cargo update` 大面积改写                                | 中（误操作）                    | 无关 crate 版本跳变、CI 噪声                  | S2 验证 (6) 拦截；`git checkout backend/Cargo.lock` 后只跑 `cargo metadata`                                                                                                                                                                                                                                                 |
+| 出现新的重复 crate 组（feature 统一失败）                        | 低（C1 已排除 reqwest/windows） | 体积膨胀                                      | S3 通过判据即为拦截点；**上报 leader，不自行改 feature**                                                                                                                                                                                                                                                                    |
+| bindings diff 溢出到无关类型                                     | 低                              | wire 意外破坏                                 | S10 步骤 4 人工审阅；溢出即回退 S7                                                                                                                                                                                                                                                                                          |
+| `ServiceStatusInfo` 镜像与上游 `StatusInfo` 字段漂移             | 中（未来 bump 时）              | 编译期即报错（字段缺失/多余）                 | 结构体字面量构造 → 上游加字段时编译不过，属于**期望的**提醒；在 doc comment 里写明                                                                                                                                                                                                                                          |
+| specta 对 `ServiceCompat` 内部标签枚举（`tag = "kind"`）导出异常 | 低                              | bindings 生成失败                             | 若 `#[serde(tag)]` 在 specta rc 下出问题，退化为外部标签（去掉 `tag = "kind"`）；wire 形状变化只影响新字段，不破坏既有消费点                                                                                                                                                                                                |
+| v1 fixture 形状与真实 v1.4.5 输出有出入                          | 低                              | T2/T3 证明力打折                              | **v1 源码可直接比对**——submodule 是上游改名合并后的同一仓库，`tag v1.4.5` 就在里面。S9.0 用 `git -C backend/nyanpasu-runtime show v1.4.5:nyanpasu_ipc/src/api/status.rs` 与 `…/types/status.rs` 取出权威定义来构造 fixture，并在引用处记录溯源标签。T1 的"不含任何 v2-only 键"断言继续保留，作为独立的严格子集证明          |
+| v2 → v1 daemon 会话中途降级时的陈旧 `Connected` 窗口             | 低                              | 最长一个轮询周期（5 s）内仍可能判为 `Service` | **已接受的过渡期残留风险**：兼容判定挂在既有 5 s 健康轮询上，缓存天然滞后。只在"会话中途把 v2 daemon 换成 v1"这条路径上出现；正常升级方向（v1 → v2）不受影响。PR-5c / C2 删除轮询线程、改由 `set_mode` / `reconcile_mode` 显式驱动后自然消失。按 task.md 措辞，Exit 判据的证明仍以 fixture 级 T8 为准，不要求覆盖该时序窗口 |
+
+**整体回滚：** 本阶段全部改动集中在 `backend/Cargo.toml`、`backend/Cargo.lock`、`backend/tauri/src/core/service/{compat.rs,ipc.rs,mod.rs}`、`backend/tauri/src/core/clash/core.rs`（仅 `RunType`）、`backend/tauri/src/ipc.rs`（仅 `mod service`）、`backend/tauri/src/utils/init/mod.rs`（仅版本解析）、fixtures、`bindings.ts`、ledger snapshot。任一步失败可 `git checkout -- <file>` 单点回滚，不存在跨文件耦合的半提交状态。
+
+---
+
+## 6. 提交切分建议
+
+单 PR，两个 commit：
+
+1. `build(deps): switch nyanpasu-utils/ipc to the nyanpasu-runtime submodule` —— S1–S3；
+2. `feat(service): fail-closed daemon major-version compat gate` —— S4–S10。
+
+commit 1 单独可编译、可测（除 bindings 因 `StatusInfo` 面扩宽需要 regen —— 若要求每个 commit 都 CI 绿，把 S10 的 bindings regen 拆一份到 commit 1）。
+
+---
+
+## 7. 明确 out-of-scope（登记去向）
+
+| 项                                                   | 去向                                                                                                                                                      |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LocalIpcPolicy::Disable` 显式设置                   | **PR-5a / A1**（`CoreBackend::Local` 构造 `ManagerOptions` 时）。核查结论：上游默认值已是 `Disable`（`spec.rs:114` + `:156` 单测），本阶段无构造点        |
+| 禁用 `Client::service_default()`（design §4）        | **PR-5a / A1**。v2 仍保留该 API（`client/mod.rs:93`），5 处调用点本阶段不动                                                                               |
+| `nyanpasu-core-manager` / `clash-api` workspace 条目 | **PR-5a**（决策点 D1 选项 A，leader 已裁定）                                                                                                              |
+| R0（`CoreErrorKind` 协议收敛）                       | **上游 submodule 的独立 PR**（roadmap §6.R0）。与本阶段**并行且互不阻塞**——PR-5-pre 不消费 typed kind，也**不 bump submodule 指针**（保持 `v2.0.0-rc.1`） |
+| `Elevated` 分支的 `todo!()`                          | **PR-5c**（roadmap §6.3）                                                                                                                                 |
+| service 5s 轮询线程与 `IPC_STATE` static 的删除      | **PR-5c / C2**                                                                                                                                            |
+| stable 渠道 bump 到正式 `v2.0.0`                     | 发布前独立动作（design §10、roadmap §6 release-gate）                                                                                                     |
+| Windows 旧 daemon 升级 smoke                         | **PR-5c / smoke 2**。本阶段只做 fixture 级验证；真机 smoke 需停掉已安装的 `moe.elaina.nyanpasu-service`（IPC 端点是全局固定路径），不纳入自动化           |

--- a/docs/superpowers/plans/2026-08-01-pr5-r0-runtime-protocol.md
+++ b/docs/superpowers/plans/2026-08-01-pr5-r0-runtime-protocol.md
@@ -1,0 +1,887 @@
+# PR-5 R0 — nyanpasu-runtime 错误分类协议收敛 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 `error_kind` 的字符串表从「ipc 常量模块 + service 侧 `map_error_kind` 匹配表」两份收敛为一份 —— `nyanpasu-core-metadata::CoreErrorKind` enum;分类逻辑下沉到错误定义所在的 `nyanpasu-core-manager::Error::kind()`;wire 字节完全不变;submodule bump 后 clash app 可直接消费 typed kind,不必在 app 侧复制第三份字符串表。
+
+**Architecture:** 单向依赖已经现成,不需要新 crate:
+
+```text
+nyanpasu-core-metadata  (CoreErrorKind —— 唯一字符串表)
+        ↑                        ↑
+nyanpasu-core-manager      nyanpasu-ipc
+ (Error::kind() 分类表)    (api 重导出 + client 解析)
+        ↑                        ↑
+        └── nyanpasu-service-runtime (只做 error → envelope 搬运)
+```
+
+`nyanpasu_ipc/Cargo.toml` 已有 `nyanpasu-core-metadata = { path = "../crates/nyanpasu-core-metadata" }`,`crates/nyanpasu-core-manager/Cargo.toml` 同样已有 —— **本 PR 不新增任何依赖项**。
+
+**Tech Stack:** Rust nightly(`rust-toolchain.toml` 为浮动 `channel = "nightly"`)、serde、specta、thiserror。
+
+**Spec:** `docs/superpowers/specs/2026-08-01-pr5-core-actor/design.md` §4.1「复用 runtime 类型」+ `task.md` §R0。
+（注:该目录下两文件的内容与文件名曾互换,leader 已于 2026-08-01 修正 —— 现在 `design.md` = 设计正文、`task.md` = 任务清单,本行引用按修正后的文件名。）
+
+---
+
+## Global Constraints
+
+- **作用域仅限 runtime 仓**,且在**隔离 worktree** `G:\Programs\Rust\.ccg\clash-nyanpasu\runtime-r0` 内实施(独立 git 仓库 + 独立 cargo workspace,见 §「Git 策略」)。app 侧 `backend/tauri` 一行不改;**父仓的 submodule 检出 `backend/nyanpasu-runtime` 全程停在 `main` @ `0d2993a` 不动**。
+- **不新建 crate、不引入 `CoreEngine` trait/工厂、不引入 transport-neutral 抽象层。**
+- **不 bump 任何 crate 版本。** 尤其 `nyanpasu_service/Cargo.toml` 的 `version = "2.0.0-rc.1"` —— app 的 `scripts/check.ts:674-691` 直接读这个文件的 `version` 字段拼出下载 tag `v2.0.0-rc.1`,改动它会让 sidecar 下载 404。`crates/nyanpasu-service-runtime` 的版本同样不动(它是 `consts::APP_VERSION`,ServiceCompat 的 major fail-closed 判据)。
+- **wire 字节不变是硬闸门。** envelope 字段 `R.error_kind` 的类型保持 `Option<Cow<'a, str>>`,12 个字符串一个字符不改;`crates/nyanpasu-service-runtime/src/server/routing/tests.rs:388,414,448,475` 四条端到端断言必须**原样不动地通过** —— 它们是「wire 没动」的最直接证据。
+- **不推送、不开 PR。** 全部工作是 worktree 内的本地 commit。推送到 `libnyanpasu/nyanpasu-runtime` 与开上游 PR 需要用户显式授权,见 §「交接边界」。
+- **不动 app 侧 submodule pin(gitlink)。** worktree 隔离从结构上保证了这一点 —— 父仓检出的 HEAD 从不移动,gitlink 漂移在物理上不可能发生。见 §「交接边界」。
+- **不动嵌套 submodule** `crates/nyanpasu-utils`(当前 `3cb3af0`)—— 但新 worktree 必须先**初始化**它才能编译,见 Task 0 Step 2。
+- pre-commit 与 CI 跑 `cargo clippy --all-targets --all-features`(`.github/workflows/ci.yml:52`)。`.cargo/config.toml` 已注入 `--cfg tokio_unstable --cfg tracing_unstable`,不需要手动带。
+- ICE 处置:本机 nightly 偶发 `query stack during panic`,**直接重跑**,不得据此 pin toolchain 日期。
+
+---
+
+## Facts established before planning (do not re-derive)
+
+| Fact                    | Value                                                                                                                                                 | Source                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| submodule 当前状态      | 分支 `main` @ `0d2993a`(**不是 detached**),`= v2.0.0-rc.1`,落后 `origin/main` 1 个 commit                                                             | `git -C backend/nyanpasu-runtime status -sb`                             |
+| tag→main 分歧           | `v2.0.0-rc.1..origin/main` = **仅 1 个 commit** `0c67f56 chore: update docs`(只改 `README.md`,+115/-18)                                               | `git log --oneline v2.0.0-rc.1..origin/main` / `git show --stat 0c67f56` |
+| 反向分歧                | `origin/main..v2.0.0-rc.1` = **空**,tag 是 main 的严格祖先(纯快进)                                                                                    | `git log --oneline origin/main..v2.0.0-rc.1`                             |
+| 字符串常量表            | 12 个 `pub const`                                                                                                                                     | `nyanpasu_ipc/src/api/mod.rs:38-66`                                      |
+| 分类匹配表              | `map_error_kind(&ManagerError) -> Option<&'static str>`                                                                                               | `crates/nyanpasu-service-runtime/src/server/manager_bridge.rs:646-665`   |
+| `ManagerError` 变体总数 | **25**(报告写「23」是 2026-07-30 的旧计数)                                                                                                            | `crates/nyanpasu-core-manager/src/error.rs:7-72`                         |
+| client 侧               | 只搬运 `Option<String>`,**今天没有任何字符串表**                                                                                                      | `nyanpasu_ipc/src/client/mod.rs:51-53,142,187`                           |
+| app 侧消费              | `rg 'error_kind\|ClientError::Server' backend/tauri/src` = **0 命中**                                                                                 | 计划期实测                                                               |
+| 依赖就绪                | ipc → core-metadata ✓;core-manager → core-metadata ✓;service-runtime → 两者 ✓                                                                         | 各 `Cargo.toml`                                                          |
+| 重导出先例              | `nyanpasu_ipc/src/api/ws/events.rs:9-11`、`crates/nyanpasu-core-manager/src/log.rs:12`、`.../kind.rs:10` 都是 `pub use nyanpasu_core_metadata::{...}` | 同上                                                                     |
+| 同层 enum 先例          | `ApplyOutcomeKind`:`#[serde(rename_all = "snake_case")]`,**未标 `#[non_exhaustive]`**                                                                 | `nyanpasu_ipc/src/api/core/apply.rs:34-60`                               |
+| 覆盖率闸门              | `cargo llvm-cov -p nyanpasu-service-runtime -p nyanpasu-ipc --fail-under-lines 53`(2026-07-29 基线 55.42%)                                            | `.github/workflows/integration.yml:127-134`                              |
+
+---
+
+## error_kind 全量清单(计划的核心,codex 不必重新发现)
+
+### 一、字符串值(12 个,全部定义于 `nyanpasu_ipc/src/api/mod.rs:38-66`)
+
+| #   | 常量                            | wire 字符串             | 目标 enum 变体        | `rename_all="snake_case"` 是否精确匹配 |
+| --- | ------------------------------- | ----------------------- | --------------------- | -------------------------------------- |
+| 1   | `NOT_STARTED` (`:40`)           | `not_started`           | `NotStarted`          | ✓                                      |
+| 2   | `ALREADY_RUNNING` (`:42`)       | `already_running`       | `AlreadyRunning`      | ✓                                      |
+| 3   | `REVISION_CONFLICT` (`:45`)     | `revision_conflict`     | `RevisionConflict`    | ✓                                      |
+| 4   | `QUARANTINED` (`:49`)           | `quarantined`           | `Quarantined`         | ✓                                      |
+| 5   | `CONFIG_CHECK_FAILED` (`:51`)   | `config_check_failed`   | `ConfigCheckFailed`   | ✓                                      |
+| 6   | `CONFIG_NOT_FOUND` (`:52`)      | `config_not_found`      | `ConfigNotFound`      | ✓                                      |
+| 7   | `BINARY_NOT_FOUND` (`:53`)      | `binary_not_found`      | `BinaryNotFound`      | ✓                                      |
+| 8   | `INVALID_CONFIG` (`:55`)        | `invalid_config`        | `InvalidConfig`       | ✓                                      |
+| 9   | `CONTROLLER_MISSING` (`:58`)    | `controller_missing`    | `ControllerMissing`   | ✓                                      |
+| 10  | `APPLY_FAILED` (`:60`)          | `apply_failed`          | `ApplyFailed`         | ✓                                      |
+| 11  | `APPLY_ROLLBACK_FAILED` (`:62`) | `apply_rollback_failed` | `ApplyRollbackFailed` | ✓                                      |
+| 12  | `STOP_UNCONFIRMED` (`:65`)      | `stop_unconfirmed`      | `StopUnconfirmed`     | ✓                                      |
+
+**12/12 精确匹配 `rename_all = "snake_case"`,不需要任何 `#[serde(rename = "...")]` 逐项覆写。**
+
+### 二、生产端(谁往 wire 上写 kind)
+
+| 位置                                                          | 输入                                                 | 产出 kind                              | R0 后                                                                       |
+| ------------------------------------------------------------- | ---------------------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------- |
+| `manager_bridge.rs:646-665` `map_error_kind`                  | `&ManagerError`                                      | 12 个中的一个或 `None`                 | **整函数删除**,改调 `error.kind()`                                          |
+| `manager_bridge.rs:89` `From<ManagerError> for OpError`       | `ManagerError`                                       | 同上                                   | `kind: error.kind()`                                                        |
+| `manager_bridge.rs:404`                                       | `find_binary_path` 的 `io::Error`                    | `BINARY_NOT_FOUND`                     | `CoreErrorKind::BinaryNotFound`(**逐点分类,不是表**,保留)                   |
+| `manager_bridge.rs:791`                                       | `canonical_config_path` 的 `io::ErrorKind::NotFound` | `CONFIG_NOT_FOUND`                     | `CoreErrorKind::ConfigNotFound`(同上,保留)                                  |
+| `manager_bridge.rs:82` `OpError::into_envelope`               | `OpError`                                            | 落到 `RBuilder::other_error_with_kind` | 签名收敛为 `Option<CoreErrorKind>`                                          |
+| `nyanpasu_ipc/src/api/mod.rs:138-147` `other_error_with_kind` | `Option<Cow<str>>`                                   | 写入 `R.error_kind`                    | 入参改 `Option<CoreErrorKind>`,内部 `.map(\|k\| Cow::Borrowed(k.as_str()))` |
+
+唯一写 `R.error_kind` 非 `None` 的构造器就是 `other_error_with_kind`(`api/mod.rs:130`/`:156` 的另两个构造器恒写 `None`)。收敛它的签名 = 从类型上杜绝手写字符串上 wire。
+
+### 三、消费端(谁读 kind)
+
+| 位置                                          | 现状                                                                                     | R0 后                                                |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `nyanpasu_ipc/src/client/mod.rs:142` (`send`) | `envelope.error_kind.map(into_owned)` → `ClientError::Server.error_kind: Option<String>` | **不变**(保留 raw,前向兼容)                          |
+| `nyanpasu_ipc/src/client/mod.rs:187` (`call`) | 同上                                                                                     | **不变**                                             |
+| app `backend/tauri`                           | 0 命中                                                                                   | 仍 0 —— R0 只把 typed 消费**变为可能**,不在 app 落地 |
+
+### 四、`ManagerError` 全 25 变体 → kind 映射(`Error::kind()` 的完整真值表)
+
+| #   | 变体(`error.rs` 行号)                     | kind                                                     |
+| --- | ----------------------------------------- | -------------------------------------------------------- |
+| 1   | `AlreadyRunning` (`:9`)                   | `AlreadyRunning`                                         |
+| 2   | `NotStarted` (`:11`)                      | `NotStarted`                                             |
+| 3   | `ConfigNotFound(_)` (`:13`)               | `ConfigNotFound`                                         |
+| 4   | `BinaryNotFound(_)` (`:15`)               | `BinaryNotFound`                                         |
+| 5   | `CoreVersionProbeFailed{..}` (`:17`)      | `None`                                                   |
+| 6   | `ControllerMissing` (`:22`)               | `ControllerMissing`                                      |
+| 7   | `RequiredLocalIpcUnsupported{..}` (`:26`) | `None`                                                   |
+| 8   | `ConfigCheckFailed(_)` (`:28`)            | `ConfigCheckFailed`                                      |
+| 9   | `InvalidConfig(_)` (`:30`)                | `InvalidConfig`                                          |
+| 10  | `InvalidManagerOptions(_)` (`:32`)        | `None`                                                   |
+| 11  | `InvalidHealthPolicy(_)` (`:34`)          | `None`                                                   |
+| 12  | `UnsafeRuntimeArtifact(_)` (`:36`)        | `None`                                                   |
+| 13  | `RuntimeDirectoryOwned(_)` (`:38`)        | `None`                                                   |
+| 14  | `StopUnconfirmed(_)` (`:40`)              | `StopUnconfirmed`                                        |
+| 15  | `ManagerQuarantined{..}` (`:42`)          | `Quarantined`                                            |
+| 16  | `RevisionConflict{..}` (`:44`)            | `RevisionConflict`                                       |
+| 17  | `ApplyFailed(_)` (`:49`)                  | `ApplyFailed`                                            |
+| 18  | `ApplyRollbackFailed{..}` (`:51`)         | `ApplyRollbackFailed`                                    |
+| 19  | `DurabilityUncertain{source,..}` (`:53`)  | **`source.kind()`(递归)**                                |
+| 20  | `StartupTimeout{..}` (`:61`)              | `None`                                                   |
+| 21  | `StartupFailed{..}` (`:63`)               | `None`                                                   |
+| 22  | `Process(_)` (`:65`)                      | `None`                                                   |
+| 23  | `Api(_)` (`:67`)                          | `None`                                                   |
+| 24  | `Yaml(_)` (`:69`)                         | `InvalidConfig`(与 `InvalidConfig` 合并,沿用现状 `:655`) |
+| 25  | `Io(_)` (`:71`)                           | `None`                                                   |
+
+合计:13 个变体 → 12 个 kind;11 个变体 → `None`;1 个递归。**R0 不改变这个分类集合** —— 把 11 个 `None` 补齐是报告的 P3,属于 wire 新增,不在本 PR。
+
+---
+
+## 关键设计决策(已裁定,codex 无需再选)
+
+### D1 — 枚举放 `nyanpasu-core-metadata`
+
+理由与 `LogFrame` 完全同构(`crates/nyanpasu-core-metadata/src/log.rs:1-6` 的模块注释就是这个论证):三层需要同一个类型 —— core-manager 产出、ipc 承载、service 搬运、app 消费,而 core-metadata 是 ipc 与 core-manager **唯一的公共下游**。放 ipc 会让 core-manager 反向依赖 ipc;放 core-manager 会让 ipc 依赖整个 manager。
+
+### D2 — `Error::kind()` 返回 `Option<CoreErrorKind>`
+
+保留 `Option` 而不是加 `Unknown`/`Unclassified` 变体:现状注释(`manager_bridge.rs:641-645`)写得很清楚 —— 「未分类」必须是「没有 kind」,不能是猜的 kind。`None` 在 wire 上表现为**整个 `error_kind` 键被省略**(`api/mod.rs:84` 的 `skip_serializing_if`),这是既有 wire 语义,加变体会破坏它。
+
+### D3 — 匹配必须**穷尽**,禁止 `_ => None` 通配
+
+`map_error_kind` 今天必须写通配符,因为 `ManagerError` 对**下游 crate**是 `#[non_exhaustive]`。`kind()` 搬进 core-manager **自身** crate 后,`#[non_exhaustive]` 不再生效,可以写穷尽匹配。**这是本 PR 最大的实质收益**:今后给 `Error` 加变体会得到编译错误而不是静默 `None`。
+
+> codex 注意:11 个未分类变体必须**逐个显式列出** `=> None`,不得偷懒写 `_ => None`。写了通配符 = 本 PR 白做。
+
+### D4 — `R.error_kind` 字段类型**不变**,仍是 `Option<Cow<'a, str>>`
+
+这是前向兼容的关键。若改成 `Option<CoreErrorKind>`:一个**更新的 service** 发来老 client 不认识的 kind(P3 会新增),会让**整个 envelope 解码失败**,而不是丢一个字段 —— 正是 `docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md:129` 拒绝动 `ResponseCode` 枚举的那个失败模式。app 通过 auto-update 让 daemon 版本 ≥ GUI 版本是常态,「新 service + 老 client」真实存在。
+
+同理 `ClientError::Server.error_kind` 保持 `Option<String>`(原始字符串不丢),typed 访问通过新增的 `ClientError::core_error_kind()` 访问器提供。
+
+### D5 — `CoreErrorKind` **不标** `#[non_exhaustive]`
+
+对齐同协议层的 `ApplyOutcomeKind`(`api/core/apply.rs:34`,未标)。理由:解码侧 `from_wire` 返回 `Option`,未知 wire 字符串**永远不会**构造出未知变体,类型本身可以是封闭的;而封闭 enum 让「上游新增 kind」在 app 侧变成编译错误而不是被通配臂静默吞掉 —— service 与 GUI 同版本分发,这正是想要的行为。
+（此项是判断题,已在报告中标为 leader 复核项,见 §「需 leader 裁决」。）
+
+### D6 — 删除 `pub mod error_kind` 常量模块,不保留 deprecated 别名
+
+Exit 判据要求「不再各自维护第二份表」。保留 12 个 `pub const NOT_STARTED: &str = CoreErrorKind::NotStarted.as_str();` 虽然只有一份真值,但那是 CLAUDE.md §11 意义上的兼容层,且没有被阻塞的理由 —— 外部消费者实测为 0(app 侧 `rg` 零命中,ipc crate 未发布到 crates.io)。按「优先可迁移的破坏性变更」直接删。
+
+### D7 — `as_str()` 与 serde 的双表用测试钉死
+
+`as_str() -> &'static str` 是必需的(envelope 需要 `&'static str` 做 `Cow::Borrowed`,不能走 serde)。它与 `#[serde(rename_all)]` 构成两种表示 —— 这是 Rust 的标准写法,`ClashCoreKind`(`crates/nyanpasu-core-metadata/src/kind.rs:31-39` 的 `AsRef<str>` + 逐项 `#[serde(rename)]`)在同一个 crate 里就是这么写的。用一条测试遍历 `ALL` 断言 `serde_json::to_string(&kind) == format!("\"{}\"", kind.as_str())` 把两者钉死即可,**不允许再手写第三份表**:`from_wire` 必须通过扫描 `ALL` + `as_str()` 实现。
+
+---
+
+## Git 策略
+
+**实施在隔离 worktree 中进行,父仓的 submodule 检出全程不动。** 依据 CLAUDE.md / AGENTS.md §17 —— 迁移类工作跑在隔离 worktree 里。对 submodule 而言这条额外买到一个结构性好处:父仓 `backend/nyanpasu-runtime` 的检出 HEAD 全程停在 `main` @ `0d2993a`,**gitlink 漂移在物理上不可能发生**,并行进行的 PR-5-pre(path 依赖)验证也不会混入 R0 的代码。
+
+- **worktree 路径:** `G:\Programs\Rust\.ccg\clash-nyanpasu\runtime-r0`(沿用 monorepo P1 的 `G:/Programs/Rust/.ccg/clash-nyanpasu/<name>` 惯例)
+- **分支名:** `feat/core-error-kind`
+- **base:** `origin/main`(= `0c67f56`),**不是** tag `v2.0.0-rc.1`。
+  理由:两者只差一个纯 `README.md` 的 doc commit,`origin/main..v2.0.0-rc.1` 为空(tag 是 main 的严格祖先),因此以 main 为基**零冲突风险、零代码差异**;而以 tag 为基会让未来的上游 PR 一开始就落后 main、合并前还要 rebase 一次。
+- **工作流:** 只在 worktree 内做本地 commit。
+
+```powershell
+git -C G:\Programs\Rust\clash-nyanpasu\backend\nyanpasu-runtime fetch origin
+git -C G:\Programs\Rust\clash-nyanpasu\backend\nyanpasu-runtime worktree add G:\Programs\Rust\.ccg\clash-nyanpasu\runtime-r0 -b feat/core-error-kind origin/main
+```
+
+worktree 与父仓检出共享同一个 git 存储,所以 `origin/main` 已经在本地、不需要重新 clone。两点代价必须预期:
+
+1. **worktree 有自己独立的 `target/`** —— Task 0 的基线测试是**冷编译**,耗时远超增量构建,不要误判为卡死。
+2. **嵌套 submodule `crates/nyanpasu-utils` 不会自动带过来** —— 新 worktree 里它是空目录,不初始化则整个 workspace 无法编译。见 Task 0 Step 2。
+
+- **commit 规范:** Conventional Commits,scope 用 crate 名。建议 5 个 commit(Task 1–5 各一),而不是一个大 commit —— 每个 Task 结束时树都是编译绿 + 测试绿的。
+- **禁止:** `git push`、`gh pr create`、`git tag`、改任何 `version =`、以及在父仓 `backend/nyanpasu-runtime` 里执行任何 `git switch` / `git checkout`。
+
+### 交接边界(需用户显式授权才能越过)
+
+1. **推送 `feat/core-error-kind` 到 `libnyanpasu/nyanpasu-runtime` 并开上游 PR** —— 计划执行到本地 commit 为止,推送必须停下来问。
+2. **app 侧 submodule pin(gitlink)何时移动** —— 上游合并前,把 app 的 gitlink 指向一个**未推送**的本地 commit 会让 CI 的 `git submodule update` 直接失败。worktree 隔离让 R0 期间的 gitlink 保持零漂移(父仓检出不动),但「何时移动」仍是独立决策:可选的过渡消费方式(继续用 `v2.0.0-rc.1` pin / 先推 branch 再 pin branch commit / 等合并后 pin main)**是 leader 的决策,本计划不预设**。
+3. **release / tag** —— R0 不发版。sidecar 仍下载已发布的 `v2.0.0-rc.1`,因为 wire 没动,该二进制与打了 R0 的 app 完全兼容。
+4. **worktree 的销毁** —— Task 6 完成后 worktree **留在原地**供阶段审查使用。`git worktree remove` / `git worktree prune` 只在分支已推送或明确废弃后执行,是 leader 的决策。
+
+---
+
+## Task 0: worktree、分支与基线
+
+**Files:** 无代码变更。**Step 1 在父仓的 submodule 检出下执行;从 Step 2 起,包括后续 Task 1–6 的全部命令,一律以 worktree `G:\Programs\Rust\.ccg\clash-nyanpasu\runtime-r0` 为工作目录**(该目录是独立 cargo workspace)。
+
+- [ ] **Step 1: 创建隔离 worktree**
+
+```powershell
+git -C G:\Programs\Rust\clash-nyanpasu\backend\nyanpasu-runtime fetch origin
+git -C G:\Programs\Rust\clash-nyanpasu\backend\nyanpasu-runtime worktree add G:\Programs\Rust\.ccg\clash-nyanpasu\runtime-r0 -b feat/core-error-kind origin/main
+cd G:\Programs\Rust\.ccg\clash-nyanpasu\runtime-r0
+git log --oneline -2
+```
+
+Expected: HEAD = `0c67f56 chore: update docs`,其父为 `0d2993a chore: bump version to v2.0.0-rc.1`;当前分支 `feat/core-error-kind`。
+
+- [ ] **Step 2: 初始化嵌套 submodule(不做则无法编译)**
+
+```powershell
+git submodule update --init
+git submodule status
+```
+
+Expected: `crates/nyanpasu-utils` 检出到 `3cb3af02222ced3972d95ade599949098b159202`,且状态行首**无** `-`(未初始化)或 `+`(与记录不符)标记。
+
+新 worktree 不会自动带上嵌套 submodule 的工作树内容 —— 不初始化时 `crates/nyanpasu-utils` 是空目录,`cargo` 会因 workspace member 缺失直接失败。
+
+判定(本 Step 之后不再触碰它):`nyanpasu-utils` 只通过 `Error::Process(ProcessError)`(变体 22)与 `From<AtomicFsError>`(→ 变体 12/13/25)进入 `ManagerError`,这三条在 R0 后全部映射 `None` 且分类集合不变 —— **`crates/nyanpasu-utils` 零改动、不 bump**。
+
+- [ ] **Step 3: 确认父仓检出未被扰动(R0 全程的不变量)**
+
+```powershell
+git -C G:\Programs\Rust\clash-nyanpasu\backend\nyanpasu-runtime status -sb
+git -C G:\Programs\Rust\clash-nyanpasu\backend\nyanpasu-runtime worktree list
+```
+
+Expected: 第一条仍是 `## main...origin/main [behind 1]` 且工作区干净(HEAD 停在 `0d2993a`);第二条列出两个 worktree —— 父仓检出与 `runtime-r0`。**Task 6 Step 4 会再验一次这条不变量。**
+
+- [ ] **Step 4: 基线断言(改动前先确认现状为绿)**
+
+```powershell
+cargo test -p nyanpasu-ipc --all-features
+cargo test -p nyanpasu-service-runtime --lib
+```
+
+Expected: 全绿。`nyanpasu-ipc --all-features` 覆盖 `wire_golden`(默认 features 即可)与 `roundtrip`(`required-features = ["client","server"]`,见 `nyanpasu_ipc/Cargo.toml:7-10`)。
+
+**注意:worktree 的 `target/` 是空的,这一步是冷编译**,耗时远超父仓检出上的增量构建。用后台执行,不要按增量构建的时间预期判定卡死。
+
+- [ ] **Step 5: 记录版本基线(收尾时要比对未变)**
+
+```powershell
+Select-String -Path nyanpasu_service/Cargo.toml,crates/nyanpasu-service-runtime/Cargo.toml,nyanpasu_ipc/Cargo.toml,crates/nyanpasu-core-manager/Cargo.toml,crates/nyanpasu-core-metadata/Cargo.toml -Pattern '^version' | Select-Object Path,Line
+```
+
+Expected: `2.0.0-rc.1` / `2.0.0-rc.1` / `2.0.0-rc.1` / `1.0.0-rc.1` / `1.0.0-rc.1`。**Task 6 Step 3 结束时必须完全一致。**
+
+---
+
+## Task 1: `nyanpasu-core-metadata` 新增 `CoreErrorKind`
+
+**Files:**
+
+- Create: `crates/nyanpasu-core-metadata/src/error_kind.rs`
+- Modify: `crates/nyanpasu-core-metadata/src/lib.rs`(12 行,加 `mod` + `pub use`)
+
+- [ ] **Step 1: 新建 `crates/nyanpasu-core-metadata/src/error_kind.rs`**
+
+模块头注释请沿用 `log.rs:1-6` 的论证口吻(说明「为什么住在这里而不是 core-manager」)。类型定义:
+
+```rust
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Type, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoreErrorKind {
+    /// The operation needs a running core and there is none.
+    NotStarted,
+    /// The operation needs a stopped core and one is running.
+    AlreadyRunning,
+    /// `expected_revision` did not match the running revision. Nothing was
+    /// applied; re-read `/status` for the current one and retry.
+    RevisionConflict,
+    /// An epoch whose death could not be confirmed has latched the manager.
+    /// Every lifecycle operation is refused until `POST /core/recover` clears it.
+    Quarantined,
+    /// The core itself rejected the config in a dry run.
+    ConfigCheckFailed,
+    ConfigNotFound,
+    BinaryNotFound,
+    /// The config could not be parsed or canonicalized.
+    InvalidConfig,
+    /// The config declares no external controller, so the core cannot be
+    /// health-probed.
+    ControllerMissing,
+    /// The apply failed and the previous revision was restored.
+    ApplyFailed,
+    /// The apply failed and so did the rollback: no epoch is running.
+    ApplyRollbackFailed,
+    /// A core process could not be proven dead; the manager is now quarantined.
+    StopUnconfirmed,
+}
+```
+
+> 12 条 doc comment 直接从 `nyanpasu_ipc/src/api/mod.rs:39-65` 原样搬运(那是被删掉的常量的文档,不能丢)。变体顺序也照搬,便于 diff 对读。
+
+方法:
+
+```rust
+impl CoreErrorKind {
+    /// Every kind, in wire-declaration order. The single place a new kind has to
+    /// be listed besides the enum itself; `from_wire` and the golden test both
+    /// walk it.
+    pub const ALL: &'static [Self] = &[
+        Self::NotStarted,
+        Self::AlreadyRunning,
+        Self::RevisionConflict,
+        Self::Quarantined,
+        Self::ConfigCheckFailed,
+        Self::ConfigNotFound,
+        Self::BinaryNotFound,
+        Self::InvalidConfig,
+        Self::ControllerMissing,
+        Self::ApplyFailed,
+        Self::ApplyRollbackFailed,
+        Self::StopUnconfirmed,
+    ];
+
+    /// The wire string. `serde` derives the same spelling from
+    /// `rename_all = "snake_case"`; the two are pinned equal by this module's
+    /// tests, and this one exists because an envelope needs a `&'static str`.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::NotStarted => "not_started",
+            Self::AlreadyRunning => "already_running",
+            Self::RevisionConflict => "revision_conflict",
+            Self::Quarantined => "quarantined",
+            Self::ConfigCheckFailed => "config_check_failed",
+            Self::ConfigNotFound => "config_not_found",
+            Self::BinaryNotFound => "binary_not_found",
+            Self::InvalidConfig => "invalid_config",
+            Self::ControllerMissing => "controller_missing",
+            Self::ApplyFailed => "apply_failed",
+            Self::ApplyRollbackFailed => "apply_rollback_failed",
+            Self::StopUnconfirmed => "stop_unconfirmed",
+        }
+    }
+
+    /// The kind a wire string names, or `None` when this build does not know it.
+    ///
+    /// `None` is not an error: a newer service may classify a failure this build
+    /// has no variant for, and the raw string stays available to the caller.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|kind| kind.as_str() == value)
+    }
+}
+
+impl std::fmt::Display for CoreErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+```
+
+- [ ] **Step 2: 模块内测试(同文件 `#[cfg(test)] mod tests`)**
+
+三条:
+
+1. `every_kind_serializes_to_its_wire_string` —— 遍历 `ALL`,断言 `serde_json::to_string(kind).unwrap() == format!("\"{}\"", kind.as_str())`,并**逐条硬编码**断言 12 个字符串字面量(不要只写循环 —— 循环只证明两种表示一致,硬编码才钉住字符串本身)。
+2. `every_wire_string_parses_back` —— 遍历 `ALL`,`from_wire(kind.as_str()) == Some(*kind)`;并 `serde_json::from_str::<CoreErrorKind>(&format!("\"{}\"", kind.as_str())).unwrap() == *kind`。
+3. `an_unknown_wire_string_has_no_kind` —— `from_wire("a_future_kind").is_none()`。
+
+- [ ] **Step 3: 注册模块 —— `crates/nyanpasu-core-metadata/src/lib.rs`**
+
+```rust
+mod dist;
+mod error_kind;   // 新增(按字母序插在 dist 之后)
+mod feature;
+mod kind;
+mod log;
+
+pub use dist::{CoreDistribution, VariantTag};
+pub use error_kind::CoreErrorKind;   // 新增
+pub use feature::{...};
+```
+
+- [ ] **Step 4: 验证**
+
+```powershell
+cargo test -p nyanpasu-core-metadata
+cargo clippy -p nyanpasu-core-metadata --all-targets
+```
+
+Expected: 新增 3 条测试全绿;无 clippy 警告。`serde_json` 已在 `[dev-dependencies]`(`crates/nyanpasu-core-metadata/Cargo.toml:15-16`),**不需要加依赖**。
+
+Commit: `feat(core-metadata): add CoreErrorKind, the single error-kind wire table`
+
+---
+
+## Task 2: `nyanpasu-core-manager::Error::kind()`
+
+**Files:**
+
+- Modify: `crates/nyanpasu-core-manager/src/error.rs`
+- Modify: `crates/nyanpasu-core-manager/src/lib.rs:21`
+
+- [ ] **Step 1: `error.rs` 顶部重导出**
+
+在 `use camino::Utf8PathBuf;` 之后加(与 `log.rs:12`、`kind.rs:10` 同款):
+
+```rust
+pub use nyanpasu_core_metadata::CoreErrorKind;
+```
+
+- [ ] **Step 2: 在 `pub enum Error {...}`(`:7-72`)之后、`impl From<AtomicFsError>`(`:74`)之前插入**
+
+```rust
+impl Error {
+    /// The machine-readable classification a caller can branch on, or `None`
+    /// when this failure has none.
+    ///
+    /// `None` means "not classified", never "no error": naming a kind is a
+    /// statement of fact about the failure, and a guessed one is worse than an
+    /// absent one. The wire omits the field entirely for `None`.
+    ///
+    /// The match is exhaustive on purpose. `Error` is `#[non_exhaustive]` only
+    /// to *downstream* crates, so this — the defining crate — is the one place
+    /// a new variant can be made to fail the build instead of silently
+    /// answering `None`. Do not collapse the unclassified arms into a wildcard.
+    pub fn kind(&self) -> Option<CoreErrorKind> {
+        match self {
+            Self::AlreadyRunning => Some(CoreErrorKind::AlreadyRunning),
+            Self::NotStarted => Some(CoreErrorKind::NotStarted),
+            Self::ConfigNotFound(_) => Some(CoreErrorKind::ConfigNotFound),
+            Self::BinaryNotFound(_) => Some(CoreErrorKind::BinaryNotFound),
+            Self::ControllerMissing => Some(CoreErrorKind::ControllerMissing),
+            Self::ConfigCheckFailed(_) => Some(CoreErrorKind::ConfigCheckFailed),
+            Self::InvalidConfig(_) | Self::Yaml(_) => Some(CoreErrorKind::InvalidConfig),
+            Self::StopUnconfirmed(_) => Some(CoreErrorKind::StopUnconfirmed),
+            Self::ManagerQuarantined { .. } => Some(CoreErrorKind::Quarantined),
+            Self::RevisionConflict { .. } => Some(CoreErrorKind::RevisionConflict),
+            Self::ApplyFailed(_) => Some(CoreErrorKind::ApplyFailed),
+            Self::ApplyRollbackFailed { .. } => Some(CoreErrorKind::ApplyRollbackFailed),
+            // The durability wrapper is a warning around a real failure; report
+            // the failure's kind so a caller can still branch on it.
+            Self::DurabilityUncertain { source, .. } => source.kind(),
+            // Unclassified, listed one by one so a new variant is a compile
+            // error here. Mapping these is the protocol report's P3.
+            Self::CoreVersionProbeFailed { .. }
+            | Self::RequiredLocalIpcUnsupported { .. }
+            | Self::InvalidManagerOptions(_)
+            | Self::InvalidHealthPolicy(_)
+            | Self::UnsafeRuntimeArtifact(_)
+            | Self::RuntimeDirectoryOwned(_)
+            | Self::StartupTimeout { .. }
+            | Self::StartupFailed { .. }
+            | Self::Process(_)
+            | Self::Api(_)
+            | Self::Io(_) => None,
+        }
+    }
+}
+```
+
+> 对照 §「全量清单」表四逐行核对 25 个变体。若编译器报 `non-exhaustive patterns`,说明 `error.rs` 在计划期之后又加了变体 —— **补上显式臂并在报告里说明**,不要加 `_ =>`。
+
+- [ ] **Step 3: `error.rs` 底部加 `#[cfg(test)] mod tests`**
+
+四条:
+
+1. `manager_errors_carry_their_wire_kind` —— 移植 `manager_bridge.rs:1238-1284` 的 8 个用例(断言值从 `Some("not_started")` 改成 `Some(CoreErrorKind::NotStarted)` 等),含 `StartupFailed → None`。
+2. `the_durability_wrapper_reports_its_source_kind` —— `DurabilityUncertain{ source: ApplyFailed } → Some(ApplyFailed)`。
+3. `a_nested_durability_wrapper_still_reaches_the_source` —— **新增**,双层 `DurabilityUncertain{ DurabilityUncertain{ RevisionConflict } } → Some(RevisionConflict)`,把「递归」而不是「剥一层」钉住。
+4. `an_unclassified_failure_has_no_kind` —— 取 `Io(std::io::Error::other("boom"))` 与 `StartupTimeout{..}` 各断言 `None`。
+
+- [ ] **Step 4: `lib.rs:21` 重导出**
+
+```rust
+pub use error::{CoreErrorKind, Error};
+```
+
+(替换原 `pub use error::Error;`。这样 `nyanpasu-service-runtime` 不必新增 core-metadata 依赖 —— 它今天只依赖 core-manager + ipc + utils。)
+
+- [ ] **Step 5: 验证**
+
+```powershell
+cargo test -p nyanpasu-core-manager --lib
+cargo clippy -p nyanpasu-core-manager --all-targets
+```
+
+Expected: 4 条新测试绿。**用 `--lib`**:`cargo test -p nyanpasu-core-manager` 不带 target 过滤会连带构建 `nyanpasu-fake-core`/`nyanpasu-manager-host` 两个测试辅助 bin 并跑全部集成测试(耗时数分钟,且部分需要真实核心二进制),本 Step 不需要。
+
+Commit: `feat(core-manager): classify errors with Error::kind()`
+
+---
+
+## Task 3: service 侧改用 `Error::kind()`,删除 `map_error_kind`
+
+**Files:**
+
+- Modify: `crates/nyanpasu-service-runtime/src/server/manager_bridge.rs`
+
+本 Task 结束时 `nyanpasu_ipc::api::error_kind` 常量模块**仍然存在**(Task 4 才删),`RBuilder::other_error_with_kind` 签名**仍是** `Option<Cow<str>>` —— 因此 `into_envelope` 需要临时用 `as_str()` 桥接一次。这是为了让每个 Task 结束时树都能编译;Task 4 会把那一行简化掉。
+
+- [ ] **Step 1: import(`:8-23`)**
+
+`nyanpasu_core_manager::{...}` 那一组里加 `CoreErrorKind`(按字母序,`ConfigRevision` 之后、`CoreKind` 之前);`nyanpasu_ipc::api::{...}` 那一组里的 `error_kind,`(`:17`)**保留到 Task 4**。
+
+- [ ] **Step 2: `OpError`(`:53-84`)**
+
+```rust
+pub(crate) struct OpError {
+    kind: Option<CoreErrorKind>,   // was Option<&'static str>
+    message: String,
+}
+```
+
+- `with_kind(kind: CoreErrorKind, message: impl Into<String>)`(`:70`)
+- `into_envelope`(`:82`)临时改为:
+
+  ```rust
+  RBuilder::other_error_with_kind(
+      Cow::Owned(self.message),
+      self.kind.map(|kind| Cow::Borrowed(kind.as_str())),
+  )
+  ```
+
+- [ ] **Step 3: `From<ManagerError> for OpError`(`:86-99`)**
+
+`kind: map_error_kind(&error)` → `kind: error.kind()`。`message` 分支(`NotStarted` → `MSG_CORE_NOT_STARTED`)**一字不改**。
+
+- [ ] **Step 4: 删除 `map_error_kind`(`:641-665` 整个函数含 doc comment)**
+
+- [ ] **Step 5: 两处逐点分类改用 enum**
+
+- `:404` → `.map_err(|error| OpError::with_kind(CoreErrorKind::BinaryNotFound, error.to_string()))`
+- `:791` → `OpError::with_kind(CoreErrorKind::ConfigNotFound, message)`
+
+这两处输入是 `io::Error` 而不是 `ManagerError`,**不是表**,保留原样语义。
+
+- [ ] **Step 6: 测试(`:1237-1293`)**
+
+- 删除 `manager_errors_map_onto_the_wire_error_kinds`(`:1237-1284`) —— 表已经不在这个 crate 了,它的 8 个用例已在 Task 2 Step 3 落到 `error.rs`。
+- 保留并改写 `the_not_started_failure_keeps_the_legacy_wire_string`(`:1288-1293`):`assert_eq!(error.kind, Some(CoreErrorKind::NotStarted));`。这条测的是**桥的行为**(legacy message + kind 透传),该留在这里。
+- `:1519` `assert_eq!(resolved.kind, Some(error_kind::CONFIG_NOT_FOUND));` → `Some(CoreErrorKind::ConfigNotFound)`
+- `:1542` `assert_eq!(error.kind, Some(error_kind::BINARY_NOT_FOUND));` → `Some(CoreErrorKind::BinaryNotFound)`
+
+- [ ] **Step 7: 验证**
+
+```powershell
+cargo test -p nyanpasu-service-runtime --lib
+cargo clippy -p nyanpasu-service-runtime --all-targets
+```
+
+Expected: 全绿,**且 `routing/tests.rs:388,414,448,475` 四条端到端 `error_kind` 断言未经修改地通过** —— 这是 wire 未动的直接证据。
+
+Commit: `refactor(service): read the error kind from the manager instead of remapping it`
+
+---
+
+## Task 4: ipc 侧删除常量表、收敛构造器签名
+
+**Files:**
+
+- Modify: `nyanpasu_ipc/src/api/mod.rs`
+- Modify: `crates/nyanpasu-service-runtime/src/server/manager_bridge.rs`(2 行:import + `into_envelope`)
+- Modify: `nyanpasu_ipc/tests/wire_golden.rs`
+- Modify: `nyanpasu_ipc/tests/roundtrip.rs`
+
+删常量模块会同时打断 3 个文件的 import,所以这 4 个文件必须在**同一个 Task 内**改完;Task 中途树不可编译是预期的。
+
+- [ ] **Step 1: `api/mod.rs` —— 删模块,加重导出**
+
+- 删除 `pub mod error_kind { ... }`(`:38-66`)整块。
+- 在 `use serde::{...};`(`:8`)之后加 `pub use nyanpasu_core_metadata::CoreErrorKind;`,并把原模块文档(`:28-37`,「These strings are protocol / ResponseCode deliberately stays a two-variant enum / Absent means not classified」那三段)改写后挂到这个重导出上 —— 它解释的是**协议决策**,不能随模块一起删掉。写法参考 `api/ws/events.rs:8-11` 的重导出注释。
+
+- [ ] **Step 2: `api/mod.rs` —— `other_error_with_kind`(`:134-147`)签名收敛**
+
+```rust
+/// An error envelope carrying a [`CoreErrorKind`] classification.
+///
+/// `kind` is `Option` because a failure the service cannot classify must still
+/// be reportable — guessing a kind is worse than omitting it. Taking the enum
+/// rather than a string is what keeps a hand-typed kind off the wire.
+pub fn other_error_with_kind(msg: Cow<'a, str>, kind: Option<CoreErrorKind>) -> R<'a, T> {
+    let code = ResponseCode::OtherError;
+    R {
+        code,
+        msg,
+        data: None,
+        ts: crate::utils::get_current_ts(),
+        error_kind: kind.map(|kind| Cow::Borrowed(kind.as_str())),
+    }
+}
+```
+
+**`R.error_kind` 字段本身(`:80-85`)不动** —— 类型仍是 `Option<Cow<'a, str>>`,`#[serde(default, skip_serializing_if = "Option::is_none")]` 仍在。见 D4。
+
+- [ ] **Step 3: 修复 3 处失效的 intra-doc link**
+
+rustdoc 的 `broken_intra_doc_links` 是默认 warn,`--all-targets` clippy 不一定报,但 doc 会脏:
+
+- `api/mod.rs:80` `see [`error_kind`]` → `see [`CoreErrorKind`]`
+- `api/mod.rs:134` `a [`error_kind`] classification` → `a [`CoreErrorKind`] classification`(已在 Step 2 覆盖)
+- `client/mod.rs:52` `See [`crate::api::error_kind`].` → `See [`crate::api::CoreErrorKind`].`
+
+（`api/core/apply.rs:27`、`check.rs:22`、`recover.rs:7` 里的 `error_kind = "revision_conflict"` 是**普通文字**不是链接,不要动。）
+
+- [ ] **Step 4: `manager_bridge.rs` 两行收尾**
+
+- `:17` 从 `nyanpasu_ipc::api::{...}` 的 import 列表里删掉 `error_kind,`。
+- `into_envelope`(`:82`)简化为 `RBuilder::other_error_with_kind(Cow::Owned(self.message), self.kind)`。
+
+- [ ] **Step 5: `wire_golden.rs`**
+
+- import(`:22`)`error_kind,` → `CoreErrorKind,`。
+- helper `error_envelope_with_kind`(`:56-64`)入参 `kind: &'static str` → `kind: CoreErrorKind`,body 不变(`Some(kind)` 直接传)。
+- `the_error_kind_strings_are_pinned`(`:703-718`)改写为对 **serde 输出**的断言,并把注释升级:
+
+```rust
+#[test]
+fn the_error_kind_strings_are_pinned() {
+    // These are protocol: a caller branches on them. The enum lives in
+    // nyanpasu-core-metadata now, so this pins what actually reaches the wire.
+    for (kind, expected) in [
+        (CoreErrorKind::NotStarted, r#""not_started""#),
+        (CoreErrorKind::AlreadyRunning, r#""already_running""#),
+        (CoreErrorKind::RevisionConflict, r#""revision_conflict""#),
+        (CoreErrorKind::Quarantined, r#""quarantined""#),
+        (CoreErrorKind::ConfigCheckFailed, r#""config_check_failed""#),
+        (CoreErrorKind::ConfigNotFound, r#""config_not_found""#),
+        (CoreErrorKind::BinaryNotFound, r#""binary_not_found""#),
+        (CoreErrorKind::InvalidConfig, r#""invalid_config""#),
+        (CoreErrorKind::ControllerMissing, r#""controller_missing""#),
+        (CoreErrorKind::ApplyFailed, r#""apply_failed""#),
+        (CoreErrorKind::ApplyRollbackFailed, r#""apply_rollback_failed""#),
+        (CoreErrorKind::StopUnconfirmed, r#""stop_unconfirmed""#),
+    ] {
+        assert_eq!(serde_json::to_string(&kind).unwrap(), expected);
+    }
+    // Every kind is covered above; a new one must be added here too.
+    assert_eq!(CoreErrorKind::ALL.len(), 12);
+}
+```
+
+（形式与同文件 `the_apply_outcome_kinds_are_pinned`(`:687-701`)一致。）
+
+- `an_error_envelope_carries_its_kind`(`:722-733`)的调用改成 `error_envelope_with_kind("config revision conflict", CoreErrorKind::RevisionConflict)`;**被断言的 JSON 字面量一个字符都不许改**。
+- `a_pre_s8_envelope_still_decodes`(`:737-743`)**完全不动**。
+
+- [ ] **Step 6: `roundtrip.rs`**
+
+- import(`:51`)`error_kind,` → `CoreErrorKind,`(注意这一组在 `nyanpasu_ipc::api::{...}` 里,按字母序位置会变 —— `CoreErrorKind` 排在 `RBuilder` 之前)。
+- `apply_config_conflict_handler`(`:399-407`)→ `Some(CoreErrorKind::RevisionConflict)`。
+- `a_server_error_kind_reaches_the_client`(`:753-780`)的 `assert_eq!(error_kind.as_deref(), Some("revision_conflict"))` **保持不变**(字段仍是 `Option<String>`),Task 5 会在其后追加 typed 断言。
+
+- [ ] **Step 7: 验证**
+
+```powershell
+cargo test -p nyanpasu-ipc --all-features
+cargo test -p nyanpasu-service-runtime --lib
+cargo doc -p nyanpasu-ipc --no-deps
+```
+
+Expected: 测试全绿;`cargo doc` 无 `unresolved link` 警告。
+
+Commit: `refactor(ipc)!: replace the error_kind string constants with CoreErrorKind`
+
+---
+
+## Task 5: client 侧 typed 访问器
+
+**Files:**
+
+- Modify: `nyanpasu_ipc/src/client/mod.rs`
+- Modify: `nyanpasu_ipc/tests/roundtrip.rs`
+
+- [ ] **Step 1: `client/mod.rs` —— 在 `enum ClientError`(`:23-63`)之后加**
+
+```rust
+impl ClientError {
+    /// The typed classification of a server-side failure, when there is one
+    /// this build knows.
+    ///
+    /// `None` covers three different things and deliberately does not
+    /// distinguish them: a transport failure with no envelope, an envelope the
+    /// service did not classify, and a kind a newer service named that this
+    /// build has no variant for. The raw string is still on
+    /// [`Self::Server::error_kind`] for the last case.
+    pub fn core_error_kind(&self) -> Option<CoreErrorKind> {
+        match self {
+            Self::Server { error_kind, .. } => {
+                error_kind.as_deref().and_then(CoreErrorKind::from_wire)
+            }
+            _ => None,
+        }
+    }
+}
+```
+
+import 加 `crate::api::CoreErrorKind`(`:5-11` 那一组)。
+
+`ClientError::Server` 的 `error_kind: Option<String>` 字段**不动** —— 见 D4。
+
+- [ ] **Step 2: `client/mod.rs` —— 同文件加 `#[cfg(test)] mod tests`**
+
+该文件今天没有测试模块,新建一个,两条(纯值构造,不起服务):
+
+1. `a_known_kind_is_typed` —— 构造 `ClientError::Server { operation: "/core/apply", code: ResponseCode::OtherError, msg: "boom".into(), error_kind: Some("revision_conflict".into()) }`,断言 `core_error_kind() == Some(CoreErrorKind::RevisionConflict)`。
+2. `an_unknown_kind_keeps_its_raw_string` —— 同样构造但 `error_kind: Some("a_future_kind".into())`,断言 `core_error_kind().is_none()` **且**原字段仍是 `Some("a_future_kind")`。这条是 D4 前向兼容契约的回归闸。
+
+- [ ] **Step 3: `roundtrip.rs` —— `a_server_error_kind_reaches_the_client`(`:756-780`)追加 typed 断言**
+
+现有 `match` 臂里已经解构出 `error_kind`,但访问器挂在 `ClientError` 上,所以改成先绑定整个错误:
+
+```rust
+    let error = client.apply_config(&apply_payload()).await.unwrap_err();
+    assert_eq!(error.core_error_kind(), Some(CoreErrorKind::RevisionConflict));
+    match error {
+        ClientError::Server { code, msg, error_kind, .. } => {
+            assert_eq!(code, ResponseCode::OtherError);
+            assert_eq!(msg, "config revision conflict");
+            assert_eq!(error_kind.as_deref(), Some("revision_conflict"));
+        }
+        other => panic!("expected a classified server error, got: {other:?}"),
+    }
+```
+
+（保留原 `msg` / raw `error_kind` 断言 —— 它们钉的是 wire。）
+
+- [ ] **Step 4: 验证**
+
+```powershell
+cargo test -p nyanpasu-ipc --all-features
+```
+
+Expected: 全绿。注意 `roundtrip.rs` 的 `run_server` 在无法绑定 socket 时返回 `None` 并静默跳过(Unix 下 `/var/run` 需要可写);Windows 走 named pipe,应当真实执行。
+
+Commit: `feat(ipc): expose the typed error kind on the client error`
+
+---
+
+## Task 6: 全量验证与收尾
+
+**Files:** 无代码变更。命令仍在 worktree `G:\Programs\Rust\.ccg\clash-nyanpasu\runtime-r0` 下执行。
+
+- [ ] **Step 1: 对齐 CI 的全量检查**
+
+```powershell
+cd G:\Programs\Rust\.ccg\clash-nyanpasu\runtime-r0
+cargo clippy --all-targets --all-features
+cargo fmt --all -- --check
+cargo test -p nyanpasu-core-metadata
+cargo test -p nyanpasu-core-manager --lib
+cargo test -p nyanpasu-ipc --all-features
+cargo test -p nyanpasu-service-runtime --lib
+```
+
+Expected: 全绿。`cargo clippy --all-targets --all-features` 是 `ci.yml:52` 的原样命令。若出现 `query stack during panic` ICE —— **重跑**,不改 toolchain。
+
+- [ ] **Step 2: 「不再有第二份表」的机械判据**
+
+```powershell
+rg 'map_error_kind|pub mod error_kind|error_kind::[A-Z_]+' --type rust .
+```
+
+Expected: **0 命中**。(`error_kind` 作为 envelope **字段名**的命中不算 —— 那是 wire,必须还在;上面的 pattern 已经排除了它。)
+
+```powershell
+rg '"not_started"|"already_running"|"revision_conflict"|"quarantined"|"config_check_failed"|"config_not_found"|"binary_not_found"|"invalid_config"|"controller_missing"|"apply_failed"|"apply_rollback_failed"|"stop_unconfirmed"' --type rust .
+```
+
+Expected: 命中只应出现在 —— `crates/nyanpasu-core-metadata/src/error_kind.rs`(`as_str()` 与其测试)、`nyanpasu_ipc/tests/wire_golden.rs`(golden)、`nyanpasu_ipc/tests/roundtrip.rs`(wire 断言)、`crates/nyanpasu-service-runtime/src/server/routing/tests.rs`(端到端 wire 断言)。**任何 `src/` 下的其它命中都是残留的第二份表。**
+
+- [ ] **Step 3: 版本未动**
+
+```powershell
+git diff origin/main --stat -- '*/Cargo.toml' 'Cargo.toml' 'Cargo.lock'
+```
+
+Expected: **空**。R0 不加依赖、不改 manifest、不动 `Cargo.lock`。若 `Cargo.lock` 出现改动,说明误加了依赖 —— 回退。
+
+- [ ] **Step 4: 嵌套 submodule 与父仓检出均未动**
+
+```powershell
+git diff origin/main -- crates/nyanpasu-utils
+git submodule status
+git -C G:\Programs\Rust\clash-nyanpasu\backend\nyanpasu-runtime status -sb
+git -C G:\Programs\Rust\clash-nyanpasu\backend\nyanpasu-runtime rev-parse HEAD
+```
+
+Expected: 空 diff;`3cb3af0` 未变;父仓检出仍是 `## main...origin/main [behind 1]`、工作区干净、HEAD = `0d2993ab...`(即 Task 0 Step 3 的不变量在整个 R0 期间成立)。父仓 HEAD 若移动了,说明有命令跑错了目录 —— 必须查清并复原后再交接。
+
+- [ ] **Step 5: 变更面复核**
+
+```powershell
+git diff origin/main --stat
+```
+
+Expected: 恰好 9 个文件 ——
+`crates/nyanpasu-core-metadata/src/error_kind.rs`(新)、
+`crates/nyanpasu-core-metadata/src/lib.rs`、
+`crates/nyanpasu-core-manager/src/error.rs`、
+`crates/nyanpasu-core-manager/src/lib.rs`、
+`crates/nyanpasu-service-runtime/src/server/manager_bridge.rs`、
+`nyanpasu_ipc/src/api/mod.rs`、
+`nyanpasu_ipc/src/client/mod.rs`、
+`nyanpasu_ipc/tests/wire_golden.rs`、
+`nyanpasu_ipc/tests/roundtrip.rs`。
+`crates/nyanpasu-service-runtime/src/server/routing/tests.rs` **不在列** —— 它出现在 diff 里就是 wire 动了的信号。
+
+- [ ] **Step 6: 停下来交接**
+
+**不要 push,不要开 PR。不要销毁 worktree。** worktree `G:\Programs\Rust\.ccg\clash-nyanpasu\runtime-r0` **原地保留**供阶段审查使用 —— `git worktree remove` / `git worktree prune` 只在分支已推送或明确废弃之后执行,由 leader 决定时机(交接边界第 4 条)。
+
+向 leader 报告:worktree 路径 + 分支名 + commit 列表 + 上述判据结果 + 父仓检出不变量验证结果 + 覆盖率影响观察(见风险 R6)。
+
+---
+
+## 测试计划总览
+
+| 测试                                                             | 位置                               | 性质                          | R0 后                                       |
+| ---------------------------------------------------------------- | ---------------------------------- | ----------------------------- | ------------------------------------------- |
+| `every_kind_serializes_to_its_wire_string`                       | core-metadata `error_kind.rs`      | 新增                          | 12 个字符串字面量 + `as_str()`↔serde 一致性 |
+| `every_wire_string_parses_back`                                  | core-metadata `error_kind.rs`      | 新增                          | `from_wire` / serde 双向 round-trip         |
+| `an_unknown_wire_string_has_no_kind`                             | core-metadata `error_kind.rs`      | 新增                          | 前向兼容                                    |
+| `manager_errors_carry_their_wire_kind`                           | core-manager `error.rs`            | 从 service 迁入               | 8 个用例(原 `manager_bridge.rs:1238`)       |
+| `the_durability_wrapper_reports_its_source_kind`                 | core-manager `error.rs`            | 新增                          | 单层递归                                    |
+| `a_nested_durability_wrapper_still_reaches_the_source`           | core-manager `error.rs`            | 新增                          | 双层递归                                    |
+| `an_unclassified_failure_has_no_kind`                            | core-manager `error.rs`            | 新增                          | `None` 语义                                 |
+| `the_not_started_failure_keeps_the_legacy_wire_string`           | `manager_bridge.rs:1288`           | 改断言类型                    | 桥的 legacy message + kind 透传             |
+| `the_error_kind_strings_are_pinned`                              | `wire_golden.rs:703`               | 改写为 serde 断言             | **比原来更强**:钉的是真正上 wire 的表示     |
+| `an_error_envelope_carries_its_kind`                             | `wire_golden.rs:722`               | 只改构造、**JSON 字面量不动** | wire 字节闸门                               |
+| `a_pre_s8_envelope_still_decodes`                                | `wire_golden.rs:737`               | **完全不动**                  | 向后兼容闸门                                |
+| `a_server_error_kind_reaches_the_client`                         | `roundtrip.rs:756`                 | 追加 typed 断言               | raw + typed 双证                            |
+| `a_known_kind_is_typed` / `an_unknown_kind_keeps_its_raw_string` | `client/mod.rs`                    | 新增                          | D4 契约回归闸                               |
+| routing 端到端 4 条                                              | `routing/tests.rs:388,414,448,475` | **完全不动**                  | wire 未动的最强证据                         |
+
+---
+
+## 风险
+
+| #   | 风险                                                                   | 处置                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | **未知 kind 的前向兼容** —— 更新的 service 发来老 client 不认识的 kind | 已决(D4):`R.error_kind` 与 `ClientError::Server.error_kind` 都保持原始字符串,typed 访问走 `from_wire → Option`。若把 wire 字段改成 `Option<CoreErrorKind>`,未知 kind 会让**整个 envelope 解码失败**,而不是丢一个字段 —— 与 `wire_golden` 保持不变的目标直接冲突,也正是报告 §4 P0-B 拒绝动 `ResponseCode` 的同一失败模式。`an_unknown_kind_keeps_its_raw_string` 是这条的回归闸。                                                                                                                        |
+| R2  | 删 `pub mod error_kind` 是 `nyanpasu-ipc` 的**破坏性 API 变更**        | 已实测外部消费者为 0:app 侧 `rg 'error_kind\|ClientError::Server' backend/tauri/src` 零命中,ipc 未发布到 crates.io,唯一消费者是同 workspace 的 `nyanpasu-service-runtime`。按 CLAUDE.md §11「优先可迁移的破坏性变更」,不留 deprecated 别名。commit message 带 `!`。                                                                                                                                                                                                                                     |
+| R3  | `Error::kind()` 写成 `_ => None` 通配                                  | 那样本 PR 就只是搬家,没拿到「新变体编译报错」的收益。Task 2 Step 2 明写禁止;review 时 `rg '_ => None' crates/nyanpasu-core-manager/src/error.rs` 应为 0。                                                                                                                                                                                                                                                                                                                                               |
+| R4  | intra-doc link 断裂(3 处)                                              | Task 4 Step 3 逐条列出;`cargo doc -p nyanpasu-ipc --no-deps` 作为验证。                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| R5  | `CoreErrorKind` 是否该 `#[non_exhaustive]`                             | 已决(D5):不标,对齐 `ApplyOutcomeKind`。**属判断题,列入 leader 裁决项。** 若 leader 改判要标,则 app 侧未来 `match` 必须留通配臂,本计划其余部分不受影响。                                                                                                                                                                                                                                                                                                                                                 |
+| R6  | **覆盖率闸门** `--fail-under-lines 53`(基线 55.42%)                    | `map_error_kind`(~19 行,被测试完全覆盖)从被测量集合(`-p nyanpasu-service-runtime -p nyanpasu-ipc`)中删除,而新增的 `kind()` 落在 core-manager —— 被 `--ignore-filename-regex 'crates/(clash-api\|nyanpasu-core-manager\|nyanpasu-core-metadata\|nyanpasu-utils)/'` 排除在外。**净效果是把一段高覆盖代码移出分母之外的分子**,理论上略微拉低百分比。19 行相对基线体量极小,2.4 个百分点的余量足够,但 codex 若本地装了 `cargo-llvm-cov` 应跑一次记录数字;没装则在交接报告里标注「未本地验证,依赖 CI 信号」。 |
+| R7  | Task 4 中途树不可编译                                                  | 预期行为(删常量同时打断 3 个文件)。Task 4 的 5 个 Step 必须一次做完再验证,不要中途 `cargo check` 就判定失败。                                                                                                                                                                                                                                                                                                                                                                                           |
+| R8  | `error.rs` 在计划期后新增了 `Error` 变体                               | 穷尽匹配会直接编译报错,补显式臂即可;**必须在交接报告里说明新变体及其 kind 判定**,不得静默塞进 `None` 组。                                                                                                                                                                                                                                                                                                                                                                                               |
+| R9  | nightly ICE(`query stack during panic`)                                | 本机已知的非确定性问题,**重跑**。不得 pin toolchain 日期(用户已明确否决)。                                                                                                                                                                                                                                                                                                                                                                                                                              |
+
+---
+
+## 明确的 Out of scope
+
+- ❌ 任何 crate 的 `version =` bump(尤其 `nyanpasu_service` 的 `2.0.0-rc.1` —— `scripts/check.ts:674-691` 的 sidecar 下载 lockstep 依赖它)
+- ❌ 新建 crate
+- ❌ `CoreEngine` trait / `CoreEngineFactory` / `EngineStatus` / `EngineError` 镜像
+- ❌ 把剩余 11 个未分类 `ManagerError` 变体补上 kind(= wire 新增,属报告 P3)
+- ❌ 改 `R.error_kind` 字段类型、改 `ResponseCode`、改任何已有 wire 字符串
+- ❌ `git push` / 开上游 PR / 打 tag
+- ❌ 动 app 仓(`backend/tauri`、`backend/Cargo.toml`、submodule gitlink)
+- ❌ 动嵌套 submodule `crates/nyanpasu-utils`
+- ❌ 动 `rust-toolchain.toml`
+
+---
+
+## 需 leader 裁决 → 裁定结果(2026-08-01)
+
+1. **D5 `#[non_exhaustive]`** —— 计划已裁定「不标」(对齐 `ApplyOutcomeKind`,让上游加 kind 时 app 侧编译报错而非静默通配)。若倾向「标」,只需在 Task 1 Step 1 加一行属性,其余不变。
+   **Leader 裁定:维持「不标」。** 解码走 `from_wire → Option`,封闭 enum 不会因未知 wire 串构造失败;service 与 GUI 同版本分发,上游新增 kind 触发 app 侧编译错误正是想要的行为。
+2. **上游推送与 PR 时机** —— 计划止步于本地 commit。
+   **Leader 裁定:确认交接边界。** R0 通过阶段审查后由 leader 向用户申请推送授权;授权前一切停在本地分支。
+3. **上游合并前 app 如何消费 R0** —— 继续 pin `v2.0.0-rc.1` / 先推分支再 pin 分支 commit / 等合并后 pin main。三者对 PR-5-pre P1(切 path 依赖)的排期影响不同,由 leader 定。
+   **Leader 裁定:PR-5-pre P1 继续 pin `v2.0.0-rc.1`,不依赖 R0;消费方式推迟到 PR-5a 启动门,与推送授权一并决。** 这一半仍然成立。
+
+   ~~补充执行约束:R0 实施结束后 submodule 工作树停在 `feat/core-error-kind` 供审查;PR-5-pre 实施开始前由 leader 将其切回 `main`(= `0d2993a`),避免 path 依赖下的验证混入 R0 代码、也避免 gitlink 误提交。~~
+   **↑ 已被 worktree 隔离取代(2026-08-02,codex 评审 Job 1)。** 该约束的存在前提是「R0 与 PR-5-pre 共用同一个 submodule 检出」,因而需要人工切分支来分隔两者。改为在 `G:\Programs\Rust\.ccg\clash-nyanpasu\runtime-r0` 的隔离 worktree 中实施后,父仓检出的 HEAD 全程停在 `main` @ `0d2993a`,**根本不需要切回** —— 「验证混入 R0 代码」与「gitlink 误提交」两个风险从结构上消失,而不是靠流程纪律规避。保留原文供追溯。
+
+附:leader 复核补充(2026-08-01) —— 计划 Task 1 使用 `specta::Type` derive 而未验证依赖,已核实 `crates/nyanpasu-core-metadata/Cargo.toml:14` 已有 `specta = { version = "^2.0.0-rc.25", features = ["derive"] }`,「不新增任何依赖」声明成立。

--- a/docs/superpowers/specs/2026-08-01-pr5-core-actor/design.md
+++ b/docs/superpowers/specs/2026-08-01-pr5-core-actor/design.md
@@ -1,0 +1,351 @@
+# PR-5 — CoreActor 迁移简化设计
+
+**日期：** 2026-08-01  
+**目标：** 迁移核心生命周期所有权，但不在 `clash-nyanpasu` 中重做一遍 `nyanpasu-runtime` 已经具备的 manager、状态机、恢复、配置应用与回滚能力。
+
+## 1. 核心结论
+
+PR-5 只新增一层 **应用事务协调**：
+
+1. `CoreActor` 负责 GUI 进程内的所有权、运行后端选择、Promoted / Applied 状态和跨步骤事务排他；
+2. `nyanpasu-core-manager` / `nyanpasu-service` 继续负责单次核心操作的内部串行、进程监督、健康检查、apply 分类与回滚；
+3. 使用一个取消安全的 `OperationId` 协议，替代 GUI 侧的 `rebuild_gate`、`clash_patch_gate` 和传统生命周期 mutex；
+4. 不新增 `CoreEngine` trait、`CoreEngineFactory`、`EngineStatus`、`EngineRevision`、`ApplyReport`、完整 `EngineError` 镜像；
+5. 不在 actor 上增加第二层自动恢复；
+6. 所有运行配置变更统一调用 runtime 的 full-config `apply_config`，不再在 GUI 侧先直接 PATCH Clash API；
+7. 换核作为普通 desired-state mutation：desired 提交成功后，若 runtime 回滚，则保留 desired 新核并返回 `CommittedDegraded`，不执行第二套应用层回滚事务。
+
+## 2. 两层串行模型
+
+只保留两层互斥：
+
+| 层             | 保护对象                                                                             | 实现                                                                                |
+| -------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| 应用事务层     | snapshot → build → check → promote → apply/start，以及换核、运行模式切换等跨组件操作 | `CoreActor` 的 `OperationId`                                                        |
+| runtime 内部层 | epoch、active instance、runtime copy、quarantine、进程切换等 manager 内部不变式      | `nyanpasu-core-manager` 自身的 `ctrl` mutex；service 保留自身 closing/control latch |
+
+`OperationId` **不替代** runtime 内部 mutex，也不替代 runtime directory ownership lock。它只替代 `clash-nyanpasu` 为跨多个 actor/RPC/文件步骤而设置的应用层锁。
+
+迁移完成后删除：
+
+- `NyanpasuClientInner::rebuild_gate`；
+- `NyanpasuClientInner::clash_patch_gate`；
+- legacy `CoreManager::lifecycle_lock`；
+- GUI 侧 API-first patch 的补偿 mutex/fence 实现。
+
+配置 actor 的普通 commit 不受 operation gate 阻塞。每次 rebuild 在读取 typed snapshots **之前**取得 `CoreOperationGuard`；构建期间发生的新 commit 由现有 dirty/coalesce 机制触发下一次 rebuild。
+
+## 3. 取消安全的 OperationId
+
+命名约定：
+
+- `OperationId`：actor 用于校验和 fencing 的一次性操作身份；
+- `CoreOperationGuard`：调用侧持有的 RAII guard；
+- `OperationGate`：actor 内部的 active + FIFO waiters 状态；
+- `OperationId` 不表示核心进程实例，也不表示登录、网络或端口 session；它没有 TTL、续租和 heartbeat 语义。
+- 迁移期间仅为兼容既有 seam，`CoreOperationGuard` 可以暂时实现旧名 `CoreLifecycleLease`；新类型与新消息不得继续使用 Lease 命名。
+
+### 3.1 为什么 OperationId 由 client 预分配
+
+actor 在 `AcquireOperation` handler 中分配 ID、再通过 RPC 返回给调用方，会有取消窗口：actor 已经登记 active operation，但调用 future 在收到 ID 前被取消，此时调用方没有 guard 可执行 `Drop`。
+
+因此 ID 必须由共享的 `CoreClient` 在发送 `AcquireOperation` 前预分配，并先构造 pending guard。
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct OperationId(NonZeroU64);
+
+#[derive(Clone)]
+pub struct CoreClient {
+    actor: ActorRef<CoreActorMessage>,
+    next_operation: Arc<AtomicU64>,
+    snapshot: watch::Receiver<CoreSnapshot>,
+}
+
+pub struct CoreOperationGuard {
+    id: OperationId,
+    client: CoreClient,
+    acquired: bool,
+}
+```
+
+`CoreClient` 的 clones 共享同一个 `AtomicU64`。`0` 保留为无效值；溢出视为进程生命周期内不可恢复的内部错误，不做持久化或跨进程协议。
+
+### 3.2 actor 状态
+
+```rust
+struct OperationGate {
+    active: Option<ActiveOperation>,
+    waiters: VecDeque<OperationWaiter>,
+}
+
+struct ActiveOperation {
+    id: OperationId,
+    acquired_at: Instant,
+}
+
+struct OperationWaiter {
+    id: OperationId,
+    reply: RpcReplyPort<Result<(), OperationError>>,
+}
+```
+
+只需要两个控制消息：
+
+```rust
+enum CoreActorMessage {
+    AcquireOperation {
+        id: OperationId,
+        reply: RpcReplyPort<Result<(), OperationError>>,
+    },
+    ReleaseOperation {
+        id: OperationId,
+    },
+
+    CheckAndPromote { operation: OperationId, request: PromoteRequest, reply: ... },
+    ApplyPromoted   { operation: OperationId, request: ApplyRequest, reply: ... },
+    StartPromoted   { operation: OperationId, reply: ... },
+    Restart         { operation: OperationId, reply: ... },
+    Stop            { operation: OperationId, reply: ... },
+    SetBackend      { operation: OperationId, mode: RunMode, reply: ... },
+    Recover         { operation: OperationId, reply: ... },
+    Shutdown        { reply: RpcReplyPort<()> },
+
+    BackendStatus(CoreStatusView),
+    BackendLog(Arc<LogFrame>),
+}
+```
+
+### 3.3 AcquireOperation / ReleaseOperation 规则
+
+- 无 active operation：立即登记为 active，并回复成功；
+- 已有 active operation：将 waiter 放入 FIFO；handler 立即返回，绝不等待释放；
+- `ReleaseOperation(active_id)`：清除 active，并从 FIFO 中寻找下一个仍有接收方的 waiter；
+- `ReleaseOperation(waiting_id)`：从 waiters 删除，等价于取消等待；
+- 过期或未知 ID：幂等 no-op，并写 debug 日志；
+- mutation 消息的 ID 与 active 不一致：返回 `StaleOperation`；
+- shutdown：拒绝全部 waiters，清空 active，再关闭 backend。
+
+`CoreOperationGuard` 在调用 `AcquireOperation` 前已经存在：
+
+```rust
+async fn begin_operation(&self) -> Result<CoreOperationGuard> {
+    let mut operation =
+        CoreOperationGuard::pending(self.clone(), self.allocate_operation_id()?);
+    operation.acquire().await?;
+    Ok(operation)
+}
+```
+
+若 future 在等待或刚获批时被取消，pending guard 的 `Drop` 都会发送 `ReleaseOperation { id }`。正常路径允许显式 `release().await`；`Drop` 只作为取消/early-return 兜底。发送失败仅意味着 actor 已终止，不再存在需要让给后续操作的 active operation。
+
+不实现：
+
+- TTL；
+- auto-steal；
+- watchdog self-message；
+- UI degradation 定时器；
+- operation 续期或心跳。
+
+可以在 `ReleaseOperation` 时对持有时长超过阈值写 warning，但不影响所有权。
+
+### 3.4 Operation 范围
+
+必须持有 `CoreOperationGuard`：
+
+- runtime build/check/promote/apply；
+- start/restart/stop；
+- change core；
+- Local ↔ Service backend 切换；
+- 与 start/stop 强关联的 macOS DNS 修改。
+
+不需要 operation guard：
+
+- 读取 status；
+- 读取 Promoted / Applied；
+- 读取日志；
+- 订阅状态或日志；
+- 普通 typed config commit。
+
+## 4. CoreBackend：封闭 enum，不使用 CoreEngine trait
+
+本项目只有两个生产后端，且两者由同一组织维护，使用封闭 enum 比 trait + factory + error/status 镜像更直接：
+
+```rust
+enum CoreBackend {
+    Local(LocalBackend),
+    Service(ServiceBackend),
+    #[cfg(test)]
+    Test(TestBackend),
+}
+```
+
+```rust
+impl CoreBackend {
+    async fn check(&self, request: &CoreRequest) -> Result<()>;
+    async fn start(&self, request: &CoreRequest) -> Result<()>;
+    async fn apply(&self, request: &CoreRequest) -> Result<CoreApplyData>;
+    async fn stop(&self) -> Result<()>;
+    async fn restart(&self) -> Result<()>;
+    async fn recover(&self) -> Result<()>;
+}
+```
+
+- Local：直接调用 `nyanpasu_core_manager::CoreManager`；
+- Service：直接调用实例化的 `nyanpasu_ipc::client::Client`；禁止 `service_default()`；
+- 测试：使用 `Test` variant，而不是为两个固定实现引入完整动态 trait 层；
+- mode 切换通过 `SetBackend` 在 operation guard 下执行，不需要 `CoreEngineFactory` 或 `pending_run_type`。调用方需要切换时先正常排队取得 `CoreOperationGuard`。
+
+### 4.1 复用 runtime 类型
+
+不在 app 侧复制以下类型：
+
+- `EngineStatus`：使用 manager status / IPC `CoreInfos` 的最小 UI 投影；
+- `ApplyReport`：统一使用 IPC 已定义的 `CoreApplyData` / `ApplyOutcomeKind`；Local 只需一个转换函数；
+- `EngineRevision`：Local 使用 `RevisionId`，Service 使用 `RevisionIdInfo`，在 backend 内转换；
+- 完整 `EngineError`：只保留机器可读 kind + 原始 message/source。
+
+建议在 `nyanpasu-runtime` 做一个小型协同修改，而不是在 app 复制字符串表：
+
+```rust
+// nyanpasu-core-metadata
+#[serde(rename_all = "snake_case")]
+pub enum CoreErrorKind { ... }
+
+// nyanpasu-core-manager
+impl Error {
+    pub fn kind(&self) -> Option<CoreErrorKind>;
+}
+```
+
+IPC 继续把它序列化为现有 `error_kind` 字符串，wire 不变；client 将字符串解析回 enum。不要新建 crate，也不要新建 transport-neutral `CoreEngine` 框架。
+
+## 5. 不增加第二层自动恢复
+
+Local manager 已经根据 `InstanceOptions` 执行有界 Supervisor 重启与指数退避；Service daemon 使用同一 manager。CoreActor 不再配置额外 `RecoverPolicy`，也不发送 delayed `Recover{attempt}`。
+
+actor 只做：
+
+- 观察 backend 最终状态；
+- Supervisor/daemon 最终放弃后，发布一次 `core_recovery_exhausted` degradation；
+- 用户显式重试时调用 `recover` 或 `restart`；
+- shutdown 时关闭 backend。
+
+这样不会产生“manager 重试 5 次 + actor 再重试 3 轮”的不可预测恢复链。
+
+## 6. RuntimeLifecycleState 由 CoreActor 单独拥有
+
+既然 check/promote/apply 都在同一个 actor operation 下完成，Promoted 与 Applied 应由同一所有者维护：
+
+```rust
+struct CoreActorState {
+    backend: CoreBackend,
+    mode: RunMode,
+    operation: OperationGate,
+    runtime: RuntimeLifecycleState, // promoted + applied
+    status: CoreStatusView,
+    logs: VecDeque<Arc<LogFrame>>,
+}
+```
+
+- `CheckAndPromote` 成功后推进 Promoted；
+- apply/start 成功且采用新 revision 后推进 Applied；
+- `RolledBack` 保持 Applied 不变；
+- apply error 保持 Applied 不变；
+- durability warning 不阻止状态推进，但返回 degraded；
+- CoreClient 通过 watch snapshot 读取状态，不为读取发送 mailbox RPC。
+
+删除 `NyanpasuClient` 中独立的 `RuntimeLifecycleStore`、`publish_promoted`、`publish_applied` 和 `restore_promoted`。
+
+## 7. 配置应用只走 full-config apply
+
+新的统一路径：
+
+1. typed desired config commit；
+2. 取得 `CoreOperationGuard`；
+3. 读取最新 typed snapshots；
+4. build candidate；
+5. backend dry-run check；
+6. 原子 promote product，推进 Promoted；
+7. `apply_config(product, expected_revision)`；
+8. 根据 `CoreApplyData.outcome` 推进 Applied 或返回 degraded；
+9. 释放 operation guard。
+
+runtime 自己选择：
+
+- `PATCH /configs`；
+- `PUT /configs`；
+- same-epoch restart；
+- core switch；
+- rollback。
+
+因此删除：
+
+- `RunningConfigPatchPort`；
+- `LegacyRunningConfigPatchBridge`；
+- `ControllerBinding` 与 actor 内 clash-api client cache；
+- `config_patch_from_mapping`；
+- `clash_patch_gate`；
+- GUI 侧 patch compensation plan/fence；
+- PR-5 中“clash-api 随核迁移”的范围。
+
+其余 proxies/connections/ws/tray 等直接 clash-api 消费者继续留给 PR-6。
+
+## 8. ChangeCore 采用普通 commit-first 语义
+
+`change_core` 不再维护专用的五分支应用层回滚事务：
+
+1. `ApplicationClient::patch(core = new_core)`；
+2. 走统一 build/check/promote/apply；
+3. runtime 若成功 switch：Applied 推进；
+4. runtime 若返回 `RolledBack`：旧核/旧 revision 仍实际运行，desired 新核与 Promoted 新配置保留，返回 `CommittedDegraded { phase: CoreRollback }`；
+5. 后续显式 retry 或下一次 rebuild 再尝试 desired 新核。
+
+这与项目的 commit-first 规则一致，并让 Promoted / Applied 的分离真正表达 desired 与 effective 不一致。
+
+删除：
+
+- legacy verge draft/discard/apply；
+- rollback rebuild；
+- product bytes restore；
+- 第二次 old-core restart；
+- `ChangeCoreReport` 专用 wire；
+- 仅为该 wire 增加的前端分支。
+
+若前端需要立即展示结果，复用一个通用 `RuntimeApplyReport`，不要定义 change-core 专属结果：
+
+```rust
+pub struct RuntimeApplyReport {
+    pub outcome: ApplyOutcomeKind,
+    pub desired_revision: u64,
+    pub applied_revision: Option<u64>,
+}
+```
+
+## 9. 其他范围收敛
+
+### 日志
+
+CoreActor 订阅 upstream `LogFrame`，只保留 GUI 所需的 100 条内存 ring。直接复用 `nyanpasu-core-metadata::LogFrame`，不定义 `LogSink` trait。manager 的 JSONL sink 保持原样。
+
+### Service control
+
+install/update/uninstall/start/stop 是 service 管理，不属于 CoreActor。保留一个具体 `ServiceController`；操作完成后调用 `CoreClient::set_mode/reconcile_mode`。不引入完整 `ServiceControlPort`，除非测试确实需要替换 OS command runner。
+
+### macOS DNS
+
+作为 start/stop 的平台 side effect 放在 actor 内，用一个小型 `MacosDnsGuard`；非 macOS 不定义空 trait。Service 模式需要提权时由 `CoreBackend::Service` 调 IPC set_dns。
+
+### Updater
+
+不为了把 `CoreManager::global()` 指标强行归零而增加 `attach_core_port()` 半迁移桥。Updater 的完整注入仍由 PR-6d 完成；PR-5 允许保留一个有明确 owner/remove condition 的 residual。
+
+## 10. 保留的安全门
+
+- submodule/path dependency 与 sidecar release lockstep；
+- `ServiceCompat` major 版本 fail-closed；
+- `LocalIpcPolicy::Disable` 显式设置；
+- stable release 前 bump 到正式 v2.0.0；
+- TempDir 测试与 `test_real_dirs == 0`；
+- Windows 旧 daemon 升级 smoke；
+- macOS TUN/DNS smoke。

--- a/docs/superpowers/specs/2026-08-01-pr5-core-actor/task.md
+++ b/docs/superpowers/specs/2026-08-01-pr5-core-actor/task.md
@@ -1,0 +1,156 @@
+# PR-5 — CoreActor 迁移简化任务
+
+关联设计：`design.md`（同目录）
+
+## 0. 全局约束
+
+1. app 只新增一个跨步骤排他机制：`OperationId` + `CoreOperationGuard`；迁移完成后删除 `rebuild_gate`、`clash_patch_gate` 和 legacy lifecycle mutex。
+2. `nyanpasu-core-manager` / service 内部 mutex、runtime directory lock 不属于替换范围。
+3. 不新增 `CoreEngine` trait/factory、Engine\* 类型镜像、第二层恢复循环或 actor-held clash-api client。
+4. 所有配置应用走 full-config `apply_config`；runtime 决定 patch/reload/restart/switch/rollback。
+5. 运行配置采用 commit-first；`RolledBack` 表示 desired 与 Applied 暂时分离，不执行应用层二次回滚。
+6. 测试只使用 TempDir；并发测试使用 RPC/barrier，不使用 sleep 断言顺序。
+
+## R0 — nyanpasu-runtime 小型协议收敛 PR
+
+- [ ] 在 `nyanpasu-core-metadata` 增加 `CoreErrorKind` enum，serde 字符串保持现有 `error_kind` 值。
+- [ ] `nyanpasu-core-manager::Error::kind()` 返回该 enum；durability wrapper 递归返回 source kind。
+- [ ] service error envelope 与 IPC client 改为复用 enum，wire golden 保持不变。
+- [ ] 不新建 crate，不引入通用 CoreEngine trait。
+
+**Exit**
+
+- manager/service/client 不再各自维护第二份 error-kind match/string 表；
+- v2 wire golden 全绿；
+- submodule bump 后 clash app 可直接消费 typed kind。
+
+## PR-5-pre — 依赖与 daemon 兼容门
+
+### P1 — path dependency + lockstep
+
+- [ ] `backend/Cargo.toml` 加 `exclude = ["nyanpasu-runtime"]`；utils/ipc/core-manager/core-metadata 使用 submodule path。
+- [ ] 删除旧 git patch/source 注释；更新 Cargo.lock。
+- [ ] 记录发布二进制体积变化。
+
+> **leader 裁定 D1=A（2026-08-02）**：上面第一条只切 `nyanpasu-utils` / `nyanpasu-ipc` 两条 path 依赖。
+> `nyanpasu-core-manager` / `nyanpasu-core-metadata`（以及 `clash-api`）推迟到 **PR-5a 的首个真实消费者**再加 workspace 条目。
+> 理由：无人引用的 `[workspace.dependencies]` 条目不会进入 Cargo.lock 解析图，属死文本（CLAUDE.md §2）；`nyanpasu-core-metadata` 本就随 ipc v2 **传递**进 lock；且这样能让依赖与体积增量完全可归因于这一次切换。
+> 这是对该行"四个 crate"措辞的**有意偏离**，已记录在案。实施计划：`docs/superpowers/plans/2026-08-01-pr5-pre.md`。
+
+### P2 — ServiceCompat
+
+- [ ] 保留 major 版本 fail-closed 分类；旧 v1 daemon 永不进入 Service backend。
+- [ ] status 返回 additive compat 信息；bindings regen。
+- [ ] 保留启动时自动 update service 的既有语义。
+
+**Exit**
+
+- `cargo metadata`、workspace tests、bindings、architecture ledger 绿；
+- v1.4.5 fixture 下没有 `/core/*` 请求；
+- 本 PR 不引入 CoreActor。
+
+## PR-5a — 最小 CoreActor + `OperationId` + backend enum
+
+### A1 — CoreBackend
+
+- [ ] 新增封闭 `CoreBackend::{Local, Service, #[cfg(test)] Test}`。
+- [ ] Local 直接包装 `nyanpasu_core_manager::CoreManager`；Service 使用实例化 IPC Client，禁止 `service_default()`。
+- [ ] 只实现 check/start/apply/stop/restart/recover 和状态/日志订阅所需方法。
+- [ ] Local apply outcome 转换为现有 `CoreApplyData`；不定义 `ApplyReport`。
+
+### A2 — 取消安全 `OperationId`
+
+- [ ] `CoreClient` 在发送 `AcquireOperation` 前分配 `OperationId`，并构造 pending `CoreOperationGuard`。
+- [ ] actor 维护 active operation + FIFO waiters；`ReleaseOperation` 同时支持释放 active operation 和取消 waiter。
+- [ ] mutation 校验 active `OperationId`；status/log/lifecycle read 不要求 `CoreOperationGuard`。
+- [ ] shutdown 拒绝全部 waiters并关闭 backend。
+- [ ] 不实现 TTL、auto-steal、watchdog 或 delayed recovery。
+
+### A3 — 接入现有生命周期 seam
+
+- [ ] 先让 `CoreClient/CoreOperationGuard` 实现现有 `CoreLifecyclePort/CoreLifecycleLease` 兼容 seam；旧 trait 名称不扩散到新代码，使 rebuild/change-core 调用点暂不重写。
+- [ ] setup 注入 CoreClient；start/stop/restart/status 改走 actor。
+- [ ] 删除 legacy `CoreManager::lifecycle_lock` 和裸线程递归 recover；自动恢复只由 runtime/daemon 负责。
+
+**Exit**
+
+- operation 测试：FIFO、等待取消、刚获批取消、stale `ReleaseOperation`、wrong-id mutation、shutdown drain；
+- Local/Service 基本生命周期 parity 测试；
+- legacy core 生命周期不再被新调用点使用。
+
+## PR-5b — 单一 runtime apply 管线
+
+### B1 — Promoted / Applied 入 actor
+
+- [ ] `CheckAndPromote` 在 `CoreOperationGuard` 下校验 candidate hash、dry-run、原子 promote，并推进 Promoted。
+- [ ] `ApplyPromoted/StartPromoted` 根据 backend outcome 推进 Applied。
+- [ ] CoreClient 通过 watch 暴露 lifecycle；删除 client `RuntimeLifecycleStore` 和 publish/restore helpers。
+
+### B2 — `CoreOperationGuard` 替换 app locks
+
+- [ ] 所有 rebuild/regenerate/start/change-core 在读取 snapshots 前取得 `CoreOperationGuard`，事务结束后释放。
+- [ ] 删除 `rebuild_gate`。
+- [ ] 保留 rebuild worker 的 capacity-1 coalesce；新 commit 在当前 build 期间发生时触发下一次 rebuild。
+
+### B3 — 删除 API-first patch/补偿层
+
+- [ ] `patch_running_config` 改为 typed desired commit + 统一 rebuild/apply。
+- [ ] 删除 `RunningConfigPatchPort`、legacy bridge、`clash_patch_gate`、ControllerBinding/cache、ConfigPatch mapper、compensation plan/fence。
+- [ ] 根据 `CoreApplyData` 映射：success 推进 Applied；RolledBack/错误保持 Applied；warning 返回 degraded。
+
+### B4 — 简化 ChangeCore
+
+- [ ] `ApplicationClient::patch(core = new)`，复用统一 apply 管线。
+- [ ] RolledBack 时保留 desired 新核与 Promoted 新配置，返回 `CommittedDegraded(CoreRollback)`。
+- [ ] 删除 legacy draft/discard、rollback rebuild、product restore、old-core 第二次 restart、专用 `ChangeCoreReport`。
+- [ ] 前端复用通用 `RuntimeApplyReport`/MutationOutcome 展示 degraded。
+
+**Exit**
+
+- `rg 'rebuild_gate|clash_patch_gate|RunningConfigPatchPort|LegacyRunningConfigPatchBridge'` 为 0；
+- apply parity：**Noop**/Patched/Reloaded/Restarted/Switched/RolledBack —— `Warning` 是与 outcome **正交的标志位**，不是第七个分支，必须与上述任一 outcome 组合验证；
+- change-core rollback 测试断言 desired=new、Promoted=new、Applied=old；
+- 两个并发 rebuild 不重叠，后一个在 `OperationGate` FIFO 后读取最新 snapshot。
+
+## PR-5c — 必要清理，不做指标驱动半迁移
+
+### C1 — 状态与日志
+
+- [ ] backend status/events 投影到 actor watch snapshot；status read 不走 mailbox RPC。
+- [ ] actor 维护 100 条 `LogFrame` ring；`get_clash_logs` 从 raw 渲染；可 additive 暴露 frames。
+- [ ] 删除 legacy Logger global。
+
+### C2 — 运行模式
+
+- [ ] app config/service control 完成后显式调用 `set_mode/reconcile_mode`；该操作正常排队取得 `CoreOperationGuard`。
+- [ ] 删除 `pending_run_type` 设计、service 轮询线程及相关 statics。
+- [ ] service install/update/uninstall 保持独立 concrete controller，不迁入 CoreActor。
+
+### C3 — macOS DNS
+
+- [ ] actor 内 `MacosDnsGuard` 与 start/stop 保序；Service backend 使用 IPC set_dns。
+- [ ] 非 macOS 不增加空 `NetworkDnsPort` 抽象。
+
+### C4 — residual 与 smoke
+
+- [ ] 删除真正已失去调用者的 core/service/logger 文件与 globals。
+- [ ] Updater 不增加 `attach_core_port` 半迁移桥；保留 PR-6d owner 的单一 residual。
+- [ ] 更新 roadmap/ledger，不以 `CoreManager::global() == 0` 作为牺牲边界的硬指标。
+
+**Exit**
+
+- smoke 1：Local 模式 patch/restart/core-switch rollback；
+- smoke 2：Windows v1 daemon 自动升级后进入 v2 Service 模式；拒绝升级时 fail-closed Local；
+- smoke 3：macOS TUN 开关与 DNS 恢复；
+- fixed-port 占用作为自动化集成测试，不要求单独手工 smoke；
+- `test_real_dirs == 0`。
+
+## 最终删除清单
+
+- [ ] app `rebuild_gate` / `clash_patch_gate`；
+- [ ] legacy lifecycle mutex / borrowed `CoreLifecycleLease` implementation；
+- [ ] CoreEngine/Engine\* 计划类型（不实施）；
+- [ ] actor 二次恢复策略（不实施）；
+- [ ] RunningConfigPatchPort 与 GUI clash-api patch 补偿；
+- [ ] ChangeCore 专用回滚编排和专用 wire；
+- [ ] Logger global 与 service 状态轮询 statics。

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -222,7 +222,9 @@ export const commands = {
   setCustomAppDir: (path: string) =>
     typedError<null, string>(__TAURI_INVOKE('set_custom_app_dir', { path })),
   statusService: () =>
-    typedError<StatusInfo, string>(__TAURI_INVOKE('status_service')),
+    typedError<ServiceStatusInfo_Serialize, string>(
+      __TAURI_INVOKE('status_service'),
+    ),
   installService: () =>
     typedError<null, string>(__TAURI_INVOKE('install_service')),
   uninstallService: () =>
@@ -587,16 +589,171 @@ export type ConfigDefinition_Serialize =
       transforms?: ProfileId[]
     } & { source?: never })
 
+/**
+ *  Identity of the config the running core actually adopted.
+ *
+ *  `source_hash` is computed over the caller's own file and `effective_hash`
+ *  over the canonical form the core is running, both FNV-1a over canonical
+ *  YAML. A caller that holds the source file can therefore confirm the
+ *  service read the same bytes it wrote, without reimplementing the hash.
+ *  The manager's private runtime copy path is deliberately not exposed: it
+ *  lives in a 0o700 directory the caller cannot read, so it would only
+ *  mislead.
+ */
+export type ConfigRevisionInfo = {
+  epoch: number
+  generation: number
+  source_hash: string
+  effective_hash: string
+}
+
 export type CopyEnvOption = 'shell' | 'cmd' | 'pwsh'
 
-export type CoreInfos = {
+/**
+ *  The core's control endpoint, as the manager resolved it.
+ *
+ *  A deliberately separate type from `clash_api::Host`: clash-api is an
+ *  internal dependency of the core manager and must not leak into the wire
+ *  dependency tree. The controller secret is never carried here — it comes
+ *  from the caller's own config, and the IPC transport's only gate is the
+ *  socket ACL.
+ */
+export type CoreControllerInfo =
+  | ({ NamedPipe: string } & { Http?: never; UnixSocket?: never })
+  | ({ UnixSocket: string } & { Http?: never; NamedPipe?: never })
+  /**  Normalized base URL with any credentials removed. */
+  | ({ Http: string } & { NamedPipe?: never; UnixSocket?: never })
+
+/**
+ *  The manager's health observation for the active core. Absent while the
+ *  core is stopping or stopped.
+ */
+export type CoreHealthInfo = {
+  state: CoreHealthState
+  /**  Unix milliseconds of the last health-state transition. */
+  changed_at: number
+  consecutive_failures: number
+  /**  Last probe failure detail, capped by the manager at 512 bytes. */
+  last_error: string | null
+  /**  Unix milliseconds of the last successful probe. */
+  last_success_at: number | null
+}
+
+/**  Health observation state for the active core. */
+export type CoreHealthState = 'Starting' | 'Healthy' | 'Unhealthy'
+
+export type CoreInfos = CoreInfos_Serialize | CoreInfos_Deserialize
+
+export type CoreInfos_Deserialize = {
   type: CoreType | null
   state: CoreState
   state_changed_at: number
   config_path: string | null
+  /**
+   *  Omitted rather than null when absent, so a payload carrying none of
+   *  the fields below is byte-identical to the pre-S7 wire format.
+   */
+  controller?: CoreControllerInfo | null
+  health?: CoreHealthInfo | null
+  revision?: ConfigRevisionInfo | null
+  detail?: CoreStateDetail | null
+}
+
+export type CoreInfos_Serialize = {
+  type: CoreType | null
+  state: CoreState
+  state_changed_at: number
+  config_path: string | null
+  /**
+   *  Omitted rather than null when absent, so a payload carrying none of
+   *  the fields below is byte-identical to the pre-S7 wire format.
+   */
+  controller?: CoreControllerInfo | null
+  health?: CoreHealthInfo | null
+  revision?: ConfigRevisionInfo | null
+  detail?: CoreStateDetail | null
 }
 
 export type CoreState = 'Running' | { Stopped: string | null }
+
+/**
+ *  The core's full lifecycle state.
+ *
+ *  [`CoreState`] is a two-valued projection kept for wire compatibility: it
+ *  reports `Starting` and `Restarting` as `Stopped(None)`, so a crash loop is
+ *  indistinguishable from a real stop. This is the faithful view; prefer it
+ *  when present.
+ */
+export type CoreStateDetail =
+  | ({
+      Stopped: {
+        reason: string | null
+      }
+    } & {
+      Restarting?: never
+      Running?: never
+      Starting?: never
+      Stopping?: never
+      Switching?: never
+    })
+  | ({
+      Starting: {
+        epoch: number
+      }
+    } & {
+      Restarting?: never
+      Running?: never
+      Stopped?: never
+      Stopping?: never
+      Switching?: never
+    })
+  | ({
+      Running: {
+        epoch: number
+        pid: number
+      }
+    } & {
+      Restarting?: never
+      Starting?: never
+      Stopped?: never
+      Stopping?: never
+      Switching?: never
+    })
+  | ({
+      Restarting: {
+        epoch: number
+        attempt: number
+      }
+    } & {
+      Running?: never
+      Starting?: never
+      Stopped?: never
+      Stopping?: never
+      Switching?: never
+    })
+  | ({
+      Switching: {
+        from: number | null
+        to: number
+      }
+    } & {
+      Restarting?: never
+      Running?: never
+      Starting?: never
+      Stopped?: never
+      Stopping?: never
+    })
+  | ({
+      Stopping: {
+        epoch: number
+      }
+    } & {
+      Restarting?: never
+      Running?: never
+      Starting?: never
+      Stopped?: never
+      Switching?: never
+    })
 
 export type CoreType = { clash: ClashCoreType } | 'singbox'
 
@@ -1025,6 +1182,102 @@ export type LocalBinding_Serialize =
       target: ExternalProfilePath
       mode: ExternalMode
     }
+
+/**
+ *  Where this service writes logs.
+ *
+ *  These are the service's own facts, not an echo of what the caller passed at
+ *  start-up, which is why they are here and not in [`RuntimeInfos`].
+ *
+ *  **These are locations, not a grant.** Both directories are restricted to the
+ *  account the service runs under plus local administrators, so a caller
+ *  running as an ordinary user generally cannot read them — surface the path
+ *  for a support request rather than building a tail on it. Live core output is
+ *  on the event stream; the service's own logs are not streamed at all.
+ *
+ *  TODO: that restriction is the open question here, not a settled posture. A
+ *  user-level GUI reading the archive would need one of: a widened DACL (which
+ *  means teaching `nyanpasu_utils::io::atomic_fs`'s hardener *and* its verifier
+ *  a second acceptable shape — the verifier rejects user-readable DACLs today,
+ *  so both move together or directory creation starts failing), some other
+ *  grant mechanism, or an RPC that serves the archive so the directory stays
+ *  closed. All three are acceptable; none is chosen yet. The two sites that
+ *  would change are `log_sink::prepare_dir` and the service's own log directory
+ *  setup.
+ */
+export type LogPathsInfo = LogPathsInfo_Serialize | LogPathsInfo_Deserialize
+
+/**
+ *  Where this service writes logs.
+ *
+ *  These are the service's own facts, not an echo of what the caller passed at
+ *  start-up, which is why they are here and not in [`RuntimeInfos`].
+ *
+ *  **These are locations, not a grant.** Both directories are restricted to the
+ *  account the service runs under plus local administrators, so a caller
+ *  running as an ordinary user generally cannot read them — surface the path
+ *  for a support request rather than building a tail on it. Live core output is
+ *  on the event stream; the service's own logs are not streamed at all.
+ *
+ *  TODO: that restriction is the open question here, not a settled posture. A
+ *  user-level GUI reading the archive would need one of: a widened DACL (which
+ *  means teaching `nyanpasu_utils::io::atomic_fs`'s hardener *and* its verifier
+ *  a second acceptable shape — the verifier rejects user-readable DACLs today,
+ *  so both move together or directory creation starts failing), some other
+ *  grant mechanism, or an RPC that serves the archive so the directory stays
+ *  closed. All three are acceptable; none is chosen yet. The two sites that
+ *  would change are `log_sink::prepare_dir` and the service's own log directory
+ *  setup.
+ */
+export type LogPathsInfo_Deserialize = {
+  /**
+   *  The service's own logs: JSON lines from `tracing-appender`, rotated
+   *  daily, seven files kept.
+   */
+  service_dir: string
+  /**
+   *  The core log archive: one rolling JSONL stream, rotated by size and
+   *  retained by count. Absent when the manager's sink is switched off, in
+   *  which case no such directory exists at all.
+   */
+  core_dir?: string | null
+}
+
+/**
+ *  Where this service writes logs.
+ *
+ *  These are the service's own facts, not an echo of what the caller passed at
+ *  start-up, which is why they are here and not in [`RuntimeInfos`].
+ *
+ *  **These are locations, not a grant.** Both directories are restricted to the
+ *  account the service runs under plus local administrators, so a caller
+ *  running as an ordinary user generally cannot read them — surface the path
+ *  for a support request rather than building a tail on it. Live core output is
+ *  on the event stream; the service's own logs are not streamed at all.
+ *
+ *  TODO: that restriction is the open question here, not a settled posture. A
+ *  user-level GUI reading the archive would need one of: a widened DACL (which
+ *  means teaching `nyanpasu_utils::io::atomic_fs`'s hardener *and* its verifier
+ *  a second acceptable shape — the verifier rejects user-readable DACLs today,
+ *  so both move together or directory creation starts failing), some other
+ *  grant mechanism, or an RPC that serves the archive so the directory stays
+ *  closed. All three are acceptable; none is chosen yet. The two sites that
+ *  would change are `log_sink::prepare_dir` and the service's own log directory
+ *  setup.
+ */
+export type LogPathsInfo_Serialize = {
+  /**
+   *  The service's own logs: JSON lines from `tracing-appender`, rotated
+   *  daily, seven files kept.
+   */
+  service_dir: string
+  /**
+   *  The core log archive: one rolling JSONL stream, rotated by size and
+   *  retained by count. Absent when the manager's sink is switched off, in
+   *  which case no such directory exists at all.
+   */
+  core_dir?: string | null
+}
 
 export type LogSpan = 'log' | 'info' | 'warn' | 'error'
 
@@ -1819,19 +2072,79 @@ export type ScriptTransform_Serialize = {
   runtime: ScriptRuntime
 }
 
+export type ServiceCompat =
+  /**  daemon 未安装 / 未运行 / 未上报 server 信息，没有可判定的版本。 */
+  | { kind: 'unknown' }
+  /**  主版本匹配，允许进入 Service backend。 */
+  | { kind: 'compatible'; server_version: string }
+  /**  主版本不匹配（典型：v1.4.5）。fail-closed。 */
+  | { kind: 'incompatible'; server_version: string; required_major: number }
+  /**  server 上报的版本不是合法 semver。fail-closed。 */
+  | { kind: 'unparsable'; server_version: string }
+
 export type ServiceStatus = 'not_installed' | 'stopped' | 'running'
 
-export type StatusInfo = {
+/**
+ *  `StatusInfo` 的 additive 镜像：字段逐一复制（specta 不支持 `serde(flatten)`，
+ *  见本文件 `GetSysProxyResponse` 的同款处理），追加 `compat`。
+ *  wire 是原结构的严格超集，前端既有消费点不受影响。
+ */
+export type ServiceStatusInfo =
+  | ServiceStatusInfo_Serialize
+  | ServiceStatusInfo_Deserialize
+
+/**
+ *  `StatusInfo` 的 additive 镜像：字段逐一复制（specta 不支持 `serde(flatten)`，
+ *  见本文件 `GetSysProxyResponse` 的同款处理），追加 `compat`。
+ *  wire 是原结构的严格超集，前端既有消费点不受影响。
+ */
+export type ServiceStatusInfo_Deserialize = {
   name: string
   version: string
   status: ServiceStatus
-  server: StatusResBody | null
+  server: StatusResBody_Deserialize | null
+  compat: ServiceCompat
 }
 
-export type StatusResBody = {
+/**
+ *  `StatusInfo` 的 additive 镜像：字段逐一复制（specta 不支持 `serde(flatten)`，
+ *  见本文件 `GetSysProxyResponse` 的同款处理），追加 `compat`。
+ *  wire 是原结构的严格超集，前端既有消费点不受影响。
+ */
+export type ServiceStatusInfo_Serialize = {
+  name: string
   version: string
-  core_infos: CoreInfos
+  status: ServiceStatus
+  server: StatusResBody_Serialize | null
+  compat: ServiceCompat
+}
+
+export type StatusResBody = StatusResBody_Serialize | StatusResBody_Deserialize
+
+export type StatusResBody_Deserialize = {
+  version: string
+  core_infos: CoreInfos_Deserialize
   runtime_infos: RuntimeInfos
+  /**
+   *  Declared last and omitted rather than null when absent, so a payload
+   *  without it is byte-identical to the pre-L3 format — the rule S7 used for
+   *  `CoreInfos`. The service always sends it; the `Option` exists so every
+   *  existing golden literal stays unchanged.
+   */
+  logs?: LogPathsInfo_Deserialize | null
+}
+
+export type StatusResBody_Serialize = {
+  version: string
+  core_infos: CoreInfos_Serialize
+  runtime_infos: RuntimeInfos
+  /**
+   *  Declared last and omitted rather than null when absent, so a payload
+   *  without it is byte-identical to the pre-L3 format — the rule S7 used for
+   *  `CoreInfos`. The service always sends it; the `Option` exists so every
+   *  existing golden literal stays unchanged.
+   */
+  logs?: LogPathsInfo_Serialize | null
 }
 
 export type StorageEntry = {

--- a/scripts/architecture-ledger.snapshot.json
+++ b/scripts/architecture-ledger.snapshot.json
@@ -4,30 +4,30 @@
   ],
   "metrics": {
     "config_calls": {
-      "total": 120,
+      "total": 116,
       "byKey": {
-        "Config::verge()": 93,
-        "Config::clash()": 27
+        "Config::verge()": 90,
+        "Config::clash()": 26
       }
     },
     "service_globals": {
-      "total": 80,
+      "total": 74,
       "byKey": {
-        "CoreManager::global()": 18,
+        "CoreManager::global()": 16,
         "ProxiesGuard::global()": 14,
         "Handle::global()": 11,
-        "Self::global()": 10,
+        "Self::global()": 9,
         "Sysopt::global()": 8,
         "WindowManager::global()": 8,
-        "Logger::global()": 5,
         "Hotkey::global()": 3,
-        "UpdaterManager::global()": 3
+        "UpdaterManager::global()": 3,
+        "Logger::global()": 2
       }
     },
     "migration_markers": {
-      "total": 18,
+      "total": 19,
       "byKey": {
-        "TODO(actor-migration)": 16,
+        "TODO(actor-migration)": 17,
         "FIXME(actor-migration)": 2
       }
     },

--- a/scripts/architecture-ledger.snapshot.json
+++ b/scripts/architecture-ledger.snapshot.json
@@ -25,9 +25,9 @@
       }
     },
     "migration_markers": {
-      "total": 18,
+      "total": 19,
       "byKey": {
-        "TODO(actor-migration)": 16,
+        "TODO(actor-migration)": 17,
         "FIXME(actor-migration)": 2
       }
     },

--- a/scripts/architecture-ledger.ts
+++ b/scripts/architecture-ledger.ts
@@ -258,25 +258,144 @@ export function matchRealDirDenylist(
   return out;
 }
 
-function stripLineComment(line: string): string {
-  let inSingle = false;
+/**
+ * Recognizes a raw string opener: `r"`, `r#"`, `r##"`, ...; `br"`, `br#"`,
+ * ...; or the raw C string forms `cr"`, `cr#"`, ...
+ */
+const RAW_STRING_START_RE = /^(?:cr|br|r)(#*)"/;
+
+/**
+ * Recognizes a Rust character literal starting at `'`: `'x'`, `'\n'`, `'\''`,
+ * `'\\'`, `'\x41'`, `'\u{7FFF}'`. Anything else starting with `'` (`'a`,
+ * `'static`, `'_`) is a lifetime, not a char literal, and must not match.
+ */
+const CHAR_LITERAL_RE =
+  /^'(?:\\(?:x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]+\}|.)|[^'\\])'/;
+
+/** True when `raw[index - 1]` (if any) is not an identifier character. */
+function isWordBoundaryBefore(raw: string, index: number): boolean {
+  return index === 0 || !/[A-Za-z0-9_]/.test(raw[index - 1]);
+}
+
+// Lexer state carried across lines: block comments nest (Rust allows
+// `/* /* */ */`), so a depth counter is tracked instead of a boolean; raw
+// strings (`r"..."`, `r#"..."#`, ...) can also span lines, so the number of
+// `#` needed to close one is carried the same way (-1 means "not in one").
+export type LexState = {
+  blockDepth: number;
+  rawStringHashes: number;
+};
+
+export function createLexState(): LexState {
+  return { blockDepth: 0, rawStringHashes: -1 };
+}
+
+// Lex `//`, `/* */`, strings, and raw strings in source order so a `//`/`/*`
+// inside a string, raw string, or comment never opens a new comment, and a
+// `"` inside a comment or raw-string body never opens a string. Inside a
+// normal string, only an even run of backslashes lets a `"` close it
+// (escapeNext tracks the run one char at a time). A `'` only opens a char
+// literal when it is actually shaped like one; otherwise (`'a`, `'static`,
+// `'_`) it is a lifetime and leaves all state alone. Literal *contents* are
+// replaced with nothing (delimiters are kept), so the returned code never
+// carries text or braces that only exist inside a literal. Shared by
+// `scanFile` and by the brace/item scanning below so both agree on what
+// counts as real code.
+export function stripCommentsAndLiterals(
+  raw: string,
+  state: LexState,
+): string {
+  let code = "";
   let inDouble = false;
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    const prev = i > 0 ? line[i - 1] : "";
-    if (ch === "'" && !inDouble && prev !== "\\") inSingle = !inSingle;
-    if (ch === '"' && !inSingle && prev !== "\\") inDouble = !inDouble;
-    if (
-      !inSingle &&
-      !inDouble &&
-      ch === "/" &&
-      i + 1 < line.length &&
-      line[i + 1] === "/"
-    ) {
-      return line.slice(0, i);
+  let escapeNext = false;
+
+  for (let j = 0; j < raw.length; j++) {
+    const ch = raw[j];
+
+    if (state.rawStringHashes >= 0) {
+      if (
+        ch === '"' &&
+        raw.slice(j + 1, j + 1 + state.rawStringHashes) ===
+          "#".repeat(state.rawStringHashes)
+      ) {
+        code += ch + raw.slice(j + 1, j + 1 + state.rawStringHashes);
+        j += state.rawStringHashes;
+        state.rawStringHashes = -1;
+      }
+      continue;
     }
+
+    if (state.blockDepth > 0) {
+      if (ch === "/" && raw[j + 1] === "*") {
+        state.blockDepth += 1;
+        j++;
+      } else if (ch === "*" && raw[j + 1] === "/") {
+        state.blockDepth -= 1;
+        j++;
+      }
+      continue;
+    }
+
+    if (inDouble) {
+      if (escapeNext) {
+        escapeNext = false;
+      } else if (ch === "\\") {
+        escapeNext = true;
+      } else if (ch === '"') {
+        inDouble = false;
+        code += ch;
+      }
+      continue;
+    }
+
+    if (
+      (ch === "r" ||
+        (ch === "b" && raw[j + 1] === "r") ||
+        (ch === "c" && raw[j + 1] === "r")) &&
+      isWordBoundaryBefore(raw, j)
+    ) {
+      const rawStart = RAW_STRING_START_RE.exec(raw.slice(j));
+      if (rawStart) {
+        code += rawStart[0];
+        state.rawStringHashes = rawStart[1].length;
+        j += rawStart[0].length - 1;
+        continue;
+      }
+    }
+
+    if (ch === "'") {
+      const charLiteral = CHAR_LITERAL_RE.exec(raw.slice(j));
+      if (charLiteral) {
+        // Delimiters kept, content blanked: a char literal like `'{'` must
+        // not feed a stray brace into brace/item scanning either.
+        code += "''";
+        j += charLiteral[0].length - 1;
+        continue;
+      }
+      // Lifetime tick (`'a`, `'static`, `'_`): not a string delimiter.
+      code += ch;
+      continue;
+    }
+
+    if (ch === '"') {
+      inDouble = true;
+      code += ch;
+      continue;
+    }
+
+    if (ch === "/" && raw[j + 1] === "/") {
+      break;
+    }
+    if (ch === "/" && raw[j + 1] === "*") {
+      state.blockDepth = 1;
+      j++;
+      continue;
+    }
+
+    code += ch;
   }
-  return line;
+
+  return code;
 }
 
 export function emptyBucket(id: string, label: string): MetricBucket {
@@ -433,8 +552,9 @@ export function testLineMask(
 function findMatchingBraceLine(lines: string[], startLine: number): number {
   let depth = 0;
   let seen = false;
+  const state = createLexState();
   for (let i = startLine; i < lines.length; i++) {
-    const line = stripLineComment(lines[i]);
+    const line = stripCommentsAndLiterals(lines[i], state);
     for (const ch of line) {
       if (ch === "{") {
         depth += 1;
@@ -454,8 +574,9 @@ function findItemEndLine(lines: string[], startLine: number): number {
   // Items with `{ ... }` end at the matching brace.
   let depth = 0;
   let seenBrace = false;
+  const state = createLexState();
   for (let i = startLine; i < lines.length; i++) {
-    const line = stripLineComment(lines[i]);
+    const line = stripCommentsAndLiterals(lines[i], state);
     for (const ch of line) {
       if (ch === "{") {
         depth += 1;
@@ -478,34 +599,12 @@ export function scanFile(
 ): void {
   const lines = source.split(/\r?\n/);
   const testMask = testLineMask(lines, isDedicatedTestPath(relPath));
-
-  // Block-comment strip is best-effort; migration TODOs live in // comments
-  // and must remain visible, so only line-level // stripping is applied for
-  // code-like metrics, while migration markers scan the raw line.
-  let inBlockComment = false;
+  const lexState = createLexState();
 
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i];
     const lineNo = i + 1;
-
-    // Track /* */ so code metrics ignore commented-out call sites.
-    let code = "";
-    for (let j = 0; j < raw.length; j++) {
-      if (!inBlockComment && raw[j] === "/" && raw[j + 1] === "*") {
-        inBlockComment = true;
-        j++;
-        continue;
-      }
-      if (inBlockComment) {
-        if (raw[j] === "*" && raw[j + 1] === "/") {
-          inBlockComment = false;
-          j++;
-        }
-        continue;
-      }
-      code += raw[j];
-    }
-    code = stripLineComment(code);
+    const code = stripCommentsAndLiterals(raw, lexState);
 
     for (const m of matchAll(CONFIG_CALL_RE, code)) {
       record(buckets.configCalls, `Config::${m.groups[0]}()`, {

--- a/scripts/architecture-ledger_test.ts
+++ b/scripts/architecture-ledger_test.ts
@@ -493,6 +493,85 @@ fn x() {}
   assertEquals(buckets.migrationMarkers.total, 1);
 });
 
+Deno.test("scanFile: a doc comment's literal /core/* does not open a block comment", () => {
+  const buckets = createBuckets();
+  const source = `
+/// see /core/* here
+fn x() {
+    let _ = Config::verge();
+}
+`;
+  scanFile("backend/tauri/src/d.rs", source, buckets);
+  assertEquals(buckets.configCalls.total, 1);
+  assertEquals(buckets.configCalls.byKey.get("Config::verge()"), 1);
+});
+
+Deno.test("scanFile: // inside a string literal does not strip the rest of the line", () => {
+  const buckets = createBuckets();
+  const source = `
+fn x() {
+    let url = "http://example.com";
+    let _ = Config::verge();
+}
+`;
+  scanFile("backend/tauri/src/e.rs", source, buckets);
+  assertEquals(buckets.configCalls.total, 1);
+  assertEquals(buckets.configCalls.byKey.get("Config::verge()"), 1);
+});
+
+Deno.test("scanFile: a real multi-line block comment still hides code between /* and */", () => {
+  const buckets = createBuckets();
+  const source = `
+/* start
+   Config::verge() should not count
+*/
+fn x() {
+    let _ = Config::clash();
+}
+`;
+  scanFile("backend/tauri/src/f.rs", source, buckets);
+  assertEquals(buckets.configCalls.total, 1);
+  assertEquals(buckets.configCalls.byKey.get("Config::clash()"), 1);
+});
+
+Deno.test("scanFile: even backslash run before a closing quote does not misparse a trailing comment", () => {
+  const buckets = createBuckets();
+  // The string contains two escaped backslashes (an even run of 4 `\`), so
+  // the closing `"` is real and `/* Config::verge() */` is a real comment.
+  const source = String.raw`let s = "\\\\"; /* Config::verge() */
+`;
+  scanFile("backend/tauri/src/escape.rs", source, buckets);
+  assertEquals(buckets.configCalls.total, 0);
+});
+
+Deno.test("scanFile: a lone lifetime tick does not corrupt string/comment state for the rest of the line", () => {
+  const buckets = createBuckets();
+  const source = `let x: &'static str = "s"; /* Config::verge() */\n`;
+  scanFile("backend/tauri/src/lifetime.rs", source, buckets);
+  assertEquals(buckets.configCalls.total, 0);
+});
+
+Deno.test("scanFile: comment-like text inside a raw string is not treated as a real comment", () => {
+  const buckets = createBuckets();
+  const source =
+    `let s = r#"contains "// looks like a comment" text"#; let _ = Config::verge();\n`;
+  scanFile("backend/tauri/src/rawstr.rs", source, buckets);
+  assertEquals(buckets.configCalls.total, 1);
+  assertEquals(buckets.configCalls.byKey.get("Config::verge()"), 1);
+});
+
+Deno.test("scanFile: nested block comments only close at the matching outer */", () => {
+  const buckets = createBuckets();
+  const source = `
+/* outer /* inner */ still outer Config::verge() */
+Config::clash();
+`;
+  scanFile("backend/tauri/src/nested.rs", source, buckets);
+  assertEquals(buckets.configCalls.total, 1);
+  assertEquals(buckets.configCalls.byKey.get("Config::clash()"), 1);
+  assertEquals(buckets.configCalls.byKey.get("Config::verge()"), undefined);
+});
+
 Deno.test("scanFile: fn definitions of denylist helpers are not hits", () => {
   const buckets = createBuckets();
   const source = `
@@ -502,4 +581,78 @@ fn tray_icons_path(mode: &str) -> PathBuf { PathBuf::from(mode) }
 `;
   scanFile("backend/tauri/src/utils/tests.rs", source, buckets);
   assertEquals(buckets.testRealDirs.total, 0);
+});
+
+// Reviewer finding (Major): a lifetime apostrophe on a `#[cfg(test)]` item's
+// signature line must not make `stripLineComment`'s old quote tracking treat
+// a trailing `// }` as unstripped code — that fake `}` closed the item early
+// and dropped `app_home_dir()` out of the test mask, undercounting the hard
+// denylist. Sharing the literal-aware lexer with brace/item scanning fixes
+// this; the file path is deliberately not a dedicated test path so the bug
+// can't be masked by whole-file test detection.
+Deno.test("scanFile: lifetime in a cfg(test) fn signature does not truncate the item mask at a fake `// }`", () => {
+  const buckets = createBuckets();
+  const source = `
+#[cfg(test)]
+fn isolated<'a>() { // }
+    let _ = app_home_dir();
+}
+`;
+  scanFile("backend/tauri/src/lifetime_mask.rs", source, buckets);
+  assertEquals(buckets.testRealDirs.total, 1);
+  assert(
+    [...buckets.testRealDirs.byKey.keys()].some((k) =>
+      k.includes("app_home_dir")
+    ),
+  );
+});
+
+// Reviewer finding (Minor): raw C strings (`cr"..."`, `cr#"..."#`) were not
+// recognized as raw-string openers, so the opening `"` was treated as a
+// normal string. An odd backslash before the closing `"#` then left the
+// (fake) normal string unterminated for the rest of the line, swallowing the
+// real `Config::global()` call that follows.
+Deno.test('scanFile: cr#"..."# raw C string opener does not swallow real code after it', () => {
+  const buckets = createBuckets();
+  const source = String.raw`let value = cr#"\"#; Config::global();
+`;
+  scanFile("backend/tauri/src/raw_c_string.rs", source, buckets);
+  assertEquals(buckets.configCalls.total, 1);
+  assertEquals(buckets.configCalls.byKey.get("Config::global()"), 1);
+  assertEquals(buckets.serviceGlobals.total, 1);
+  assertEquals(buckets.serviceGlobals.byKey.get("Config::global()"), 1);
+});
+
+// Reviewer finding (Minor): string/raw-string/char-literal contents were
+// copied verbatim into `code` before the metric regexes ran, so metric-like
+// text inside a literal produced a false positive.
+Deno.test("scanFile: metric-like text inside a raw string literal is not counted", () => {
+  const buckets = createBuckets();
+  const source = `let example = r#"Config::global()"#;\n`;
+  scanFile("backend/tauri/src/literal_text.rs", source, buckets);
+  assertEquals(buckets.configCalls.total, 0);
+  assertEquals(buckets.serviceGlobals.total, 0);
+});
+
+// Bonus correctness win from sharing the lexer: a `}` inside a string
+// literal must not feed brace/item scanning, or it closes a cfg(test) item
+// early and drops the real code after it out of the test mask — the same
+// undercount shape as the Major finding, triggered by a brace instead of a
+// lifetime.
+Deno.test("scanFile: an unmatched brace inside a string literal does not end cfg(test) item scanning early", () => {
+  const buckets = createBuckets();
+  const source = `
+#[cfg(test)]
+fn braces_in_string() {
+    let _ = "unexpected } inside string";
+    let _ = app_home_dir();
+}
+`;
+  scanFile("backend/tauri/src/brace_in_string.rs", source, buckets);
+  assertEquals(buckets.testRealDirs.total, 1);
+  assert(
+    [...buckets.testRealDirs.byKey.keys()].some((k) =>
+      k.includes("app_home_dir")
+    ),
+  );
 });

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -671,17 +671,32 @@ function getMeowInfo(): BinInfo {
   };
 }
 
-// TODO: temporarily pinned instead of resolving the latest release, so the
-// sidecar stays on the same released version as the `nyanpasu-ipc` tag pinned
-// in `backend/Cargo.toml`. Unpin when both sides move together.
-const NYANPASU_SERVICE_VERSION = "v1.4.5";
+// The sidecar version follows the `nyanpasu-service` crate in the local
+// `nyanpasu-runtime` submodule, whose releases are tagged `v<crate version>`.
+const NYANPASU_SERVICE_MANIFEST = path.join(
+  WORKSPACE_ROOT,
+  "backend/nyanpasu-runtime/nyanpasu_service/Cargo.toml",
+);
 
-function getNyanpasuServiceInfo(): BinInfo {
-  const SERVICE_REPO = "libnyanpasu/nyanpasu-service";
+async function getNyanpasuServiceVersion(): Promise<string> {
+  const manifest = await Deno.readTextFile(NYANPASU_SERVICE_MANIFEST);
+  const match = manifest.match(
+    /^\[package\][^[]*?^version\s*=\s*"([^"]+)"/ms,
+  );
+  if (!match) {
+    throw new Error(
+      `failed to parse nyanpasu-service version from ${NYANPASU_SERVICE_MANIFEST}`,
+    );
+  }
+  return `v${match[1]}`;
+}
+
+async function getNyanpasuServiceInfo(): Promise<BinInfo> {
+  const SERVICE_REPO = "libnyanpasu/nyanpasu-runtime";
   const isWin = SIDECAR_HOST!.includes("windows");
   const urlExt = isWin ? "zip" : "tar.gz";
 
-  const version = NYANPASU_SERVICE_VERSION;
+  const version = await getNyanpasuServiceVersion();
   debugLog(`nyanpasu-service version: ${version}`);
 
   const name = "nyanpasu-service";


### PR DESCRIPTION
First of five stacked PRs migrating the core process lifecycle off `CoreManager::global()` into a ractor actor. **Stack:** this → `pr5/2-core-lifecycle` → `pr5/3-runtime-apply` → `pr5/4-residual-cleanup` → `pr5/5-roadmap`.

Read `docs/design/pr5-core-actor-roadmap.md` (added in the last PR of the stack) for the diagrams.

## What this does

- Moves `nyanpasu-utils` / `nyanpasu-ipc` off standalone git sources onto the vendored `nyanpasu-runtime` submodule.
- Adds a major-version compatibility gate for the daemon.
- Switches `IpcState` transitions to a strong CAS.

## Why the gate is fail-closed

An incompatible or unparseable daemon status resolves to `Disconnected` rather than being optimistically treated as usable. A version-skewed daemon therefore degrades to Local instead of being driven with a protocol it does not implement.

`ServiceCompat::Unknown` has two distinct sources — the daemon is not running, and the daemon is running but did not report a server. They are kept distinguishable because the baseline warning condition is a conjunction over both.

## Scope

No `CoreActor` is introduced here. This stage only prepares the dependency and compatibility surface.

## Verification

387 application tests green. Bindings diff is exactly `StatusInfo` widening plus `ServiceStatusInfo`.

## Note on history

The original working branch carried 126 commits, most of them planning-document revisions. Each stage is squashed to one implementation commit plus one docs commit; every stage tree is byte-identical to the corresponding tip of the original branch, which is preserved at `refactor/core-manager-actor`.