### PR TITLE
PR-5a: own the core process lifecycle in CoreActor

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1817,6 +1817,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clash-api"
+version = "1.0.0-rc.1"
+dependencies = [
+ "backon",
+ "chrono",
+ "futures-core",
+ "futures-util",
+ "indexmap 2.14.0",
+ "ipnet",
+ "reqwest 0.13.4",
+ "reqwest-websocket",
+ "serde",
+ "serde_json",
+ "specta",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "clash-nyanpasu"
 version = "0.1.0"
 dependencies = [
@@ -1864,6 +1886,7 @@ dependencies = [
  "humansize",
  "image",
  "indexmap 2.14.0",
+ "interprocess",
  "itertools 0.15.0",
  "log",
  "md-5",
@@ -1876,6 +1899,8 @@ dependencies = [
  "notify-debouncer-full",
  "nyanpasu-config",
  "nyanpasu-core",
+ "nyanpasu-core-manager",
+ "nyanpasu-core-metadata",
  "nyanpasu-egui",
  "nyanpasu-ipc",
  "nyanpasu-macro",
@@ -1913,7 +1938,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "serde_yaml_ng",
+ "serde_yaml_ng 0.10.0 (git+https://github.com/libnyanpasu/serde-yaml-ng.git?rev=363da138dc97f90ef0a356f971c2dc1d8fe04c9e)",
  "sha2 0.10.9",
  "single-instance",
  "smol-cancellation-token",
@@ -5012,6 +5037,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iptools"
@@ -6214,7 +6242,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml_ng",
+ "serde_yaml_ng 0.10.0 (git+https://github.com/libnyanpasu/serde-yaml-ng.git?rev=363da138dc97f90ef0a356f971c2dc1d8fe04c9e)",
  "slab",
  "specta",
  "struct-patch",
@@ -6244,10 +6272,32 @@ dependencies = [
  "indexmap 2.14.0",
  "nyanpasu-utils",
  "serde",
- "serde_yaml_ng",
+ "serde_yaml_ng 0.10.0 (git+https://github.com/libnyanpasu/serde-yaml-ng.git?rev=363da138dc97f90ef0a356f971c2dc1d8fe04c9e)",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "nyanpasu-core-manager"
+version = "1.0.0-rc.1"
+dependencies = [
+ "camino",
+ "chrono",
+ "clash-api",
+ "enumset",
+ "nyanpasu-core-metadata",
+ "nyanpasu-utils",
+ "parking_lot",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "specta",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -6337,11 +6387,13 @@ dependencies = [
  "dirs 6.0.0",
  "encoding_rs",
  "kill_tree",
+ "libc",
  "log",
  "memchr",
  "nix 0.31.3",
  "os_pipe",
  "parking_lot",
+ "processkit",
  "serde",
  "shared_child",
  "specta",
@@ -6349,6 +6401,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-attributes",
  "windows 0.62.2",
@@ -7821,6 +7874,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "processkit"
+version = "2.2.5"
+source = "git+https://github.com/ZelAnton/ProcessKit-rs?rev=2adad322f1e3d7c471f3b9c8c625e44f356e416b#2adad322f1e3d7c471f3b9c8c625e44f356e416b"
+dependencies = [
+ "async-trait",
+ "encoding_rs",
+ "libc",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8405,6 +8474,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -9201,6 +9271,19 @@ dependencies = [
 [[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "git+https://github.com/libnyanpasu/serde-yaml-ng.git?rev=363da138dc97f90ef0a356f971c2dc1d8fe04c9e#363da138dc97f90ef0a356f971c2dc1d8fe04c9e"
 dependencies = [
  "indexmap 2.14.0",
@@ -9664,6 +9747,7 @@ version = "2.0.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f9a30cbcbb7011f1da7d73483983bf838af123883e45f2b36ed76328df9c50"
 dependencies = [
+ "chrono",
  "indexmap 2.14.0",
  "paste",
  "rustc_version 0.4.1",
@@ -10902,6 +10986,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -39,6 +39,8 @@ nyanpasu-ipc = { path = "nyanpasu-runtime/nyanpasu_ipc", features = [
   "client",
   "specta",
 ] } # IPC bridge between the UI process and service process
+nyanpasu-core-manager = { path = "nyanpasu-runtime/crates/nyanpasu-core-manager" }
+nyanpasu-core-metadata = { path = "nyanpasu-runtime/crates/nyanpasu-core-metadata" }
 
 # --- forks ---
 # `rev` values are the commits Cargo.lock already resolved.

--- a/backend/fake-core/Cargo.toml
+++ b/backend/fake-core/Cargo.toml
@@ -15,6 +15,10 @@ path = "src/lib.rs"
 name = "fake-core"
 path = "src/main.rs"
 
+[[bin]]
+name = "manager-probe-core"
+path = "src/bin/manager_probe_core.rs"
+
 [dependencies]
 # Intentionally empty: std-only for cross-platform process lifecycle tests.
 

--- a/backend/fake-core/src/bin/manager_probe_core.rs
+++ b/backend/fake-core/src/bin/manager_probe_core.rs
@@ -1,0 +1,123 @@
+use std::{
+    env,
+    io::{Read, Write},
+    net::{Shutdown, TcpListener, TcpStream},
+    path::Path,
+    process::ExitCode,
+    time::Duration,
+};
+
+use fake_core::{Mode, parse_args};
+
+const CHECK_EXIT_ENV: &str = "MANAGER_PROBE_CHECK_EXIT";
+
+fn main() -> ExitCode {
+    let args = env::args().collect::<Vec<_>>();
+    if args.get(1).is_some_and(|arg| arg == "-v") {
+        println!("manager-probe");
+        return ExitCode::SUCCESS;
+    }
+    match parse_args(args) {
+        Ok(Mode::Check { config, .. }) => run_check(&config),
+        Ok(Mode::Start { config, .. }) => run(&config),
+        Err(error) => fail(error),
+    }
+}
+
+fn run_check(config: &Path) -> ExitCode {
+    if let Err(error) = std::fs::read_to_string(config) {
+        return fail(format!(
+            "failed to read config `{}`: {error}",
+            config.display()
+        ));
+    }
+
+    match env::var(CHECK_EXIT_ENV) {
+        Ok(value) => match value.parse::<u8>() {
+            Ok(code) => ExitCode::from(code),
+            Err(_) => fail(format!("{CHECK_EXIT_ENV} must be an integer from 0 to 255")),
+        },
+        Err(env::VarError::NotPresent) => ExitCode::SUCCESS,
+        Err(env::VarError::NotUnicode(_)) => fail(format!("{CHECK_EXIT_ENV} must be UTF-8")),
+    }
+}
+
+fn run(config: &Path) -> ExitCode {
+    let source = match std::fs::read_to_string(config) {
+        Ok(source) => source,
+        Err(error) => {
+            return fail(format!(
+                "failed to read config `{}`: {error}",
+                config.display()
+            ));
+        }
+    };
+    let controller = match external_controller(&source) {
+        Ok(controller) => controller,
+        Err(error) => return fail(error),
+    };
+    let listener = match TcpListener::bind(&controller) {
+        Ok(listener) => listener,
+        Err(error) => return fail(format!("failed to bind {controller}: {error}")),
+    };
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                if let Err(error) = respond(stream) {
+                    eprintln!("manager-probe-core: request failed: {error}");
+                }
+            }
+            Err(error) => return fail(format!("accept failed: {error}")),
+        }
+    }
+
+    ExitCode::SUCCESS
+}
+
+fn external_controller(source: &str) -> Result<String, String> {
+    source
+        .lines()
+        .find_map(|line| {
+            line.trim_start()
+                .strip_prefix("external-controller:")
+                .map(str::trim)
+        })
+        .map(|value| value.trim_matches(['\'', '"']).to_owned())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "config is missing external-controller".to_owned())
+}
+
+fn respond(mut stream: TcpStream) -> std::io::Result<()> {
+    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(2)))?;
+
+    let mut request = [0u8; 4096];
+    let size = stream.read(&mut request)?;
+    let first_line = String::from_utf8_lossy(&request[..size])
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .to_owned();
+    let is_version = first_line
+        .split_whitespace()
+        .take(2)
+        .eq(["GET", "/version"]);
+    let (status, body) = if is_version {
+        ("200 OK", r#"{"version":"manager-probe"}"#)
+    } else {
+        ("404 Not Found", "")
+    };
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(response.as_bytes())?;
+    stream.flush()?;
+    stream.shutdown(Shutdown::Write)
+}
+
+fn fail(error: impl std::fmt::Display) -> ExitCode {
+    eprintln!("manager-probe-core: {error}");
+    ExitCode::from(2)
+}

--- a/backend/fake-core/src/lib.rs
+++ b/backend/fake-core/src/lib.rs
@@ -50,6 +50,10 @@ pub const BIN_NAME: &str = "fake-core";
 /// Runtime path override for cross-crate consumers / harnesses.
 pub const PATH_ENV: &str = "NYANPASU_FAKE_CORE";
 
+pub const PROBE_BIN_NAME: &str = "manager-probe-core";
+
+pub const PROBE_PATH_ENV: &str = "NYANPASU_MANAGER_PROBE_CORE";
+
 /// Process-wide lock for tests that observe or mutate [`PATH_ENV`].
 ///
 /// libtest may run tests on multiple threads; `set_var` / `remove_var` are not
@@ -413,6 +417,66 @@ pub fn require_bin_path() -> io::Result<PathBuf> {
                  Optional override: set non-empty {PATH_ENV}. \
                  Note: a `dev-dependency` on fake-core does not build this binary and \
                  does not set `CARGO_BIN_EXE_fake-core` for the dependent package.",
+                path.display()
+            ),
+        ))
+    }
+}
+
+fn probe_bin_file_name() -> String {
+    format!("{PROBE_BIN_NAME}{}", std::env::consts::EXE_SUFFIX)
+}
+
+fn resolve_probe_from_current_exe() -> Option<PathBuf> {
+    let exe = env::current_exe().ok()?;
+    let parent = exe.parent()?;
+    let file_name = probe_bin_file_name();
+
+    if parent.file_name().and_then(|name| name.to_str()) == Some("deps") {
+        let profile_dir = parent.parent()?;
+        let candidate = profile_dir.join(&file_name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    let sibling = parent.join(&file_name);
+    sibling.is_file().then_some(sibling)
+}
+
+fn probe_target_fallback_path() -> PathBuf {
+    let target_dir = env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../target"));
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    target_dir.join(profile).join(probe_bin_file_name())
+}
+
+pub fn resolve_probe_bin_path() -> PathBuf {
+    if let Ok(path) = env::var(PROBE_PATH_ENV)
+        && !path.is_empty()
+    {
+        return PathBuf::from(path);
+    }
+
+    resolve_probe_from_current_exe().unwrap_or_else(probe_target_fallback_path)
+}
+
+pub fn require_probe_bin_path() -> io::Result<PathBuf> {
+    let path = resolve_probe_bin_path();
+    if path.is_file() {
+        Ok(path)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "manager probe core binary not found at `{}`. Prebuild with \
+                 `cargo build -p fake-core --bin manager-probe-core`, then re-run the consumer \
+                 tests. Optional override: set non-empty {PROBE_PATH_ENV}.",
                 path.display()
             ),
         ))

--- a/backend/tauri/Cargo.toml
+++ b/backend/tauri/Cargo.toml
@@ -30,6 +30,8 @@ nyanpasu-core = { path = "../nyanpasu-core" }
 nyanpasu-config = { path = "../nyanpasu-config" }
 nyanpasu-utils = { workspace = true }
 nyanpasu-egui = { path = "../nyanpasu-egui" }
+nyanpasu-core-manager = { workspace = true }
+nyanpasu-core-metadata = { workspace = true }
 
 # Common Utilities
 tokio = { workspace = true, features = ["test-util"] }
@@ -272,6 +274,7 @@ webview2-com = "0.38"
 
 [dev-dependencies]
 mockall = "0.15"
+interprocess = { version = "2.4.2", features = ["tokio"] }
 # Test-only protocol helpers + binary discovery for later process-lifecycle
 # matrix tests. A dev-dependency does NOT build the fake-core binary and does
 # NOT set CARGO_BIN_EXE_fake-core for this package. Prebuild with

--- a/backend/tauri/src/bridge/verge.rs
+++ b/backend/tauri/src/bridge/verge.rs
@@ -732,7 +732,8 @@ mod tests {
         client::{
             ClientError, ClientSetupArgs, CompensationFailure, LegacyBridgeSet,
             LegacyRunningConfigPatchBridge, LegacyVergeDomain, MockRunningCoreBridge,
-            NoopUiEventSink, NyanpasuClient,
+            NoopUiEventSink, NyanpasuClient, test_binary_resolver, test_degradation_sink,
+            test_service_control,
         },
         config::{
             IClashTemp,
@@ -1078,7 +1079,10 @@ mod tests {
                 clash,
             },
             ui_sink: Arc::new(NoopUiEventSink),
-            core: Arc::new(MockRunningCoreBridge::new()),
+            core: Some(Arc::new(MockRunningCoreBridge::new())),
+            binary_resolver: test_binary_resolver(dir),
+            degradation: test_degradation_sink(),
+            service_control: test_service_control(),
             clash_patch: Some(Arc::new(LegacyRunningConfigPatchBridge)),
             system_dns: Arc::new(crate::client::NoopSystemDnsCache),
         })

--- a/backend/tauri/src/client/core.rs
+++ b/backend/tauri/src/client/core.rs
@@ -1,0 +1,1198 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use nyanpasu_config::application::ClashCore;
+use ractor::{Actor, ActorRef, RpcReplyPort, rpc::CallResult};
+use tokio::sync::watch;
+
+use super::{
+    ApplicationClient, CoreLifecycleLease, CoreLifecyclePort, RuntimePaths,
+    core_bridge::{CoreStatusSnapshot, restore_product},
+    runtime::CandidateFile,
+};
+use crate::core::{
+    RunType,
+    actor::{
+        CoreActor, CoreActorArgs, CoreActorMessage, OperationError, OperationId,
+        backend::CoreDegradationSink,
+        request::CoreRequestFactory,
+        types::{BackendObservation, CoreActorError, CoreRequest, CoreStatusView},
+    },
+};
+
+const CORE_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(120);
+
+pub(crate) struct CoreClientArgs {
+    pub(crate) mode: RunType,
+    pub(crate) requests: CoreRequestFactory,
+    pub(crate) degradation: Arc<dyn CoreDegradationSink>,
+}
+
+struct CoreClientInner {
+    actor_ref: ActorRef<CoreActorMessage>,
+    next_operation: AtomicU64,
+    status_rx: watch::Receiver<CoreStatusView>,
+    hint_pending: Arc<AtomicBool>,
+}
+
+#[derive(Clone)]
+pub struct CoreClient {
+    inner: Arc<CoreClientInner>,
+}
+
+pub struct CoreOperationGuard {
+    id: OperationId,
+    client: CoreClient,
+    acquired: bool,
+}
+
+impl CoreClient {
+    pub(crate) async fn new(args: CoreClientArgs) -> anyhow::Result<Self> {
+        #[cfg(test)]
+        return Self::spawn(args, None, None, None).await;
+        #[cfg(not(test))]
+        Self::spawn(args).await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn new_with_backend(
+        args: CoreClientArgs,
+        backend: crate::core::actor::backend::BackendSlot,
+    ) -> anyhow::Result<Self> {
+        Self::spawn(args, Some(backend), None, None).await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn new_with_backend_and_replace_barrier(
+        args: CoreClientArgs,
+        backend: crate::core::actor::backend::BackendSlot,
+        replace_barrier: crate::core::actor::ReplaceBarrier,
+    ) -> anyhow::Result<Self> {
+        Self::spawn(args, Some(backend), Some(replace_barrier), None).await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn new_with_reconciled_backend(
+        args: CoreClientArgs,
+        backend: crate::core::actor::backend::TestBackend,
+    ) -> anyhow::Result<Self> {
+        Self::spawn(
+            args,
+            Some(crate::core::actor::backend::BackendSlot::Ready(
+                crate::core::actor::backend::CoreBackend::Test(backend.clone()),
+            )),
+            None,
+            Some(backend),
+        )
+        .await
+    }
+
+    async fn spawn(
+        args: CoreClientArgs,
+        #[cfg(test)] backend: Option<crate::core::actor::backend::BackendSlot>,
+        #[cfg(test)] replace_barrier: Option<crate::core::actor::ReplaceBarrier>,
+        #[cfg(test)] replacement_backend: Option<crate::core::actor::backend::TestBackend>,
+    ) -> anyhow::Result<Self> {
+        let (status_tx, status_rx) = watch::channel(CoreStatusView::initial());
+        let hint_pending = Arc::new(AtomicBool::new(false));
+        let actor_ref = Actor::spawn(
+            None,
+            CoreActor,
+            CoreActorArgs {
+                mode: args.mode,
+                requests: args.requests,
+                degradation: args.degradation,
+                status_tx,
+                hint_pending: hint_pending.clone(),
+                #[cfg(test)]
+                backend,
+                #[cfg(test)]
+                replace_barrier,
+                #[cfg(test)]
+                replacement_backend,
+            },
+        )
+        .await
+        .context("failed to spawn core actor")?
+        .0;
+        Ok(Self {
+            inner: Arc::new(CoreClientInner {
+                actor_ref,
+                next_operation: AtomicU64::new(1),
+                status_rx,
+                hint_pending,
+            }),
+        })
+    }
+
+    pub(crate) fn status(&self) -> CoreStatusView {
+        self.inner.status_rx.borrow().clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn subscribe_status(&self) -> watch::Receiver<CoreStatusView> {
+        self.inner.status_rx.clone()
+    }
+
+    pub(crate) async fn begin_operation(&self) -> Result<CoreOperationGuard, OperationError> {
+        let mut operation = CoreOperationGuard::pending(self.clone(), self.allocate_operation_id());
+        operation.acquire().await?;
+        Ok(operation)
+    }
+
+    pub(crate) async fn refresh_status(
+        &self,
+        operation: &CoreOperationGuard,
+    ) -> Result<BackendObservation, CoreActorError> {
+        self.call(|reply| CoreActorMessage::RefreshStatus {
+            operation: operation.id(),
+            reply,
+        })
+        .await
+    }
+
+    pub(crate) async fn running(
+        &self,
+        operation: &CoreOperationGuard,
+    ) -> Result<Option<CoreRequest>, CoreActorError> {
+        self.call(|reply| CoreActorMessage::RunningIdentity {
+            operation: operation.id(),
+            reply,
+        })
+        .await
+    }
+
+    pub(crate) async fn check(
+        &self,
+        operation: &CoreOperationGuard,
+        request: &CoreRequest,
+    ) -> Result<(), CoreActorError> {
+        self.call(|reply| CoreActorMessage::Check {
+            operation: operation.id(),
+            request: request.clone(),
+            reply,
+        })
+        .await
+    }
+
+    pub(crate) async fn run(
+        &self,
+        operation: &CoreOperationGuard,
+        request: &CoreRequest,
+    ) -> Result<(), CoreActorError> {
+        self.call(|reply| CoreActorMessage::Run {
+            operation: operation.id(),
+            request: request.clone(),
+            reply,
+        })
+        .await
+    }
+
+    pub(crate) async fn stop(&self, operation: &CoreOperationGuard) -> Result<(), CoreActorError> {
+        self.call(|reply| CoreActorMessage::Stop {
+            operation: operation.id(),
+            reply,
+        })
+        .await
+    }
+
+    pub(crate) async fn set_backend(
+        &self,
+        operation: &CoreOperationGuard,
+        mode: RunType,
+    ) -> Result<(), CoreActorError> {
+        self.call(|reply| CoreActorMessage::SetBackend {
+            operation: operation.id(),
+            mode,
+            reply,
+        })
+        .await
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        let _ = self
+            .inner
+            .actor_ref
+            .call(CoreActorMessage::Shutdown, None)
+            .await;
+    }
+
+    pub fn hint_refresh(&self) {
+        if self
+            .inner
+            .hint_pending
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        if self
+            .inner
+            .actor_ref
+            .cast(CoreActorMessage::RefreshHint)
+            .is_err()
+        {
+            self.inner.hint_pending.store(false, Ordering::Release);
+        }
+    }
+
+    fn allocate_operation_id(&self) -> OperationId {
+        let value = self.inner.next_operation.fetch_add(1, Ordering::Relaxed);
+        OperationId::new(value).expect("core operation id space exhausted")
+    }
+
+    async fn call<T, F>(&self, make: F) -> Result<T, CoreActorError>
+    where
+        T: Send + 'static,
+        F: FnOnce(RpcReplyPort<Result<T, CoreActorError>>) -> CoreActorMessage,
+    {
+        match self.inner.actor_ref.call(make, None).await {
+            Ok(CallResult::Success(result)) => result,
+            Ok(CallResult::SenderError | CallResult::Timeout) | Err(_) => {
+                Err(CoreActorError::ShuttingDown)
+            }
+        }
+    }
+}
+
+impl CoreOperationGuard {
+    fn pending(client: CoreClient, id: OperationId) -> Self {
+        Self {
+            id,
+            client,
+            acquired: true,
+        }
+    }
+
+    fn id(&self) -> OperationId {
+        self.id
+    }
+
+    async fn acquire(&mut self) -> Result<(), OperationError> {
+        match self
+            .client
+            .inner
+            .actor_ref
+            .call(
+                |reply| CoreActorMessage::AcquireOperation { id: self.id, reply },
+                Some(CORE_ACQUIRE_TIMEOUT),
+            )
+            .await
+        {
+            Ok(CallResult::Success(result)) => result,
+            Ok(CallResult::Timeout) => Err(OperationError::AcquireTimeout),
+            Ok(CallResult::SenderError) | Err(_) => Err(OperationError::ShuttingDown),
+        }
+    }
+
+    pub(crate) async fn release(mut self) {
+        if self.acquired {
+            let _ = self
+                .client
+                .inner
+                .actor_ref
+                .cast(CoreActorMessage::ReleaseOperation { id: self.id });
+            self.acquired = false;
+        }
+    }
+}
+
+impl Drop for CoreOperationGuard {
+    fn drop(&mut self) {
+        if self.acquired {
+            let _ = self
+                .client
+                .inner
+                .actor_ref
+                .cast(CoreActorMessage::ReleaseOperation { id: self.id });
+        }
+    }
+}
+
+impl Drop for CoreClientInner {
+    fn drop(&mut self) {
+        self.actor_ref.stop(None);
+    }
+}
+
+pub(crate) struct CoreLifecycleAdapter {
+    core: CoreClient,
+    application: ApplicationClient,
+    requests: CoreRequestFactory,
+}
+
+pub(crate) struct CoreLeaseAdapter {
+    guard: CoreOperationGuard,
+    core: CoreClient,
+    application: ApplicationClient,
+    requests: CoreRequestFactory,
+    runtime_paths: RuntimePaths,
+    target_core: Option<ClashCore>,
+}
+
+impl CoreLifecycleAdapter {
+    pub(crate) fn new(
+        core: CoreClient,
+        application: ApplicationClient,
+        requests: CoreRequestFactory,
+    ) -> Self {
+        Self {
+            core,
+            application,
+            requests,
+        }
+    }
+}
+
+#[async_trait]
+impl CoreLifecyclePort for CoreLifecycleAdapter {
+    async fn begin(&self) -> anyhow::Result<Box<dyn CoreLifecycleLease>> {
+        // Lock order: clash_patch_gate -> rebuild_gate -> OperationGate. Every lifecycle caller
+        // follows this order; PR-5b will absorb the first two gates.
+        let guard = self.core.begin_operation().await?;
+        Ok(Box::new(CoreLeaseAdapter {
+            guard,
+            core: self.core.clone(),
+            application: self.application.clone(),
+            requests: self.requests.clone(),
+            runtime_paths: self.requests.runtime_paths().clone(),
+            target_core: None,
+        }))
+    }
+
+    async fn status(&self) -> anyhow::Result<CoreStatusSnapshot> {
+        let status = self.core.status();
+        Ok(CoreStatusSnapshot {
+            state: status.state,
+            state_changed_at: status.state_changed_at,
+            run_type: status.run_type,
+        })
+    }
+
+    async fn on_profile_change(&self) {
+        // TODO(actor-migration): connection interruption still reads Config::verge().
+        // Reason: break_when_* and clash API client migration is PR-6 scope.
+        // Remove when: interruption reads typed ClashConfig.break_connection.
+        let _ =
+            crate::core::connection_interruption::ConnectionInterruptionService::on_profile_change(
+            )
+            .await;
+    }
+}
+
+#[async_trait]
+impl CoreLifecycleLease for CoreLeaseAdapter {
+    async fn check_and_promote(
+        &mut self,
+        candidate: &CandidateFile,
+        target_core: ClashCore,
+        product: &camino::Utf8Path,
+    ) -> anyhow::Result<[u8; 32]> {
+        use sha2::Digest as _;
+
+        self.target_core = Some(target_core);
+        anyhow::ensure!(
+            product == self.runtime_paths.product(),
+            "product path must match the lifecycle adapter runtime product"
+        );
+        let bytes = tokio::fs::read(candidate.path()).await?;
+        let mut request = self.requests.for_product(target_core)?;
+        request.config_path = candidate.path().to_owned();
+        self.core.check(&self.guard, &request).await?;
+
+        let after = tokio::fs::read(candidate.path()).await?;
+        anyhow::ensure!(
+            after == bytes,
+            "candidate config changed between check and promote"
+        );
+        let candidate_hash: [u8; 32] = sha2::Sha256::digest(&bytes).into();
+        anyhow::ensure!(
+            candidate_hash == candidate.bytes_sha256(),
+            "candidate config hash changed before promotion"
+        );
+
+        restore_product(product.as_std_path(), &bytes).await?;
+        let promoted = tokio::fs::read(product).await?;
+        let promoted_hash: [u8; 32] = sha2::Sha256::digest(&promoted).into();
+        anyhow::ensure!(
+            promoted_hash == candidate.bytes_sha256(),
+            "promoted runtime product hash does not match candidate"
+        );
+        Ok(promoted_hash)
+    }
+
+    async fn apply_candidate(
+        &mut self,
+        candidate: &CandidateFile,
+        target_core: ClashCore,
+    ) -> anyhow::Result<()> {
+        use sha2::Digest as _;
+
+        let bytes = tokio::fs::read(candidate.path()).await?;
+        let candidate_hash: [u8; 32] = sha2::Sha256::digest(&bytes).into();
+        anyhow::ensure!(
+            candidate_hash == candidate.bytes_sha256(),
+            "candidate config hash changed before check"
+        );
+        let mut request = self.requests.for_product(target_core)?;
+        request.config_path = candidate.path().to_owned();
+        self.core.check(&self.guard, &request).await?;
+        let after = tokio::fs::read(candidate.path()).await?;
+        anyhow::ensure!(
+            after == bytes,
+            "candidate config changed between check and apply"
+        );
+        apply_config_from(candidate.path()).await
+    }
+
+    async fn apply_promoted(&mut self, product: &camino::Utf8Path) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            product == self.runtime_paths.product(),
+            "product path must match the lifecycle adapter runtime product"
+        );
+        apply_config_from(product).await
+    }
+
+    async fn restart(&mut self) -> anyhow::Result<()> {
+        let core = match self.target_core.take() {
+            Some(core) => core,
+            None => self.application.get().await?.state.core,
+        };
+        let request = self.requests.for_product(core)?;
+        self.core.run(&self.guard, &request).await?;
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> anyhow::Result<()> {
+        self.core.stop(&self.guard).await?;
+        Ok(())
+    }
+}
+
+async fn apply_config_from(product: &camino::Utf8Path) -> anyhow::Result<()> {
+    for attempt in 0..5 {
+        match crate::core::clash::api::put_configs(product.as_str()).await {
+            Ok(()) => break,
+            Err(error) if attempt < 4 => log::info!(target: "app", "{error:?}"),
+            Err(error) => return Err(error),
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::{Future, poll_fn},
+        pin::Pin,
+        sync::Mutex,
+        task::Poll,
+    };
+
+    use camino::Utf8PathBuf;
+    use nyanpasu_ipc::api::status::{ConfigRevisionInfo, CoreState};
+    use nyanpasu_utils::core::{ClashCoreType, CoreType};
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::{
+        client::runtime::{Degradation, DegradationPhase},
+        core::actor::{
+            ReplaceBarrier,
+            backend::{BackendSlot, CoreBackend, LocalBackend, TestBackend},
+            request::CoreBinaryResolver,
+            types::FaithfulLifecycle,
+        },
+        utils::path::PathResolver,
+    };
+
+    const RECOVERY_EXHAUSTED_PREFIX: &str = "core kept crashing; restart budget exhausted";
+
+    #[derive(Clone)]
+    struct FixedBinary(Utf8PathBuf);
+
+    impl CoreBinaryResolver for FixedBinary {
+        fn resolve(&self, _kind: &CoreType) -> anyhow::Result<Utf8PathBuf> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingSink(Mutex<Vec<Degradation>>);
+
+    impl CoreDegradationSink for RecordingSink {
+        fn publish(&self, degradation: Degradation) {
+            self.0.lock().unwrap().push(degradation);
+        }
+    }
+
+    struct TestClient {
+        client: CoreClient,
+        backend: TestBackend,
+        requests: CoreRequestFactory,
+        sink: Arc<RecordingSink>,
+        _dir: TempDir,
+    }
+
+    async fn running_request(client: &CoreClient) -> CoreRequest {
+        let operation = client.begin_operation().await.unwrap();
+        client.running(&operation).await.unwrap().unwrap()
+    }
+
+    async fn poll_once_pending<F: Future>(mut future: Pin<&mut F>) {
+        poll_fn(|context| {
+            assert!(future.as_mut().poll(context).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+    }
+
+    fn observation(
+        state: CoreState,
+        lifecycle: FaithfulLifecycle,
+        generation: Option<u64>,
+    ) -> BackendObservation {
+        BackendObservation {
+            view: CoreStatusView {
+                state,
+                state_changed_at: generation.unwrap_or_default() as i64 + 1,
+                run_type: RunType::Normal,
+                revision: generation.map(|generation| ConfigRevisionInfo {
+                    epoch: 1,
+                    generation,
+                    source_hash: format!("source-{generation}"),
+                    effective_hash: format!("effective-{generation}"),
+                }),
+                recovery_exhausted: matches!(
+                    &lifecycle,
+                    FaithfulLifecycle::Stopped { reason: Some(reason) }
+                        if reason.starts_with(RECOVERY_EXHAUSTED_PREFIX)
+                ),
+            },
+            lifecycle,
+        }
+    }
+
+    fn running(generation: u64) -> BackendObservation {
+        observation(
+            CoreState::Running,
+            FaithfulLifecycle::Running,
+            Some(generation),
+        )
+    }
+
+    fn stopped(reason: Option<String>) -> BackendObservation {
+        observation(
+            CoreState::Stopped(reason.clone()),
+            FaithfulLifecycle::Stopped { reason },
+            None,
+        )
+    }
+
+    fn exhausted(reason_suffix: &str) -> BackendObservation {
+        let reason = format!("{RECOVERY_EXHAUSTED_PREFIX}\n{reason_suffix}");
+        stopped(Some(reason))
+    }
+
+    async fn test_client(initial: BackendObservation) -> TestClient {
+        test_client_with_options(initial, None, false).await
+    }
+
+    async fn test_client_with_replace_barrier(
+        initial: BackendObservation,
+        replace_barrier: Option<ReplaceBarrier>,
+    ) -> TestClient {
+        test_client_with_options(initial, replace_barrier, false).await
+    }
+
+    async fn test_client_with_scripted_replacement(initial: BackendObservation) -> TestClient {
+        test_client_with_options(initial, None, true).await
+    }
+
+    async fn test_client_with_options(
+        initial: BackendObservation,
+        replace_barrier: Option<ReplaceBarrier>,
+        scripted_replacement: bool,
+    ) -> TestClient {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config");
+        let data = dir.path().join("data");
+        std::fs::create_dir_all(&config).unwrap();
+        std::fs::create_dir_all(&data).unwrap();
+        let paths = PathResolver::with_base_dirs(config.clone(), data);
+        let runtime = Utf8PathBuf::from_path_buf(config.join("runtime")).unwrap();
+        let requests = CoreRequestFactory::new(
+            &paths,
+            RuntimePaths::new(runtime.join("config.yaml"), runtime.join(".candidates")),
+            Arc::new(FixedBinary(Utf8PathBuf::from("core"))),
+        )
+        .unwrap();
+        let backend = TestBackend::new(initial);
+        let sink = Arc::new(RecordingSink::default());
+        let args = CoreClientArgs {
+            mode: RunType::Normal,
+            requests: requests.clone(),
+            degradation: sink.clone(),
+        };
+        let client = if scripted_replacement {
+            CoreClient::new_with_reconciled_backend(args, backend.clone()).await
+        } else {
+            let slot = BackendSlot::Ready(CoreBackend::Test(backend.clone()));
+            match replace_barrier {
+                Some(barrier) => {
+                    CoreClient::new_with_backend_and_replace_barrier(args, slot, barrier).await
+                }
+                None => CoreClient::new_with_backend(args, slot).await,
+            }
+        }
+        .unwrap();
+        TestClient {
+            client,
+            backend,
+            requests,
+            sink,
+            _dir: dir,
+        }
+    }
+
+    fn request(factory: &CoreRequestFactory, core: ClashCore) -> CoreRequest {
+        factory.for_product(core).unwrap()
+    }
+
+    #[tokio::test]
+    async fn mutation_with_wrong_id_returns_stale() {
+        let test = test_client(stopped(None)).await;
+        let active = test.client.begin_operation().await.unwrap();
+        let wrong = OperationId::new(active.id().get() + 1).unwrap();
+        let result = test
+            .client
+            .call(|reply| CoreActorMessage::Run {
+                operation: wrong,
+                request: request(&test.requests, ClashCore::Mihomo),
+                reply,
+            })
+            .await;
+        assert!(matches!(result, Err(CoreActorError::StaleOperation)));
+        assert_eq!(test.backend.run_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_waiters_and_stops_backend() {
+        let test = test_client(stopped(None)).await;
+        let active = test.client.begin_operation().await.unwrap();
+        let first_client = test.client.clone();
+        let second_client = test.client.clone();
+        let first = tokio::spawn(async move { first_client.begin_operation().await });
+        let second = tokio::spawn(async move { second_client.begin_operation().await });
+        tokio::task::yield_now().await;
+        test.client.shutdown().await;
+        assert!(matches!(
+            first.await.unwrap(),
+            Err(OperationError::ShuttingDown)
+        ));
+        assert!(matches!(
+            second.await.unwrap(),
+            Err(OperationError::ShuttingDown)
+        ));
+        assert_eq!(test.backend.shutdown_calls(), 1);
+        drop(active);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn acquire_times_out_and_releases_the_waiter() {
+        let test = test_client(stopped(None)).await;
+        let active = test.client.begin_operation().await.unwrap();
+        let waiting_client = test.client.clone();
+        let waiting = tokio::spawn(async move { waiting_client.begin_operation().await });
+        tokio::task::yield_now().await;
+        tokio::time::advance(CORE_ACQUIRE_TIMEOUT).await;
+        assert!(matches!(
+            waiting.await.unwrap(),
+            Err(OperationError::AcquireTimeout)
+        ));
+        tokio::task::yield_now().await;
+        active.release().await;
+        let third = test.client.begin_operation().await.unwrap();
+        third.release().await;
+    }
+
+    #[tokio::test]
+    async fn dropping_a_waiting_begin_operation_allows_the_next_waiter() {
+        let test = test_client(stopped(None)).await;
+        let first = test.client.begin_operation().await.unwrap();
+        let mut second = Box::pin(test.client.begin_operation());
+        poll_once_pending(second.as_mut()).await;
+        let mut third = Box::pin(test.client.begin_operation());
+        poll_once_pending(third.as_mut()).await;
+        test.client.refresh_status(&first).await.unwrap();
+
+        drop(second);
+        drop(first);
+        let third = third.await.unwrap();
+        third.release().await;
+    }
+
+    #[tokio::test]
+    async fn dropping_a_just_granted_operation_guard_releases_the_next_waiter() {
+        let test = test_client(stopped(None)).await;
+        let first = test.client.begin_operation().await.unwrap();
+        let mut second = Box::pin(test.client.begin_operation());
+        poll_once_pending(second.as_mut()).await;
+        let mut third = Box::pin(test.client.begin_operation());
+        poll_once_pending(third.as_mut()).await;
+        test.client.refresh_status(&first).await.unwrap();
+
+        drop(first);
+        let second = second.await.unwrap();
+        drop(second);
+        let third = third.await.unwrap();
+        third.release().await;
+    }
+
+    #[tokio::test]
+    async fn operation_and_refresh_both_update_revision() {
+        let test = test_client(stopped(None)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        test.backend.set_observation(running(1));
+        test.client
+            .run(&operation, &request(&test.requests, ClashCore::Mihomo))
+            .await
+            .unwrap();
+        assert_eq!(test.client.status().revision.unwrap().generation, 1);
+        test.backend.set_observation(running(2));
+        test.client.refresh_status(&operation).await.unwrap();
+        assert_eq!(test.client.status().revision.unwrap().generation, 2);
+    }
+
+    #[tokio::test]
+    async fn guarded_and_hint_refreshes_obey_the_gate() {
+        let test = test_client(stopped(None)).await;
+        let baseline = test.backend.observe_calls();
+        let operation = test.client.begin_operation().await.unwrap();
+        let wrong = OperationId::new(operation.id().get() + 1).unwrap();
+        let wrong_result = test
+            .client
+            .call(|reply| CoreActorMessage::RefreshStatus {
+                operation: wrong,
+                reply,
+            })
+            .await;
+        assert!(matches!(wrong_result, Err(CoreActorError::StaleOperation)));
+        assert_eq!(test.backend.observe_calls(), baseline);
+
+        test.client.hint_refresh();
+        tokio::task::yield_now().await;
+        assert_eq!(test.backend.observe_calls(), baseline);
+
+        test.backend.set_observation(running(3));
+        test.client.refresh_status(&operation).await.unwrap();
+        assert_eq!(test.client.status().revision.unwrap().generation, 3);
+        operation.release().await;
+
+        let mut status_rx = test.client.inner.status_rx.clone();
+        status_rx.borrow_and_update();
+        test.backend.set_observation(running(4));
+        test.client.hint_refresh();
+        status_rx.changed().await.unwrap();
+        assert_eq!(test.client.status().revision.unwrap().generation, 4);
+    }
+
+    #[tokio::test]
+    async fn operation_result_is_committed_before_reply() {
+        let test = test_client(stopped(None)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        test.backend.set_observation(running(5));
+        test.client
+            .run(&operation, &request(&test.requests, ClashCore::Mihomo))
+            .await
+            .unwrap();
+        assert_eq!(test.client.status().revision.unwrap().generation, 5);
+    }
+
+    #[tokio::test]
+    async fn failed_refresh_does_not_pollute_the_cache() {
+        let test = test_client(running(6)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        test.backend.fail_next_observe();
+        assert!(test.client.refresh_status(&operation).await.is_err());
+        assert_eq!(test.client.status().revision.unwrap().generation, 6);
+    }
+
+    #[tokio::test]
+    async fn ui_hint_eventually_observes_exhaustion_once() {
+        let test = test_client(running(1)).await;
+        let mut status_rx = test.client.inner.status_rx.clone();
+        status_rx.borrow_and_update();
+        test.backend.set_observation(exhausted("diagnostic"));
+        let before = test.client.status();
+        assert!(!before.recovery_exhausted);
+        test.client.hint_refresh();
+        status_rx.changed().await.unwrap();
+        assert!(test.client.status().recovery_exhausted);
+        assert_eq!(test.sink.0.lock().unwrap().len(), 1);
+        test.client.hint_refresh();
+        status_rx.changed().await.unwrap();
+        assert_eq!(test.sink.0.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn status_read_remains_live_while_run_is_blocked() {
+        let test = test_client(stopped(None)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        test.backend.set_observation(running(7));
+        let (started, release) = test.backend.block_next_run();
+        let client = test.client.clone();
+        let request = request(&test.requests, ClashCore::Mihomo);
+        let run = tokio::spawn(async move {
+            let result = client.run(&operation, &request).await;
+            drop(operation);
+            result
+        });
+        started.await.unwrap();
+        assert!(matches!(test.client.status().state, CoreState::Stopped(_)));
+        release.send(()).unwrap();
+        run.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn shutdown_publishes_a_distinct_terminal_snapshot() {
+        let test = test_client(running(8)).await;
+        assert!(matches!(test.client.status().state, CoreState::Running));
+        let mut receiver = test.client.inner.status_rx.clone();
+        test.client.shutdown().await;
+        receiver.changed().await.unwrap();
+        assert!(matches!(receiver.borrow().state, CoreState::Stopped(_)));
+    }
+
+    #[tokio::test]
+    async fn external_apply_stays_stale_until_an_idle_hint() {
+        let test = test_client(running(1)).await;
+        test.backend.set_observation(running(9));
+        assert_eq!(test.client.status().revision.unwrap().generation, 1);
+        let mut receiver = test.client.inner.status_rx.clone();
+        receiver.borrow_and_update();
+        test.client.hint_refresh();
+        receiver.changed().await.unwrap();
+        assert_eq!(test.client.status().revision.unwrap().generation, 9);
+    }
+
+    #[tokio::test]
+    async fn refresh_hints_are_coalesced() {
+        let test = test_client(running(1)).await;
+        let baseline = test.backend.observe_calls();
+        for _ in 0..10 {
+            test.client.hint_refresh();
+        }
+        for _ in 0..10 {
+            if test.backend.observe_calls() > baseline {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(test.backend.observe_calls() - baseline <= 2);
+    }
+
+    #[tokio::test]
+    async fn running_identity_is_actor_owned_not_typed_desired() {
+        let test = test_client(stopped(None)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        test.backend.set_observation(running(1));
+        let request_b = request(&test.requests, ClashCore::ClashRs);
+        test.client.run(&operation, &request_b).await.unwrap();
+        let actual = test.client.running(&operation).await.unwrap().unwrap();
+        assert_eq!(actual.core_type, CoreType::Clash(ClashCoreType::ClashRust));
+    }
+
+    #[test]
+    fn initial_watch_snapshot_matches_legacy_empty_status() {
+        let view = CoreStatusView::initial();
+        assert!(matches!(view.state, CoreState::Stopped(None)));
+        assert_eq!(view.state_changed_at, 0);
+        assert_eq!(view.run_type, RunType::default());
+        assert!(view.revision.is_none());
+        assert!(!view.recovery_exhausted);
+    }
+
+    #[tokio::test]
+    async fn recovery_exhaustion_is_published_once_even_after_recover() {
+        let test = test_client(running(1)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        test.backend.set_observation(exhausted("first"));
+        test.client.refresh_status(&operation).await.unwrap();
+        test.client.refresh_status(&operation).await.unwrap();
+        test.client
+            .call(|reply| CoreActorMessage::Recover {
+                operation: operation.id(),
+                reply,
+            })
+            .await
+            .unwrap();
+        assert_eq!(test.sink.0.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn active_lifecycle_resets_the_recovery_latch() {
+        let test = test_client(running(1)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        test.backend.set_observation(exhausted("first"));
+        test.client.refresh_status(&operation).await.unwrap();
+        test.backend.set_observation(running(2));
+        test.client.refresh_status(&operation).await.unwrap();
+        test.backend.set_observation(exhausted("second"));
+        test.client.refresh_status(&operation).await.unwrap();
+        assert_eq!(test.sink.0.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn latch_uses_faithful_lifecycle_before_lossy_projection() {
+        let test = test_client(running(1)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        test.backend.set_observation(exhausted("first"));
+        test.client.refresh_status(&operation).await.unwrap();
+        test.backend.set_observation(observation(
+            CoreState::Stopped(None),
+            FaithfulLifecycle::Starting,
+            None,
+        ));
+        test.client.refresh_status(&operation).await.unwrap();
+        test.backend.set_observation(exhausted("second"));
+        test.client.refresh_status(&operation).await.unwrap();
+        assert_eq!(test.sink.0.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn recovery_degradation_dto_is_bounded_and_complete() {
+        let test = test_client(running(1)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        test.backend.set_observation(exhausted(&"界".repeat(400)));
+        test.client.refresh_status(&operation).await.unwrap();
+        let degradations = test.sink.0.lock().unwrap();
+        let degradation = &degradations[0];
+        assert_eq!(degradation.phase, DegradationPhase::CoreLifecycle);
+        assert_eq!(degradation.code, "core_recovery_exhausted");
+        assert!(degradation.retryable);
+        assert!(degradation.message.contains(RECOVERY_EXHAUSTED_PREFIX));
+        assert!(degradation.message.len() <= 512);
+        assert!(
+            degradation
+                .message
+                .is_char_boundary(degradation.message.len())
+        );
+    }
+
+    #[tokio::test]
+    async fn set_backend_clears_running_identity() {
+        let test = test_client(stopped(None)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        test.backend.set_observation(running(1));
+        test.client
+            .run(&operation, &request(&test.requests, ClashCore::Mihomo))
+            .await
+            .unwrap();
+        assert!(test.client.running(&operation).await.unwrap().is_some());
+        let _ = test.client.set_backend(&operation, RunType::Service).await;
+        assert!(test.client.running(&operation).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn backend_switch_publishes_transient_stopped() {
+        let (barrier, entered, release) = ReplaceBarrier::new();
+        let test = test_client_with_replace_barrier(running(1), Some(barrier)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        let mut receiver = test.client.inner.status_rx.clone();
+        receiver.borrow_and_update();
+        let client = test.client.clone();
+        let switching = tokio::spawn(async move {
+            let result = client.set_backend(&operation, RunType::Normal).await;
+            (result, operation)
+        });
+        entered.await.unwrap();
+        receiver.changed().await.unwrap();
+        assert!(matches!(receiver.borrow().state, CoreState::Stopped(None)));
+        release.send(()).unwrap();
+        let (result, operation) = switching.await.unwrap();
+        result.unwrap();
+        operation.release().await;
+        test.client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn failed_backend_slot_is_queryable_and_recoverable() {
+        let test = test_client(stopped(None)).await;
+        let holding = LocalBackend::new(&test.requests).await.unwrap();
+        let operation = test.client.begin_operation().await.unwrap();
+        let first_error = match test.client.set_backend(&operation, RunType::Normal).await {
+            Err(CoreActorError::NoBackend { last_error }) => last_error,
+            other => panic!("expected failed backend slot, got {other:?}"),
+        };
+        assert!(matches!(
+            test.client.status().state,
+            CoreState::Stopped(Some(_))
+        ));
+        let queried_error = match test.client.running(&operation).await {
+            Err(CoreActorError::NoBackend { last_error }) => last_error,
+            _ => panic!("expected failed backend query"),
+        };
+        assert!(Arc::ptr_eq(&first_error, &queried_error));
+
+        CoreBackend::Local(holding).shutdown().await.unwrap();
+        test.client
+            .set_backend(&operation, RunType::Normal)
+            .await
+            .unwrap();
+        assert!(test.client.running(&operation).await.unwrap().is_none());
+        operation.release().await;
+        test.client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn failed_replacement_preserves_run_type_until_a_real_backend_commits() {
+        let test = test_client_with_scripted_replacement(running(1)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        test.backend.fail_next_replace();
+
+        assert!(
+            test.client
+                .set_backend(&operation, RunType::Service)
+                .await
+                .is_err()
+        );
+        assert_eq!(test.client.status().run_type, RunType::Normal);
+
+        test.client
+            .set_backend(&operation, RunType::Service)
+            .await
+            .unwrap();
+        assert_eq!(test.client.status().run_type, RunType::Service);
+    }
+
+    #[tokio::test]
+    async fn terminal_observation_clears_running_identity() {
+        let test = test_client(stopped(None)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        test.backend.set_observation(running(1));
+        test.client
+            .run(&operation, &request(&test.requests, ClashCore::Mihomo))
+            .await
+            .unwrap();
+        test.backend
+            .set_observation(stopped(Some("crashed".to_owned())));
+        test.client.refresh_status(&operation).await.unwrap();
+        assert!(test.client.running(&operation).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn running_identity_without_the_active_guard_is_rejected() {
+        let test = test_client(running(1)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        let wrong = OperationId::new(operation.id().get() + 1).unwrap();
+        let result = test
+            .client
+            .call(|reply| CoreActorMessage::RunningIdentity {
+                operation: wrong,
+                reply,
+            })
+            .await;
+        assert!(matches!(result, Err(CoreActorError::StaleOperation)));
+    }
+
+    #[tokio::test]
+    async fn promoted_restart_uses_the_transaction_target_core() {
+        let test = test_client(stopped(None)).await;
+        let application =
+            crate::client::tests::test_application_client(&test._dir, ClashCore::Mihomo).await;
+        let adapter =
+            CoreLifecycleAdapter::new(test.client.clone(), application, test.requests.clone());
+        let candidate = test
+            .requests
+            .runtime_paths()
+            .create_candidate(b"mode: rule\n")
+            .await
+            .unwrap();
+        let mut lease = adapter.begin().await.unwrap();
+        lease
+            .check_and_promote(
+                &candidate,
+                ClashCore::ClashRs,
+                test.requests.runtime_paths().product(),
+            )
+            .await
+            .unwrap();
+        test.backend.set_observation(running(1));
+        lease.restart().await.unwrap();
+        drop(lease);
+
+        assert_eq!(
+            running_request(&test.client).await.core_type,
+            CoreType::Clash(ClashCoreType::ClashRust)
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_target_restart_falls_back_to_the_rollback_core() {
+        let test = test_client(stopped(None)).await;
+        let application =
+            crate::client::tests::test_application_client(&test._dir, ClashCore::Mihomo).await;
+        let adapter =
+            CoreLifecycleAdapter::new(test.client.clone(), application, test.requests.clone());
+        let candidate = test
+            .requests
+            .runtime_paths()
+            .create_candidate(b"mode: rule\n")
+            .await
+            .unwrap();
+        let mut lease = adapter.begin().await.unwrap();
+        lease
+            .check_and_promote(
+                &candidate,
+                ClashCore::ClashRs,
+                test.requests.runtime_paths().product(),
+            )
+            .await
+            .unwrap();
+        test.backend.fail_next_run();
+        assert!(lease.restart().await.is_err());
+        lease
+            .check_and_promote(
+                &candidate,
+                ClashCore::Mihomo,
+                test.requests.runtime_paths().product(),
+            )
+            .await
+            .unwrap();
+        test.backend.set_observation(running(2));
+        lease.restart().await.unwrap();
+        drop(lease);
+
+        assert_eq!(
+            running_request(&test.client).await.core_type,
+            CoreType::Clash(ClashCoreType::Mihomo)
+        );
+    }
+
+    #[tokio::test]
+    async fn pure_restart_uses_the_typed_snapshot_core() {
+        let test = test_client(stopped(None)).await;
+        let application =
+            crate::client::tests::test_application_client(&test._dir, ClashCore::Meow).await;
+        let adapter =
+            CoreLifecycleAdapter::new(test.client.clone(), application, test.requests.clone());
+        let mut lease = adapter.begin().await.unwrap();
+        test.backend.set_observation(running(3));
+        lease.restart().await.unwrap();
+        drop(lease);
+
+        assert_eq!(
+            running_request(&test.client).await.core_type,
+            CoreType::Clash(ClashCoreType::Meow)
+        );
+    }
+}

--- a/backend/tauri/src/client/core_bridge.rs
+++ b/backend/tauri/src/client/core_bridge.rs
@@ -1,19 +1,12 @@
 //! Core lifecycle port (S04): exclusive lease over check/promote/apply/restart/stop.
-//!
-//! Application code depends on [`CoreLifecyclePort`] and its borrowed lease so
-//! lifecycle operations cannot re-lock `CoreManager` in the middle of a
-//! transaction. The legacy adapter acquires the process-wide lifecycle mutex
-//! once and delegates through the unlocked lease methods.
 
 use std::path::{Path, PathBuf};
 
+use super::runtime::CandidateFile;
 use async_trait::async_trait;
 use camino::Utf8Path;
 use nyanpasu_config::application::ClashCore;
 use nyanpasu_ipc::api::status::CoreState;
-use sha2::Digest;
-
-use super::runtime::{CandidateFile, RuntimePaths};
 
 /// Narrow boundary for API-first updates to the running core configuration.
 #[cfg_attr(test, mockall::automock)]
@@ -88,142 +81,6 @@ pub(crate) async fn restore_product(product: &Path, bytes: &[u8]) -> anyhow::Res
     .await?
     .map_err(|error| anyhow::anyhow!("failed to promote runtime config: {error}"))?;
     Ok(())
-}
-
-/// Map the typed snapshot core to the legacy manager's equivalent enum.
-impl From<ClashCore> for crate::config::nyanpasu::ClashCore {
-    fn from(core: ClashCore) -> Self {
-        match core {
-            ClashCore::ClashPremium => Self::ClashPremium,
-            ClashCore::ClashRs => Self::ClashRs,
-            ClashCore::Mihomo => Self::Mihomo,
-            ClashCore::MihomoAlpha => Self::MihomoAlpha,
-            ClashCore::ClashRsAlpha => Self::ClashRsAlpha,
-            ClashCore::Meow => Self::Meow,
-        }
-    }
-}
-
-pub struct LegacyCoreBridge {
-    runtime_paths: RuntimePaths,
-}
-
-impl LegacyCoreBridge {
-    pub fn new(runtime_paths: RuntimePaths) -> Self {
-        Self { runtime_paths }
-    }
-}
-
-struct LegacyCoreLifecycleLease {
-    lease: crate::core::CoreLifecycleLease<'static>,
-    runtime_paths: RuntimePaths,
-}
-
-#[async_trait]
-impl CoreLifecyclePort for LegacyCoreBridge {
-    async fn begin(&self) -> anyhow::Result<Box<dyn CoreLifecycleLease>> {
-        // TODO(actor-migration): temporary bridge to CoreManager::global().
-        // Reason: core ownership migrates in PR-5 (CoreActor).
-        // Remove when: the composition root injects the core lifecycle owner.
-        let lease = crate::core::CoreManager::global().begin_lifecycle().await;
-        Ok(Box::new(LegacyCoreLifecycleLease {
-            lease,
-            runtime_paths: self.runtime_paths.clone(),
-        }))
-    }
-
-    async fn status(&self) -> anyhow::Result<CoreStatusSnapshot> {
-        let (state, state_changed_at, run_type) = crate::core::CoreManager::global().status().await;
-        Ok(CoreStatusSnapshot {
-            state: state.into_owned(),
-            state_changed_at,
-            run_type,
-        })
-    }
-
-    async fn on_profile_change(&self) {
-        // TODO(actor-migration): connection interruption still reads Config::verge().
-        // Reason: break_when_* and clash API client migration is PR-6 scope.
-        // Remove when: interruption reads typed ClashConfig.break_connection.
-        let _ =
-            crate::core::connection_interruption::ConnectionInterruptionService::on_profile_change(
-            )
-            .await;
-    }
-}
-
-#[async_trait]
-impl CoreLifecycleLease for LegacyCoreLifecycleLease {
-    async fn check_and_promote(
-        &mut self,
-        candidate: &CandidateFile,
-        target_core: ClashCore,
-        product: &Utf8Path,
-    ) -> anyhow::Result<[u8; 32]> {
-        anyhow::ensure!(
-            product == self.runtime_paths.product(),
-            "product path must match the lifecycle adapter runtime product"
-        );
-        let bytes = tokio::fs::read(candidate.path()).await?;
-        self.lease
-            .check_config(candidate.path(), target_core.into())
-            .await?;
-
-        let after = tokio::fs::read(candidate.path().as_std_path()).await?;
-        if after != bytes {
-            anyhow::bail!("candidate config changed between check and promote");
-        }
-        let candidate_hash: [u8; 32] = sha2::Sha256::digest(&bytes).into();
-        if candidate_hash != candidate.bytes_sha256() {
-            anyhow::bail!("candidate config hash changed before promotion");
-        }
-
-        restore_product(product.as_std_path(), &bytes).await?;
-        let promoted = tokio::fs::read(product.as_std_path()).await?;
-        let promoted_hash: [u8; 32] = sha2::Sha256::digest(&promoted).into();
-        if promoted_hash != candidate.bytes_sha256() {
-            anyhow::bail!("promoted runtime product hash does not match candidate");
-        }
-        Ok(promoted_hash)
-    }
-
-    async fn apply_candidate(
-        &mut self,
-        candidate: &CandidateFile,
-        target_core: ClashCore,
-    ) -> anyhow::Result<()> {
-        let bytes = tokio::fs::read(candidate.path()).await?;
-        let candidate_hash: [u8; 32] = sha2::Sha256::digest(&bytes).into();
-        anyhow::ensure!(
-            candidate_hash == candidate.bytes_sha256(),
-            "candidate config hash changed before check"
-        );
-        self.lease
-            .check_config(candidate.path(), target_core.into())
-            .await?;
-        let after = tokio::fs::read(candidate.path()).await?;
-        anyhow::ensure!(
-            after == bytes,
-            "candidate config changed between check and apply"
-        );
-        self.lease.apply_config_from(candidate.path()).await
-    }
-
-    async fn apply_promoted(&mut self, product: &Utf8Path) -> anyhow::Result<()> {
-        anyhow::ensure!(
-            product == self.runtime_paths.product(),
-            "product path must match the lifecycle adapter runtime product"
-        );
-        self.lease.apply_config_from(product).await
-    }
-
-    async fn restart(&mut self) -> anyhow::Result<()> {
-        self.lease.run_core_from(self.runtime_paths.product()).await
-    }
-
-    async fn stop(&mut self) -> anyhow::Result<()> {
-        self.lease.stop_core().await
-    }
 }
 
 #[cfg(test)]

--- a/backend/tauri/src/client/event_sink.rs
+++ b/backend/tauri/src/client/event_sink.rs
@@ -1,6 +1,11 @@
+use std::sync::Arc;
+
 use crate::{
     client::Result,
-    core::handle::{Message, StateChanged},
+    core::{
+        actor::backend::CoreDegradationSink,
+        handle::{Message, StateChanged},
+    },
 };
 use tauri::{Emitter, Manager};
 
@@ -74,6 +79,29 @@ impl<R: tauri::Runtime> UiEventSink for TauriUiEventSink<R> {
     fn update_systray_part(&self) -> Result<()> {
         crate::core::tray::Tray::update_part(&self.app_handle)?;
         Ok(())
+    }
+}
+
+pub struct TauriCoreDegradationSink {
+    ui_sink: Arc<dyn UiEventSink>,
+}
+
+impl TauriCoreDegradationSink {
+    pub fn new(ui_sink: Arc<dyn UiEventSink>) -> Self {
+        Self { ui_sink }
+    }
+}
+
+impl CoreDegradationSink for TauriCoreDegradationSink {
+    fn publish(&self, degradation: crate::client::runtime::Degradation) {
+        tracing::warn!(
+            code = %degradation.code,
+            phase = ?degradation.phase,
+            message = %degradation.message,
+            "core degradation"
+        );
+        self.ui_sink
+            .notice_message(&Message::SetConfig(Err(degradation.message)));
     }
 }
 

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -1,5 +1,6 @@
 mod application;
 mod clash_config;
+mod core;
 mod core_bridge;
 mod error;
 mod event_sink;
@@ -12,10 +13,8 @@ pub mod runtime;
 mod session_state;
 mod system_dns;
 
-use self::{
-    application::ApplicationClient, clash_config::ClashConfigClient,
-    session_state::SessionStateClient,
-};
+pub(crate) use self::application::ApplicationClient;
+use self::{clash_config::ClashConfigClient, session_state::SessionStateClient};
 use crate::{
     enhance::{
         EnhanceScriptRunner, FsProfileContentSource, RuntimeBuildInput, RuntimeBuilder,
@@ -55,15 +54,18 @@ use sha2::{Digest, Sha256};
 use std::{path::PathBuf, sync::Arc};
 use struct_patch::Patch as _;
 
+#[cfg(test)]
+pub(crate) use core::CoreClientArgs;
+#[allow(unused_imports)]
+pub use core::{CoreClient, CoreOperationGuard};
 pub use core_bridge::{
-    CoreLifecycleLease, CoreLifecyclePort, LegacyCoreBridge, LegacyRunningConfigPatchBridge,
-    RunningConfigPatchPort,
+    CoreLifecycleLease, CoreLifecyclePort, LegacyRunningConfigPatchBridge, RunningConfigPatchPort,
 };
 pub use error::{ClientError, Result};
 pub(crate) use error::{CompensationFailure, LegacyVergeDomain, PartialCommit};
 #[cfg(test)]
 pub use event_sink::NoopUiEventSink;
-pub use event_sink::{TauriUiEventSink, UiEventSink};
+pub use event_sink::{TauriCoreDegradationSink, TauriUiEventSink, UiEventSink};
 pub use ports::SessionPortResolver;
 pub use runtime::RuntimePaths;
 #[cfg(test)]
@@ -71,13 +73,18 @@ pub use system_dns::{MockSystemDnsCache, NoopSystemDnsCache};
 pub use system_dns::{OsSystemDnsCache, SystemDnsCache};
 #[cfg(test)]
 pub use tests::{MockRunningCoreBridge, TestRunningCoreBridge as RunningCoreBridge};
+#[cfg(test)]
+pub(crate) use tests::{test_binary_resolver, test_degradation_sink, test_service_control};
 
 pub struct ClientSetupArgs {
     pub paths: PathResolver,
     pub runtime_paths: RuntimePaths,
     pub bridges: LegacyBridgeSet,
     pub ui_sink: Arc<dyn UiEventSink>,
-    pub core: Arc<dyn CoreLifecyclePort>,
+    pub core: Option<Arc<dyn CoreLifecyclePort>>,
+    pub binary_resolver: Arc<dyn crate::core::actor::request::CoreBinaryResolver>,
+    pub degradation: Arc<dyn crate::core::actor::backend::CoreDegradationSink>,
+    pub(crate) service_control: Arc<dyn crate::core::actor::backend::ServiceControlOps>,
     /// Optional during the staged caller migration; setup always injects it.
     pub clash_patch: Option<Arc<dyn RunningConfigPatchPort>>,
     pub system_dns: Arc<dyn SystemDnsCache>,
@@ -232,7 +239,10 @@ struct NyanpasuClientInner {
     profiles_dir: PathBuf,
     runtime_paths: RuntimePaths,
     ui_sink: Arc<dyn UiEventSink>,
+    core_client: CoreClient,
     core: Arc<dyn CoreLifecyclePort>,
+    requests: crate::core::actor::request::CoreRequestFactory,
+    service_control: Arc<dyn crate::core::actor::backend::ServiceControlOps>,
     clash_patch: Arc<dyn RunningConfigPatchPort>,
     /// Serializes API-first running-core patches through desired-state rebuild
     /// and any revision-fenced compensation.
@@ -259,6 +269,9 @@ impl NyanpasuClient {
             bridges,
             ui_sink,
             core,
+            binary_resolver,
+            degradation,
+            service_control,
             clash_patch,
             system_dns,
         } = args;
@@ -269,48 +282,85 @@ impl NyanpasuClient {
         let profiles_dir = paths.app_profiles_dir();
         let profiles_path = utf8_path(paths.profiles_path())?;
         let runtime_paths_for_setup = runtime_paths.clone();
-        let (application, session_state, clash_config, profiles, runtime_store, ports, fs, rebuild) =
-            tauri::async_runtime::block_on(async move {
-                runtime_paths_for_setup
-                    .cleanup_stale_candidates(std::time::Duration::from_secs(24 * 60 * 60))
-                    .await
-                    .context("failed to clean stale runtime candidates")?;
-                let (application, session_state, clash_config) =
-                    new_typed_config_clients(paths.clone(), bridges).await?;
+        let (
+            application,
+            session_state,
+            clash_config,
+            profiles,
+            runtime_store,
+            ports,
+            fs,
+            rebuild,
+            core_client,
+            core,
+            requests,
+        ) = tauri::async_runtime::block_on(async move {
+            runtime_paths_for_setup
+                .cleanup_stale_candidates(std::time::Duration::from_secs(24 * 60 * 60))
+                .await
+                .context("failed to clean stale runtime candidates")?;
+            let (application, session_state, clash_config) =
+                new_typed_config_clients(paths.clone(), bridges).await?;
+            let app = application.get().await?.state;
+            let mode = crate::core::RunType::classify(
+                app.enable_service_mode,
+                crate::core::service::ipc::get_ipc_state(),
+            );
+            let requests = crate::core::actor::request::CoreRequestFactory::new(
+                &paths,
+                runtime_paths_for_setup.clone(),
+                binary_resolver,
+            )?;
+            let core_client = CoreClient::new(core::CoreClientArgs {
+                mode,
+                requests: requests.clone(),
+                degradation,
+            })
+            .await?;
+            let core = core.unwrap_or_else(|| {
+                Arc::new(core::CoreLifecycleAdapter::new(
+                    core_client.clone(),
+                    application.clone(),
+                    requests.clone(),
+                )) as Arc<dyn CoreLifecyclePort>
+            });
 
-                // Eager session port resolution: the core is not running yet,
-                // so probing strategies is race-free (design §19.2 caller duty).
-                let ports = Arc::new(SessionPortResolver::default());
-                let clash_snapshot = clash_config.get().await?.state;
-                ports
-                    .resolve(&clash_snapshot)
-                    .context("failed to resolve session ports")?;
+            // Eager session port resolution: the core is not running yet,
+            // so probing strategies is race-free (design §19.2 caller duty).
+            let ports = Arc::new(SessionPortResolver::default());
+            let clash_snapshot = clash_config.get().await?.state;
+            ports
+                .resolve(&clash_snapshot)
+                .context("failed to resolve session ports")?;
 
-                let file_service = Arc::new(ProfileFileService::new(
-                    paths,
-                    ports.clone() as Arc<dyn SelfProxyPortSource>,
-                ));
-                let rebuild = rebuild::RebuildCoordinator::new();
-                let profiles = profiles::ProfilesClient::new(
-                    profiles_path,
-                    file_service.clone() as Arc<dyn ProfileFsPort>,
-                    file_service.clone() as Arc<dyn SubscriptionFetcher>,
-                    file_service.clone() as Arc<dyn ProfileMaterializationPort>,
-                    Arc::new(rebuild.notifier()),
-                )
-                .await?;
-                let runtime_store = runtime::new_runtime_lifecycle_store().await?;
-                anyhow::Ok((
-                    application,
-                    session_state,
-                    clash_config,
-                    profiles,
-                    runtime_store,
-                    ports,
-                    file_service as Arc<dyn ProfileFsPort>,
-                    rebuild,
-                ))
-            })?;
+            let file_service = Arc::new(ProfileFileService::new(
+                paths,
+                ports.clone() as Arc<dyn SelfProxyPortSource>,
+            ));
+            let rebuild = rebuild::RebuildCoordinator::new();
+            let profiles = profiles::ProfilesClient::new(
+                profiles_path,
+                file_service.clone() as Arc<dyn ProfileFsPort>,
+                file_service.clone() as Arc<dyn SubscriptionFetcher>,
+                file_service.clone() as Arc<dyn ProfileMaterializationPort>,
+                Arc::new(rebuild.notifier()),
+            )
+            .await?;
+            let runtime_store = runtime::new_runtime_lifecycle_store().await?;
+            anyhow::Ok((
+                application,
+                session_state,
+                clash_config,
+                profiles,
+                runtime_store,
+                ports,
+                file_service as Arc<dyn ProfileFsPort>,
+                rebuild,
+                core_client,
+                core,
+                requests,
+            ))
+        })?;
         let client = Self::with_parts(
             application,
             session_state,
@@ -321,7 +371,10 @@ impl NyanpasuClient {
             profiles_dir,
             runtime_paths,
             ui_sink,
+            core_client,
             core,
+            requests,
+            service_control,
             clash_patch,
             system_dns,
             runtime_store,
@@ -342,7 +395,10 @@ impl NyanpasuClient {
         profiles_dir: PathBuf,
         runtime_paths: RuntimePaths,
         ui_sink: Arc<dyn UiEventSink>,
+        core_client: CoreClient,
         core: Arc<dyn CoreLifecyclePort>,
+        requests: crate::core::actor::request::CoreRequestFactory,
+        service_control: Arc<dyn crate::core::actor::backend::ServiceControlOps>,
         clash_patch: Arc<dyn RunningConfigPatchPort>,
         system_dns: Arc<dyn SystemDnsCache>,
         runtime: runtime::RuntimeLifecycleStore,
@@ -359,7 +415,10 @@ impl NyanpasuClient {
                 profiles_dir,
                 runtime_paths,
                 ui_sink,
+                core_client,
                 core,
+                requests,
+                service_control,
                 clash_patch,
                 clash_patch_gate: tokio::sync::Mutex::new(()),
                 system_dns,
@@ -389,18 +448,119 @@ impl NyanpasuClient {
         });
     }
 
-    /// Stop the instance-owned **rebuild coordinator worker** and await its exit.
+    /// Stop the instance-owned rebuild worker and core actor, awaiting both exits.
     ///
-    /// Contract (PR-4S S09):
-    /// - Shuts down only the capacity-1 dirty rebuild worker owned by this client graph.
+    /// Contract (PR-5a S11):
+    /// - Shuts down the capacity-1 dirty rebuild worker before the core actor/backend.
     /// - Does **not** act as a general service locator teardown.
-    /// - Does **not** stop desired-state actors, CoreManager globals, system proxy,
-    ///   or OS-side resources — those remain PR-5/6 residuals and existing
-    ///   `cleanup_processes` / core stop paths.
+    /// - Does **not** stop desired-state actors, system proxy, or unrelated OS resources.
     /// - Safe to call multiple times; post-shutdown dirty notifications are no-ops.
     /// - An already in-flight rebuild is allowed to finish; coalesce waits abort.
     pub async fn shutdown(&self) {
         self.inner.rebuild.shutdown().await;
+        self.inner.core_client.shutdown().await;
+    }
+
+    fn core_mode_reconciler(&self) -> crate::core::actor::request::CoreModeReconciler {
+        crate::core::actor::request::CoreModeReconciler {
+            core: self.inner.core_client.clone(),
+            application: self.inner.application.clone(),
+            requests: self.inner.requests.clone(),
+        }
+    }
+
+    pub fn core_status(
+        &self,
+    ) -> (
+        std::borrow::Cow<'static, nyanpasu_ipc::api::status::CoreState>,
+        i64,
+        crate::core::RunType,
+    ) {
+        let status = self.inner.core_client.status();
+        self.inner.core_client.hint_refresh();
+        (
+            std::borrow::Cow::Owned(status.state),
+            status.state_changed_at,
+            status.run_type,
+        )
+    }
+
+    pub async fn restart_core(&self) -> Result<()> {
+        let result: anyhow::Result<()> = async {
+            let app = self.inner.application.get().await?.state;
+            let operation = self.inner.core_client.begin_operation().await?;
+            let request = self.inner.requests.for_product(app.core)?;
+            self.inner.core_client.run(&operation, &request).await?;
+            Ok(())
+        }
+        .await;
+        result?;
+        Ok(())
+    }
+
+    pub async fn install_service(&self) -> Result<()> {
+        self.inner
+            .service_control
+            .install(self.core_mode_reconciler())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn start_service(&self) -> Result<()> {
+        let control = self
+            .inner
+            .service_control
+            .start(self.core_mode_reconciler())
+            .await;
+        self.reconcile_service_mode().await;
+        control?;
+        Ok(())
+    }
+
+    pub async fn stop_service(&self) -> Result<()> {
+        let control = self.inner.service_control.stop().await;
+        self.reconcile_service_mode().await;
+        control?;
+        Ok(())
+    }
+
+    pub async fn restart_service(&self) -> Result<()> {
+        let control = self
+            .inner
+            .service_control
+            .restart(self.core_mode_reconciler())
+            .await;
+        self.reconcile_service_mode().await;
+        control?;
+        Ok(())
+    }
+
+    async fn reconcile_service_mode(&self) {
+        if let Err(error) = self
+            .core_mode_reconciler()
+            .reconcile(crate::core::service::ipc::get_ipc_state())
+            .await
+        {
+            log::error!(target: "app", "{error}");
+        }
+    }
+
+    pub async fn init_service_health(&self) -> Result<()> {
+        let app = self.inner.application.get().await?.state;
+        crate::utils::init::init_service(app.enable_service_mode, self.core_mode_reconciler())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn update_core(
+        &self,
+        core_type: crate::config::nyanpasu::ClashCore,
+    ) -> Result<usize> {
+        Ok(crate::core::updater::UpdaterManager::global()
+            .write()
+            .await
+            .update_core(&core_type, self.inner.core_client.clone())
+            .await?)
     }
 
     pub(crate) fn runtime_paths(&self) -> &RuntimePaths {
@@ -1369,36 +1529,37 @@ impl NyanpasuClient {
             .map_err(ClientError::Anyhow)?;
 
         let client = self.clone();
-        let result = crate::feat::patch_clash_with_rebuild(patch, |restart| async move {
-            let operation = async {
-                let snapshot = client
-                    .regenerate_for_legacy_inner(&mut *lease)
-                    .await
-                    .map_err(anyhow::Error::from)?;
-                if restart {
-                    lease.restart().await?;
-                } else {
-                    lease
-                        .apply_promoted(client.inner.runtime_paths.product())
-                        .await?;
-                }
-                Ok::<_, anyhow::Error>(snapshot)
-            };
-            match operation.await {
-                Ok(snapshot) => Ok(snapshot),
-                Err(primary) => {
-                    client
-                        .restore_applied_after_patch_failure(
-                            &mut *lease,
-                            captured_lifecycle,
-                            compensation,
-                            primary.to_string(),
-                        )
+        let result =
+            crate::feat::patch_clash_with_rebuild(self.clone(), patch, |restart| async move {
+                let operation = async {
+                    let snapshot = client
+                        .regenerate_for_legacy_inner(&mut *lease)
                         .await
+                        .map_err(anyhow::Error::from)?;
+                    if restart {
+                        lease.restart().await?;
+                    } else {
+                        lease
+                            .apply_promoted(client.inner.runtime_paths.product())
+                            .await?;
+                    }
+                    Ok::<_, anyhow::Error>(snapshot)
+                };
+                match operation.await {
+                    Ok(snapshot) => Ok(snapshot),
+                    Err(primary) => {
+                        client
+                            .restore_applied_after_patch_failure(
+                                &mut *lease,
+                                captured_lifecycle,
+                                compensation,
+                                primary.to_string(),
+                            )
+                            .await
+                    }
                 }
-            }
-        })
-        .await;
+            })
+            .await;
         match result {
             Ok(snapshot) => {
                 self.publish_applied(snapshot).await?;
@@ -1554,7 +1715,15 @@ mod tests {
         },
         state::window::{WindowLabel, WindowState},
     };
-    use std::{collections::BTreeMap, sync::Mutex as StdMutex};
+    use std::{
+        collections::BTreeMap,
+        sync::{
+            Condvar, Mutex as StdMutex,
+            atomic::{AtomicUsize, Ordering},
+            mpsc,
+        },
+        time::Duration,
+    };
     use struct_patch::Patch;
     use tempfile::{TempDir, tempdir};
 
@@ -1764,6 +1933,23 @@ mod tests {
         }
     }
 
+    pub(crate) async fn test_application_client(
+        dir: &TempDir,
+        core: nyanpasu_config::application::ClashCore,
+    ) -> ApplicationClient {
+        let seed = NyanpasuAppConfig {
+            core,
+            ..NyanpasuAppConfig::default()
+        };
+        ApplicationClient::new(
+            temp_config_path(dir, "application.yaml"),
+            seed,
+            Arc::new(NoopVergeBridge),
+        )
+        .await
+        .unwrap()
+    }
+
     struct RecordingVergeBridge {
         mirrored_theme_color: Arc<StdMutex<Option<String>>>,
     }
@@ -1820,6 +2006,380 @@ mod tests {
         async fn patch(&self, _patch: &serde_yaml::Mapping) -> anyhow::Result<()> {
             Ok(())
         }
+    }
+
+    struct FixedCoreBinaryResolver(Utf8PathBuf);
+
+    impl crate::core::actor::request::CoreBinaryResolver for FixedCoreBinaryResolver {
+        fn resolve(&self, _kind: &nyanpasu_utils::core::CoreType) -> anyhow::Result<Utf8PathBuf> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[derive(Default)]
+    struct NoopCoreDegradationSink;
+
+    impl crate::core::actor::backend::CoreDegradationSink for NoopCoreDegradationSink {
+        fn publish(&self, _degradation: runtime::Degradation) {}
+    }
+
+    #[derive(Default)]
+    struct RecordingCoreDegradationSink(StdMutex<Vec<runtime::Degradation>>);
+
+    impl crate::core::actor::backend::CoreDegradationSink for RecordingCoreDegradationSink {
+        fn publish(&self, degradation: runtime::Degradation) {
+            self.0.lock().unwrap().push(degradation);
+        }
+    }
+
+    #[derive(Default)]
+    struct NoopServiceControlOps;
+
+    #[async_trait]
+    impl crate::core::actor::backend::ServiceControlOps for NoopServiceControlOps {
+        async fn install(
+            &self,
+            _reconciler: crate::core::actor::request::CoreModeReconciler,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn start(
+            &self,
+            _reconciler: crate::core::actor::request::CoreModeReconciler,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn stop(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn restart(
+            &self,
+            _reconciler: crate::core::actor::request::CoreModeReconciler,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct ScriptedServiceControlOps {
+        error: Option<&'static str>,
+        calls: AtomicUsize,
+    }
+
+    struct BlockingVergeBridge {
+        entered: mpsc::Sender<()>,
+        release: Arc<(StdMutex<bool>, Condvar)>,
+    }
+
+    impl VergeLegacyBridgeTrait for BlockingVergeBridge {
+        fn prepare(
+            &self,
+            _snap: &NyanpasuAppConfig,
+        ) -> anyhow::Result<Box<dyn PreparedLegacyMirror>> {
+            self.entered.send(()).unwrap();
+            let (lock, wake) = &*self.release;
+            let mut released = lock.lock().unwrap();
+            while !*released {
+                released = wake.wait(released).unwrap();
+            }
+            Ok(Box::new(NoopPreparedLegacyMirror))
+        }
+
+        fn snapshot_legacy(&self) -> anyhow::Result<NyanpasuAppConfig> {
+            Ok(NyanpasuAppConfig::default())
+        }
+    }
+
+    impl ScriptedServiceControlOps {
+        fn success() -> Self {
+            Self {
+                error: None,
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn failing(error: &'static str) -> Self {
+            Self {
+                error: Some(error),
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn result(&self) -> anyhow::Result<()> {
+            self.calls.fetch_add(1, Ordering::AcqRel);
+            match self.error {
+                Some(error) => anyhow::bail!(error),
+                None => Ok(()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl crate::core::actor::backend::ServiceControlOps for ScriptedServiceControlOps {
+        async fn install(
+            &self,
+            _reconciler: crate::core::actor::request::CoreModeReconciler,
+        ) -> anyhow::Result<()> {
+            self.result()
+        }
+
+        async fn start(
+            &self,
+            _reconciler: crate::core::actor::request::CoreModeReconciler,
+        ) -> anyhow::Result<()> {
+            self.result()
+        }
+
+        async fn stop(&self) -> anyhow::Result<()> {
+            self.result()
+        }
+
+        async fn restart(
+            &self,
+            _reconciler: crate::core::actor::request::CoreModeReconciler,
+        ) -> anyhow::Result<()> {
+            self.result()
+        }
+    }
+
+    struct FailingCoreBinaryResolver;
+
+    impl crate::core::actor::request::CoreBinaryResolver for FailingCoreBinaryResolver {
+        fn resolve(&self, _kind: &nyanpasu_utils::core::CoreType) -> anyhow::Result<Utf8PathBuf> {
+            anyhow::bail!("scripted binary resolution failure")
+        }
+    }
+
+    pub(crate) fn test_binary_resolver(
+        dir: &TempDir,
+    ) -> Arc<dyn crate::core::actor::request::CoreBinaryResolver> {
+        Arc::new(FixedCoreBinaryResolver(
+            Utf8PathBuf::from_path_buf(dir.path().join("fake-core")).unwrap(),
+        ))
+    }
+
+    pub(crate) fn test_degradation_sink()
+    -> Arc<dyn crate::core::actor::backend::CoreDegradationSink> {
+        Arc::new(NoopCoreDegradationSink)
+    }
+
+    pub(crate) fn test_service_control() -> Arc<dyn crate::core::actor::backend::ServiceControlOps>
+    {
+        Arc::new(NoopServiceControlOps)
+    }
+
+    async fn test_actor_parts(
+        paths: &PathResolver,
+        runtime_paths: RuntimePaths,
+    ) -> (CoreClient, crate::core::actor::request::CoreRequestFactory) {
+        let requests = crate::core::actor::request::CoreRequestFactory::new(
+            paths,
+            runtime_paths,
+            Arc::new(FixedCoreBinaryResolver(
+                Utf8PathBuf::from_path_buf(paths.app_data_dir().join("fake-core")).unwrap(),
+            )),
+        )
+        .unwrap();
+        let core = CoreClient::new(core::CoreClientArgs {
+            mode: crate::core::RunType::Normal,
+            requests: requests.clone(),
+            degradation: Arc::new(NoopCoreDegradationSink),
+        })
+        .await
+        .unwrap();
+        (core, requests)
+    }
+
+    pub(crate) async fn actor_backed_test_client(
+        dir: &TempDir,
+        backend: crate::core::actor::backend::TestBackend,
+        degradation: Arc<dyn crate::core::actor::backend::CoreDegradationSink>,
+    ) -> NyanpasuClient {
+        let (application, session_state, clash_config) = test_typed_config_clients(dir).await;
+        let paths = PathResolver::with_base_dirs(dir.path().into(), dir.path().join("data"));
+        let ports = Arc::new(SessionPortResolver::default());
+        ports.resolve(&ClashConfig::default()).unwrap();
+        let file_service = Arc::new(ProfileFileService::new(
+            paths.clone(),
+            ports.clone() as Arc<dyn SelfProxyPortSource>,
+        ));
+        let rebuild = rebuild::RebuildCoordinator::new();
+        let profiles = profiles::ProfilesClient::new(
+            temp_config_path(dir, "profiles.yaml"),
+            file_service.clone() as Arc<dyn ProfileFsPort>,
+            file_service.clone() as Arc<dyn SubscriptionFetcher>,
+            file_service.clone() as Arc<dyn ProfileMaterializationPort>,
+            Arc::new(rebuild.notifier()),
+        )
+        .await
+        .unwrap();
+        let runtime_paths = RuntimePaths::from_resolver(&paths).unwrap();
+        let requests = crate::core::actor::request::CoreRequestFactory::new(
+            &paths,
+            runtime_paths.clone(),
+            test_binary_resolver(dir),
+        )
+        .unwrap();
+        let core_client = CoreClient::new_with_reconciled_backend(
+            core::CoreClientArgs {
+                mode: crate::core::RunType::Normal,
+                requests: requests.clone(),
+                degradation,
+            },
+            backend,
+        )
+        .await
+        .unwrap();
+        let core = Arc::new(core::CoreLifecycleAdapter::new(
+            core_client.clone(),
+            application.clone(),
+            requests.clone(),
+        ));
+        NyanpasuClient::with_parts(
+            application,
+            session_state,
+            clash_config,
+            profiles,
+            file_service.clone() as Arc<dyn ProfileFsPort>,
+            ports,
+            paths.app_profiles_dir(),
+            runtime_paths,
+            Arc::new(crate::client::event_sink::NoopUiEventSink),
+            core_client,
+            core,
+            requests,
+            test_service_control(),
+            Arc::new(NoopRunningConfigPatchPort),
+            Arc::new(NoopSystemDnsCache),
+            crate::client::runtime::new_runtime_lifecycle_store()
+                .await
+                .unwrap(),
+            rebuild,
+        )
+    }
+
+    async fn service_facade(
+        dir: &TempDir,
+        enable_service: bool,
+        backend: crate::core::actor::backend::TestBackend,
+        binary: Arc<dyn crate::core::actor::request::CoreBinaryResolver>,
+        service_control: Arc<dyn crate::core::actor::backend::ServiceControlOps>,
+        application: Option<ApplicationClient>,
+    ) -> NyanpasuClient {
+        let (default_application, session_state, clash_config) =
+            test_typed_config_clients(dir).await;
+        let application = match application {
+            Some(application) => application,
+            None => {
+                let mut patch = NyanpasuAppConfig::new_empty_patch();
+                patch.enable_service_mode = Some(enable_service);
+                default_application.patch(patch).await.unwrap();
+                default_application
+            }
+        };
+        let profiles = profiles::ProfilesClient::new(
+            temp_config_path(dir, "profiles.yaml"),
+            Arc::new(MockProfileFsPort::new()),
+            Arc::new(MockSubscriptionFetcher::new()),
+            test_materialization_port(),
+            Arc::new(MockRebuildNotifier::new()),
+        )
+        .await
+        .unwrap();
+        let paths = PathResolver::with_base_dirs(dir.path().into(), dir.path().join("data"));
+        let runtime_paths = RuntimePaths::from_resolver(&paths).unwrap();
+        let requests = crate::core::actor::request::CoreRequestFactory::new(
+            &paths,
+            runtime_paths.clone(),
+            binary,
+        )
+        .unwrap();
+        let core_client = CoreClient::new_with_reconciled_backend(
+            core::CoreClientArgs {
+                mode: crate::core::RunType::Normal,
+                requests: requests.clone(),
+                degradation: test_degradation_sink(),
+            },
+            backend,
+        )
+        .await
+        .unwrap();
+        let ports = Arc::new(SessionPortResolver::default());
+        ports.resolve(&ClashConfig::default()).unwrap();
+        NyanpasuClient::with_parts(
+            application,
+            session_state,
+            clash_config,
+            profiles,
+            Arc::new(MockProfileFsPort::new()),
+            ports,
+            paths.app_profiles_dir(),
+            runtime_paths,
+            Arc::new(crate::client::event_sink::NoopUiEventSink),
+            core_client,
+            test_core_port(Arc::new(MockRunningCoreBridge::new())),
+            requests,
+            service_control,
+            Arc::new(NoopRunningConfigPatchPort),
+            Arc::new(NoopSystemDnsCache),
+            crate::client::runtime::new_runtime_lifecycle_store()
+                .await
+                .unwrap(),
+            rebuild::RebuildCoordinator::new(),
+        )
+    }
+
+    fn facade_backend() -> crate::core::actor::backend::TestBackend {
+        crate::core::actor::backend::TestBackend::new(
+            crate::core::actor::types::BackendObservation {
+                view: crate::core::actor::types::CoreStatusView {
+                    state: nyanpasu_ipc::api::status::CoreState::Running,
+                    state_changed_at: 1,
+                    run_type: crate::core::RunType::Normal,
+                    revision: None,
+                    recovery_exhausted: false,
+                },
+                lifecycle: crate::core::actor::types::FaithfulLifecycle::Running,
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn core_status_facade_refreshes_stale_state_and_publishes_degradation_once() {
+        let dir = tempdir().unwrap();
+        let backend = facade_backend();
+        let degradation = Arc::new(RecordingCoreDegradationSink::default());
+        let client = actor_backed_test_client(&dir, backend.clone(), degradation.clone()).await;
+        let mut status = client.inner.core_client.subscribe_status();
+        status.borrow_and_update();
+        let reason = "core kept crashing; restart budget exhausted\nfacade".to_owned();
+        backend.set_observation(crate::core::actor::types::BackendObservation {
+            view: crate::core::actor::types::CoreStatusView {
+                state: nyanpasu_ipc::api::status::CoreState::Stopped(Some(reason.clone())),
+                state_changed_at: 2,
+                run_type: crate::core::RunType::Normal,
+                revision: None,
+                recovery_exhausted: true,
+            },
+            lifecycle: crate::core::actor::types::FaithfulLifecycle::Stopped {
+                reason: Some(reason),
+            },
+        });
+
+        assert!(matches!(
+            client.core_status().0,
+            std::borrow::Cow::Owned(nyanpasu_ipc::api::status::CoreState::Running)
+        ));
+        status.changed().await.unwrap();
+        assert!(matches!(
+            client.core_status().0,
+            std::borrow::Cow::Owned(nyanpasu_ipc::api::status::CoreState::Stopped(Some(_)))
+        ));
+        status.changed().await.unwrap();
+        assert_eq!(degradation.0.lock().unwrap().len(), 1);
+        client.shutdown().await;
     }
 
     #[derive(Default)]
@@ -2030,6 +2590,9 @@ mod tests {
         ports
             .resolve(&ClashConfig::default())
             .expect("default ports should resolve");
+        let paths = PathResolver::with_base_dirs(dir.path().into(), dir.path().join("data"));
+        let runtime_paths = RuntimePaths::from_resolver(&paths).unwrap();
+        let (core_client, requests) = test_actor_parts(&paths, runtime_paths.clone()).await;
         NyanpasuClient::with_parts(
             application,
             session_state,
@@ -2038,13 +2601,12 @@ mod tests {
             Arc::new(MockProfileFsPort::new()),
             ports,
             dir.path().join("profiles"),
-            RuntimePaths::from_resolver(&PathResolver::with_base_dirs(
-                dir.path().into(),
-                dir.path().join("data"),
-            ))
-            .unwrap(),
+            runtime_paths,
             Arc::new(crate::client::event_sink::NoopUiEventSink),
+            core_client,
             test_core_port(Arc::new(MockRunningCoreBridge::new())),
+            requests,
+            test_service_control(),
             Arc::new(NoopRunningConfigPatchPort),
             system_dns,
             crate::client::runtime::new_runtime_lifecycle_store()
@@ -2081,6 +2643,183 @@ mod tests {
         assert!(error.to_string().contains("dns flush exploded"));
     }
 
+    #[tokio::test]
+    async fn service_control_failure_still_reconciles_and_remains_the_result() {
+        let dir = tempdir().unwrap();
+        let backend = facade_backend();
+        let control = Arc::new(ScriptedServiceControlOps::failing("control-a"));
+        let client = service_facade(
+            &dir,
+            true,
+            backend.clone(),
+            test_binary_resolver(&dir),
+            control.clone(),
+            None,
+        )
+        .await;
+
+        let error = client.start_service().await.unwrap_err();
+        assert!(error.to_string().contains("control-a"));
+        assert_eq!(control.calls.load(Ordering::Acquire), 1);
+        assert_eq!(backend.run_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn disabled_service_mode_does_not_touch_the_core_actor() {
+        let dir = tempdir().unwrap();
+        let backend = facade_backend();
+        let client = service_facade(
+            &dir,
+            false,
+            backend.clone(),
+            test_binary_resolver(&dir),
+            Arc::new(ScriptedServiceControlOps::success()),
+            None,
+        )
+        .await;
+
+        client.start_service().await.unwrap();
+        assert_eq!(backend.run_calls(), 0);
+        assert_eq!(backend.shutdown_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn backend_replacement_failure_does_not_replace_control_success() {
+        let dir = tempdir().unwrap();
+        let backend = facade_backend();
+        backend.fail_next_replace();
+        let client = service_facade(
+            &dir,
+            true,
+            backend.clone(),
+            test_binary_resolver(&dir),
+            Arc::new(ScriptedServiceControlOps::success()),
+            None,
+        )
+        .await;
+
+        client.start_service().await.unwrap();
+        assert_eq!(backend.run_calls(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn snapshot_read_failure_does_not_replace_control_success() {
+        let dir = tempdir().unwrap();
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let release = Arc::new((StdMutex::new(false), Condvar::new()));
+        let seed = NyanpasuAppConfig {
+            enable_service_mode: true,
+            ..NyanpasuAppConfig::default()
+        };
+        let application = ApplicationClient::new(
+            temp_config_path(&dir, "blocked-application.yaml"),
+            seed,
+            Arc::new(BlockingVergeBridge {
+                entered: entered_tx,
+                release: release.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+        let control = Arc::new(ScriptedServiceControlOps::success());
+        let client = service_facade(
+            &dir,
+            true,
+            facade_backend(),
+            test_binary_resolver(&dir),
+            control.clone(),
+            Some(application.clone()),
+        )
+        .await;
+        let mut patch = NyanpasuAppConfig::new_empty_patch();
+        patch.enable_silent_start = Some(true);
+        let patch_task = tokio::spawn(async move { application.patch(patch).await });
+        entered_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+
+        let result = client.start_service().await;
+        let (lock, wake) = &*release;
+        *lock.lock().unwrap() = true;
+        wake.notify_all();
+        patch_task.await.unwrap().unwrap();
+
+        result.unwrap();
+        assert_eq!(control.calls.load(Ordering::Acquire), 1);
+    }
+
+    #[tokio::test]
+    async fn request_and_run_failures_do_not_replace_control_success() {
+        let request_dir = tempdir().unwrap();
+        let request_backend = facade_backend();
+        let request_client = service_facade(
+            &request_dir,
+            true,
+            request_backend.clone(),
+            Arc::new(FailingCoreBinaryResolver),
+            Arc::new(ScriptedServiceControlOps::success()),
+            None,
+        )
+        .await;
+        request_client.start_service().await.unwrap();
+        assert_eq!(request_backend.run_calls(), 0);
+
+        let run_dir = tempdir().unwrap();
+        let run_backend = facade_backend();
+        run_backend.fail_next_run();
+        let run_client = service_facade(
+            &run_dir,
+            true,
+            run_backend.clone(),
+            test_binary_resolver(&run_dir),
+            Arc::new(ScriptedServiceControlOps::success()),
+            None,
+        )
+        .await;
+        run_client.start_service().await.unwrap();
+        assert_eq!(run_backend.run_calls(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn operation_timeout_does_not_replace_control_success() {
+        let dir = tempdir().unwrap();
+        let client = service_facade(
+            &dir,
+            true,
+            facade_backend(),
+            test_binary_resolver(&dir),
+            Arc::new(ScriptedServiceControlOps::success()),
+            None,
+        )
+        .await;
+        let held = client.inner.core_client.begin_operation().await.unwrap();
+        let call = tokio::spawn({
+            let client = client.clone();
+            async move { client.start_service().await }
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_secs(121)).await;
+
+        call.await.unwrap().unwrap();
+        drop(held);
+    }
+
+    #[tokio::test]
+    async fn control_error_is_not_replaced_by_a_reconcile_error() {
+        let dir = tempdir().unwrap();
+        let client = service_facade(
+            &dir,
+            true,
+            facade_backend(),
+            Arc::new(FailingCoreBinaryResolver),
+            Arc::new(ScriptedServiceControlOps::failing("control-a")),
+            None,
+        )
+        .await;
+
+        let error = client.start_service().await.unwrap_err();
+        assert!(error.to_string().contains("control-a"));
+        assert!(!error.to_string().contains("binary resolution"));
+    }
+
     /// Like [`test_profiles_client_args`], but accepts an already-typed
     /// [`CoreLifecyclePort`] (e.g. process-backed S09 adapter) without the
     /// mockall `TestRunningCoreBridge` wrapper.
@@ -2099,7 +2838,10 @@ mod tests {
                 clash: Arc::new(NoopClashBridge),
             },
             ui_sink: Arc::new(crate::client::event_sink::NoopUiEventSink),
-            core,
+            core: Some(core),
+            binary_resolver: test_binary_resolver(dir),
+            degradation: test_degradation_sink(),
+            service_control: test_service_control(),
             clash_patch: Some(Arc::new(NoopRunningConfigPatchPort)),
             system_dns: Arc::new(NoopSystemDnsCache),
         }
@@ -2112,7 +2854,7 @@ mod tests {
         test_client_args_with_lifecycle(dir, test_core_port(core))
     }
 
-    fn minimal_file_profile_request() -> NewProfileRequest {
+    pub(crate) fn minimal_file_profile_request() -> NewProfileRequest {
         NewProfileRequest {
             metadata: ProfileMetadata {
                 name: "t".into(),
@@ -2165,6 +2907,8 @@ mod tests {
         )
         .await
         .expect("profiles client should be created");
+        let runtime_paths = RuntimePaths::from_resolver(&paths).unwrap();
+        let (core_client, requests) = test_actor_parts(&paths, runtime_paths.clone()).await;
         let client = NyanpasuClient::with_parts(
             application,
             session_state,
@@ -2173,9 +2917,12 @@ mod tests {
             file_service.clone() as Arc<dyn ProfileFsPort>,
             ports,
             paths.app_profiles_dir(),
-            RuntimePaths::from_resolver(&paths).unwrap(),
+            runtime_paths,
             Arc::new(crate::client::event_sink::NoopUiEventSink),
+            core_client,
             test_core_port(core),
+            requests,
+            test_service_control(),
             Arc::new(NoopRunningConfigPatchPort),
             Arc::new(NoopSystemDnsCache),
             crate::client::runtime::new_runtime_lifecycle_store()
@@ -2331,7 +3078,10 @@ mod tests {
                 clash: Arc::new(NoopClashBridge),
             },
             ui_sink: Arc::new(crate::client::event_sink::NoopUiEventSink),
-            core: test_core_port(Arc::new(MockRunningCoreBridge::new())),
+            core: Some(test_core_port(Arc::new(MockRunningCoreBridge::new()))),
+            binary_resolver: test_binary_resolver(&dir),
+            degradation: test_degradation_sink(),
+            service_control: test_service_control(),
             clash_patch: Some(Arc::new(NoopRunningConfigPatchPort)),
             system_dns: Arc::new(NoopSystemDnsCache),
         })

--- a/backend/tauri/src/client/rebuild.rs
+++ b/backend/tauri/src/client/rebuild.rs
@@ -953,7 +953,7 @@ mod tests {
         });
         let client =
             crate::client::NyanpasuClient::try_new_with_args(crate::client::ClientSetupArgs {
-                core: core.clone(),
+                core: Some(core.clone()),
                 ..crate::client::tests::test_profiles_client_args(
                     &dir,
                     Arc::new(crate::client::tests::MockRunningCoreBridge::new()),
@@ -1270,6 +1270,69 @@ mod tests {
             nyanpasu_config::application::ClashCore::ClashRs,
             "rollback rebuild must target the restored old selected core"
         );
+    }
+
+    #[test]
+    fn rollback_build_failure_restarts_the_committed_old_core() {
+        let dir = tempfile::tempdir().unwrap();
+        let backend = crate::core::actor::backend::TestBackend::new(
+            crate::core::actor::types::BackendObservation {
+                view: crate::core::actor::types::CoreStatusView {
+                    state: nyanpasu_ipc::api::status::CoreState::Running,
+                    state_changed_at: 1,
+                    run_type: crate::core::RunType::Normal,
+                    revision: None,
+                    recovery_exhausted: false,
+                },
+                lifecycle: crate::core::actor::types::FaithfulLifecycle::Running,
+            },
+        );
+        let client =
+            tauri::async_runtime::block_on(crate::client::tests::actor_backed_test_client(
+                &dir,
+                backend.clone(),
+                crate::client::tests::test_degradation_sink(),
+            ));
+
+        tauri::async_runtime::block_on(async {
+            let report = client
+                .inner
+                .profiles
+                .add(
+                    crate::client::tests::minimal_file_profile_request(),
+                    Some("proxies: []\nmode: rule\n".into()),
+                )
+                .await
+                .unwrap();
+            let uid = report.created.unwrap();
+            client
+                .inner
+                .profiles
+                .set_current(Some(uid.clone()))
+                .await
+                .unwrap();
+            let materialized = client.get_profile_materialized_path(uid).await.unwrap();
+            assert!(materialized.is_file());
+            backend.fail_next_run_with(move || std::fs::remove_file(materialized).unwrap());
+
+            let result = client
+                .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+                .await;
+            assert!(result.is_err());
+            assert_eq!(backend.check_calls(), 1);
+            let requests = backend.run_requests();
+            assert_eq!(requests.len(), 2);
+            assert_eq!(
+                requests[0].core_type,
+                nyanpasu_utils::core::CoreType::Clash(
+                    nyanpasu_utils::core::ClashCoreType::ClashRust
+                )
+            );
+            assert_eq!(
+                requests[1].core_type,
+                nyanpasu_utils::core::CoreType::Clash(nyanpasu_utils::core::ClashCoreType::Mihomo)
+            );
+        });
     }
 
     /// Default fallback publishes Promoted only — Applied stays unset until a

--- a/backend/tauri/src/client/runtime.rs
+++ b/backend/tauri/src/client/runtime.rs
@@ -467,6 +467,7 @@ pub enum DegradationPhase {
     CoreRollback,
     SystemEffect,
     UiEffect,
+    CoreLifecycle,
 }
 
 #[cfg(test)]

--- a/backend/tauri/src/core/actor/backend.rs
+++ b/backend/tauri/src/core/actor/backend.rs
@@ -1,0 +1,1221 @@
+use std::{borrow::Cow, sync::Arc};
+
+use async_trait::async_trait;
+use nyanpasu_core_manager::{
+    ApplyOutcome, CoreManager, CoreSpec, CoreState as ManagerCoreState, InstanceOptions,
+    InstanceSpec, LocalIpcPolicy, ManagerOptions, RevisionId,
+};
+use nyanpasu_ipc::{
+    SERVICE_PLACEHOLDER,
+    api::{
+        core::{
+            apply::{ApplyOutcomeKind, CoreApplyData, CoreApplyReq},
+            check::CoreCheckReq,
+            start::CoreStartReq,
+        },
+        error_kind,
+        status::{ConfigRevisionInfo, CoreInfos, CoreState, CoreStateDetail, RevisionIdInfo},
+    },
+    client::{Client, ClientError},
+};
+use nyanpasu_utils::core::{ClashCoreType, CoreType};
+use tokio::sync::watch;
+
+use super::{
+    error_kind::service_error_kind,
+    request::{CoreModeReconciler, CoreRequestFactory},
+    types::{
+        BackendObservation, CoreRequest, CoreStatusView, FaithfulLifecycle, is_recovery_exhausted,
+    },
+};
+
+pub(crate) struct LocalBackend {
+    pub(crate) manager: Arc<CoreManager>,
+    status: watch::Receiver<nyanpasu_core_manager::CoreStatus>,
+}
+
+pub(crate) struct ServiceBackend {
+    pub(crate) client: Client,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct TestBackend {
+    state: Arc<TestBackendState>,
+}
+
+#[cfg(test)]
+struct TestBackendState {
+    observation: std::sync::Mutex<BackendObservation>,
+    observe_calls: std::sync::atomic::AtomicUsize,
+    check_calls: std::sync::atomic::AtomicUsize,
+    run_calls: std::sync::atomic::AtomicUsize,
+    run_requests: std::sync::Mutex<Vec<CoreRequest>>,
+    shutdown_calls: std::sync::atomic::AtomicUsize,
+    fail_observe: std::sync::atomic::AtomicBool,
+    fail_run: std::sync::atomic::AtomicBool,
+    fail_run_action: std::sync::Mutex<Option<Box<dyn FnOnce() + Send>>>,
+    fail_replace: std::sync::atomic::AtomicBool,
+    run_barrier: std::sync::Mutex<Option<TestRunBarrier>>,
+}
+
+#[cfg(test)]
+struct TestRunBarrier {
+    started: tokio::sync::oneshot::Sender<()>,
+    release: tokio::sync::oneshot::Receiver<()>,
+}
+
+pub(crate) enum CoreBackend {
+    Local(LocalBackend),
+    Service(ServiceBackend),
+    #[cfg(test)]
+    Test(TestBackend),
+}
+
+pub(crate) enum BackendSlot {
+    Ready(CoreBackend),
+    Failed { error: Arc<CoreBackendError> },
+}
+
+impl LocalBackend {
+    pub(crate) async fn new(requests: &CoreRequestFactory) -> Result<Self, CoreBackendError> {
+        let manager = Arc::new(
+            CoreManager::new(local_manager_options(requests.manager_runtime_dir()))
+                .await
+                .map_err(|error| CoreBackendError::Construct(anyhow::Error::new(error)))?,
+        );
+        let status = manager.subscribe();
+        Ok(Self { manager, status })
+    }
+}
+
+impl ServiceBackend {
+    pub(crate) fn new() -> Result<Self, CoreBackendError> {
+        Self::with_placeholder(SERVICE_PLACEHOLDER)
+    }
+
+    pub(crate) fn with_placeholder(placeholder: &str) -> Result<Self, CoreBackendError> {
+        let client = Client::new(placeholder)
+            .map_err(|error| CoreBackendError::Construct(anyhow::Error::new(error)))?;
+        Ok(Self { client })
+    }
+}
+
+#[cfg(test)]
+impl TestBackend {
+    pub(crate) fn new(observation: BackendObservation) -> Self {
+        Self {
+            state: Arc::new(TestBackendState {
+                observation: std::sync::Mutex::new(observation),
+                observe_calls: std::sync::atomic::AtomicUsize::new(0),
+                check_calls: std::sync::atomic::AtomicUsize::new(0),
+                run_calls: std::sync::atomic::AtomicUsize::new(0),
+                run_requests: std::sync::Mutex::new(Vec::new()),
+                shutdown_calls: std::sync::atomic::AtomicUsize::new(0),
+                fail_observe: std::sync::atomic::AtomicBool::new(false),
+                fail_run: std::sync::atomic::AtomicBool::new(false),
+                fail_run_action: std::sync::Mutex::new(None),
+                fail_replace: std::sync::atomic::AtomicBool::new(false),
+                run_barrier: std::sync::Mutex::new(None),
+            }),
+        }
+    }
+
+    pub(crate) fn set_observation(&self, observation: BackendObservation) {
+        *self.state.observation.lock().unwrap() = observation;
+    }
+
+    pub(crate) fn fail_next_observe(&self) {
+        self.state
+            .fail_observe
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    pub(crate) fn fail_next_run(&self) {
+        self.state
+            .fail_run
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    pub(crate) fn fail_next_run_with(&self, action: impl FnOnce() + Send + 'static) {
+        *self.state.fail_run_action.lock().unwrap() = Some(Box::new(action));
+        self.fail_next_run();
+    }
+
+    pub(crate) fn fail_next_replace(&self) {
+        self.state
+            .fail_replace
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    pub(crate) fn take_replace_failure(&self) -> bool {
+        self.state
+            .fail_replace
+            .swap(false, std::sync::atomic::Ordering::AcqRel)
+    }
+
+    pub(crate) fn block_next_run(
+        &self,
+    ) -> (
+        tokio::sync::oneshot::Receiver<()>,
+        tokio::sync::oneshot::Sender<()>,
+    ) {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        *self.state.run_barrier.lock().unwrap() = Some(TestRunBarrier {
+            started: started_tx,
+            release: release_rx,
+        });
+        (started_rx, release_tx)
+    }
+
+    pub(crate) fn observe_calls(&self) -> usize {
+        self.state
+            .observe_calls
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    pub(crate) fn run_calls(&self) -> usize {
+        self.state
+            .run_calls
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    pub(crate) fn check_calls(&self) -> usize {
+        self.state
+            .check_calls
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    pub(crate) fn run_requests(&self) -> Vec<CoreRequest> {
+        self.state.run_requests.lock().unwrap().clone()
+    }
+
+    pub(crate) fn shutdown_calls(&self) -> usize {
+        self.state
+            .shutdown_calls
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    async fn wait_for_run_barrier(&self) {
+        let barrier = self.state.run_barrier.lock().unwrap().take();
+        if let Some(barrier) = barrier {
+            let _ = barrier.started.send(());
+            let _ = barrier.release.await;
+        }
+    }
+
+    fn observation(&self) -> Result<BackendObservation, CoreBackendError> {
+        self.state
+            .observe_calls
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        if self
+            .state
+            .fail_observe
+            .swap(false, std::sync::atomic::Ordering::AcqRel)
+        {
+            return Err(CoreBackendError::Construct(anyhow::anyhow!(
+                "scripted status failure"
+            )));
+        }
+        Ok(self.state.observation.lock().unwrap().clone())
+    }
+}
+
+impl CoreBackend {
+    pub(crate) async fn new(
+        mode: crate::core::RunType,
+        requests: &CoreRequestFactory,
+    ) -> Result<Self, CoreBackendError> {
+        match mode {
+            crate::core::RunType::Service => Ok(Self::Service(ServiceBackend::new()?)),
+            crate::core::RunType::Normal | crate::core::RunType::Elevated => {
+                Ok(Self::Local(LocalBackend::new(requests).await?))
+            }
+        }
+    }
+
+    pub(crate) async fn check(&self, request: &CoreRequest) -> Result<(), CoreBackendError> {
+        match self {
+            Self::Local(local) => local.manager.check_config(&instance_spec(request)?).await?,
+            Self::Service(service) => {
+                service
+                    .client
+                    .check_config(&CoreCheckReq {
+                        core_type: Cow::Borrowed(&request.core_type),
+                        config_file: Cow::Owned(request.config_path.as_std_path().to_path_buf()),
+                    })
+                    .await?;
+            }
+            #[cfg(test)]
+            Self::Test(test) => {
+                test.state
+                    .check_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn run(
+        &self,
+        request: &CoreRequest,
+    ) -> Result<BackendObservation, CoreBackendError> {
+        match self {
+            Self::Local(local) => {
+                local.manager.switch(instance_spec(request)?).await?;
+            }
+            Self::Service(service) => {
+                let status = service.client.status().await?;
+                if service_needs_stop(&status.core_infos)
+                    && let Err(error) = service.client.stop_core().await
+                    && service_error_kind(&error) != Some(error_kind::NOT_STARTED)
+                {
+                    return Err(error.into());
+                }
+                service
+                    .client
+                    .start_core(&CoreStartReq {
+                        core_type: Cow::Borrowed(&request.core_type),
+                        config_file: Cow::Owned(request.config_path.as_std_path().to_path_buf()),
+                    })
+                    .await?;
+            }
+            #[cfg(test)]
+            Self::Test(test) => {
+                test.state
+                    .run_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+                test.state
+                    .run_requests
+                    .lock()
+                    .unwrap()
+                    .push(request.clone());
+                if test
+                    .state
+                    .fail_run
+                    .swap(false, std::sync::atomic::Ordering::AcqRel)
+                {
+                    if let Some(action) = test.state.fail_run_action.lock().unwrap().take() {
+                        action();
+                    }
+                    return Err(CoreBackendError::Construct(anyhow::anyhow!(
+                        "scripted run failure"
+                    )));
+                }
+                test.wait_for_run_barrier().await;
+            }
+        }
+        self.observe_status().await
+    }
+
+    pub(crate) async fn stop(&self) -> Result<BackendObservation, CoreBackendError> {
+        match self {
+            Self::Local(local) => local.manager.stop().await?,
+            Self::Service(service) => service.client.stop_core().await?,
+            #[cfg(test)]
+            Self::Test(_) => {}
+        }
+        self.observe_status().await
+    }
+
+    pub(crate) async fn recover(&self) -> Result<BackendObservation, CoreBackendError> {
+        match self {
+            Self::Local(local) => local.manager.recover_quarantine().await?,
+            Self::Service(service) => service.client.recover_core().await?,
+            #[cfg(test)]
+            Self::Test(_) => {}
+        }
+        self.observe_status().await
+    }
+
+    pub(crate) async fn observe_status(&self) -> Result<BackendObservation, CoreBackendError> {
+        match self {
+            Self::Local(local) => Ok(map_local_status(&local.status.borrow().clone())),
+            Self::Service(service) => {
+                let status = service.client.status().await?;
+                Ok(map_service_status(&status.core_infos))
+            }
+            #[cfg(test)]
+            Self::Test(test) => test.observation(),
+        }
+    }
+
+    pub(crate) async fn apply(
+        &self,
+        request: &CoreRequest,
+        expected: Option<RevisionIdInfo>,
+    ) -> Result<CoreApplyData, CoreBackendError> {
+        match self {
+            Self::Local(local) => {
+                let outcome = local
+                    .manager
+                    .apply_config(
+                        instance_spec(request)?,
+                        expected.as_ref().map(map_revision_id),
+                    )
+                    .await?;
+                Ok(map_apply_outcome(&outcome))
+            }
+            Self::Service(service) => Ok(service
+                .client
+                .apply_config(&CoreApplyReq {
+                    core_type: Cow::Borrowed(&request.core_type),
+                    config_file: Cow::Owned(request.config_path.as_std_path().to_path_buf()),
+                    expected_revision: expected,
+                })
+                .await?),
+            #[cfg(test)]
+            Self::Test(_) => unreachable!("test backend does not implement apply"),
+        }
+    }
+
+    pub(crate) async fn shutdown(self) -> Result<(), CoreBackendError> {
+        match self {
+            Self::Local(local) => local.manager.shutdown().await?,
+            Self::Service(service) => {
+                if let Err(error) = service.client.stop_core().await
+                    && service_error_kind(&error) != Some(error_kind::NOT_STARTED)
+                {
+                    return Err(error.into());
+                }
+            }
+            #[cfg(test)]
+            Self::Test(test) => {
+                test.state
+                    .shutdown_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn local_manager_options(runtime_dir: camino::Utf8PathBuf) -> ManagerOptions {
+    ManagerOptions {
+        runtime_dir: Some(runtime_dir),
+        // The upstream default is already Disable; spelling it out keeps this safety gate auditable here.
+        local_ipc_policy: LocalIpcPolicy::Disable,
+        ..ManagerOptions::default()
+    }
+}
+
+fn instance_spec(request: &CoreRequest) -> Result<InstanceSpec, CoreBackendError> {
+    Ok(InstanceSpec {
+        core: CoreSpec {
+            kind: core_kind(&request.core_type)?,
+            binary_path: request.binary_path.clone(),
+            version: None,
+            features: Vec::new(),
+        },
+        config_path: request.config_path.clone(),
+        working_dir: request.working_dir.clone(),
+        pid_file: request.pid_path.clone(),
+        options: InstanceOptions::default(),
+    })
+}
+
+fn core_kind(
+    core_type: &CoreType,
+) -> Result<nyanpasu_core_metadata::ClashCoreKind, CoreBackendError> {
+    match core_type {
+        CoreType::Clash(ClashCoreType::Mihomo | ClashCoreType::MihomoAlpha) => {
+            Ok(nyanpasu_core_metadata::ClashCoreKind::Mihomo)
+        }
+        CoreType::Clash(ClashCoreType::ClashRust | ClashCoreType::ClashRustAlpha) => {
+            Ok(nyanpasu_core_metadata::ClashCoreKind::ClashRust)
+        }
+        CoreType::Clash(ClashCoreType::ClashPremium) => {
+            Ok(nyanpasu_core_metadata::ClashCoreKind::ClashPremium)
+        }
+        CoreType::Clash(ClashCoreType::Meow) => Ok(nyanpasu_core_metadata::ClashCoreKind::Meow),
+        CoreType::SingBox => Err(CoreBackendError::Binary(anyhow::anyhow!(
+            "sing-box is not a supported core"
+        ))),
+    }
+}
+
+fn map_local_status(status: &nyanpasu_core_manager::CoreStatus) -> BackendObservation {
+    let lifecycle = match &status.state {
+        ManagerCoreState::Stopped { reason } => FaithfulLifecycle::Stopped {
+            reason: reason.as_ref().map(ToString::to_string),
+        },
+        ManagerCoreState::Starting { .. } => FaithfulLifecycle::Starting,
+        ManagerCoreState::Running { .. } => FaithfulLifecycle::Running,
+        ManagerCoreState::Restarting { .. } => FaithfulLifecycle::Restarting,
+        ManagerCoreState::Switching { .. } => FaithfulLifecycle::Switching,
+        ManagerCoreState::Stopping { .. } => FaithfulLifecycle::Stopping,
+        _ => FaithfulLifecycle::Stopped { reason: None },
+    };
+    let state = match &status.state {
+        ManagerCoreState::Running { .. }
+        | ManagerCoreState::Switching { .. }
+        | ManagerCoreState::Stopping { .. } => CoreState::Running,
+        ManagerCoreState::Stopped { reason } => {
+            CoreState::Stopped(reason.as_ref().map(ToString::to_string))
+        }
+        _ => CoreState::Stopped(None),
+    };
+    observation(
+        state,
+        status.changed_at,
+        status.revision.as_ref().map(map_revision),
+        lifecycle,
+        crate::core::RunType::Normal,
+    )
+}
+
+fn map_service_status(infos: &CoreInfos) -> BackendObservation {
+    let lifecycle = match infos.detail.as_ref() {
+        Some(CoreStateDetail::Stopped { reason }) => FaithfulLifecycle::Stopped {
+            reason: reason.clone(),
+        },
+        Some(CoreStateDetail::Starting { .. }) => FaithfulLifecycle::Starting,
+        Some(CoreStateDetail::Running { .. }) => FaithfulLifecycle::Running,
+        Some(CoreStateDetail::Restarting { .. }) => FaithfulLifecycle::Restarting,
+        Some(CoreStateDetail::Switching { .. }) => FaithfulLifecycle::Switching,
+        Some(CoreStateDetail::Stopping { .. }) => FaithfulLifecycle::Stopping,
+        None => match &infos.state {
+            CoreState::Running => FaithfulLifecycle::Running,
+            CoreState::Stopped(reason) => FaithfulLifecycle::Stopped {
+                reason: reason.clone(),
+            },
+        },
+    };
+    observation(
+        infos.state.clone(),
+        infos.state_changed_at,
+        infos.revision.clone(),
+        lifecycle,
+        crate::core::RunType::Service,
+    )
+}
+
+fn observation(
+    state: CoreState,
+    state_changed_at: i64,
+    revision: Option<ConfigRevisionInfo>,
+    lifecycle: FaithfulLifecycle,
+    run_type: crate::core::RunType,
+) -> BackendObservation {
+    let recovery_exhausted = match &lifecycle {
+        FaithfulLifecycle::Stopped {
+            reason: Some(reason),
+        } => is_recovery_exhausted(reason),
+        _ => false,
+    };
+    BackendObservation {
+        view: CoreStatusView {
+            state,
+            state_changed_at,
+            run_type,
+            revision,
+            recovery_exhausted,
+        },
+        lifecycle,
+    }
+}
+
+fn map_revision(revision: &nyanpasu_core_manager::ConfigRevision) -> ConfigRevisionInfo {
+    ConfigRevisionInfo {
+        epoch: revision.epoch,
+        generation: revision.generation,
+        source_hash: revision.source_hash.clone(),
+        effective_hash: revision.effective_hash.clone(),
+    }
+}
+
+fn map_revision_id(info: &RevisionIdInfo) -> RevisionId {
+    RevisionId {
+        epoch: info.epoch,
+        generation: info.generation,
+        effective_hash: info.effective_hash.clone(),
+    }
+}
+
+fn map_apply_outcome(outcome: &ApplyOutcome) -> CoreApplyData {
+    let mut warnings = Vec::new();
+    let mut current = outcome;
+    while let ApplyOutcome::DurabilityUncertain { outcome, warning } = current {
+        warnings.push(warning.clone());
+        current = outcome;
+    }
+    let (outcome, revision, failed_apply) = match current {
+        ApplyOutcome::Noop { revision } => (ApplyOutcomeKind::Noop, revision, None),
+        ApplyOutcome::Patched { revision } => (ApplyOutcomeKind::Patched, revision, None),
+        ApplyOutcome::Reloaded { revision } => (ApplyOutcomeKind::Reloaded, revision, None),
+        ApplyOutcome::Restarted { revision } => (ApplyOutcomeKind::Restarted, revision, None),
+        ApplyOutcome::Switched { revision } => (ApplyOutcomeKind::Switched, revision, None),
+        ApplyOutcome::RolledBack {
+            revision,
+            failed_apply,
+        } => (
+            ApplyOutcomeKind::RolledBack,
+            revision,
+            Some(failed_apply.clone()),
+        ),
+        ApplyOutcome::DurabilityUncertain { .. } => unreachable!("unwrapped above"),
+    };
+    CoreApplyData {
+        outcome,
+        revision: map_revision(revision),
+        warning: (!warnings.is_empty()).then(|| warnings.join("; ")),
+        failed_apply,
+    }
+}
+
+pub(super) fn service_needs_stop(infos: &CoreInfos) -> bool {
+    match infos.detail.as_ref() {
+        Some(CoreStateDetail::Stopped { .. }) => false,
+        Some(
+            CoreStateDetail::Starting { .. }
+            | CoreStateDetail::Running { .. }
+            | CoreStateDetail::Restarting { .. }
+            | CoreStateDetail::Switching { .. }
+            | CoreStateDetail::Stopping { .. },
+        )
+        | None => true,
+    }
+}
+
+pub trait CoreDegradationSink: Send + Sync + 'static {
+    fn publish(&self, degradation: crate::client::runtime::Degradation);
+}
+
+#[async_trait]
+pub(crate) trait ServiceControlOps: Send + Sync + 'static {
+    async fn install(&self, reconciler: CoreModeReconciler) -> anyhow::Result<()>;
+    async fn start(&self, reconciler: CoreModeReconciler) -> anyhow::Result<()>;
+    async fn stop(&self) -> anyhow::Result<()>;
+    async fn restart(&self, reconciler: CoreModeReconciler) -> anyhow::Result<()>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CoreBackendError {
+    #[error("local core manager: {0}")]
+    Local(#[from] nyanpasu_core_manager::Error),
+    #[error("service ipc: {0}")]
+    Service(#[from] ClientError),
+    #[error("core binary: {0}")]
+    Binary(#[source] anyhow::Error),
+    #[error("backend construction: {0}")]
+    Construct(#[source] anyhow::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        borrow::Cow,
+        collections::VecDeque,
+        path::PathBuf,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicU64, Ordering},
+        },
+    };
+
+    use axum::{
+        Json, Router,
+        extract::State,
+        http::StatusCode,
+        routing::{get, post},
+    };
+    use camino::Utf8PathBuf;
+    use interprocess::local_socket::{
+        GenericFilePath, ListenerNonblockingMode, ListenerOptions, ToFsName,
+        tokio::{Listener, Stream as IpcStream, prelude::*},
+    };
+    use nyanpasu_config::application::ClashCore;
+    use nyanpasu_core_manager::{ApplyOutcome, ConfigRevision, Error as ManagerError, StopReason};
+    use nyanpasu_ipc::api::{
+        RBuilder,
+        core::{
+            check::{CORE_CHECK_ENDPOINT, CoreCheckReq, CoreCheckRes},
+            recover::{CORE_RECOVER_ENDPOINT, CoreRecoverRes},
+            start::{CORE_START_ENDPOINT, CoreStartReq, CoreStartRes},
+            stop::{CORE_STOP_ENDPOINT, CoreStopRes},
+        },
+        status::{
+            ConfigRevisionInfo, CoreInfos, CoreState, CoreStateDetail, RuntimeInfos,
+            STATUS_ENDPOINT, StatusRes, StatusResBody,
+        },
+    };
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::{
+        client::RuntimePaths,
+        core::actor::{
+            error_kind::local_error_kind,
+            request::{CoreBinaryResolver, CoreRequestFactory},
+            types::RECOVERY_EXHAUSTED_PREFIX,
+        },
+        utils::path::PathResolver,
+    };
+
+    #[derive(Clone)]
+    struct FixedBinary(Utf8PathBuf);
+
+    impl CoreBinaryResolver for FixedBinary {
+        fn resolve(&self, _kind: &CoreType) -> anyhow::Result<Utf8PathBuf> {
+            Ok(self.0.clone())
+        }
+    }
+
+    fn test_factory(dir: &TempDir, binary: Utf8PathBuf) -> CoreRequestFactory {
+        let config = dir.path().join("config");
+        let data = dir.path().join("data");
+        std::fs::create_dir_all(&config).unwrap();
+        std::fs::create_dir_all(&data).unwrap();
+        let paths = PathResolver::with_base_dirs(config.clone(), data);
+        let runtime = Utf8PathBuf::from_path_buf(config.join("runtime")).unwrap();
+        CoreRequestFactory::new(
+            &paths,
+            RuntimePaths::new(runtime.join("config.yaml"), runtime.join(".candidates")),
+            Arc::new(FixedBinary(binary)),
+        )
+        .unwrap()
+    }
+
+    fn revision(generation: u64) -> ConfigRevision {
+        ConfigRevision {
+            epoch: 3,
+            generation,
+            source_hash: format!("source-{generation}"),
+            effective_hash: format!("effective-{generation}"),
+            runtime_path: Utf8PathBuf::from(format!("runtime-{generation}.yaml")),
+        }
+    }
+
+    fn free_port() -> u16 {
+        std::net::TcpListener::bind(("127.0.0.1", 0))
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    fn write_config(request: &CoreRequest, port: u16) {
+        std::fs::create_dir_all(request.config_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &request.config_path,
+            format!(
+                "external-controller: 127.0.0.1:{port}\nproxies: []\nproxy-groups: []\nrules: []\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    fn stopped_infos() -> CoreInfos {
+        CoreInfos {
+            r#type: None,
+            state: CoreState::Stopped(None),
+            state_changed_at: 1,
+            config_path: None,
+            controller: None,
+            health: None,
+            revision: None,
+            detail: Some(CoreStateDetail::Stopped { reason: None }),
+        }
+    }
+
+    #[derive(Clone)]
+    struct Harness(Arc<Mutex<HarnessState>>);
+
+    struct HarnessState {
+        infos: CoreInfos,
+        calls: VecDeque<&'static str>,
+        stop_error_kind: Option<&'static str>,
+        generation: u64,
+    }
+
+    impl Harness {
+        fn new() -> Self {
+            Self(Arc::new(Mutex::new(HarnessState {
+                infos: stopped_infos(),
+                calls: VecDeque::new(),
+                stop_error_kind: None,
+                generation: 0,
+            })))
+        }
+
+        fn running(&self) {
+            let mut state = self.0.lock().unwrap();
+            state.infos.state = CoreState::Running;
+            state.infos.detail = Some(CoreStateDetail::Running { epoch: 1, pid: 7 });
+        }
+
+        fn set_stop_error(&self, kind: &'static str) {
+            self.0.lock().unwrap().stop_error_kind = Some(kind);
+        }
+
+        fn set_revision(&self, generation: u64) {
+            let mut state = self.0.lock().unwrap();
+            state.generation = generation;
+            state.infos.revision = Some(ConfigRevisionInfo {
+                epoch: 1,
+                generation,
+                source_hash: format!("source-{generation}"),
+                effective_hash: format!("effective-{generation}"),
+            });
+        }
+
+        fn take_calls(&self) -> Vec<&'static str> {
+            self.0.lock().unwrap().calls.drain(..).collect()
+        }
+    }
+
+    async fn status_handler(State(harness): State<Harness>) -> Json<StatusRes<'static>> {
+        let mut state = harness.0.lock().unwrap();
+        state.calls.push_back("status");
+        Json(RBuilder::success(StatusResBody {
+            version: Cow::Borrowed("test"),
+            core_infos: state.infos.clone(),
+            runtime_infos: RuntimeInfos {
+                service_data_dir: Cow::Owned(PathBuf::from("service-data")),
+                service_config_dir: Cow::Owned(PathBuf::from("service-config")),
+                nyanpasu_config_dir: Cow::Owned(PathBuf::from("config")),
+                nyanpasu_data_dir: Cow::Owned(PathBuf::from("data")),
+            },
+            logs: None,
+        }))
+    }
+
+    async fn check_handler(
+        State(harness): State<Harness>,
+        Json(_request): Json<CoreCheckReq<'static>>,
+    ) -> Json<CoreCheckRes<'static>> {
+        harness.0.lock().unwrap().calls.push_back("check");
+        Json(RBuilder::success(()))
+    }
+
+    async fn start_handler(
+        State(harness): State<Harness>,
+        Json(request): Json<CoreStartReq<'static>>,
+    ) -> Json<CoreStartRes<'static>> {
+        let mut state = harness.0.lock().unwrap();
+        state.calls.push_back("start");
+        state.generation += 1;
+        let generation = state.generation;
+        state.infos.r#type = Some(request.core_type.into_owned());
+        state.infos.state = CoreState::Running;
+        state.infos.detail = Some(CoreStateDetail::Running { epoch: 1, pid: 100 });
+        state.infos.revision = Some(ConfigRevisionInfo {
+            epoch: 1,
+            generation,
+            source_hash: "source".to_owned(),
+            effective_hash: "effective".to_owned(),
+        });
+        Json(RBuilder::success(()))
+    }
+
+    async fn stop_handler(
+        State(harness): State<Harness>,
+    ) -> (StatusCode, Json<CoreStopRes<'static>>) {
+        let mut state = harness.0.lock().unwrap();
+        state.calls.push_back("stop");
+        if let Some(kind) = state.stop_error_kind.take() {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(RBuilder::other_error_with_kind(
+                    Cow::Borrowed("scripted stop error"),
+                    Some(Cow::Borrowed(kind)),
+                )),
+            );
+        }
+        state.infos.state = CoreState::Stopped(None);
+        state.infos.detail = Some(CoreStateDetail::Stopped { reason: None });
+        (StatusCode::OK, Json(RBuilder::success(())))
+    }
+
+    async fn recover_handler(State(harness): State<Harness>) -> Json<CoreRecoverRes<'static>> {
+        harness.0.lock().unwrap().calls.push_back("recover");
+        Json(RBuilder::success(()))
+    }
+
+    struct IpcListener(Listener, String);
+
+    impl axum::serve::Listener for IpcListener {
+        type Io = IpcStream;
+        type Addr = String;
+
+        async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+            loop {
+                if let Ok(stream) = self.0.accept().await {
+                    return (stream, self.1.clone());
+                }
+                tokio::task::yield_now().await;
+            }
+        }
+
+        fn local_addr(&self) -> tokio::io::Result<Self::Addr> {
+            Ok(self.1.clone())
+        }
+    }
+
+    fn socket_path(placeholder: &str) -> String {
+        if cfg!(windows) {
+            format!("\\\\.\\pipe\\{placeholder}")
+        } else {
+            format!("/var/run/{placeholder}.sock")
+        }
+    }
+
+    #[cfg(windows)]
+    fn transport_available() -> bool {
+        true
+    }
+
+    #[cfg(unix)]
+    fn transport_available() -> bool {
+        static AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *AVAILABLE.get_or_init(|| {
+            let probe = format!("/var/run/.nyanpasu-ipc-probe-{}", std::process::id());
+            match std::fs::File::create(&probe) {
+                Ok(_) => {
+                    let _ = std::fs::remove_file(&probe);
+                    true
+                }
+                Err(error) => {
+                    eprintln!(
+                        "skipping core actor unix socket tests: /var/run is not writable \
+                         ({error}); run as root for unix socket coverage"
+                    );
+                    false
+                }
+            }
+        })
+    }
+
+    fn spawn_harness(harness: Harness) -> (String, tokio::sync::oneshot::Sender<()>) {
+        static NEXT: AtomicU64 = AtomicU64::new(1);
+        let placeholder = format!(
+            "nyanpasu_core_actor_{}_{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        );
+        let path = socket_path(&placeholder);
+        #[cfg(unix)]
+        let _ = std::fs::remove_file(&path);
+        let name = path.as_str().to_fs_name::<GenericFilePath>().unwrap();
+        let listener = ListenerOptions::new()
+            .name(name)
+            .nonblocking(ListenerNonblockingMode::Both)
+            .create_tokio()
+            .unwrap();
+        let router = Router::new()
+            .route(STATUS_ENDPOINT, get(status_handler))
+            .route(CORE_CHECK_ENDPOINT, post(check_handler))
+            .route(CORE_START_ENDPOINT, post(start_handler))
+            .route(CORE_STOP_ENDPOINT, post(stop_handler))
+            .route(CORE_RECOVER_ENDPOINT, post(recover_handler))
+            .with_state(harness);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            axum::serve(IpcListener(listener, path.clone()), router)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+            #[cfg(unix)]
+            let _ = std::fs::remove_file(path);
+        });
+        (placeholder, shutdown_tx)
+    }
+
+    #[test]
+    fn local_backend_explicitly_disables_local_ipc() {
+        let options = local_manager_options(Utf8PathBuf::from("runtime"));
+        assert_eq!(options.local_ipc_policy, LocalIpcPolicy::Disable);
+    }
+
+    #[test]
+    fn apply_outcome_mapping_preserves_all_outcomes_and_nested_warnings() {
+        let cases = [
+            (
+                ApplyOutcome::Noop {
+                    revision: revision(1),
+                },
+                ApplyOutcomeKind::Noop,
+            ),
+            (
+                ApplyOutcome::Patched {
+                    revision: revision(2),
+                },
+                ApplyOutcomeKind::Patched,
+            ),
+            (
+                ApplyOutcome::Reloaded {
+                    revision: revision(3),
+                },
+                ApplyOutcomeKind::Reloaded,
+            ),
+            (
+                ApplyOutcome::Restarted {
+                    revision: revision(4),
+                },
+                ApplyOutcomeKind::Restarted,
+            ),
+            (
+                ApplyOutcome::Switched {
+                    revision: revision(5),
+                },
+                ApplyOutcomeKind::Switched,
+            ),
+            (
+                ApplyOutcome::RolledBack {
+                    revision: revision(6),
+                    failed_apply: "failed".to_owned(),
+                },
+                ApplyOutcomeKind::RolledBack,
+            ),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(map_apply_outcome(&input).outcome, expected);
+        }
+        let nested = ApplyOutcome::DurabilityUncertain {
+            outcome: Box::new(ApplyOutcome::DurabilityUncertain {
+                outcome: Box::new(ApplyOutcome::Noop {
+                    revision: revision(7),
+                }),
+                warning: "inner".to_owned(),
+            }),
+            warning: "outer".to_owned(),
+        };
+        let mapped = map_apply_outcome(&nested);
+        assert_eq!(mapped.outcome, ApplyOutcomeKind::Noop);
+        assert_eq!(mapped.warning.as_deref(), Some("outer; inner"));
+    }
+
+    #[test]
+    fn local_error_kind_maps_all_twelve_protocol_constants() {
+        let expected = RevisionId {
+            epoch: 1,
+            generation: 1,
+            effective_hash: "hash".to_owned(),
+        };
+        let cases = [
+            (ManagerError::NotStarted, error_kind::NOT_STARTED),
+            (ManagerError::AlreadyRunning, error_kind::ALREADY_RUNNING),
+            (
+                ManagerError::RevisionConflict {
+                    expected,
+                    actual: None,
+                },
+                error_kind::REVISION_CONFLICT,
+            ),
+            (
+                ManagerError::ManagerQuarantined {
+                    epoch: 1,
+                    reason: "reason".to_owned(),
+                },
+                error_kind::QUARANTINED,
+            ),
+            (
+                ManagerError::ConfigCheckFailed("bad".to_owned()),
+                error_kind::CONFIG_CHECK_FAILED,
+            ),
+            (
+                ManagerError::ConfigNotFound(Utf8PathBuf::from("missing")),
+                error_kind::CONFIG_NOT_FOUND,
+            ),
+            (
+                ManagerError::BinaryNotFound(Utf8PathBuf::from("missing")),
+                error_kind::BINARY_NOT_FOUND,
+            ),
+            (
+                ManagerError::InvalidConfig("bad".to_owned()),
+                error_kind::INVALID_CONFIG,
+            ),
+            (
+                ManagerError::ControllerMissing,
+                error_kind::CONTROLLER_MISSING,
+            ),
+            (
+                ManagerError::ApplyFailed("bad".to_owned()),
+                error_kind::APPLY_FAILED,
+            ),
+            (
+                ManagerError::ApplyRollbackFailed {
+                    apply: "bad".to_owned(),
+                    rollback: "worse".to_owned(),
+                },
+                error_kind::APPLY_ROLLBACK_FAILED,
+            ),
+            (
+                ManagerError::StopUnconfirmed("unknown".to_owned()),
+                error_kind::STOP_UNCONFIRMED,
+            ),
+        ];
+        for (error, kind) in cases {
+            assert_eq!(local_error_kind(&error), Some(kind));
+        }
+    }
+
+    #[test]
+    fn recovery_exhausted_matches_only_the_upstream_prefix() {
+        assert!(is_recovery_exhausted(&format!(
+            "{RECOVERY_EXHAUSTED_PREFIX}\ndiagnostic"
+        )));
+        assert!(!is_recovery_exhausted("core stopped normally"));
+    }
+
+    #[test]
+    fn config_revision_maps_without_runtime_path() {
+        let mapped = map_revision(&revision(9));
+        assert_eq!(mapped.epoch, 3);
+        assert_eq!(mapped.generation, 9);
+        assert_eq!(mapped.source_hash, "source-9");
+        assert_eq!(mapped.effective_hash, "effective-9");
+    }
+
+    #[test]
+    fn revision_id_maps_all_three_fields() {
+        let mapped = map_revision_id(&RevisionIdInfo {
+            epoch: 4,
+            generation: 8,
+            effective_hash: "hash".to_owned(),
+        });
+        assert_eq!(mapped.epoch, 4);
+        assert_eq!(mapped.generation, 8);
+        assert_eq!(mapped.effective_hash, "hash");
+    }
+
+    #[test]
+    fn service_needs_stop_covers_every_faithful_state_and_missing_detail() {
+        let cases = [
+            (Some(CoreStateDetail::Stopped { reason: None }), false),
+            (Some(CoreStateDetail::Starting { epoch: 1 }), true),
+            (Some(CoreStateDetail::Running { epoch: 1, pid: 2 }), true),
+            (
+                Some(CoreStateDetail::Restarting {
+                    epoch: 1,
+                    attempt: 2,
+                }),
+                true,
+            ),
+            (
+                Some(CoreStateDetail::Switching {
+                    from: Some(1),
+                    to: 2,
+                }),
+                true,
+            ),
+            (Some(CoreStateDetail::Stopping { epoch: 1 }), true),
+            (None, true),
+        ];
+        for (detail, expected) in cases {
+            let mut infos = stopped_infos();
+            infos.detail = detail;
+            assert_eq!(service_needs_stop(&infos), expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn local_backend_releases_runtime_directory_lock_when_consumed() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory = test_factory(&dir, Utf8PathBuf::from("unused"));
+        let first = LocalBackend::new(&factory).await.unwrap();
+        CoreBackend::Local(first).shutdown().await.unwrap();
+        let second = LocalBackend::new(&factory).await.unwrap();
+        CoreBackend::Local(second).shutdown().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn local_and_service_backends_have_real_lifecycle_parity() {
+        if !transport_available() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let probe =
+            Utf8PathBuf::from_path_buf(fake_core::require_probe_bin_path().unwrap()).unwrap();
+        let factory = test_factory(&dir, probe);
+        let request = factory.for_product(ClashCore::Mihomo).unwrap();
+        write_config(&request, free_port());
+        let local = CoreBackend::Local(LocalBackend::new(&factory).await.unwrap());
+
+        let harness = Harness::new();
+        let (placeholder, shutdown) = spawn_harness(harness);
+        let service = CoreBackend::Service(ServiceBackend::with_placeholder(&placeholder).unwrap());
+
+        local.check(&request).await.unwrap();
+        service.check(&request).await.unwrap();
+        let local_running = local.run(&request).await.unwrap();
+        let service_running = service.run(&request).await.unwrap();
+        assert!(matches!(local_running.view.state, CoreState::Running));
+        assert!(matches!(service_running.view.state, CoreState::Running));
+        assert!(local_running.view.revision.is_some());
+        assert!(service_running.view.revision.is_some());
+
+        let local_stopped = local.stop().await.unwrap();
+        let service_stopped = service.stop().await.unwrap();
+        assert!(matches!(local_stopped.view.state, CoreState::Stopped(_)));
+        assert!(matches!(service_stopped.view.state, CoreState::Stopped(_)));
+
+        let local_recovered = local.recover().await.unwrap();
+        let service_recovered = service.recover().await.unwrap();
+        assert!(matches!(local_recovered.view.state, CoreState::Stopped(_)));
+        assert!(matches!(
+            service_recovered.view.state,
+            CoreState::Stopped(_)
+        ));
+
+        local.shutdown().await.unwrap();
+        service.shutdown().await.unwrap();
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn service_run_suppresses_only_not_started_stop_races() {
+        if !transport_available() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let factory = test_factory(&dir, Utf8PathBuf::from("unused"));
+        let request = factory.for_product(ClashCore::Mihomo).unwrap();
+        let harness = Harness::new();
+        let (placeholder, shutdown) = spawn_harness(harness.clone());
+        let service = CoreBackend::Service(ServiceBackend::with_placeholder(&placeholder).unwrap());
+
+        harness.running();
+        harness.set_stop_error(error_kind::NOT_STARTED);
+        service.run(&request).await.unwrap();
+        assert_eq!(harness.take_calls(), ["status", "stop", "start", "status"]);
+
+        harness.running();
+        harness.set_stop_error(error_kind::QUARANTINED);
+        assert!(service.run(&request).await.is_err());
+        assert_eq!(harness.take_calls(), ["status", "stop"]);
+
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn service_run_and_refresh_relearn_revision() {
+        if !transport_available() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let factory = test_factory(&dir, Utf8PathBuf::from("unused"));
+        let request = factory.for_product(ClashCore::Mihomo).unwrap();
+        let harness = Harness::new();
+        let (placeholder, shutdown) = spawn_harness(harness.clone());
+        let service = CoreBackend::Service(ServiceBackend::with_placeholder(&placeholder).unwrap());
+
+        let running = service.run(&request).await.unwrap();
+        assert_eq!(running.view.revision.unwrap().generation, 1);
+        harness.set_revision(9);
+        let refreshed = service.observe_status().await.unwrap();
+        assert_eq!(refreshed.view.revision.unwrap().generation, 9);
+
+        service.shutdown().await.unwrap();
+        let _ = shutdown.send(());
+    }
+
+    #[test]
+    fn stop_reason_display_is_the_recovery_latch_input() {
+        let reason = StopReason::Error(format!("{RECOVERY_EXHAUSTED_PREFIX}\ntrace"));
+        assert!(is_recovery_exhausted(&reason.to_string()));
+    }
+}

--- a/backend/tauri/src/core/actor/error_kind.rs
+++ b/backend/tauri/src/core/actor/error_kind.rs
@@ -1,0 +1,38 @@
+//! Machine-readable core error classification compatibility layer.
+//!
+//! The current submodule pin has no `Error::kind()`, and the upstream mapping
+//! is private to `nyanpasu-service-runtime`.
+//!
+//! TODO(actor-migration): compatibility mapping for manager error kinds.
+//! Reason: `nyanpasu_core_manager::Error::kind()` is absent from v2.0.0-rc.1.
+//! Remove when: the submodule points at a release containing the typed error kind.
+
+use nyanpasu_ipc::{api::error_kind, client::ClientError};
+
+pub(super) fn local_error_kind(error: &nyanpasu_core_manager::Error) -> Option<&'static str> {
+    use nyanpasu_core_manager::Error;
+
+    match error {
+        Error::NotStarted => Some(error_kind::NOT_STARTED),
+        Error::AlreadyRunning => Some(error_kind::ALREADY_RUNNING),
+        Error::RevisionConflict { .. } => Some(error_kind::REVISION_CONFLICT),
+        Error::ManagerQuarantined { .. } => Some(error_kind::QUARANTINED),
+        Error::ConfigCheckFailed(_) => Some(error_kind::CONFIG_CHECK_FAILED),
+        Error::ConfigNotFound(_) => Some(error_kind::CONFIG_NOT_FOUND),
+        Error::BinaryNotFound(_) => Some(error_kind::BINARY_NOT_FOUND),
+        Error::InvalidConfig(_) | Error::Yaml(_) => Some(error_kind::INVALID_CONFIG),
+        Error::ControllerMissing => Some(error_kind::CONTROLLER_MISSING),
+        Error::ApplyFailed(_) => Some(error_kind::APPLY_FAILED),
+        Error::ApplyRollbackFailed { .. } => Some(error_kind::APPLY_ROLLBACK_FAILED),
+        Error::StopUnconfirmed(_) => Some(error_kind::STOP_UNCONFIRMED),
+        Error::DurabilityUncertain { source, .. } => local_error_kind(source),
+        _ => None,
+    }
+}
+
+pub(super) fn service_error_kind(error: &ClientError) -> Option<&str> {
+    match error {
+        ClientError::Server { error_kind, .. } => error_kind.as_deref(),
+        _ => None,
+    }
+}

--- a/backend/tauri/src/core/actor/gate.rs
+++ b/backend/tauri/src/core/actor/gate.rs
@@ -1,0 +1,208 @@
+use std::{collections::VecDeque, time::Instant};
+
+use ractor::RpcReplyPort;
+
+use super::OperationId;
+
+pub(super) struct OperationGate {
+    pub(super) active: Option<ActiveOperation>,
+    pub(super) waiters: VecDeque<OperationWaiter>,
+}
+
+impl OperationGate {
+    pub(super) fn new() -> Self {
+        Self {
+            active: None,
+            waiters: VecDeque::new(),
+        }
+    }
+
+    pub(super) fn acquire(
+        &mut self,
+        id: OperationId,
+        reply: RpcReplyPort<Result<(), OperationError>>,
+    ) {
+        if self.active.is_some() {
+            self.waiters.push_back(OperationWaiter { id, reply });
+            return;
+        }
+        self.grant(id, reply);
+    }
+
+    pub(super) fn release(&mut self, id: OperationId) {
+        if self.active.as_ref().is_some_and(|active| active.id == id) {
+            if let Some(active) = self.active.take() {
+                tracing::debug!(?id, held_for = ?active.acquired_at.elapsed(), "released core operation");
+            }
+            self.grant_next();
+            return;
+        }
+        let before = self.waiters.len();
+        self.waiters.retain(|waiter| waiter.id != id);
+        if before == self.waiters.len() {
+            tracing::debug!(?id, "ignored stale core operation release");
+        }
+    }
+
+    pub(super) fn is_active(&self, id: OperationId) -> bool {
+        self.active.as_ref().is_some_and(|active| active.id == id)
+    }
+
+    pub(super) fn is_idle(&self) -> bool {
+        self.active.is_none()
+    }
+
+    pub(super) fn shutdown(&mut self) {
+        self.active = None;
+        for waiter in self.waiters.drain(..) {
+            let _ = waiter.reply.send(Err(OperationError::ShuttingDown));
+        }
+    }
+
+    fn grant(&mut self, id: OperationId, reply: RpcReplyPort<Result<(), OperationError>>) {
+        self.active = Some(ActiveOperation {
+            id,
+            acquired_at: Instant::now(),
+        });
+        if reply.send(Ok(())).is_err() {
+            self.active = None;
+            self.grant_next();
+        }
+    }
+
+    fn grant_next(&mut self) {
+        while let Some(waiter) = self.waiters.pop_front() {
+            self.active = Some(ActiveOperation {
+                id: waiter.id,
+                acquired_at: Instant::now(),
+            });
+            if waiter.reply.send(Ok(())).is_ok() {
+                return;
+            }
+            self.active = None;
+        }
+    }
+}
+
+pub(super) struct ActiveOperation {
+    pub(super) id: OperationId,
+    pub(super) acquired_at: Instant,
+}
+
+pub(super) struct OperationWaiter {
+    pub(super) id: OperationId,
+    pub(super) reply: RpcReplyPort<Result<(), OperationError>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum OperationError {
+    #[error("timed out acquiring the core operation")]
+    AcquireTimeout,
+    #[error("core actor is shutting down")]
+    ShuttingDown,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(value: u64) -> OperationId {
+        OperationId::new(value).unwrap()
+    }
+
+    fn waiter() -> (
+        RpcReplyPort<Result<(), OperationError>>,
+        tokio::sync::oneshot::Receiver<Result<(), OperationError>>,
+    ) {
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        (sender.into(), receiver)
+    }
+
+    #[tokio::test]
+    async fn waiters_are_granted_in_fifo_order() {
+        let mut gate = OperationGate::new();
+        let (first_tx, first_rx) = waiter();
+        let (second_tx, mut second_rx) = waiter();
+        let (third_tx, mut third_rx) = waiter();
+        gate.acquire(id(1), first_tx);
+        gate.acquire(id(2), second_tx);
+        gate.acquire(id(3), third_tx);
+        assert!(first_rx.await.unwrap().is_ok());
+        assert!(second_rx.try_recv().is_err());
+        assert!(third_rx.try_recv().is_err());
+        gate.release(id(1));
+        assert!(second_rx.await.unwrap().is_ok());
+        assert!(third_rx.try_recv().is_err());
+        gate.release(id(2));
+        assert!(third_rx.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn dropping_a_waiting_guard_cancels_it() {
+        let mut gate = OperationGate::new();
+        let (first_tx, first_rx) = waiter();
+        let (second_tx, second_rx) = waiter();
+        let (third_tx, third_rx) = waiter();
+        gate.acquire(id(1), first_tx);
+        gate.acquire(id(2), second_tx);
+        gate.acquire(id(3), third_tx);
+        assert!(first_rx.await.unwrap().is_ok());
+        drop(second_rx);
+        gate.release(id(2));
+        gate.release(id(1));
+        assert!(third_rx.await.unwrap().is_ok());
+        assert!(gate.is_active(id(3)));
+    }
+
+    #[tokio::test]
+    async fn guard_dropped_right_after_grant_releases_active() {
+        let mut gate = OperationGate::new();
+        let (first_tx, first_rx) = waiter();
+        let (second_tx, second_rx) = waiter();
+        let (third_tx, third_rx) = waiter();
+        gate.acquire(id(1), first_tx);
+        gate.acquire(id(2), second_tx);
+        gate.acquire(id(3), third_tx);
+        assert!(first_rx.await.unwrap().is_ok());
+        gate.release(id(1));
+        assert!(second_rx.await.unwrap().is_ok());
+        gate.release(id(2));
+        assert!(third_rx.await.unwrap().is_ok());
+        assert!(gate.is_active(id(3)));
+    }
+
+    #[tokio::test]
+    async fn stale_release_is_idempotent_noop() {
+        let mut gate = OperationGate::new();
+        let (active_tx, active_rx) = waiter();
+        gate.acquire(id(1), active_tx);
+        assert!(active_rx.await.unwrap().is_ok());
+        gate.release(id(99));
+        assert!(gate.is_active(id(1)));
+        gate.release(id(1));
+        gate.release(id(1));
+        assert!(gate.is_idle());
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_all_waiters() {
+        let mut gate = OperationGate::new();
+        let (first_tx, first_rx) = waiter();
+        let (second_tx, second_rx) = waiter();
+        let (third_tx, third_rx) = waiter();
+        gate.acquire(id(1), first_tx);
+        gate.acquire(id(2), second_tx);
+        gate.acquire(id(3), third_tx);
+        assert!(first_rx.await.unwrap().is_ok());
+        gate.shutdown();
+        assert!(matches!(
+            second_rx.await.unwrap(),
+            Err(OperationError::ShuttingDown)
+        ));
+        assert!(matches!(
+            third_rx.await.unwrap(),
+            Err(OperationError::ShuttingDown)
+        ));
+        assert!(gate.is_idle());
+    }
+}

--- a/backend/tauri/src/core/actor/mod.rs
+++ b/backend/tauri/src/core/actor/mod.rs
@@ -1,0 +1,510 @@
+use std::{
+    num::NonZeroU64,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+use tokio::sync::watch;
+
+use self::{
+    backend::{BackendSlot, CoreBackend, CoreBackendError, CoreDegradationSink},
+    request::CoreRequestFactory,
+    types::{
+        BackendObservation, CoreActorError, CoreRequest, CoreStatusView, FaithfulLifecycle,
+        is_recovery_exhausted,
+    },
+};
+pub(crate) use gate::OperationError;
+use gate::OperationGate;
+
+pub(crate) mod backend;
+mod error_kind;
+mod gate;
+pub(crate) mod request;
+pub(crate) mod types;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct OperationId(NonZeroU64);
+
+pub(crate) struct CoreActorArgs {
+    pub(crate) mode: crate::core::RunType,
+    pub(crate) requests: CoreRequestFactory,
+    pub(crate) degradation: Arc<dyn CoreDegradationSink>,
+    pub(crate) status_tx: watch::Sender<CoreStatusView>,
+    pub(crate) hint_pending: Arc<AtomicBool>,
+    #[cfg(test)]
+    pub(crate) backend: Option<BackendSlot>,
+    #[cfg(test)]
+    pub(crate) replacement_backend: Option<backend::TestBackend>,
+    #[cfg(test)]
+    pub(crate) replace_barrier: Option<ReplaceBarrier>,
+}
+
+pub(crate) struct CoreActorState {
+    pub(crate) backend: Option<BackendSlot>,
+    pub(crate) mode: crate::core::RunType,
+    operation: OperationGate,
+    pub(crate) observed: BackendObservation,
+    pub(crate) running: Option<CoreRequest>,
+    pub(crate) status_tx: watch::Sender<CoreStatusView>,
+    pub(crate) hint_pending: Arc<AtomicBool>,
+    pub(crate) recovery_exhausted_published: bool,
+    pub(crate) degradation: Arc<dyn CoreDegradationSink>,
+    pub(crate) requests: CoreRequestFactory,
+    #[cfg(test)]
+    replace_barrier: Option<ReplaceBarrier>,
+    #[cfg(test)]
+    replacement_backend: Option<backend::TestBackend>,
+}
+
+#[cfg(test)]
+pub(crate) struct ReplaceBarrier {
+    entered: tokio::sync::oneshot::Sender<()>,
+    release: tokio::sync::oneshot::Receiver<()>,
+}
+
+pub(crate) enum CoreActorMessage {
+    AcquireOperation {
+        id: OperationId,
+        reply: RpcReplyPort<Result<(), OperationError>>,
+    },
+    ReleaseOperation {
+        id: OperationId,
+    },
+    Check {
+        operation: OperationId,
+        request: CoreRequest,
+        reply: RpcReplyPort<Result<(), CoreActorError>>,
+    },
+    Run {
+        operation: OperationId,
+        request: CoreRequest,
+        reply: RpcReplyPort<Result<(), CoreActorError>>,
+    },
+    Stop {
+        operation: OperationId,
+        reply: RpcReplyPort<Result<(), CoreActorError>>,
+    },
+    Recover {
+        operation: OperationId,
+        reply: RpcReplyPort<Result<(), CoreActorError>>,
+    },
+    SetBackend {
+        operation: OperationId,
+        mode: crate::core::RunType,
+        reply: RpcReplyPort<Result<(), CoreActorError>>,
+    },
+    RefreshStatus {
+        operation: OperationId,
+        reply: RpcReplyPort<Result<BackendObservation, CoreActorError>>,
+    },
+    RefreshHint,
+    RunningIdentity {
+        operation: OperationId,
+        reply: RpcReplyPort<Result<Option<CoreRequest>, CoreActorError>>,
+    },
+    Shutdown(RpcReplyPort<()>),
+}
+
+pub(crate) struct CoreActor;
+
+impl OperationId {
+    pub(crate) fn new(value: u64) -> Option<Self> {
+        NonZeroU64::new(value).map(Self)
+    }
+
+    pub(crate) fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+#[cfg(test)]
+impl ReplaceBarrier {
+    pub(crate) fn new() -> (
+        Self,
+        tokio::sync::oneshot::Receiver<()>,
+        tokio::sync::oneshot::Sender<()>,
+    ) {
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        (
+            Self {
+                entered: entered_tx,
+                release: release_rx,
+            },
+            entered_rx,
+            release_tx,
+        )
+    }
+
+    async fn wait(self) {
+        let _ = self.entered.send(());
+        let _ = self.release.await;
+    }
+}
+
+impl CoreActorState {
+    fn backend(&self) -> Result<&CoreBackend, CoreActorError> {
+        match self.backend.as_ref() {
+            Some(BackendSlot::Ready(backend)) => Ok(backend),
+            Some(BackendSlot::Failed { error }) => Err(CoreActorError::NoBackend {
+                last_error: error.clone(),
+            }),
+            None => Err(CoreActorError::ShuttingDown),
+        }
+    }
+
+    fn validate_operation(&self, operation: OperationId) -> Result<(), CoreActorError> {
+        self.operation
+            .is_active(operation)
+            .then_some(())
+            .ok_or(CoreActorError::StaleOperation)
+    }
+
+    fn commit(&mut self, observation: BackendObservation) {
+        self.evaluate_recovery_latch(&observation.lifecycle);
+        if matches!(observation.lifecycle, FaithfulLifecycle::Stopped { .. }) {
+            self.running = None;
+        }
+        self.observed = observation;
+        self.status_tx.send_replace(self.observed.view.clone());
+    }
+
+    fn commit_backend(&mut self, mut observation: BackendObservation) {
+        observation.view.run_type = self.mode;
+        self.commit(observation);
+    }
+
+    fn evaluate_recovery_latch(&mut self, lifecycle: &FaithfulLifecycle) {
+        match lifecycle {
+            FaithfulLifecycle::Starting
+            | FaithfulLifecycle::Running
+            | FaithfulLifecycle::Restarting
+            | FaithfulLifecycle::Switching => {
+                self.recovery_exhausted_published = false;
+            }
+            FaithfulLifecycle::Stopped {
+                reason: Some(reason),
+            } if is_recovery_exhausted(reason) && !self.recovery_exhausted_published => {
+                self.degradation.publish(recovery_degradation(reason));
+                self.recovery_exhausted_published = true;
+            }
+            FaithfulLifecycle::Stopped { .. } | FaithfulLifecycle::Stopping => {}
+        }
+    }
+
+    fn synthetic_stopped(&self, reason: Option<String>) -> BackendObservation {
+        let mut view = self.observed.view.clone();
+        view.state = nyanpasu_ipc::api::status::CoreState::Stopped(reason.clone());
+        view.state_changed_at = now_ms();
+        BackendObservation {
+            view,
+            lifecycle: FaithfulLifecycle::Stopped { reason },
+        }
+    }
+
+    async fn replace_backend(&mut self, mode: crate::core::RunType) -> Result<(), CoreActorError> {
+        let old = self.backend.take();
+        self.running = None;
+        self.recovery_exhausted_published = false;
+        self.commit(self.synthetic_stopped(None));
+
+        let shutdown_error = match old {
+            Some(BackendSlot::Ready(backend)) => backend.shutdown().await.err(),
+            Some(BackendSlot::Failed { .. }) | None => None,
+        };
+
+        #[cfg(test)]
+        if let Some(barrier) = self.replace_barrier.take() {
+            barrier.wait().await;
+        }
+
+        self.mode = mode;
+        #[cfg(test)]
+        let replacement = match self.replacement_backend.as_ref() {
+            Some(backend) if backend.take_replace_failure() => {
+                Err(backend::CoreBackendError::Construct(anyhow::anyhow!(
+                    "scripted backend replacement failure"
+                )))
+            }
+            Some(backend) => Ok(CoreBackend::Test(backend.clone())),
+            None => CoreBackend::new(mode, &self.requests).await,
+        };
+        #[cfg(not(test))]
+        let replacement = CoreBackend::new(mode, &self.requests).await;
+        match replacement {
+            Ok(backend) => {
+                let observation = backend.observe_status().await;
+                self.backend = Some(BackendSlot::Ready(backend));
+                match observation {
+                    Ok(observation) => self.commit_backend(observation),
+                    Err(error) => return Err(CoreActorError::Backend(Arc::new(error))),
+                }
+                if let Some(error) = shutdown_error {
+                    return Err(CoreActorError::Backend(Arc::new(error)));
+                }
+                Ok(())
+            }
+            Err(error) => {
+                let error = Arc::new(error);
+                self.backend = Some(BackendSlot::Failed {
+                    error: error.clone(),
+                });
+                self.commit(self.synthetic_stopped(Some(error.to_string())));
+                Err(CoreActorError::NoBackend { last_error: error })
+            }
+        }
+    }
+}
+
+fn recovery_degradation(reason: &str) -> crate::client::runtime::Degradation {
+    crate::client::runtime::Degradation {
+        phase: crate::client::runtime::DegradationPhase::CoreLifecycle,
+        code: "core_recovery_exhausted".to_owned(),
+        message: bounded_recovery_message(reason),
+        retryable: true,
+    }
+}
+
+fn bounded_recovery_message(reason: &str) -> String {
+    const PREFIX: &str = "core restart budget exhausted; the core is not running (";
+    const SUFFIX: &str = ")";
+    const ELLIPSIS: &str = "…";
+    const MAX_BYTES: usize = 512;
+
+    if PREFIX.len() + reason.len() + SUFFIX.len() <= MAX_BYTES {
+        return format!("{PREFIX}{reason}{SUFFIX}");
+    }
+    let limit = MAX_BYTES - PREFIX.len() - ELLIPSIS.len() - SUFFIX.len();
+    let mut end = reason.len().min(limit);
+    while !reason.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{PREFIX}{}{ELLIPSIS}{SUFFIX}", &reason[..end])
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+fn backend_error(error: CoreBackendError) -> CoreActorError {
+    CoreActorError::Backend(Arc::new(error))
+}
+
+impl Actor for CoreActor {
+    type Msg = CoreActorMessage;
+    type State = CoreActorState;
+    type Arguments = CoreActorArgs;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let mut observed = BackendObservation {
+            view: CoreStatusView::initial(),
+            lifecycle: FaithfulLifecycle::Stopped { reason: None },
+        };
+        observed.view.run_type = args.mode;
+        #[cfg(test)]
+        let injected_backend = args.backend;
+        #[cfg(not(test))]
+        let injected_backend: Option<BackendSlot> = None;
+        let backend = if let Some(backend) = injected_backend {
+            if let BackendSlot::Ready(backend) = &backend
+                && let Ok(current) = backend.observe_status().await
+            {
+                observed = current;
+                observed.view.run_type = args.mode;
+            }
+            Some(backend)
+        } else {
+            match CoreBackend::new(args.mode, &args.requests).await {
+                Ok(backend) => {
+                    if let Ok(current) = backend.observe_status().await {
+                        observed = current;
+                        observed.view.run_type = args.mode;
+                    }
+                    Some(BackendSlot::Ready(backend))
+                }
+                Err(error) => {
+                    let error = Arc::new(error);
+                    observed.view.state =
+                        nyanpasu_ipc::api::status::CoreState::Stopped(Some(error.to_string()));
+                    observed.view.state_changed_at = now_ms();
+                    observed.lifecycle = FaithfulLifecycle::Stopped {
+                        reason: Some(error.to_string()),
+                    };
+                    Some(BackendSlot::Failed { error })
+                }
+            }
+        };
+        args.status_tx.send_replace(observed.view.clone());
+        Ok(CoreActorState {
+            backend,
+            mode: args.mode,
+            operation: OperationGate::new(),
+            observed,
+            running: None,
+            status_tx: args.status_tx,
+            hint_pending: args.hint_pending,
+            recovery_exhausted_published: false,
+            degradation: args.degradation,
+            requests: args.requests,
+            #[cfg(test)]
+            replace_barrier: args.replace_barrier,
+            #[cfg(test)]
+            replacement_backend: args.replacement_backend,
+        })
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            CoreActorMessage::AcquireOperation { id, reply } => {
+                state.operation.acquire(id, reply);
+            }
+            CoreActorMessage::ReleaseOperation { id } => state.operation.release(id),
+            CoreActorMessage::Check {
+                operation,
+                request,
+                reply,
+            } => {
+                let result = match state.validate_operation(operation) {
+                    Ok(()) => match state.backend() {
+                        Ok(backend) => backend.check(&request).await.map_err(backend_error),
+                        Err(error) => Err(error),
+                    },
+                    Err(error) => Err(error),
+                };
+                let _ = reply.send(result);
+            }
+            CoreActorMessage::Run {
+                operation,
+                request,
+                reply,
+            } => {
+                let result = match state.validate_operation(operation) {
+                    Ok(()) => match state.backend() {
+                        Ok(backend) => backend.run(&request).await.map_err(backend_error),
+                        Err(error) => Err(error),
+                    },
+                    Err(error) => Err(error),
+                };
+                let result = match result {
+                    Ok(observation) => {
+                        state.running = Some(request);
+                        state.commit_backend(observation);
+                        Ok(())
+                    }
+                    Err(error) => Err(error),
+                };
+                let _ = reply.send(result);
+            }
+            CoreActorMessage::Stop { operation, reply } => {
+                let result = match state.validate_operation(operation) {
+                    Ok(()) => match state.backend() {
+                        Ok(backend) => backend.stop().await.map_err(backend_error),
+                        Err(error) => Err(error),
+                    },
+                    Err(error) => Err(error),
+                };
+                let result = match result {
+                    Ok(observation) => {
+                        state.running = None;
+                        state.commit_backend(observation);
+                        Ok(())
+                    }
+                    Err(error) => Err(error),
+                };
+                let _ = reply.send(result);
+            }
+            CoreActorMessage::Recover { operation, reply } => {
+                let result = match state.validate_operation(operation) {
+                    Ok(()) => match state.backend() {
+                        Ok(backend) => backend.recover().await.map_err(backend_error),
+                        Err(error) => Err(error),
+                    },
+                    Err(error) => Err(error),
+                };
+                let result = match result {
+                    Ok(observation) => {
+                        state.commit_backend(observation);
+                        Ok(())
+                    }
+                    Err(error) => Err(error),
+                };
+                let _ = reply.send(result);
+            }
+            CoreActorMessage::SetBackend {
+                operation,
+                mode,
+                reply,
+            } => {
+                let result = match state.validate_operation(operation) {
+                    Ok(()) => state.replace_backend(mode).await,
+                    Err(error) => Err(error),
+                };
+                let _ = reply.send(result);
+            }
+            CoreActorMessage::RefreshStatus { operation, reply } => {
+                let result = match state.validate_operation(operation) {
+                    Ok(()) => match state.backend() {
+                        Ok(backend) => backend.observe_status().await.map_err(backend_error),
+                        Err(error) => Err(error),
+                    },
+                    Err(error) => Err(error),
+                };
+                if let Ok(observation) = &result {
+                    state.commit_backend(observation.clone());
+                }
+                let _ = reply.send(result);
+            }
+            CoreActorMessage::RefreshHint => {
+                state.hint_pending.store(false, Ordering::Release);
+                if state.operation.is_idle() {
+                    let result = match state.backend() {
+                        Ok(backend) => backend.observe_status().await.map_err(backend_error),
+                        Err(error) => Err(error),
+                    };
+                    match result {
+                        Ok(observation) => state.commit_backend(observation),
+                        Err(error) => tracing::debug!(%error, "core status refresh hint failed"),
+                    }
+                }
+            }
+            CoreActorMessage::RunningIdentity { operation, reply } => {
+                let result = match state.validate_operation(operation) {
+                    Ok(()) => state.backend().map(|_| state.running.clone()),
+                    Err(error) => Err(error),
+                };
+                let _ = reply.send(result);
+            }
+            CoreActorMessage::Shutdown(reply) => {
+                state.operation.shutdown();
+                state.running = None;
+                let backend = state.backend.take();
+                state.commit(state.synthetic_stopped(None));
+                if let Some(BackendSlot::Ready(backend)) = backend
+                    && let Err(error) = backend.shutdown().await
+                {
+                    tracing::warn!(%error, "core backend shutdown failed");
+                }
+                let _ = reply.send(());
+                myself.stop(None);
+            }
+        }
+        Ok(())
+    }
+}

--- a/backend/tauri/src/core/actor/request.rs
+++ b/backend/tauri/src/core/actor/request.rs
@@ -1,0 +1,93 @@
+use std::sync::Arc;
+
+use camino::Utf8PathBuf;
+use nyanpasu_config::application::ClashCore;
+
+use crate::{
+    client::{ApplicationClient, CoreClient},
+    utils::path::PathResolver,
+};
+
+use super::types::CoreRequest;
+
+pub trait CoreBinaryResolver: Send + Sync + 'static {
+    fn resolve(&self, kind: &nyanpasu_utils::core::CoreType) -> anyhow::Result<Utf8PathBuf>;
+}
+
+#[derive(Clone)]
+pub(crate) struct CoreRequestFactory {
+    data_dir: Utf8PathBuf,
+    pid_path: Utf8PathBuf,
+    runtime_paths: crate::client::RuntimePaths,
+    binary: Arc<dyn CoreBinaryResolver>,
+}
+
+impl CoreRequestFactory {
+    pub(crate) fn new(
+        paths: &PathResolver,
+        runtime_paths: crate::client::RuntimePaths,
+        binary: Arc<dyn CoreBinaryResolver>,
+    ) -> anyhow::Result<Self> {
+        let data_dir = Utf8PathBuf::from_path_buf(paths.app_data_dir().to_path_buf())
+            .map_err(|path| anyhow::anyhow!("data directory is not UTF-8: {path:?}"))?;
+        let pid_path = Utf8PathBuf::from_path_buf(paths.clash_pid_path())
+            .map_err(|path| anyhow::anyhow!("pid path is not UTF-8: {path:?}"))?;
+        Ok(Self {
+            data_dir,
+            pid_path,
+            runtime_paths,
+            binary,
+        })
+    }
+
+    pub(crate) fn for_product(
+        &self,
+        core: ClashCore,
+    ) -> Result<CoreRequest, super::backend::CoreBackendError> {
+        let core_type = (&core).into();
+        let binary_path = self
+            .binary
+            .resolve(&core_type)
+            .map_err(super::backend::CoreBackendError::Binary)?;
+        Ok(CoreRequest {
+            core_type,
+            binary_path,
+            config_path: self.runtime_paths.product().to_owned(),
+            working_dir: self.data_dir.clone(),
+            pid_path: Some(self.pid_path.clone()),
+        })
+    }
+
+    pub(crate) fn manager_runtime_dir(&self) -> Utf8PathBuf {
+        self.runtime_paths.candidate_dir().join(".core-manager")
+    }
+
+    pub(crate) fn runtime_paths(&self) -> &crate::client::RuntimePaths {
+        &self.runtime_paths
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CoreModeReconciler {
+    pub(crate) core: CoreClient,
+    pub(crate) application: ApplicationClient,
+    pub(crate) requests: CoreRequestFactory,
+}
+
+impl CoreModeReconciler {
+    pub(crate) async fn reconcile(
+        &self,
+        ipc_state: crate::core::service::ipc::IpcState,
+    ) -> anyhow::Result<()> {
+        let app = self.application.get().await?.state;
+        if !app.enable_service_mode {
+            return Ok(());
+        }
+        let mode = crate::core::RunType::classify(true, ipc_state);
+        let operation = self.core.begin_operation().await?;
+        self.core.set_backend(&operation, mode).await?;
+        let request = self.requests.for_product(app.core)?;
+        self.core.run(&operation, &request).await?;
+        Ok(())
+    }
+}

--- a/backend/tauri/src/core/actor/types.rs
+++ b/backend/tauri/src/core/actor/types.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use camino::Utf8PathBuf;
+
+use super::backend::CoreBackendError;
+
+pub(super) const RECOVERY_EXHAUSTED_PREFIX: &str = "core kept crashing; restart budget exhausted";
+
+#[derive(Clone)]
+pub(crate) struct CoreRequest {
+    pub(crate) core_type: nyanpasu_utils::core::CoreType,
+    pub(crate) binary_path: Utf8PathBuf,
+    pub(crate) config_path: Utf8PathBuf,
+    pub(crate) working_dir: Utf8PathBuf,
+    pub(crate) pid_path: Option<Utf8PathBuf>,
+}
+
+#[derive(Clone)]
+pub(crate) struct CoreStatusView {
+    pub(crate) state: nyanpasu_ipc::api::status::CoreState,
+    pub(crate) state_changed_at: i64,
+    pub(crate) run_type: crate::core::RunType,
+    pub(crate) revision: Option<nyanpasu_ipc::api::status::ConfigRevisionInfo>,
+    pub(crate) recovery_exhausted: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct BackendObservation {
+    pub(crate) view: CoreStatusView,
+    pub(crate) lifecycle: FaithfulLifecycle,
+}
+
+#[derive(Clone)]
+pub(crate) enum FaithfulLifecycle {
+    Stopped { reason: Option<String> },
+    Starting,
+    Running,
+    Restarting,
+    Switching,
+    Stopping,
+}
+
+impl CoreStatusView {
+    pub(crate) fn initial() -> Self {
+        Self {
+            state: nyanpasu_ipc::api::status::CoreState::Stopped(None),
+            state_changed_at: 0,
+            run_type: crate::core::RunType::default(),
+            revision: None,
+            recovery_exhausted: false,
+        }
+    }
+}
+
+pub(super) fn is_recovery_exhausted(reason: &str) -> bool {
+    reason.starts_with(RECOVERY_EXHAUSTED_PREFIX)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CoreActorError {
+    #[error("operation id does not match the active operation")]
+    StaleOperation,
+    #[error("no core backend is available: {last_error}")]
+    NoBackend { last_error: Arc<CoreBackendError> },
+    #[error(transparent)]
+    Backend(Arc<CoreBackendError>),
+    #[error("core actor is shutting down")]
+    ShuttingDown,
+}

--- a/backend/tauri/src/core/clash/core.rs
+++ b/backend/tauri/src/core/clash/core.rs
@@ -2,11 +2,10 @@ use super::api;
 use crate::{
     config::{Config, nyanpasu::ClashCore},
     core::logger::Logger,
-    log_err,
     utils::dirs,
 };
-use anyhow::{Context, Result, bail};
-use camino::{Utf8Path, Utf8PathBuf};
+use anyhow::Result;
+use camino::Utf8Path;
 #[cfg(target_os = "macos")]
 use nyanpasu_ipc::api::network::set_dns::NetworkSetDnsReq;
 use nyanpasu_ipc::{
@@ -18,7 +17,7 @@ use nyanpasu_utils::{
         CommandEvent,
         instance::{CoreInstance, CoreInstanceBuilder},
     },
-    runtime::{block_on, spawn},
+    runtime::spawn,
 };
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
@@ -31,9 +30,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, AtomicI64, Ordering},
     },
-    time::Duration,
 };
-use tokio::time::sleep;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Type)]
 #[serde(rename_all = "snake_case")]
@@ -222,20 +219,7 @@ impl Instance {
                                                     err_buf.join("\n")
                                                 ));
                                                 tracing::error!("{}\n{}", err, err_buf.join("\n"));
-                                                if tx.send(Err(err)).await.is_err()
-                                                    && !kill_flag.load(Ordering::Acquire)
-                                                {
-                                                    std::thread::spawn(move || {
-                                                        block_on(async {
-                                                            tracing::info!(
-                                                                "Trying to recover core."
-                                                            );
-                                                            let _ = CoreManager::global()
-                                                                .recover_core()
-                                                                .await;
-                                                        });
-                                                    });
-                                                }
+                                                let _ = tx.send(Err(err)).await;
                                             }
                                             break;
                                         }
@@ -383,49 +367,9 @@ impl Instance {
     }
 }
 
-/// Exclusive guard for core lifecycle mutations.
-#[must_use = "the lifecycle lease releases the mutex when dropped"]
-pub(crate) struct CoreLifecycleLease<'a> {
-    manager: &'a CoreManager,
-    _guard: tokio::sync::MutexGuard<'a, ()>,
-}
-
-impl CoreLifecycleLease<'_> {
-    pub(crate) async fn check_config(
-        &self,
-        config_path: &Utf8Path,
-        clash_core: ClashCore,
-    ) -> Result<()> {
-        self.manager
-            .check_config_with_lease(self, config_path, clash_core)
-            .await
-    }
-
-    pub(crate) async fn run_core_from(&self, config_path: &Utf8Path) -> Result<()> {
-        self.manager.run_core_with_lease(self, config_path).await
-    }
-
-    #[allow(dead_code)]
-    pub(crate) async fn recover_core(&self) -> Result<()> {
-        self.manager.recover_core_with_lease(self).await
-    }
-
-    pub(crate) async fn stop_core(&self) -> Result<()> {
-        self.manager.stop_core_with_lease(self).await
-    }
-
-    pub(crate) async fn apply_config_from(&self, product: &Utf8Path) -> Result<()> {
-        self.manager
-            .apply_config_from_with_lease(self, product)
-            .await
-    }
-}
-
 #[derive(Debug)]
 pub struct CoreManager {
     instance: Mutex<Option<Arc<Instance>>>,
-    /// Single mutex domain for run/restart, stop, check, apply, and recover.
-    lifecycle_lock: tokio::sync::Mutex<()>,
     #[cfg(target_os = "macos")]
     previous_dns: tokio::sync::Mutex<Option<Vec<std::net::IpAddr>>>,
 }
@@ -435,17 +379,9 @@ impl CoreManager {
         static CORE_MANAGER: OnceCell<CoreManager> = OnceCell::new();
         CORE_MANAGER.get_or_init(|| CoreManager {
             instance: Mutex::new(None),
-            lifecycle_lock: tokio::sync::Mutex::new(()),
             #[cfg(target_os = "macos")]
             previous_dns: tokio::sync::Mutex::new(None),
         })
-    }
-
-    pub(crate) async fn begin_lifecycle(&self) -> CoreLifecycleLease<'_> {
-        CoreLifecycleLease {
-            manager: self,
-            _guard: self.lifecycle_lock.lock().await,
-        }
     }
 
     pub async fn status<'a>(&self) -> (Cow<'a, CoreState>, i64, RunType) {
@@ -463,204 +399,6 @@ impl CoreManager {
                 RunType::default(),
             )
         }
-    }
-
-    #[allow(dead_code)]
-    pub fn init(&self) -> Result<()> {
-        tauri::async_runtime::spawn(async {
-            // 启动clash
-            log_err!(Self::global().run_core().await);
-        });
-
-        Ok(())
-    }
-
-    /// 检查配置是否正确
-    #[allow(dead_code)]
-    pub async fn check_config(&self, config_path: &Utf8Path, clash_core: ClashCore) -> Result<()> {
-        let lease = self.begin_lifecycle().await;
-        self.check_config_with_lease(&lease, config_path, clash_core)
-            .await
-    }
-
-    pub(crate) async fn check_config_with_lease(
-        &self,
-        _lease: &CoreLifecycleLease<'_>,
-        config_path: &Utf8Path,
-        clash_core: ClashCore,
-    ) -> Result<()> {
-        use nyanpasu_utils::core::instance::CoreInstance;
-        let clash_core: nyanpasu_utils::core::CoreType = (&clash_core).into();
-
-        let app_dir = dirs::app_data_dir()?;
-        let app_dir = Utf8PathBuf::from_path_buf(app_dir)
-            .map_err(|_| anyhow::anyhow!("failed to convert app dir to utf8 path"))?;
-        let binary_path = find_binary_path(&clash_core)?;
-        let binary_path = Utf8PathBuf::from_path_buf(binary_path)
-            .map_err(|_| anyhow::anyhow!("failed to convert binary path to utf8 path"))?;
-        log::debug!(target: "app", "check config in `{clash_core}`");
-        CoreInstance::check_config_(&clash_core, config_path, &binary_path, &app_dir)
-            .await
-            .context("failed to check config")
-            .inspect_err(|e| log::error!(target: "app", "failed to check config: {e:?}"))?;
-
-        Ok(())
-    }
-
-    pub(crate) async fn run_core_with_lease(
-        &self,
-        _lease: &CoreLifecycleLease<'_>,
-        config_path: &Utf8Path,
-    ) -> Result<()> {
-        {
-            let instance = {
-                let instance = self.instance.lock();
-                instance.as_ref().cloned()
-            };
-            if let Some(instance) = instance.as_ref()
-                && matches!(instance.state().await.as_ref(), CoreState::Running)
-            {
-                log::debug!(target: "app", "core is already running, stop it first...");
-                instance.stop().await?;
-            }
-        }
-
-        // T07 review fix: port ownership moved to SessionPortResolver (resolved at
-        // startup, written back by resolve_setup). Re-picking external-controller
-        // here (legacy prepare_external_controller_port) could select a NEW port on
-        // core restart — e.g. while the old core still holds the current one — and
-        // desync the api client from the runtime config generated off session ports.
-        let run_type = RunType::default();
-        let instance = Arc::new(Instance::try_new(run_type, config_path)?);
-
-        #[cfg(target_os = "macos")]
-        {
-            let enable_tun = Config::verge().latest().enable_tun_mode.unwrap_or(false);
-            let _ = self
-                .change_default_network_dns(enable_tun)
-                .await
-                .inspect_err(|e| log::error!(target: "app", "failed to set system dns: {:?}", e));
-        }
-
-        {
-            let mut this = self.instance.lock();
-            *this = Some(instance.clone());
-        }
-        instance.start().await
-    }
-
-    pub async fn run_core_from(&self, config_path: &Utf8Path) -> Result<()> {
-        let lease = self.begin_lifecycle().await;
-        self.run_core_with_lease(&lease, config_path).await
-    }
-
-    // TODO(actor-migration): compatibility bridge for legacy lifecycle callers.
-    // Reason: service/updater/IPC lifecycle routing is completed by S04.
-    // Remove when: all lifecycle callers receive the injected core port.
-    pub async fn run_core(&self) -> Result<()> {
-        let paths = crate::utils::path::PathResolver::from_env()?;
-        let runtime_paths = crate::client::RuntimePaths::from_resolver(&paths)?;
-        self.run_core_from(runtime_paths.product()).await
-    }
-
-    /// 重启内核
-    pub async fn recover_core(&'static self) -> Result<()> {
-        let result = {
-            let lease = self.begin_lifecycle().await;
-            self.recover_core_with_lease(&lease).await
-        };
-
-        if let Err(err) = result {
-            log::error!(target: "app", "failed to recover clash core");
-            log::error!(target: "app", "{err:?}");
-            tokio::time::sleep(Duration::from_secs(5)).await;
-            std::thread::spawn(move || {
-                block_on(async {
-                    let _ = CoreManager::global().recover_core().await;
-                })
-            });
-        }
-
-        Ok(())
-    }
-
-    pub(crate) async fn recover_core_with_lease(
-        &self,
-        lease: &CoreLifecycleLease<'_>,
-    ) -> Result<()> {
-        {
-            let instance = {
-                let mut this = self.instance.lock();
-                this.take()
-            };
-            if let Some(instance) = instance
-                && matches!(instance.state().await.as_ref(), CoreState::Running)
-            {
-                log::debug!(target: "app", "core is running, stop it first...");
-                instance.stop().await?;
-            }
-        }
-
-        let paths = crate::utils::path::PathResolver::from_env()?;
-        let runtime_paths = crate::client::RuntimePaths::from_resolver(&paths)?;
-        self.run_core_with_lease(lease, runtime_paths.product())
-            .await
-    }
-
-    /// 停止核心运行
-    pub async fn stop_core(&self) -> Result<()> {
-        let lease = self.begin_lifecycle().await;
-        self.stop_core_with_lease(&lease).await
-    }
-
-    pub(crate) async fn stop_core_with_lease(&self, _lease: &CoreLifecycleLease<'_>) -> Result<()> {
-        #[cfg(target_os = "macos")]
-        let _ = self
-            .change_default_network_dns(false)
-            .await
-            .inspect_err(|e| log::error!(target: "app", "failed to set system dns: {:?}", e));
-        let instance = {
-            let instance = self.instance.lock();
-            instance.as_ref().cloned()
-        };
-        if let Some(instance) = instance.as_ref() {
-            instance.stop().await?;
-        }
-        Ok(())
-    }
-
-    /// Push the promoted runtime product to the running core over the api.
-    /// Check + promote happen in the rebuild pipeline (RunningCoreBridge::
-    /// check_and_promote) before this is called.
-    #[allow(dead_code)]
-    pub async fn apply_config_from(&self, product: &Utf8Path) -> Result<()> {
-        let lease = self.begin_lifecycle().await;
-        self.apply_config_from_with_lease(&lease, product).await
-    }
-
-    pub(crate) async fn apply_config_from_with_lease(
-        &self,
-        _lease: &CoreLifecycleLease<'_>,
-        product: &Utf8Path,
-    ) -> Result<()> {
-        let path = product.as_str();
-
-        // 发送请求 发送5次
-        for i in 0..5 {
-            match api::put_configs(path).await {
-                Ok(_) => break,
-                Err(err) => {
-                    if i < 4 {
-                        log::info!(target: "app", "{err:?}");
-                    } else {
-                        bail!(err);
-                    }
-                }
-            }
-            sleep(Duration::from_millis(250)).await;
-        }
-
-        Ok(())
     }
 
     #[cfg(target_os = "macos")]

--- a/backend/tauri/src/core/mod.rs
+++ b/backend/tauri/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod actor;
 pub mod clash;
 pub mod connection_interruption;
 pub mod download;

--- a/backend/tauri/src/core/service/control.rs
+++ b/backend/tauri/src/core/service/control.rs
@@ -1,4 +1,8 @@
-use crate::utils::dirs::{app_config_dir, app_data_dir, app_install_dir};
+use crate::{
+    core::actor::{backend::ServiceControlOps, request::CoreModeReconciler},
+    utils::dirs::{app_config_dir, app_data_dir, app_install_dir},
+};
+use async_trait::async_trait;
 use runas::Command as RunasCommand;
 use std::ffi::OsString;
 
@@ -51,7 +55,7 @@ pub async fn get_service_install_args() -> Result<Vec<OsString>, anyhow::Error> 
     Ok(args)
 }
 
-pub async fn install_service() -> anyhow::Result<()> {
+pub async fn install_service(reconciler: CoreModeReconciler) -> anyhow::Result<()> {
     let args = get_service_install_args().await?;
     let child = tokio::task::spawn_blocking(move || {
         #[cfg(not(target_os = "macos"))]
@@ -94,7 +98,7 @@ pub async fn install_service() -> anyhow::Result<()> {
     }
     // Due to most platform, the service will be started automatically after installed
     if !super::ipc::HEALTH_CHECK_RUNNING.load(std::sync::atomic::Ordering::Relaxed) {
-        super::ipc::spawn_health_check();
+        super::ipc::spawn_health_check(reconciler);
     }
     Ok(())
 }
@@ -181,7 +185,7 @@ pub async fn uninstall_service() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn start_service() -> anyhow::Result<()> {
+pub async fn start_service(reconciler: CoreModeReconciler) -> anyhow::Result<()> {
     let child = tokio::task::spawn_blocking(move || {
         const ARGS: &[&str] = &["start"];
         #[cfg(not(target_os = "macos"))]
@@ -222,7 +226,7 @@ pub async fn start_service() -> anyhow::Result<()> {
         );
     }
     if !super::ipc::HEALTH_CHECK_RUNNING.load(std::sync::atomic::Ordering::Acquire) {
-        super::ipc::spawn_health_check();
+        super::ipc::spawn_health_check(reconciler);
     }
     Ok(())
 }
@@ -276,7 +280,7 @@ pub async fn stop_service() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn restart_service() -> anyhow::Result<()> {
+pub async fn restart_service(reconciler: CoreModeReconciler) -> anyhow::Result<()> {
     let child = tokio::task::spawn_blocking(move || {
         const ARGS: &[&str] = &["restart"];
         #[cfg(not(target_os = "macos"))]
@@ -317,9 +321,30 @@ pub async fn restart_service() -> anyhow::Result<()> {
         );
     }
     if !super::ipc::HEALTH_CHECK_RUNNING.load(std::sync::atomic::Ordering::Acquire) {
-        super::ipc::spawn_health_check();
+        super::ipc::spawn_health_check(reconciler);
     }
     Ok(())
+}
+
+pub(crate) struct OsServiceControlOps;
+
+#[async_trait]
+impl ServiceControlOps for OsServiceControlOps {
+    async fn install(&self, reconciler: CoreModeReconciler) -> anyhow::Result<()> {
+        install_service(reconciler).await
+    }
+
+    async fn start(&self, reconciler: CoreModeReconciler) -> anyhow::Result<()> {
+        start_service(reconciler).await
+    }
+
+    async fn stop(&self) -> anyhow::Result<()> {
+        stop_service().await
+    }
+
+    async fn restart(&self, reconciler: CoreModeReconciler) -> anyhow::Result<()> {
+        restart_service(reconciler).await
+    }
 }
 
 #[tracing::instrument]

--- a/backend/tauri/src/core/service/ipc.rs
+++ b/backend/tauri/src/core/service/ipc.rs
@@ -7,7 +7,7 @@ use nyanpasu_utils::runtime::block_on;
 use serde::Serialize;
 use tracing::instrument;
 
-use crate::log_err;
+use crate::core::actor::request::CoreModeReconciler;
 
 use super::compat::ServiceCompat;
 
@@ -33,12 +33,12 @@ pub fn get_ipc_state() -> IpcState {
     IPC_STATE.load(Ordering::Relaxed)
 }
 
-pub(super) fn set_ipc_state(state: IpcState) {
+pub(super) fn set_ipc_state(state: IpcState, reconciler: &CoreModeReconciler) {
     IPC_STATE.store(state, Ordering::Relaxed);
-    on_ipc_state_changed(state);
+    on_ipc_state_changed(state, reconciler.clone());
 }
 
-fn dispatch_disconnected() {
+fn dispatch_disconnected(reconciler: &CoreModeReconciler) {
     // Strong CAS on purpose: a spurious `compare_exchange_weak` failure here
     // would leave a stale `Connected` past the accepted poll window and weaken
     // the fail-closed compat gate riding on this transition.
@@ -51,11 +51,11 @@ fn dispatch_disconnected() {
         )
         .is_ok()
     {
-        on_ipc_state_changed(IpcState::Disconnected)
+        on_ipc_state_changed(IpcState::Disconnected, reconciler.clone())
     }
 }
 
-fn dispatch_connected() {
+fn dispatch_connected(reconciler: &CoreModeReconciler) {
     if IPC_STATE
         .compare_exchange(
             IpcState::Disconnected,
@@ -65,58 +65,43 @@ fn dispatch_connected() {
         )
         .is_ok()
     {
-        on_ipc_state_changed(IpcState::Connected)
+        on_ipc_state_changed(IpcState::Connected, reconciler.clone())
     }
 }
 
 // TODO: it might be moved to outer scope?
-#[instrument]
-fn on_ipc_state_changed(state: IpcState) {
+#[instrument(skip(reconciler))]
+fn on_ipc_state_changed(state: IpcState, reconciler: CoreModeReconciler) {
     tracing::info!("IPC state changed: {:?}", state);
-    let enabled_service = {
-        *crate::config::Config::verge()
-            .latest()
-            .enable_service_mode
-            .as_ref()
-            .unwrap_or(&false)
-    };
     std::thread::spawn(move || {
         nyanpasu_utils::runtime::block_on(async move {
-            if enabled_service {
-                let (_, _, run_type) = crate::core::CoreManager::global().status().await;
-                match (state, run_type) {
-                    (IpcState::Connected, crate::core::RunType::Normal)
-                    | (IpcState::Disconnected, crate::core::RunType::Service) => {
-                        tracing::info!("Restarting core due to IPC state change");
-                        log_err!(crate::core::CoreManager::global().run_core().await);
-                    }
-                    _ => {}
-                }
+            if let Err(error) = reconciler.reconcile(state).await {
+                log::error!(target: "app", "{error}");
             }
         })
     });
 }
 
-pub(super) fn spawn_health_check() {
+pub(super) fn spawn_health_check(reconciler: CoreModeReconciler) {
     KILL_FLAG.store(false, Ordering::Relaxed);
-    std::thread::spawn(|| {
+    std::thread::spawn(move || {
         HEALTH_CHECK_RUNNING.store(true, Ordering::Release);
         block_on(async {
             loop {
                 if KILL_FLAG.load(Ordering::Acquire) {
-                    set_ipc_state(IpcState::Disconnected);
+                    set_ipc_state(IpcState::Disconnected, &reconciler);
                     HEALTH_CHECK_RUNNING.store(false, Ordering::Release);
                     break;
                 }
-                health_check().await;
+                health_check(&reconciler).await;
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
             }
         })
     });
 }
 
-#[instrument]
-async fn health_check() {
+#[instrument(skip(reconciler))]
+async fn health_check(reconciler: &CoreModeReconciler) {
     match super::control::status().await {
         Ok(info) => {
             let (state, compat) = target_ipc_state(&info);
@@ -127,13 +112,13 @@ async fn health_check() {
                 );
             }
             match state {
-                IpcState::Connected => dispatch_connected(),
-                IpcState::Disconnected => dispatch_disconnected(),
+                IpcState::Connected => dispatch_connected(reconciler),
+                IpcState::Disconnected => dispatch_disconnected(reconciler),
             }
         }
         Err(e) => {
             tracing::error!("IPC health check failed: {}", e);
-            dispatch_disconnected();
+            dispatch_disconnected(reconciler);
         }
     }
 }

--- a/backend/tauri/src/core/service/mod.rs
+++ b/backend/tauri/src/core/service/mod.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use nyanpasu_ipc::types::StatusInfo;
 use once_cell::sync::Lazy;
 
-use crate::{config::Config, utils::dirs::app_install_dir};
+use crate::{core::actor::request::CoreModeReconciler, utils::dirs::app_install_dir};
 
 pub mod compat;
 pub mod control;
@@ -15,21 +15,14 @@ static SERVICE_PATH: Lazy<PathBuf> = Lazy::new(|| {
     app_path.join(format!("{}{}", SERVICE_NAME, std::env::consts::EXE_SUFFIX))
 });
 
-pub async fn init_service() {
-    let enable_service = {
-        *Config::verge()
-            .latest()
-            .enable_service_mode
-            .as_ref()
-            .unwrap_or(&false)
-    };
+pub async fn init_service(enable_service: bool, reconciler: CoreModeReconciler) {
     if let Ok(StatusInfo {
         status: nyanpasu_ipc::types::ServiceStatus::Running,
         ..
     }) = control::status().await
         && enable_service
     {
-        ipc::spawn_health_check();
+        ipc::spawn_health_check(reconciler);
         while !ipc::HEALTH_CHECK_RUNNING.load(std::sync::atomic::Ordering::Acquire) {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }

--- a/backend/tauri/src/core/tray/mod.rs
+++ b/backend/tauri/src/core/tray/mod.rs
@@ -449,7 +449,12 @@ impl Tray {
             "open_app_data_dir" => crate::log_err!(ipc::open_app_data_dir()),
             "open_core_dir" => crate::log_err!(ipc::open_core_dir()),
             "open_logs_dir" => crate::log_err!(ipc::open_logs_dir()),
-            "restart_clash" => feat::restart_clash_core(),
+            "restart_clash" => feat::restart_clash_core(
+                app_handle
+                    .state::<crate::client::NyanpasuClient>()
+                    .inner()
+                    .clone(),
+            ),
             "restart_app" => help::restart_application(app_handle),
             "quit" => {
                 help::quit_application(app_handle);

--- a/backend/tauri/src/core/updater/instance.rs
+++ b/backend/tauri/src/core/updater/instance.rs
@@ -1,10 +1,8 @@
 use super::shared::{self, CoreTypeMeta};
 use crate::{
+    client::CoreClient,
     config::nyanpasu::ClashCore,
-    core::{
-        CoreManager,
-        download::{DownloadSession, DownloadStatus},
-    },
+    core::download::{DownloadSession, DownloadStatus},
 };
 use anyhow::anyhow;
 use runas::Command as RunasCommand;
@@ -35,6 +33,7 @@ pub(super) struct Updater {
     artifact: String,
     inner: parking_lot::RwLock<UpdaterInner>,
     downloader: Arc<DownloadSession>,
+    core: CoreClient,
 }
 
 struct UpdaterInner {
@@ -54,6 +53,7 @@ pub(super) struct UpdaterBuilder {
     mirror: Option<String>,
     artifact: Option<String>,
     tag: Option<CoreTypeMeta>,
+    core: Option<CoreClient>,
 }
 
 impl UpdaterBuilder {
@@ -64,6 +64,7 @@ impl UpdaterBuilder {
             mirror: None,
             artifact: None,
             tag: None,
+            core: None,
         }
     }
 
@@ -92,6 +93,11 @@ impl UpdaterBuilder {
         self
     }
 
+    pub fn set_core(mut self, core: CoreClient) -> Self {
+        self.core = Some(core);
+        self
+    }
+
     pub async fn build(self) -> anyhow::Result<Updater> {
         let client = self.client.ok_or(anyhow::anyhow!("client is required"))?;
         let core_type = self
@@ -102,6 +108,7 @@ impl UpdaterBuilder {
             .ok_or(anyhow::anyhow!("artifact is required"))?;
         let tag = self.tag.ok_or(anyhow::anyhow!("tag is required"))?;
         let mirror = self.mirror.ok_or(anyhow::anyhow!("mirror is required"))?;
+        let core = self.core.ok_or(anyhow::anyhow!("core is required"))?;
 
         let temp_dir = TempDir::new()?;
         let inner = UpdaterInner {
@@ -124,6 +131,7 @@ impl UpdaterBuilder {
             inner: parking_lot::RwLock::new(inner),
             artifact,
             downloader,
+            core,
         })
     }
 }
@@ -198,26 +206,12 @@ impl Updater {
 
     async fn replace_core(&self) -> anyhow::Result<()> {
         self.dispatch_state(UpdaterState::Replacing);
-        let core_manager = CoreManager::global();
-        // TODO(actor-migration): temporary bridge to the legacy global core manager.
-        // Reason: the updater has not yet been injected with the core lifecycle port.
-        // Remove when: the updater receives the lifecycle port through the composition root.
-        let lifecycle = core_manager.begin_lifecycle().await;
-        let current_core = crate::config::Config::verge()
-            .latest()
-            .clash_core
-            .unwrap_or_default();
-        tracing::debug!("current core: {}", current_core);
+        let (operation, restart_target) = replacement_target(&self.core, self.core_type).await?;
 
-        let runtime_paths = if current_core == self.core_type {
-            let resolver = crate::utils::path::PathResolver::from_env()?;
-            let runtime_paths = crate::client::RuntimePaths::from_resolver(&resolver)?;
+        if restart_target.is_some() {
             tracing::debug!("stopping core to replace");
-            lifecycle.stop_core().await?;
-            Some(runtime_paths)
-        } else {
-            None
-        };
+            self.core.stop(&operation).await?;
+        }
         #[cfg(target_os = "windows")]
         let target_core = format!("{}.exe", self.core_type);
         #[cfg(not(target_os = "windows"))]
@@ -274,9 +268,9 @@ impl Updater {
             }
         };
 
-        if let Some(runtime_paths) = runtime_paths.as_ref() {
+        if let Some(request) = restart_target.as_ref() {
             self.dispatch_state(UpdaterState::Restarting);
-            lifecycle.run_core_from(runtime_paths.product()).await?;
+            self.core.run(&operation, request).await?;
         }
 
         Ok(())
@@ -321,5 +315,88 @@ impl Updater {
 
     pub fn get_updater_id(&self) -> usize {
         self.id
+    }
+}
+
+async fn replacement_target(
+    core: &CoreClient,
+    target: ClashCore,
+) -> anyhow::Result<(
+    crate::client::CoreOperationGuard,
+    Option<crate::core::actor::types::CoreRequest>,
+)> {
+    let operation = core.begin_operation().await?;
+    let running = core.running(&operation).await?;
+    let restart_target = running
+        .filter(|request| request.core_type == nyanpasu_utils::core::CoreType::from(&target));
+    Ok((operation, restart_target))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use camino::Utf8PathBuf;
+
+    use super::*;
+    use crate::{
+        client::CoreClientArgs,
+        core::{
+            RunType,
+            actor::{
+                backend::{BackendSlot, CoreBackendError, CoreDegradationSink},
+                request::{CoreBinaryResolver, CoreRequestFactory},
+            },
+        },
+        utils::path::PathResolver,
+    };
+
+    struct FixedBinary(Utf8PathBuf);
+
+    impl CoreBinaryResolver for FixedBinary {
+        fn resolve(&self, _kind: &nyanpasu_utils::core::CoreType) -> anyhow::Result<Utf8PathBuf> {
+            Ok(self.0.clone())
+        }
+    }
+
+    struct NoopDegradation;
+
+    impl CoreDegradationSink for NoopDegradation {
+        fn publish(&self, _degradation: crate::client::runtime::Degradation) {}
+    }
+
+    #[tokio::test]
+    async fn failed_backend_slot_aborts_replacement_without_typed_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = PathResolver::with_base_dirs(dir.path().into(), dir.path().join("data"));
+        let runtime_paths = crate::client::RuntimePaths::from_resolver(&paths).unwrap();
+        let requests = CoreRequestFactory::new(
+            &paths,
+            runtime_paths,
+            Arc::new(FixedBinary(
+                Utf8PathBuf::from_path_buf(dir.path().join("fake-core")).unwrap(),
+            )),
+        )
+        .unwrap();
+        let core = CoreClient::new_with_backend(
+            CoreClientArgs {
+                mode: RunType::Normal,
+                requests,
+                degradation: Arc::new(NoopDegradation),
+            },
+            BackendSlot::Failed {
+                error: Arc::new(CoreBackendError::Construct(anyhow::anyhow!(
+                    "backend unavailable"
+                ))),
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = match replacement_target(&core, ClashCore::Mihomo).await {
+            Ok(_) => panic!("failed backend slot must abort replacement"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("no core backend is available"));
     }
 }

--- a/backend/tauri/src/core/updater/mod.rs
+++ b/backend/tauri/src/core/updater/mod.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use crate::{
+    client::CoreClient,
     config::nyanpasu::ClashCore,
     utils::candy::{ReqwestSpeedTestExt, parse_gh_url},
 };
@@ -219,7 +220,7 @@ impl UpdaterManager {
         Ok(())
     }
 
-    pub async fn update_core(&mut self, core_type: &ClashCore) -> Result<usize> {
+    pub async fn update_core(&mut self, core_type: &ClashCore, core: CoreClient) -> Result<usize> {
         self.mirror_speed_test().await?;
         let (artifact, tag) = self
             .manifest_version
@@ -233,6 +234,7 @@ impl UpdaterManager {
                 .set_mirror(mirror)
                 .set_artifact(artifact)
                 .set_tag(tag)
+                .set_core(core)
                 .build()
                 .await?,
         );

--- a/backend/tauri/src/feat.rs
+++ b/backend/tauri/src/feat.rs
@@ -53,9 +53,9 @@ pub fn toggle_dashboard() {
 }
 
 // 重启clash
-pub fn restart_clash_core() {
-    tauri::async_runtime::spawn(async {
-        match CoreManager::global().run_core().await {
+pub fn restart_clash_core(client: crate::client::NyanpasuClient) {
+    tauri::async_runtime::spawn(async move {
+        match client.restart_core().await {
             Ok(_) => {
                 handle::Handle::refresh_clash();
                 handle::Handle::notice_message(&Message::SetConfig(Ok(())));
@@ -237,7 +237,7 @@ pub(crate) fn requires_core_restart(patch: &Mapping) -> bool {
 /// land without a corresponding apply (use `regenerate_and_apply_for_legacy`).
 #[allow(dead_code)]
 pub async fn patch_clash(client: crate::client::NyanpasuClient, patch: Mapping) -> Result<()> {
-    patch_clash_with_rebuild(patch, |restart| {
+    patch_clash_with_rebuild(client.clone(), patch, |restart| {
         let client = client.clone();
         async move {
             if restart {
@@ -251,7 +251,11 @@ pub async fn patch_clash(client: crate::client::NyanpasuClient, patch: Mapping) 
     .await
 }
 
-pub async fn patch_clash_with_rebuild<F, Fut, T>(patch: Mapping, rebuild: F) -> Result<T>
+pub async fn patch_clash_with_rebuild<F, Fut, T>(
+    client: crate::client::NyanpasuClient,
+    patch: Mapping,
+    rebuild: F,
+) -> Result<T>
 where
     F: FnOnce(bool) -> Fut,
     Fut: Future<Output = Result<T>>,
@@ -289,7 +293,7 @@ where
                 let strategy = Config::verge()
                     .latest()
                     .get_external_controller_port_strategy();
-                let core_state = crate::core::CoreManager::global().status().await;
+                let core_state = client.core_status();
                 if matches!(core_state.0.as_ref(), &CoreState::Running)
                     && get_clash_external_port(&strategy, port).is_err()
                 {
@@ -382,13 +386,16 @@ pub async fn patch_verge(client: crate::client::NyanpasuClient, patch: IVerge) -
                     flag = true;
                 }
             }
-            let (state, _, _) = CoreManager::global().status().await;
+            let (state, _, _) = client.core_status();
             if flag || matches!(state.as_ref(), CoreState::Stopped(_)) {
                 log::debug!(target: "app", "core is stopped, restart core");
                 client.regenerate_and_restart_for_legacy().await?;
             } else {
                 log::debug!(target: "app", "update core config");
                 #[cfg(target_os = "macos")]
+                // TODO(actor-migration): macOS DNS still uses the legacy CoreManager.
+                // Reason: ordered MacosDnsGuard lifecycle ownership belongs to PR-5c / C3.
+                // Remove when: PR-5c moves MacosDnsGuard into CoreActor.
                 let _ = CoreManager::global()
                     .change_default_network_dns(tun_mode.unwrap_or(false))
                     .await

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -396,11 +396,10 @@ pub async fn get_postprocessing_output(
 
 #[tauri::command]
 #[specta::specta]
-pub async fn get_core_status() -> Result<(Cow<'static, CoreState>, i64, RunType)> {
-    // TODO(actor-migration): compatibility bridge for legacy core manager status.
-    // Reason: core lifecycle/status is not yet owned by an injected typed client here.
-    // Remove when: CoreClient exposes typed status through NyanpasuClient or command adapters.
-    Ok(CoreManager::global().status().await)
+pub async fn get_core_status(
+    client: State<'_, NyanpasuClient>,
+) -> Result<(Cow<'static, CoreState>, i64, RunType)> {
+    Ok(client.core_status())
 }
 
 #[tauri::command]
@@ -499,8 +498,8 @@ pub async fn change_clash_core(
 /// restart the sidecar
 #[tauri::command]
 #[specta::specta]
-pub async fn restart_sidecar() -> Result {
-    (CoreManager::global().run_core().await)?;
+pub async fn restart_sidecar(client: State<'_, NyanpasuClient>) -> Result {
+    client.restart_core().await?;
     Ok(())
 }
 
@@ -636,13 +635,11 @@ pub async fn collect_logs(app_handle: AppHandle) -> Result {
 
 #[tauri::command]
 #[specta::specta]
-pub async fn update_core(core_type: nyanpasu::ClashCore) -> Result<usize> {
-    let event_id = (updater::UpdaterManager::global()
-        .write()
-        .await
-        .update_core(&core_type)
-        .await)?;
-    Ok(event_id)
+pub async fn update_core(
+    client: State<'_, NyanpasuClient>,
+    core_type: nyanpasu::ClashCore,
+) -> Result<usize> {
+    Ok(client.update_core(core_type).await?)
 }
 
 #[tauri::command]
@@ -904,7 +901,8 @@ pub async fn is_tray_icon_set(mode: TrayIcon) -> Result<bool> {
 
 pub mod service {
     use super::Result;
-    use crate::core::service;
+    use crate::{client::NyanpasuClient, core::service};
+    use tauri::State;
 
     /// `StatusInfo` 的 additive 镜像：字段逐一复制（specta 不支持 `serde(flatten)`，
     /// 见本文件 `GetSysProxyResponse` 的同款处理），追加 `compat`。
@@ -934,8 +932,8 @@ pub mod service {
 
     #[tauri::command]
     #[specta::specta]
-    pub async fn install_service() -> Result {
-        (service::control::install_service().await)?;
+    pub async fn install_service(client: State<'_, NyanpasuClient>) -> Result {
+        client.install_service().await?;
         Ok(())
     }
 
@@ -948,53 +946,23 @@ pub mod service {
 
     #[tauri::command]
     #[specta::specta]
-    pub async fn start_service() -> Result {
-        let res = service::control::start_service().await;
-        let enabled_service = {
-            *crate::config::Config::verge()
-                .latest()
-                .enable_service_mode
-                .as_ref()
-                .unwrap_or(&false)
-        };
-        if enabled_service && let Err(e) = crate::core::CoreManager::global().run_core().await {
-            log::error!(target: "app", "{e}");
-        }
-        Ok(res?)
+    pub async fn start_service(client: State<'_, NyanpasuClient>) -> Result {
+        client.start_service().await?;
+        Ok(())
     }
 
     #[tauri::command]
     #[specta::specta]
-    pub async fn stop_service() -> Result {
-        let res = service::control::stop_service().await;
-        let enabled_service = {
-            *crate::config::Config::verge()
-                .latest()
-                .enable_service_mode
-                .as_ref()
-                .unwrap_or(&false)
-        };
-        if enabled_service && let Err(e) = crate::core::CoreManager::global().run_core().await {
-            log::error!(target: "app", "{e}");
-        }
-        Ok(res?)
+    pub async fn stop_service(client: State<'_, NyanpasuClient>) -> Result {
+        client.stop_service().await?;
+        Ok(())
     }
 
     #[tauri::command]
     #[specta::specta]
-    pub async fn restart_service() -> Result {
-        let res = service::control::restart_service().await;
-        let enabled_service = {
-            *crate::config::Config::verge()
-                .latest()
-                .enable_service_mode
-                .as_ref()
-                .unwrap_or(&false)
-        };
-        if enabled_service && let Err(e) = crate::core::CoreManager::global().run_core().await {
-            log::error!(target: "app", "{e}");
-        }
-        Ok(res?)
+    pub async fn restart_service(client: State<'_, NyanpasuClient>) -> Result {
+        client.restart_service().await?;
+        Ok(())
     }
 }
 

--- a/backend/tauri/src/setup.rs
+++ b/backend/tauri/src/setup.rs
@@ -8,8 +8,8 @@ use crate::{
         window::LegacyWindowBridge,
     },
     client::{
-        ClientSetupArgs, LegacyBridgeSet, LegacyCoreBridge, LegacyRunningConfigPatchBridge,
-        NyanpasuClient, OsSystemDnsCache, RuntimePaths, TauriUiEventSink,
+        ClientSetupArgs, LegacyBridgeSet, LegacyRunningConfigPatchBridge, NyanpasuClient,
+        OsSystemDnsCache, RuntimePaths, TauriCoreDegradationSink, TauriUiEventSink, UiEventSink,
     },
     utils::path::PathResolver,
 };
@@ -39,16 +39,21 @@ pub fn setup<R: tauri::Runtime, M: tauri::Manager<R>>(app: &M) -> Result<(), any
     let legacy_lock = Arc::new(parking_lot::Mutex::new(()));
     let legacy_verge_store: Arc<dyn LegacyVergeStore> =
         Arc::new(ConfigLegacyVergeStore::new(legacy_lock.clone()));
+    let binary_resolver = Arc::new(OsCoreBinaryResolver::new(&paths)?);
+    let ui_sink: Arc<dyn UiEventSink> = Arc::new(TauriUiEventSink::<R>::new(app_handle));
     let client = NyanpasuClient::try_new_with_args(ClientSetupArgs {
         paths,
-        runtime_paths: runtime_paths.clone(),
+        runtime_paths,
         bridges: LegacyBridgeSet {
             verge: Arc::new(LegacyVergeBridge::with_store(legacy_verge_store.clone())),
             window: Arc::new(LegacyWindowBridge::new(legacy_lock.clone())),
             clash: Arc::new(LegacyClashBridge::new(legacy_lock)),
         },
-        ui_sink: Arc::new(TauriUiEventSink::<R>::new(app_handle)),
-        core: Arc::new(LegacyCoreBridge::new(runtime_paths)),
+        ui_sink: ui_sink.clone(),
+        core: None,
+        binary_resolver,
+        degradation: Arc::new(TauriCoreDegradationSink::new(ui_sink)),
+        service_control: Arc::new(crate::core::service::control::OsServiceControlOps),
         clash_patch: Some(Arc::new(LegacyRunningConfigPatchBridge)),
         system_dns: Arc::new(OsSystemDnsCache),
     })
@@ -63,6 +68,39 @@ pub fn setup<R: tauri::Runtime, M: tauri::Manager<R>>(app: &M) -> Result<(), any
     // FIXME: this is a background setup, so be careful use this state in ipc.
     // crate::logging::setup(app).context("Failed to setup logging")?;
     Ok(())
+}
+
+struct OsCoreBinaryResolver {
+    data_dir: Utf8PathBuf,
+    install_dir: Utf8PathBuf,
+}
+
+impl OsCoreBinaryResolver {
+    fn new(paths: &PathResolver) -> anyhow::Result<Self> {
+        let data_dir = Utf8PathBuf::from_path_buf(paths.app_data_dir().to_path_buf())
+            .map_err(|path| anyhow::anyhow!("data directory is not UTF-8: {path:?}"))?;
+        let install_dir = Utf8PathBuf::from_path_buf(paths.app_install_dir()?)
+            .map_err(|path| anyhow::anyhow!("install directory is not UTF-8: {path:?}"))?;
+        Ok(Self {
+            data_dir,
+            install_dir,
+        })
+    }
+}
+
+impl crate::core::actor::request::CoreBinaryResolver for OsCoreBinaryResolver {
+    fn resolve(&self, kind: &nyanpasu_utils::core::CoreType) -> anyhow::Result<Utf8PathBuf> {
+        let executable = kind.get_executable_name();
+        let data_binary = self.data_dir.join(executable);
+        if data_binary.exists() {
+            return Ok(data_binary);
+        }
+        let install_binary = self.install_dir.join(executable);
+        if install_binary.exists() {
+            return Ok(install_binary);
+        }
+        anyhow::bail!("{} not found", executable)
+    }
 }
 
 fn utf8_path(path: std::path::PathBuf) -> anyhow::Result<Utf8PathBuf> {

--- a/backend/tauri/src/utils/help.rs
+++ b/backend/tauri/src/utils/help.rs
@@ -258,14 +258,13 @@ pub fn cleanup_processes(app_handle: &AppHandle) {
     let client = app_handle
         .try_state::<crate::client::NyanpasuClient>()
         .map(|state| state.inner().clone());
-    let _ = nyanpasu_utils::runtime::block_on(async {
+    nyanpasu_utils::runtime::block_on(async {
         if let Some(client) = client.as_ref() {
             client.shutdown().await;
         }
         if let Err(e) = widget_manager.stop().await {
             log::error!("failed to stop widget manager: {e:?}");
         };
-        crate::core::CoreManager::global().stop_core().await
     });
     #[cfg(windows)]
     crate::shutdown_hook::set_ready_for_shutdown();

--- a/backend/tauri/src/utils/init/mod.rs
+++ b/backend/tauri/src/utils/init/mod.rs
@@ -228,51 +228,42 @@ pub fn init_resources() -> Result<()> {
 
 /// initialize service resources
 /// after tauri setup
-#[instrument]
-pub fn init_service() -> Result<()> {
-    use nyanpasu_utils::runtime::block_on;
+#[instrument(skip(reconciler))]
+pub async fn init_service(
+    enable_service: bool,
+    reconciler: crate::core::actor::request::CoreModeReconciler,
+) -> Result<()> {
     tracing::debug!("init services");
-    block_on(async move {
-        let enable_service = {
-            *Config::verge()
-                .latest()
-                .enable_service_mode
-                .as_ref()
-                .unwrap_or(&false)
-        };
-        if enable_service {
-            match crate::core::service::control::status().await {
-                Ok(status) => {
-                    tracing::info!(
-                        "service mode is enabled and service is running, do a update check"
-                    );
-                    if let Some(info) = status.server
-                        && let (Some(server_ver), Some(app_ver)) = (
-                            compat::parse_service_version(info.version.as_ref()),
-                            compat::parse_service_version(status.version.as_ref()),
-                        )
-                    {
-                        if app_ver > server_ver {
-                            tracing::info!(
-                                "client service ver is newer than exist one, do service update"
-                            );
-                            if let Err(e) = crate::core::service::control::update_service().await {
-                                log::error!(target: "app", "failed to update service: {e:?}");
-                            }
-                        }
-                    } else {
-                        tracing::warn!(
-                            "service version not comparable; skipping the auto-update check"
+    if enable_service {
+        match crate::core::service::control::status().await {
+            Ok(status) => {
+                tracing::info!("service mode is enabled and service is running, do a update check");
+                if let Some(info) = status.server
+                    && let (Some(server_ver), Some(app_ver)) = (
+                        compat::parse_service_version(info.version.as_ref()),
+                        compat::parse_service_version(status.version.as_ref()),
+                    )
+                {
+                    if app_ver > server_ver {
+                        tracing::info!(
+                            "client service ver is newer than exist one, do service update"
                         );
+                        if let Err(e) = crate::core::service::control::update_service().await {
+                            log::error!(target: "app", "failed to update service: {e:?}");
+                        }
                     }
-                }
-                Err(e) => {
-                    log::error!(target: "app", "failed to get service status: {e:?}");
+                } else {
+                    tracing::warn!(
+                        "service version not comparable; skipping the auto-update check"
+                    );
                 }
             }
+            Err(e) => {
+                log::error!(target: "app", "failed to get service status: {e:?}");
+            }
         }
-        crate::core::service::init_service().await;
-    });
+    }
+    crate::core::service::init_service(enable_service, reconciler).await;
     Ok(())
 }
 

--- a/backend/tauri/src/utils/resolve.rs
+++ b/backend/tauri/src/utils/resolve.rs
@@ -149,7 +149,10 @@ pub fn resolve_setup(app: &mut App) {
     crate::consts::setup_app_handle(app.app_handle().clone());
 
     log_err!(init::init_resources());
-    log_err!(init::init_service());
+    let service_client = app.state::<crate::client::NyanpasuClient>().inner().clone();
+    log_err!(tauri::async_runtime::block_on(
+        service_client.init_service_health()
+    ));
 
     // FIXME(actor-migration): write the session-resolved ports back into the
     // legacy mirrors (IVerge/IClashTemp) so sysproxy & the clash api client keep
@@ -285,7 +288,6 @@ fn spawn_window_ready_timeout(app_handle: AppHandle) {
 /// reset system proxy
 pub fn resolve_reset() {
     log_err!(sysopt::Sysopt::global().reset_sysproxy());
-    log_err!(block_on(CoreManager::global().stop_core()));
 }
 
 /// Main window implementation (new UI)

--- a/docs/superpowers/plans/2026-08-02-pr5a-core-actor.md
+++ b/docs/superpowers/plans/2026-08-02-pr5a-core-actor.md
@@ -1,0 +1,1847 @@
+# PR-5a 实施计划 — 最小 CoreActor + `OperationId` + `CoreBackend` enum
+
+**日期：** 2026-08-02
+**分支基线：** `refactor/core-manager-actor` @ `4583048b5`（含 PR-5-pre 三提交：`4f22eaddb` 依赖切换 / `cca7f654f` 兼容门 / `4583048b5` ledger 同步）
+**权威 spec：** `docs/superpowers/specs/2026-08-01-pr5-core-actor/design.md` §3–§6、同目录 `task.md` 卡 A1/A2/A3
+**路线图定位：** `docs/design/actor-migration-roadmap.md` §6.1；必答项 §6.4 RQ-02 / RQ-04
+**平台：** Windows 11 / PowerShell
+**版本：** v13（2026-08-02，**终版**）——v1–v12 经 codex 对抗审查十二轮；v13 修完机械项后由 leader 亲验关门，不再发起第 13 轮文档审（理由见处置表末行）
+
+---
+
+## 0.1 审查处置表（十二轮 + 终止决定）
+
+历轮发现**全部经本人复核源码确认成立**（无一条被驳回）。第六轮后 leader 以**范围裁定**收敛，第八轮再以**裁定 A-v2** 修正其中一处过度裁剪。
+
+> **v3 的教训**：第三轮修订时会话中断，重写只传播到部分小节，下游多处停留在 v2，导致三审看到自相矛盾的文档。**第四轮起改为逐项定点 Edit，不做整文件重写**，每完成一项即汇报。
+
+| #   | 级别   | 问题                                                                          | 处置                                                                                                                                 | 落点                                    |
+| --- | ------ | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
+| 1   | High   | Updater 依赖 S10 要删的 lease API → **必然编译失败**                          | 改用注入的 `CoreClient` + guard 迁移 `replace_core`；不加全局桥；UpdaterActor 仍归 6d                                                | 事实 A16f；**S9.1**；§0；§8             |
+| 2   | High   | `start` / `restart` 都不是 request-bearing 原语，全新 backend 上 restart 无效 | 收敛为**单一 `run(request)`** 迁移原语；Local 用 `switch(spec)` 一次调用覆盖两种情形，Service 用 stop-then-start                     | 事实 R5b/R5c、DV-F；S3、S5、S7、S8      |
+| 3   | High   | 组合根注入图不可实现（`core` 在 `block_on` 前就被解构）                       | `CoreClient` 在 typed 快照后于 block 内构造；typed 字段入 `NyanpasuClientInner`；`args.core` 改 `Option`；两个无注入点消费者显式穿线 | 事实 A17f；**S8** 全节重写              |
+| 4   | Medium | `events()` 不重连；过期 `/status` 可回退 revision；start 不返回 revision      | actor 自管可取消重连循环 + **generation 栅栏** + start 后同步回填                                                                    | **RQ-02** 重写；T-RV-02/04/05           |
+| 5   | Medium | `shutdown()` 不释放目录锁，换槽会拿不到锁                                     | 槽位改 `Option`；六步换槽协议（取消→join→shutdown→drop 全部 `Arc`→构造→写回）；定义无 backend 失败态                                 | 事实 R6b；**D2** 重写；T-BK-08/09       |
+| 6   | Medium | 漏第二条裸线程恢复；DNS 是第二个 residual；`resolve_reset` 已先停一次核       | S10 删两条路径；DNS **allowlist 到 5c**（leader 裁定）；`resolve_reset` 移除停核（已验证仅一个调用者）                               | 事实 A18f/A20f；S9.2、S10、**S11** 重写 |
+| 7   | Medium | 只算 flag，未满足 design §5 的"发布一次"                                      | 新增窄 `CoreDegradationSink`（单方法、可 mock）+ per-episode latch + 复位规则                                                        | **D5** 重写；T-BK-06/07                 |
+| 8   | Medium | parity 允许降级为 TestBackend，等于架空 A-Exit                                | 承诺真实双端：fake-core 补 `GET /version`（或新增探针 bin）+ 真实 IPC roundtrip harness；**禁止降级**                                | 事实 A19f；**S12.1 / S12.2**            |
+| 9   | Low    | `ConfigRevision` 字段描述、seam 覆盖遗漏、DV-B 指错                           | T-RV-03 拆成 03a/03b 两个转换；A9f 补第 4 个 seam 实现；DV-B 改指 S4                                                                 | A9f、DV-B、T-RV-03a/03b                 |
+| 10  | —      | **（自查）** S13 的 ledger 基线用了 5-pre **之前**的快照数字                  | 改用 2026-08-02 实测基线 116/74/19/300/0，并给出逐项加减预期（19 → 17）                                                              | **S13**                                 |
+
+**第二轮（v2 → v3）发现的处置：**
+
+| #   | 级别   | 问题                                                                | 处置                                                                                                 | 落点                   |
+| --- | ------ | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------- |
+| 11  | High   | Updater 注入链只说"构造点会接受"，且类型名 `UpdaterInstance` 不存在 | 写出真实四段链与逐点签名；`CoreClient` 只随调用传递                                                  | 事实 A16g；S9.1        |
+| 12  | Medium | Service run 判定读了有损的 `CoreState`                              | 改读 `CoreInfos.detail`，只有 `Stopped` 是终止态；`detail` 缺失时保守当作在跑；只抑制 `not_started`  | 事实 R5d；S3           |
+| 13  | High   | 适配器缺 core-type 来源；health-check 穿线漏 3 个消费者             | **leader 裁定**：注入 `ApplicationClient` + `RuntimePaths`，每次现读 typed 快照；穿线表补到 6 个入口 | 事实 A21f/A22f；S7、S8 |
+| 14  | High   | revision 栅栏挡不住同连接乱序；`run` 返回 `()` 却声称同步刷新       | 引入两级机制；`run` 改返回 `CoreStatusView` 并在同一消息处理内提交                                   | RQ-02；S3              |
+| 15  | Medium | latch 在 `recover` 成功时复位（`recover` 只清 quarantine）          | 复位条件收紧为"观察到活跃态"或"backend 身份变化"两条                                                 | D5                     |
+| 16  | Medium | parity 允许裸 `#[ignore]`；fake-core barrier 未规划                 | 见第三轮 #21/#22（v3 未完成，第四轮补齐）                                                            | S12.1 / S12.2          |
+
+**第三轮（v3 → v4）发现的处置：**
+
+| #   | 级别   | 问题                                                                                | 处置                                                                                                                                                                                                                                                  | 落点                     |
+| --- | ------ | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| 17  | Medium | Service 判定改对了但**没加测试**                                                    | T-BK-10（6 个 `CoreStateDetail` 变体 + `None` 共 7 例，表驱动）、T-BK-11（stop 竞态到 `not_started`）                                                                                                                                                 | S12 测试表               |
+| 18  | High   | 穿线仍只列 2 个消费者；适配器 core-type 来源仍未解决                                | S8(3) 换成 6 行表（含 `control.rs:97/225/320` 与其 IPC 入口）；S7 增 `CoreLifecycleAdapter` 三依赖定义                                                                                                                                                | S8、S7                   |
+| 19  | High   | 观察版本协议**对流式帧不可实现**（第 2 帧起会被自己的栅栏误杀）                     | 拆成两套：推送帧只带 `ConnectionId`、actor 自增版本；`RefreshToken` 只用于请求/响应。加 T-RV-08 作回归钉                                                                                                                                              | RQ-02；S5；T-RV-04/06/08 |
+| 20  | Medium | 无生产 sink 实现；`phase`/`message` 未定；latch 读投影后的两值状态看不见 `Starting` | 定义 `TauriCoreDegradationSink` + 四字段 DTO 表；**新增 `DegradationPhase::CoreLifecycle` 变体**（leader 2026-08-02 裁定：`RuntimeApply` 是语义谎言，接受一处声明在案的 bindings 新增）；latch 改为**投影前**读 crate-private 忠实视图。加 T-BK-12/13 | D5；S12 测试表；S13      |
+| 21  | Medium | S12.1 停留在 v2（未规划 barrier / 端口 / 环境）                                     | 推荐新增不需父进程 barrier 的 `manager-probe-core` bin；备选路径写全 6 步 barrier 生命周期与串行化要求                                                                                                                                                | S12.1                    |
+| 22  | Medium | S12.2 仍允许裸 `#[ignore]`                                                          | CI 支持平台必须常规运行；确需跳过则必须配显式门禁脚本**且进 CI**                                                                                                                                                                                      | S12.2                    |
+| 23  | —      | **（自查）** `run()` 的返回类型与 S3 方法表不一致                                   | S3 的 `run` 签名同步改为返回 `CoreStatusView` 并加注释说明原因                                                                                                                                                                                        | S3                       |
+| 24  | Low    | T-BK-08 同模式换槽可能 no-op（假阳性）                                              | 改 Local→Service→Local，并断言 backend 身份确实变化（构造计数 / `Arc::ptr_eq` 判否）                                                                                                                                                                  | S12 测试表               |
+| 25  | Low    | S9 陈旧路由（`Start` 消息、`resolve.rs` 的 `Stop`）                                 | 改为 `Run { request }` / "按 S11 删除该行停核"                                                                                                                                                                                                        | S9                       |
+| 26  | Low    | `runtime_path` 措辞说 app 读不到（Local 其实读得到）                                | 改为"为保持与 IPC 同构的单一表示、不泄漏 runtime 内部路径而丢弃"；不可访问性只对 Service 侧成立                                                                                                                                                       | RQ-02                    |
+| 27  | Medium | `core_client()` 是内部 client 访问器，不是领域 facade                               | **leader 裁定**：改为 `NyanpasuClient::update_core(core_type)` 领域方法，不暴露访问器                                                                                                                                                                 | S9.1                     |
+| 28  | Low    | 文档版本与处置表未推进                                                              | 本节（三轮全覆盖）+ 头部 v4                                                                                                                                                                                                                           | 头部、§0.1               |
+
+**第四轮（v4 → v5）发现的处置：**
+
+| #   | 级别   | 问题                                                                                | 处置                                                                                                                          | 落点                  |
+| --- | ------ | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| 29  | —      | **（自查）** Exit 判据仍写 `T-BK-01…09`，把新增的 latch/DTO/判定测试排除在验收外    | 改为 `T-BK-01…13`                                                                                                             | §5 Exit 表            |
+| 30  | High   | 消息集缺 `ConnectionOpened` / `RefreshCompleted`；S5 注释仍写"必须带 token"自相矛盾 | 补两条消息 + 三步激活顺序；注释改为"只带连接身份、actor 自增 version"；慢刷新独立 `tokio::spawn` 回投，不阻塞 mailbox         | S5；RQ-02；T-RV-09/10 |
+| 31  | High   | `Run` 前排队的当前连接帧会覆盖 post-run 提交，T-RV-07 失效                          | **把 `Run` 当作一次连接轮换**：调 backend 前先换 `ConnectionId`，早于该点排队的帧全部作废。T-RV-07 重定向到该交错             | RQ-02；T-RV-07        |
+| 32  | High   | S8 仍写 `core_client.as_lifecycle_port()`，少 `ApplicationClient` / `RuntimePaths`  | 构造行改 `CoreLifecycleAdapter::new(core, application, runtime_paths)`；S7 开头改为"由适配器实现"而非"给 CoreClient 实现"     | S7；S8                |
+| 33  | High   | 三个 service IPC 命令拿不到私有 `CoreClient`（且正确地禁止访问器）                  | **leader 裁定**：facade 加 `install_service` / `start_service` / `restart_service` 三个领域方法；命令退化为薄适配器           | S8(4)                 |
+| 34  | Medium | fake-core 备选路径**是错的**——RELEASE 即退出，release 后 HTTP 服务已消失            | **leader 裁定**：整段删除，`manager-probe-core` 为唯一 parity 路径；保留一段"为何无效"的说明防止重蹈                          | S12.1                 |
+| 35  | Medium | `message` 截断规则与 T-BK-13 互相矛盾                                               | **leader 裁定**：整条最终 message 上限 512 字节，只截 reason 段，按 UTF-8 字符边界并补 `…`                                    | D5 DTO 表             |
+| 36  | Low    | 两处仍要求 bindings **完全**零 diff，与 S13 的"恰好新增 `core_lifecycle`"矛盾       | 两处改为"除已声明的 `core_lifecycle` 联合成员外无其它 diff"                                                                   | S8；S9.1              |
+| 37  | Low    | Exit / RQ 摘要未点名 T-RV-08 与 T-SM-01/02                                          | RQ-02 摘要改 `T-RV-01/02/03a/03b/05/06/07/08`；Exit 表逐项点名并新增一行 seam 回归判据                                        | RQ-02；§5 Exit 表     |
+| 38  | Low    | 回滚/提交切分仍以 "改 fake-core 加 `/version`" 为主语，未覆盖新 bin 路径所需文件    | 回滚清单补 `manager_probe_core.rs` / `Cargo.toml` `[[bin]]` / `control.rs` / `runtime.rs` / `event_sink.rs` 等；commit 1 改名 | §6 回滚；§7 切分      |
+
+**第五轮（v5 → v6）发现的处置：** 剩余缺口全部集中在一个子系统，因此本轮改为**整体规范化**而非继续打补丁——新增 **§2.1「观察协议规范」**（状态表 × 消息集 × 转换规则 R1–R7 × 不变量 I1–I3），RQ-02 / S3 / S5 一律改为引用。
+
+| #   | 级别   | 问题                                                                             | 处置                                                                                                                                                       | 落点               |
+| --- | ------ | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| 39  | High   | `Run` 轮换后旧订阅任务永远盖死 ID，此后推送全被丢弃                              | **裁定**：每次 `Run`（成功**或**失败）后 cancel + restart 订阅，新任务重新握手 = §2.1 **R6** / 不变量 **I1**                                               | §2.1；T-RV-11      |
+| 40  | High   | `ConnectionOpened` 无世代栅栏；被取消任务的握手可能"复活"                        | **裁定**：加 `subscription_epoch`，回 `Result<ConnectionId, StaleSubscription>` = §2.1 **R1**；join 不清 mailbox 已写明                                    | §2.1；T-RV-12      |
+| 41  | High   | 握手 await 不可取消 → SetBackend join 任务、任务等 handler 的死锁                | **裁定**：`tokio::select!` + cancel token = §2.1 **R7**                                                                                                    | §2.1；T-RV-14      |
+| 42  | High   | `status()` 的读语义未定（缓存 vs 等刷新）                                        | **裁定**（design §6）：一律返回缓存 watch 快照；`RefreshCompleted` 无 caller reply port，纯内部缓存维护 = §2.1 **R5/I3**                                   | §2.1；T-RV-13      |
+| 43  | High   | D5 要求投影前的忠实生命周期，但没有任何类型承载它                                | 引入 crate-private `BackendObservation { view, lifecycle }`，贯穿推送帧 / `RefreshCompleted` / `run()` 返回值                                              | §2.1.3；S3         |
+| 44  | High   | facade 漏 `stop_service`；且是 `control::*` 直通而非完整 typed 事务              | 补齐**六个**方法（四 service + `core_status` + `restart_core`），写出完整事务；**保留**"控制失败仍尝试拉核"的既有语义                                      | S8(4)；T-FA-01…04  |
+| 45  | Medium | parity 会定位到错误的二进制；gate 命令在无 Cargo.toml 的仓库根执行               | 新增 `resolve_probe_bin_path` / `require_probe_bin_path` 具名 resolver；gate 改 `--manifest-path .ackend\Cargo.toml -p fake-core --bin manager-probe-core` | S12.1；S13         |
+| 46  | Low    | T-RV-07 在单 FIFO mailbox 下不可构造                                             | 重定向到可构造交错（backend 内轮换后 barrier 暂停 → 投旧 ID 帧）                                                                                           | T-RV-07            |
+| 47  | Low    | T-RV-09/10 未进摘要与 Exit；风险表仍写已删除的"路径 A/B"                         | 范围改 **T-RV-01/02/03a/03b/05/06/07/08**；风险行改写为单一探针 bin 路径                                                                                   | RQ-02 摘要；§5；§6 |
+| 48  | —      | **（自查）** S2 仍写请求路径来自 `dirs::*()`，与 S7 的注入式 `RuntimePaths` 冲突 | S2 改为"路径一律来自注入的 `RuntimePaths` / `PathResolver`，禁 `dirs::*()`；core type 来自 typed 快照"                                                     | S2                 |
+
+**第六轮（v6 → v7）：leader 范围裁定 + 幸存发现。**
+
+> **裁定：5a 整体移除推送式观察。** 六轮审查的发现高度集中在同一子系统（订阅流 / 连接身份 / 陈旧帧栅栏），v6 的 §2.1 规范化仍被查出"协议自身会接受它本该拒绝的陈旧帧"。依据 task.md：**"status read 不走 mailbox RPC" 与 watch 投影明确写在 C1 卡**，A1–A3 与 A-Exit 无一需要实时推送。因此把整套机制移出 5a——**陈旧帧问题在没有推送流时不存在**。新模型见 §2.1（两个观察来源 + guard 下刷新 = 构造上无竞态）。
+
+| #   | 级别   | 问题                                                                                                                        | 处置                                                                                                                                       | 落点              |
+| --- | ------ | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------- |
+| 49  | High   | §2.1 协议会接受本该拒绝的陈旧帧；取消/watch/观察类型/请求路径/健康检查依赖均不可实现                                        | **范围裁定**：整套推送机制移出 5a（七审确认 #1–#5 MOOT）。**注**：#6 观察载荷**未**随之消失，见第 56 行                                    | §2.1              |
+| 50  | High   | S2 的注入式请求路径不可实现（`RuntimePaths` 缺 binary/pid/working-dir；`find_binary_path` 调 `dirs::*`；字段名应为 `core`） | 新增 `CoreRequestFactory`（持 `PathResolver` + `RuntimePaths`），resolver 版二进制查找；`snapshot.core` + 显式 `ClashCore → CoreType` 转换 | S2；S7；S8        |
+| 51  | High   | 健康检查只穿 `CoreClient`，凑不齐 typed 快照与请求路径                                                                      | 改穿 `CoreModeReconciler{core, application, requests}`，四个调用者共用                                                                     | S8(3)             |
+| 52  | High   | facade 伪码里快照/guard/SetBackend/请求构造仍用 `?`，会顶替控制结果                                                         | 整个对账块捕获成一个 `Result`，块内**一律不 `?`**；`control?` 最后抛；新增可注入 `ServiceControlOps` seam 供 T-FA 制造控制失败             | S8(4)；T-FA-01…05 |
+| 53  | Medium | S9 仍让命令层直接调 `CoreClient`，与 S8 的私有边界及 T-FA-04 矛盾                                                           | S9 表全部改为 facade 目标；facade 领域方法总计 **7 个**                                                                                    | S9                |
+| 54  | Medium | `NoBackend { last_error }` 无法从 actor 状态复现                                                                            | 槽位显式建模为 `BackendSlot::{Ready, Failed{error}}`                                                                                       | S5；D2            |
+| 55  | Low    | 清单陈旧：`fake-core/src/lib.rs` 未进回滚/commit 1；"三个 service 命令"                                                     | 两处清单补齐；计数改为四个                                                                                                                 | §6；§7；S8        |
+
+**第七轮（v7 → v8）：模型获认可，补齐实现契约。** 七审确认"no-push + mailbox 串行"模型可行，round-6 #1–#5 判 MOOT；剩余为完成度缺口。
+
+| #   | 级别   | 问题                                                                                                    | 处置                                                                                                                                         | 落点                |
+| --- | ------ | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| 56  | High   | `RefreshStatus` 无 `OperationId`，§2.1 的结构论证只是文字                                               | **裁定 A**：`RefreshStatus { operation: Option<OperationId> }` + 两条准入规则（`Some` 须等于 active；`None` 仅 gate 空闲时执行，否则回缓存） | §2.1.2；T-RV-06     |
+| 57  | High   | D5 的"下次 UI 读取即观察到耗尽"没有实现机制                                                             | `core_status()` 走 `None` 路径，gate 空闲时真查 backend——权衡变成**已实现机制**，弱化措辞删除                                                | §2.1.3；D5；T-RV-09 |
+| 58  | High   | `FaithfulLifecycle` 无定义；`run/stop/recover/status` 签名与 `BackendObservation` 矛盾                  | 定义归一化枚举 + 两侧映射表（含 `detail` 缺失的降级）；四个方法统一返回 `BackendObservation`，`observe_status()` 改 async                    | §2.1.4；S3          |
+| 59  | High   | `CoreRequestFactory` 仍不可完全注入（`PathResolver::app_install_dir` 走 `dirs::*`）；Updater 路径不存在 | 抽 `CoreBinaryResolver` 可注入策略；工厂 `derive(Clone)` 并存入 `Inner`；Updater 由 facade 递交**已构造的** `CoreRequest`                    | S2；S8；S9.1        |
+| 60  | High   | `ServiceControlOps` 声明了但没接进对象图                                                                | 四步注入链：`ClientSetupArgs` → `Inner` → `setup.rs` 生产适配器 → facade 调注入 ops                                                          | S8(4)               |
+| 61  | Medium | 六行穿线表仍写裸 `CoreClient`                                                                           | 四行改为 `CoreModeReconciler`；`spawn_health_check` 签名同步                                                                                 | S8(3)               |
+| 62  | Medium | `BackendSlot` 无法表达换槽瞬态；错误不可克隆                                                            | **裁定 B**：`Option<BackendSlot>`，`Failed { error: Arc<CoreBackendError> }`                                                                 | S5；D2              |
+| 63  | Medium | v6 残留：三来源措辞、`/ws/events`、旧测试范围、RQ-04 的"不走 mailbox"                                   | 定点清扫；测试清单固定为 **T-RV-01/02/03a/03b/05/06/07/08 + 09**                                                                             | RQ-02；S3；S12；§5  |
+
+**第八轮（v8 → v9）：watch 投影回归 + 收尾。**
+
+> **裁定 A-v2**：v8 让 `status()` 走 mailbox RPC，八审指出这在慢操作（apply 30–80 s）期间会让所有读排队超时——**这正是 design.md §6 当初指定 watch 读的原因**。第七轮砍掉的是 **backend→actor 推送流**（订阅/连接/栅栏，仍归 C1）；**actor→client watch 投影**是单写入者、无并发危害、约 30 行，从来不是有争议的部分，因此接回 5a。
+
+| #   | 级别   | 问题                                                                     | 处置                                                                                                                                                                         | 落点                |
+| --- | ------ | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| 64  | High   | mailbox 串行下慢操作期间一切读排队超时（活性缺陷）                       | **裁定 A-v2**：actor 持 `watch::Sender`，每次提交发布；`status()` = 同步 watch 克隆，零 mailbox；删 `CORE_READ_TIMEOUT`                                                      | §2.1.1；S6；T-RV-10 |
+| 65  | High   | `RefreshStatus` 的 reply 类型与调用形态未分化                            | 拆成守卫 `call`（必填 `OperationId`）与 UI `cast RefreshHint`（空闲才处理，否则丢弃）；定义 `CoreActorError` 四变体                                                          | §2.1.3；S5；T-RV-06 |
+| 66  | Medium | S5 仍有第三个 `RefreshStatus` / watch 读；缓存只存投影后的视图           | 删 `RefreshStatus` / watch 读；缓存改存完整 `BackendObservation`（保留忠实 lifecycle）；加 `status_tx`                                                                       | S5                  |
+| 67  | Medium | T-BK-09 期望 `None`，与"`None` 仅瞬态"矛盾                               | 改为期望 `Some(BackendSlot::Failed { error })`                                                                                                                               | T-BK-09             |
+| 68  | Medium | 工厂未单次构造入 `Inner`；updater 仍有两处 legacy 查找；健康检查无注入根 | 工厂在 block 内一次构造后 clone；updater 用 request 的 typed `core_type` 比较（删两处查找）；健康检查根落在 `resolve.rs:152` 的 facade 入口，两处 `Config::verge()` 改为传值 | S8；S9.1            |
+| 69  | Low    | RQ-02 来源表重复且写"三条"；Exit 未含 T-RV-09/10                         | 表去重为两条；Exit 与摘要同步                                                                                                                                                | RQ-02；§5           |
+
+**第九轮（v9 → v10）：最窄一轮，全部局部。**
+
+| #   | 级别   | 问题                                                                                                                 | 处置                                                                                                                                                                                                                | 落点              |
+| --- | ------ | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| 70  | High   | watch 接线不可编译：无通道创建点、`CoreClientInner` 缺 receiver、`CoreActorArgs` 缺 `status_tx`、无 `refresh_status` | 新增 §2.1.7：通道在组合根创建、`Sender` 进启动参数、`Receiver` 进 client；给出 `status()` / `refresh_status()` / `hint_refresh()` 全签名与初值语义；单一 `commit()` helper；`None`/`Failed`/shutdown 三种合成观察表 | §2.1.7            |
+| 71  | High   | **round-7 的"预构造请求"裁定制造了陈旧竞态**：`replace_core` 在下载/解压**之后**才跑，调用时刻的快照可能已过期       | **推翻该裁定**：注入窄 `CoreRequestProvider`，请求在**替换 guard 内**解析；Updater 只带目标 core type                                                                                                               | S9.1；T-RV-15     |
+| 72  | High   | `BackendObservation` / `FaithfulLifecycle` 未 `Clone`，actor 无法既留存又回传                                        | 三个类型（含 `CoreStatusView`）补 `#[derive(Clone)]`                                                                                                                                                                | §2.1.5；§2.1.7    |
+| 73  | Medium | `RefreshHint` 无去重，空闲期会积压 N 次查询                                                                          | 共享 `Arc<AtomicBool>` pending 位：client CAS 后才 `cast`，actor 处理开头清位；登记为唯一跨边界共享量                                                                                                               | §2.1.6；T-RV-14   |
+| 74  | Medium | 最终一致性未写明例外                                                                                                 | 明确 D3 的 out-of-actor `put_configs` **不发布**，靠后续 idle hint 恢复；随 B3 消失                                                                                                                                 | §2.1.6.1；T-RV-13 |
+| 75  | Medium | `None` 瞬态与 shutdown 的发布无测试钉                                                                                | T-RV-11 / T-RV-12 用 barrier 断言两处都发布                                                                                                                                                                         | T-RV-11/12        |
+| 76  | Low    | T-RV-10 写成阻塞 `apply`（D3=A 下 apply 不占 handler）；v8 措辞残留；模块路径 `pub mod client` 有误                  | T-RV-10 改为阻塞 `Run`；措辞与 C1 指针清扫；`actor/mod.rs` 不声明 `pub mod client`（typed client 在 `client/core.rs`）                                                                                              | 多处              |
+
+**第十轮（v10 → v11）：附录 A 落地 + 运行身份归位。**
+
+> **反漂移机制**：v3 起反复出现"同一类型在不同小节写成不同字段"的缺陷，逐轮打补丁只会再生。v11 新增 **附录 A**——5a 全部类型与构造顺序的**唯一声明处**，其余小节一律引用。
+
+| #   | 级别   | 问题                                                                                                                                   | 处置                                                                                                                             | 落点          |
+| --- | ------ | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| 77  | High   | 对象图自相矛盾：`CoreClientArgs` 未定义、`CoreActorArgs` 与 S8 传参不符、`status_rx` 缺失                                              | **附录 A**：A.1 单点声明全部类型，A.2 列 `ClientSetupArgs` 新增字段，A.3 给编号构造序列；§2.1.7 / S5 / S6 / S8 改为引用          | 附录 A        |
+| 78  | High   | **Updater 与 lease 都把 typed desired 当成实际运行身份**：`change_core` 在 legacy 里改核、`restart()` 之后才重播 typed，读快照必得旧核 | A.4 两条互补修法：lease 从 `check_and_promote` 记住 `target_core` 供 `restart()` 消费（回滚覆写）；Updater 查 actor 的 `running` | S7；S9.1；A.4 |
+| 79  | Medium | `hint_pending` 只在 §2.1.6 出现，接线处缺失                                                                                            | 进附录 A（args/state/inner 三处同名字段）；CAS-before-cast、失败重置、handler 入口清位写进 §2.1.7                                | A.1；§2.1.7   |
+| 80  | Medium | T-RV-12 可从初值假通过                                                                                                                 | 改为先提交可区分的 running 观察、持 receiver、断言 `changed()` + 终值                                                            | T-RV-12       |
+| 81  | Medium | 合成观察字段不完整；`initial()` 缺 `run_type`                                                                                          | A.5：统一为"克隆上次 view，只改表列字段"；`initial()` 明确 `run_type = RunType::default()`，T-RV-16 断言 legacy 等价             | A.5；T-RV-16  |
+| 82  | Low    | 可见性规则内部不一致                                                                                                                   | A.6 给出判定口径：类型可见性 ≥ 其出现的最宽签名                                                                                  | A.6           |
+| 83  | Low    | v10 措辞残留（`Run / apply`、`run()` 返回类型、C1 归属）                                                                               | 定点清扫                                                                                                                         | 多处          |
+
+**第十一轮（v11 → v12）：编译面收口。**
+
+| #   | 级别   | 问题                                                                                                                                                     | 处置                                                                                                                                                                                     | 落点                  |
+| --- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| 84  | High   | `CoreBackendError` / `OperationError` 被全篇引用却从未定义；`CoreActorError` 缺 `Debug+Error`（Updater 用 `?` 进 `anyhow`）；模块树缺 `request` / `gate` | 新增 **A.1b**（三个错误枚举 + `thiserror` 派生 + 可转换性说明）与 **A.1c**（模块树与 `pub(super)` 可见性）                                                                               | A.1b；A.1c            |
+| 85  | High   | `CoreRequestProvider::running()` 不带 `OperationId`，也没有对应 actor 消息；`state.running` 在换槽/失败/崩溃后陈旧                                       | **裁定**：删除该 trait，改守卫消息 `RunningIdentity { operation, reply }` + `CoreClient::running(&guard)`；A.4 给出 `running` 的**六行生命周期表**（含观察到终止态即清空）与三种查询处置 | A.4；S9.1；T-AD-04…07 |
+| 86  | Medium | 可见性规则被自身声明违反                                                                                                                                 | `ServiceControlOps` 与 `ClientSetupArgs.service_control` 收窄为 `pub(crate)`（参数含 crate-private 的 `CoreModeReconciler`）；`CoreRequestProvider` 随 #85 消失；A.6 重写                | A.6                   |
+| 87  | Low    | 编辑残留（已删消息、`run()` 返回类型、backend `status()` 名、Exit 测试清单）                                                                             | 定点清扫；Exit 补 T-RV-16 与 T-AD-01…03                                                                                                                                                  | 多处                  |
+
+**第十二轮（v12 → v13）：纯文档 lint，行为级发现连续两轮归零。**
+
+| #   | 级别 | 问题                                                                                       | 处置                                                                                                                                 | 落点        |
+| --- | ---- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| 88  | Lint | `ServiceControlOps` 缺右花括号；`OperationGate` 经 `pub(crate)` 重导出被拓宽               | 补花括号；改为 `use gate::OperationGate;`（私有）+ 仅重导出 `OperationError`                                                         | A.1 / A.1c  |
+| 89  | Lint | v12 关于 `Arc<T: Error>` 的说明**写反了**                                                  | **已用 `rustc` 最小探针实测**：std 确有 `impl<T: Error + ?Sized> Error for Arc<T>`，`#[error(transparent)]` 可用；删除错误的回退告诫 | A.1b        |
+| 90  | Lint | provider 删除不彻底：链路图/manager 签名/facade 仍是三参                                   | 全链改两参；S9.1 叙述改为"guard 内向 actor 查询运行身份"                                                                             | S9.1        |
+| 91  | Lint | 附录漏声明 `CoreClient` / `CoreOperationGuard` / 两个 adapter / 消息枚举 reply 类型        | 新增 **A.1d**（client 与 adapter，含全部方法可见性）与 **A.1e**（完整消息枚举，真实 reply 类型 + `RunningIdentity`）；S5 改引用      | A.1d / A.1e |
+| 92  | Lint | A.6 与 S2 的 `CoreBinaryResolver` 可见性矛盾                                               | 按 A.6 的"注入点公开"规则统一为 `pub`；`ServiceControlOps` 维持 `pub(crate)`（参数含 crate-private 类型）                            | A.6 / S2    |
+| 93  | Lint | 残留：`NoBackend` 归属写成 `CoreBackendError`；`NotRunning` 变体因 `Ok(None)` 语义而死代码 | 归属更正为 `CoreActorError::NoBackend`；**删除** `NotRunning`（而非保留待用）                                                        | :518；A.1b  |
+
+> **终止决定（leader，2026-08-02）**：v13 为**最终修订轮**。此后由 leader 亲自核验被引用的站点并关闭双审门，**不再发起第 13 轮 codex 文档审**。理由：(1) 该缺陷类（花括号、可见性、声明遗漏）的权威裁决者是实施期的 `cargo check`，不是文档审；(2) 设计自 v10 起未再变动，行为级发现连续两轮为零；(3) 文档 lint 的边际收益已为负。实施指令将带首步指令——**先把附录 A 的骨架编译通过，再写任何逻辑**——让 rustc 兜住 markdown 审查漏掉的部分。
+
+> 对 #9 的一点澄清：审查说"`ConfigRevision` 比 `RevisionId` 多了 `source_hash` 和 `runtime_path`"——这是拿 `ConfigRevision` 与 `RevisionId` 比。原文 RQ-02 里"多一个 `runtime_path`"是拿 `ConfigRevision` 与 **`ConfigRevisionInfo`** 比，那句本身成立。**但结论一致**：原 T-RV-03 把两个不同的转换混成一句，断言不成立，必须拆开。已按建议拆分。
+
+---
+
+## 0. 本阶段的边界
+
+**做（= task.md A1/A2/A3）：**
+
+1. 封闭 `CoreBackend` enum，`Local` 包装 `nyanpasu_core_manager::CoreManager`，`Service` 持有实例化的 `nyanpasu_ipc::client::Client`；
+2. 取消安全的 `OperationId` / `OperationGate` / `CoreOperationGuard`，client 侧预分配 ID；
+3. `CoreClient` 通过既有 `CoreLifecyclePort` / `CoreLifecycleLease` seam 接入，组合根注入，start/stop/restart/status 改走 actor；
+4. 删除 legacy `CoreManager::lifecycle_lock` 与**两条**裸线程递归 recover；
+5. **把 Updater 的核心依赖显式化**（`replace_core` 改用注入的 `CoreClient` + operation guard）——这不是范围扩张，是 S10 删除 legacy lease API 的**编译必要条件**，见 S9.1。
+
+**不做（越界即返工）：**
+
+- 不改 apply 管线语义（`check_and_promote` / `apply_candidate` / `apply_promoted` 的**实现路径**保持现状，见决策点 D3）；
+- 不动 `rebuild_gate` / `clash_patch_gate` / `RuntimeLifecycleStore` / `publish_promoted` / `publish_applied` / `restore_promoted`（全部是 B1/B2/B3 的范围）；
+- 不改 `change_core` 的编排与回滚（B4）；
+- 不删除 `RunningConfigPatchPort` / `LegacyRunningConfigPatchBridge`（B3）；
+- **不做 UpdaterActor**，也不加 `attach_core_port` 全局桥——S9.1 只把 core 依赖显式注入，`UpdaterManager::global()` 仍是 PR-6d 的 residual；
+- **不迁移 macOS DNS**（`feat.rs:392`）——allowlist 到 PR-5c / C3，见 S9.2；
+- 不做日志 ring / watch 投影 / `set_mode` / `reconcile_mode`（C1–C2）；
+- 不删除 5 s 健康轮询线程与 `IPC_STATE` static（C2）；
+- 不改 `get_core_status` 的 wire 形状（C1 才做 additive 扩展）；本阶段唯一的 wire 变化是`DegradationPhase` 新增 `CoreLifecycle` 变体（D5，backend-only，不动前端）。
+
+---
+
+## 1. 已核验事实
+
+> 全部为本次会话直接读源码所得。`nyanpasu-runtime` submodule 确认在 tag `v2.0.0-rc.1`（`git -C backend/nyanpasu-runtime describe --tags HEAD`）。
+> 下表 `RT/` = `backend/nyanpasu-runtime/`，`APP/` = `backend/tauri/src/`。
+
+### 1.1 runtime 侧（`nyanpasu-core-manager` @ v2.0.0-rc.1）
+
+| ID  | 事实                                                                                                                                                                                                                                                                                                                                                                                                       | 锚点                                                                                                               |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| R1  | 构造是 **async** 且 **runtime_dir 必填**：`pub async fn new(options: ManagerOptions) -> Result<Self, Error>`；缺 `runtime_dir` 返回 `Error::InvalidManagerOptions("runtime_dir is required")`                                                                                                                                                                                                              | `RT/crates/nyanpasu-core-manager/src/manager/mod.rs:212`、`:218-221`                                               |
+| R2  | **构造会取运行目录独占锁**，失败返回 `Error::RuntimeDirectoryOwned(path)`；同时校验 controller 模板、拒绝零超时、清扫孤儿 epoch、拉起 JSONL log sink                                                                                                                                                                                                                                                       | `manager/mod.rs:223`、`:229-274`                                                                                   |
+| R3  | `ManagerOptions::default()` 的 `local_ipc_policy` **已经是 `LocalIpcPolicy::Disable`**（`spec.rs:114`，`spec.rs:154-162` 有单测钉住）。A1 要求的"显式写出"是可审性要求，不是行为修复                                                                                                                                                                                                                       | `RT/crates/nyanpasu-core-manager/src/spec.rs:65-128`                                                               |
+| R4  | **`CoreManager` 不是 `Clone`**（`struct CoreManager { inner: Arc<Inner> }`，未派生 Clone）→ app 侧必须 `Arc<CoreManager>`                                                                                                                                                                                                                                                                                  | `manager/mod.rs:87-89`                                                                                             |
+| R5  | 生命周期方法全部 `&self` + async，错误类型 `nyanpasu_core_manager::Error`：`start(InstanceSpec)`、`stop()`、`check_config(&InstanceSpec)`、`shutdown()`、`restart() -> SwitchOutcome`、`switch(InstanceSpec) -> SwitchOutcome`                                                                                                                                                                             | `manager/mod.rs:319,438,509,541`；`manager/switching.rs:45,52`                                                     |
+| R5b | **`switch(spec)` 同时覆盖"未跑"与"在跑"两种情形**，是唯一 request-bearing 的运行迁移原语：`switch_locked` 先判 running；**不在跑** → 清理 stale epoch 后 `start_locked(ctrl, spec)`，返回 `SwitchOutcome::Hard { reason: NoBackend }`；**在跑** → 按能力选 graceful（零停机）或 hard switch。这与 legacy `run_core_with_lease` 的"在跑就先停再按请求启动"语义**完全对应**，且更优                          | `manager/switching.rs:52,58-103`                                                                                   |
+| R5c | 反之 `start(spec)` 在核心已在跑时**直接返回 `Error::AlreadyRunning`**；`restart()` 依赖 `ctrl.last_spec`，全新 backend 上返回 `Error::NotStarted`。二者都**不能**充当"按请求运行"原语                                                                                                                                                                                                                      | `manager/mod.rs:319-328`；`manager/switching.rs:45-49`                                                             |
+| R6  | **没有 `recover()`**；实际名字是 `recover_quarantine() -> Result<(), Error>`，语义是"清除 quarantine 闩锁"，不是"重启核心"                                                                                                                                                                                                                                                                                 | `manager/quarantine.rs:18`                                                                                         |
+| R5d | **wire `CoreState` 是有损两值投影**：上游 doc 原文"it reports `Starting` and `Restarting` as `Stopped(None)`, so a crash loop is indistinguishable from a real stop"。**忠实视图只在 `CoreStateDetail` 里**（`Stopped` / `Starting` / `Running` / `Restarting` / `Switching` / `Stopping`），经 `CoreInfos.detail` 送达。因此 Service 的"是否在跑"判定**必须读 `detail`**，读 `state` 会把过渡态误判成已停 | `RT/nyanpasu_ipc/src/api/status.rs:107-122,133-141`                                                                |
+| R6b | **`shutdown()` 不释放运行目录锁**。锁是 `RuntimeDirectoryLock { _lock: atomic_fs::DirLock }`（文件系统目录锁），作为 `_runtime_lock` 字段挂在 `Inner` 上并**声明在最后**（注释："so ordinary Inner destruction drops instances/tasks before releasing directory ownership"）。因此它只在**最后一个 `Arc<Inner>` 被 drop 时**才释放                                                                         | `manager/mod.rs:118-124`；`config/runtime_store.rs:24-26,338-340`                                                  |
+| R7  | `apply_config(&self, input: InstanceSpec, expected_revision: Option<RevisionId>) -> Result<ApplyOutcome, Error>`——参数是**整个 `InstanceSpec` 按值**，不是配置路径；要求核心已在跑，否则 `Error::NotStarted`                                                                                                                                                                                               | `manager/apply.rs:19-23`、`:26-29`                                                                                 |
+| R8  | CAS 失败返回 `Error::RevisionConflict { expected: RevisionId, actual: Option<RevisionId> }`，且**不应用任何东西**                                                                                                                                                                                                                                                                                          | `manager/apply.rs:30-38`；`src/error.rs:43-47`                                                                     |
+| R9  | `RevisionId { epoch: u64, generation: u64, effective_hash: String }`，**不是 `Copy`**；由 `ConfigRevision::id()` 取得，`ConfigRevision` 挂在 `CoreStatus.revision: Option<ConfigRevision>` 上；**没有 `CoreManager::revision()` 访问器**                                                                                                                                                                   | `src/state.rs:143-167`、`:189`                                                                                     |
+| R10 | 状态与日志订阅：`subscribe() -> watch::Receiver<CoreStatus>`、`subscribe_logs() -> broadcast::Receiver<Arc<LogFrame>>`（容量 256，可在首次 `start()` 前调用）、`status() -> CoreStatus`                                                                                                                                                                                                                    | `manager/mod.rs:292,296,308`；`src/log.rs:16`                                                                      |
+| R11 | 本地 `ApplyOutcome` 有 7 个分支：`Noop` / `Patched` / `Reloaded` / `Restarted` / `Switched` / `RolledBack{failed_apply}` / `DurabilityUncertain{outcome, warning}`。**`Warning` 是包装器不是 outcome**（印证 RQ-03）                                                                                                                                                                                       | `manager/mod.rs:57-85`                                                                                             |
+| R12 | 供抄写的 outcome 映射参考实现：`map_apply_outcome`（把 `DurabilityUncertain` 拆成 `CoreApplyData.warning`，可嵌套两层、用 `"; "` 拼接）                                                                                                                                                                                                                                                                    | `RT/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs:605-639`                                          |
+| R13 | **manager 自身已做有界重启 + 指数退避**（委托 `nyanpasu_utils::process::Supervisor`）：`InstanceOptions.restart_policy` 默认 `OnFailure{max_restarts: 5}`、`backoff` 默认 `exponential(1s, 30s).with_jitter()`；另有**不可通过 `InstanceOptions` 配置**的 storm guard（默认 5 次/5 分钟）                                                                                                                  | `src/spec.rs:31-50`；`src/instance.rs:229-237`；`RT/crates/nyanpasu-utils/src/process/supervisor.rs:36-55,431-466` |
+| R14 | **恢复耗尽没有 typed 信号**——唯一机器可读线索是 `CoreState::Stopped { reason: Some(StopReason::Error(msg)) }` 且 `msg` 以 `"core kept crashing; restart budget exhausted\n"` 开头；上游自己的测试也在字符串匹配                                                                                                                                                                                            | `src/instance.rs:631-641`；`RT/.../tests/instance_lifecycle.rs:246-252`                                            |
+| R15 | 第二个不可恢复闩锁是 **quarantine**：`Error::StopUnconfirmed` → `latch_quarantine`，此后所有受门操作（start/switch/restart/apply）都被拒，直到 `recover_quarantine()` 成功。`stop()`/`shutdown()` 故意绕过该门                                                                                                                                                                                             | `manager/quarantine.rs:8-13`；`manager/mod.rs:434-437,537-540`                                                     |
+| R16 | **`Error::kind()` 在本 tag 不存在**（整个 crate 没有 `impl Error` 块）。可用的机器可读分类是：ipc 侧的 `nyanpasu_ipc::api::error_kind` 字符串常量表 + 一个**私有**映射函数 `map_error_kind`（位于 `nyanpasu-service-runtime`，app 不依赖该 crate）                                                                                                                                                         | `RT/nyanpasu_ipc/src/api/mod.rs:38-66`；`manager_bridge.rs:646-665`                                                |
+| R17 | 可抄的测试脚手架：`tests/common/mod.rs` 的 `fast_options()`（`max_restarts: 2`、50ms→200ms backoff、50ms 健康间隔）、`wait_for_state()`、`wait_for_health()`、`utf8_tempdir()`。fake core 是**该 crate 自己的 `[[bin]]`**，app 侧**拿不到** `CARGO_BIN_EXE_*`                                                                                                                                              | `RT/crates/nyanpasu-core-manager/tests/common/mod.rs:18-147`；`Cargo.toml:12-15`                                   |
+
+### 1.2 runtime 侧（`nyanpasu-ipc` v2 client）
+
+| ID  | 事实                                                                                                                                                                                                                                            | 锚点                                                       |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| R18 | 可实例化构造：`Client::new(placeholder: &str) -> Result<Self>`；`Client` 是 `Clone + Debug`。`service_default()` 仍在（`OnceLock`），A1 禁止使用它                                                                                              | `RT/nyanpasu_ipc/src/client/mod.rs:67-99`                  |
+| R19 | 默认端点常量 `pub const SERVICE_PLACEHOLDER: &str = "nyanpasu_ipc"`；placeholder 映射为 Windows `\\.\pipe\{p}` / Unix `/var/run/{p}.sock`                                                                                                       | `RT/nyanpasu_ipc/src/lib.rs:12`；`client/mod.rs:76-79`     |
+| R20 | `apply_config(&CoreApplyReq) -> Result<CoreApplyData>`；`CoreApplyReq { core_type, config_file, expected_revision: Option<RevisionIdInfo> }`，`None` = 无条件                                                                                   | `client/shortcuts.rs:51-62`；`src/api/core/apply.rs:21-31` |
+| R21 | `check_config(&CoreCheckReq)`、`start_core(&CoreStartReq)`、`stop_core()`、`restart_core()`、`recover_core()`、`status() -> StatusResBody`、`events() -> EventStream`                                                                           | `client/shortcuts.rs:26-110`                               |
+| R22 | `Client::recover_core()` 的语义是"清 quarantine 闩锁，幂等"——与 Local 的 `recover_quarantine()` **对称**，不是"重启核心"                                                                                                                        | `client/shortcuts.rs:69`                                   |
+| R23 | `ApplyOutcomeKind` 六个 wire 分支含 **`Noop`**；`Warning` 是 `CoreApplyData.warning: Option<String>` **字段**不是分支                                                                                                                           | `src/api/core/apply.rs:34-60,70-85`                        |
+| R24 | `/ws/events` 的 `Event` 三个分支：`CoreStateChanged(CoreState)`（有损两值）、`CoreStatusChanged(CoreInfos)`（**完整快照，连接即推一次、丢事件恢复后再推、每次转换都推**）、`CoreLog(Arc<LogFrame>)`。日志与状态**无顺序保证**；连接时不重放日志 | `src/api/ws/events.rs:26-68`                               |
+| R25 | Service 侧 revision 载体是 `ConfigRevisionInfo { epoch, generation, source_hash, effective_hash }`，CAS token 是 `RevisionIdInfo { epoch, generation, effective_hash }`，由 `ConfigRevisionInfo::id()` 取得                                     | `RT/nyanpasu_ipc/src/api/status.rs:69-105`                 |
+| R26 | 错误分类在 client 侧以 `error_kind: Option<String>` 到达                                                                                                                                                                                        | `RT/nyanpasu_ipc/src/client/mod.rs:51-53`                  |
+
+### 1.3 app 侧现状
+
+| ID   | 事实                                                                                                                                                                                                                                                                                                                                                                                                          | 锚点                                                                                                                                 |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| A1f  | 既有 seam：`CoreLifecyclePort { begin() -> Box<dyn CoreLifecycleLease>, status() -> CoreStatusSnapshot, on_profile_change() }`；`CoreLifecycleLease: Send`（**不是 Sync**）有 5 个方法 `check_and_promote` / `apply_candidate` / `apply_promoted` / `restart` / `stop`                                                                                                                                        | `APP/client/core_bridge.rs:43-74`                                                                                                    |
+| A2f  | 组合根在 `setup.rs:42-55`，`core: Arc::new(LegacyCoreBridge::new(runtime_paths))` 从这里注入；`NyanpasuClient::try_new_with_args` 是 **sync fn**，内部 `tauri::async_runtime::block_on`；四个 typed actor 各自在自己的 `Client::new()` 里 `Actor::spawn`                                                                                                                                                      | `APP/setup.rs:42-61`；`APP/client/mod.rs:255-332,273`                                                                                |
+| A3f  | **`begin()` 共 10 个生产调用点**，`rebuild_gate` 在**全部 10 处都先于** `core.begin()` 获取；`patch_running_config` 是最严格的三层顺序 `clash_patch_gate → rebuild_gate → begin()`                                                                                                                                                                                                                            | `APP/client/mod.rs:1231,1276,1351-1353,1413,1429`；`APP/client/rebuild.rs:232,257,268,282,406`                                       |
+| A4f  | lease 以 **`&mut dyn`** 跨函数传递（4 处签名），并且 `patch_running_config` 把 lease **move 进 `async move` 闭包**交给 `feat::patch_clash_with_rebuild` → guard 必须 `Send` 且可移动进 boxed future                                                                                                                                                                                                           | `APP/client/mod.rs:1285-1291,1371-1400,1436-1439,1452-1459`；`APP/client/rebuild.rs:239-242`                                         |
+| A5f  | `CoreLifecyclePort::status()` **没有生产调用者**；生产状态读取仍直连 `CoreManager::global().status()`                                                                                                                                                                                                                                                                                                         | `APP/ipc.rs:403`；`APP/feat.rs:292,385`；`APP/core/service/ipc.rs:83`                                                                |
+| A6f  | `CoreLifecycleLease::stop()` **没有生产调用者**；生产停核走 `CoreManager::global().stop_core()`                                                                                                                                                                                                                                                                                                               | `APP/utils/help.rs:268`；`APP/utils/resolve.rs:288`                                                                                  |
+| A7f  | typed actor client 房规：`Clone` via `Arc<…Inner>`；每个 client 一个手写 `call` helper，把 `CallResult::{SenderError, Timeout}` 映射成显式错误；**读用 `Some(5s)`，写用 `None`**；`Drop for …Inner` 调 `actor_ref.stop(None)`                                                                                                                                                                                 | `APP/client/application.rs:17-162`                                                                                                   |
+| A8f  | 测试注入钩子已存在：`test_client_args_with_lifecycle(dir, core: Arc<dyn CoreLifecyclePort>) -> ClientSetupArgs`——**5a 直接复用**，无需新建测试图                                                                                                                                                                                                                                                              | `APP/client/mod.rs:2087-2106`                                                                                                        |
+| A9f  | 需要更新的 lease 测试替身共 6 个：`MockRunningCoreBridge`/`MockCoreLease`、`TestCorePort`/`TestCoreLease`、`CompensationLease`、`BarrierCompensationLease`、`BarrierCore`/`BarrierLease`，外加 trait 上的 `#[cfg_attr(test, mockall::automock)]`。**另有第 4 个 `CoreLifecyclePort` 生产形态实现** `ProcessCoreLifecycleAdapter`（S09 的进程背书 test-only adapter），seam 若改签名它也必须跟着改             | `APP/client/mod.rs:1589-1919`；`APP/client/rebuild.rs:814-928`；`core_bridge.rs:53`；**`APP/client/process_core_bridge.rs:206,256`** |
+| A16f | **Updater 直接依赖 S10 要删的 legacy lease API**：`replace_core()` 里 `CoreManager::global()` → `begin_lifecycle()` → `lifecycle.stop_core()` → `lifecycle.run_core_from(product)`。不迁移它则 5a **无法编译**；且即便能编译，legacy 单例也停不掉 CoreActor 拥有的新 manager 实例                                                                                                                             | `APP/core/updater/instance.rs:201,205,216,279`                                                                                       |
+| A16g | **Updater 的真实构造链是四段**：`ipc::update_core(core_type)` → `UpdaterManager::global().write().await.update_core(&core_type)` → `instance::UpdaterBuilder::new().set_*(..).build().await` → `Updater`。**类型名是 `Updater`，不是 `UpdaterInstance`**（v2 计划写错了）；`UpdaterBuilder` 现有 5 个 `Option` 字段：`client` / `core_type` / `mirror` / `artifact` / `tag`                                   | `APP/ipc.rs:639-646`；`APP/core/updater/mod.rs:222-244`；`APP/core/updater/instance.rs:31-38,51-58`                                  |
+| A21f | `spawn_health_check()` 的调用者共 **4 处**：`core/service/control.rs:97`（install）、`:225`（start）、`:320`（restart），以及 `core/service/mod.rs:32`（`init_service`）。v2 计划只列了最后一处                                                                                                                                                                                                               | 上述四处                                                                                                                             |
+| A22f | `ClientSetupArgs` 的**字面构造点共 5 处**（改字段时全部要动）：`setup.rs:42`（生产）、`bridge/verge.rs:1072`、`client/mod.rs:2093`、`client/mod.rs:2325`、`client/rebuild.rs:955`（后四处为测试）                                                                                                                                                                                                             | 上述五处                                                                                                                             |
+| A23f | **`Degradation` 是 mutation 响应体上的字段，不是推送通道**：前端在 `provider/index.tsx:46-53` 拦截 mutation 结果里的 `degradations` 数组再交给 handler。`Message` 枚举只有 `SetConfig(Result<(), String>)` 一个变体（`core/handle.rs:25-27`），也不适合承载它。`DegradationPhase` 的 10 个变体里**没有**核心生命周期相关项；前端 `localizeDegradationPhase` 有 `default` 分支，故新增变体不会打断 TS 类型检查 | `APP/client/runtime.rs:446-470`；`frontend/interface/src/provider/index.tsx:46-53`；`frontend/nyanpasu/src/pages/__root.tsx:123-145` |
+| A24f | fake-core 的长驻启动**强制要求 `FAKE_CORE_READY_ADDR`**（TCP ready/release barrier）：doc 原文 "Long-running start requires `FAKE_CORE_READY_ADDR`… Without either `START_EXIT` or a barrier, the process fails fast with exit 2"。HTTP 端口由 `FAKE_CORE_HTTP_PORT` 决定。**只加 `GET /version` 路由不足以让它被 manager 拉起来**                                                                            | `backend/fake-core/src/main.rs:13-18,137-147`；`backend/fake-core/src/lib.rs:144,147`                                                |
+| A17f | **组合根注入图不可实现（如原 S8 所写）**：`try_new_with_args` 在**进入 `block_on` 之前**就把 `core` 从 `ClientSetupArgs` 解构出来；而 typed `application` client（`enable_service_mode` 的来源）在 block 内部第 279 行才被创建。因此 `setup.rs` 无法构造一个依赖 typed 快照的 `CoreClient` 再传进来                                                                                                           | `APP/client/mod.rs:255-264,273,279`；`APP/setup.rs:42-55`                                                                            |
+| A18f | **`cleanup_processes` 的真实顺序**是 `save_window_state` → **`resolve_reset()`（内部已经停核）** → `client.shutdown()` → widget stop → `CoreManager::global().stop_core()`（第二次停核）。`resolve_reset` 全仓**只有这一个调用者**                                                                                                                                                                            | `APP/utils/help.rs:249-271`；`APP/utils/resolve.rs:286-289`                                                                          |
+| A19f | **本仓 fake-core 无法满足 manager 的默认就绪探针**：manager 默认 readiness 是 `ControllerVersionProbe`——"healthy iff `GET /version` succeeds"；而 fake-core 的内置 HTTP 只对**精确** `PUT /configs` / `PATCH /configs` 作答，其余一律 404，且长驻启动强制要求 `READY_ADDR` barrier                                                                                                                            | `RT/crates/nyanpasu-core-manager/src/health/probe.rs:109-125`；`backend/fake-core/src/main.rs:22-23,137-147,305-344`                 |
+| A20f | 第二条**裸线程递归恢复**路径在 `Instance` 事件循环内（核心异常退出且 `tx.send` 失败时 `std::thread::spawn` → `CoreManager::global().recover_core()`），与 `recover_core()` 自身的 5 s 重试是**两处独立**的实现                                                                                                                                                                                                | `APP/core/clash/core.rs:228-238`（另一处 `:577-582`）                                                                                |
+| A10f | 测试全程**零 sleep**：oneshot barrier / `AtomicUsize` / `mockall::Sequence` / `tokio::time::pause()` / `Notify`。5a 必须延续                                                                                                                                                                                                                                                                                  | `APP/client/rebuild.rs:930-1000`                                                                                                     |
+| A11f | `NyanpasuClient::shutdown()` 目前**只**关 rebuild worker；生产顺序是 `client.shutdown()` → widget stop → `CoreManager::global().stop_core()`                                                                                                                                                                                                                                                                  | `APP/client/mod.rs:392-404`；`APP/utils/help.rs:249-272`                                                                             |
+| A12f | `RunType::classify(enable_service, ipc_state)` 已由 PR-5-pre 抽出为纯函数；`IpcState` 只由 `health_check()` 翻转，兼容门在 `target_ipc_state()`                                                                                                                                                                                                                                                               | `APP/core/clash/core.rs:50-67`；`APP/core/service/ipc.rs:143`                                                                        |
+| A13f | `Instance::try_new` 展示了构造核心进程所需的全部输入：core_type、app_data_dir、binary（`find_binary_path`）、config_path、pid_path                                                                                                                                                                                                                                                                            | `APP/core/clash/core.rs:83-124,711-728`                                                                                              |
+| A14f | `ractor = "0.16"`；`nyanpasu-core-manager` / `nyanpasu-core-metadata` **当前不在** workspace 依赖里（PR-5-pre 的 D1=A 推迟到本阶段）                                                                                                                                                                                                                                                                          | `backend/tauri/Cargo.toml:63`；`backend/Cargo.toml:27-41`                                                                            |
+| A15f | 本仓 `backend/fake-core` 对 `backend/tauri` 是 **dev-dependency**，因此**既不构建该 binary 也不设置 `CARGO_BIN_EXE_fake-core`**。既有做法是预构建（`cargo build -p fake-core`）+ 运行时定位 `fake_core::require_bin_path()`（current_exe profile/triple 查找 → 非空 `NYANPASU_FAKE_CORE` 覆盖 → target 目录回退）                                                                                             | `backend/tauri/Cargo.toml:273-281`；`backend/fake-core/src/lib.rs:399-418`；消费者示例 `APP/client/process_core_bridge.rs:18-20`     |
+
+### 1.4 与 spec 正文的偏差（必须按事实实现，spec 措辞为准的地方已注明）
+
+| 偏差 | design 措辞                                                                       | 实际                                                                                                                                                                                      | 处理                                                                                                                                             |
+| ---- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| DV-A | §4 `async fn recover(&self) -> Result<()>`                                        | Local 是 `recover_quarantine()`，Service 是 `recover_core()`，二者语义都是**清 quarantine 闩锁**（R6/R22）                                                                                | `CoreBackend::recover()` 保留此名，doc 注明真实语义是 clear-quarantine，**不是**重启                                                             |
+| DV-B | §4.1 "只保留机器可读 kind + 原始 message/source"                                  | 本 tag 无 `Error::kind()`（R16），R0 才加                                                                                                                                                 | 见 **S4**：隔离一个 `error_kind` 模块作为过渡；R0 合并并 bump submodule 后一步替换（去向登记在 §8）                                              |
+| DV-C | §5 "Supervisor/daemon 最终放弃后，发布一次 `core_recovery_exhausted` degradation" | 无 typed 信号，只有字符串前缀（R14）                                                                                                                                                      | 见决策点 D5                                                                                                                                      |
+| DV-D | §4 `async fn apply(&self, request: &CoreRequest) -> Result<CoreApplyData>`        | Local 返回本地 `ApplyOutcome`（7 分支），需要按 R12 映射成 `CoreApplyData`                                                                                                                | backend 内转换，app 侧不新增 outcome 类型                                                                                                        |
+| DV-E | §6 `CoreActorState` 含 `runtime: RuntimeLifecycleState` 与 `logs: VecDeque`       | 那是 **B1/C1** 的字段                                                                                                                                                                     | 5a 的 actor state **不含**这两项，见 §0 不做清单                                                                                                 |
+| DV-F | §4 把 `start` 与 `restart` 列为两个平级 backend 方法                              | 二者都**不是** request-bearing 的运行原语：`start` 在跑时报 `AlreadyRunning`，`restart` 在全新 backend 上报 `NotStarted`（R5c）。legacy `run_core` 的真实语义是"在跑就先停，再按请求启动" | backend 暴露**一个** `run(request)` 迁移原语：Local 用 `switch(spec)`（R5b 一次调用覆盖两种情形），Service 用 stop-then-start 组合。详见 S3 / S7 |
+
+---
+
+## 2. RQ 必答（roadmap §6.4）
+
+### RQ-04 — `begin_operation` 的调用侧有限超时
+
+**答：** 超时加在 **client 的 RPC 等待**上，不是 actor 里。actor 的 `AcquireOperation` handler 永远立即返回（design §3.3），真正在等的是调用方手里的 reply future。
+
+```rust
+/// 排队等待 operation 的上限。不是单次核心操作的上限——
+/// 排在前面的一次 apply/start 本身就可能跑满 runtime 的 startup_timeout(30s)
+/// + reconcile_timeout(30s)（见事实 R13），所以这个值必须显著大于单次操作。
+/// 它存在的唯一目的是：actor 卡死时调用方能失败返回，而不是永久挂起。
+const CORE_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(120);
+```
+
+取值依据：runtime 默认 `startup_timeout` 30 s、`reconcile_timeout` 30 s、`stop_timeout` 10 s、`control_timeout` 10 s（R1/R13），单次最坏 ≈ 80 s；120 s 留余量且仍然有限。
+
+超时后的行为**复用既有 drop 路径**，不新增机制：
+
+1. `.call(..., Some(CORE_ACQUIRE_TIMEOUT))` 返回 `CallResult::Timeout`；
+2. `begin_operation` 返回 `Err(OperationError::AcquireTimeout)`；
+3. **pending guard 随栈展开被 drop**，其 `Drop` 用 `cast`（fire-and-forget，可在同步 `Drop` 里安全调用）发出 `ReleaseOperation { id }`；
+4. actor 收到后：若该 ID 在 waiters 里 → 删除（等价取消）；若刚好已被提升为 active → 清空 active 并放行下一个 waiter；若未知 → 幂等 no-op + debug 日志。
+
+第 4 步的三分支正是 design §3.3 的规则，**不需要为超时新增任何状态**。
+
+**明确不实现**：TTL、auto-steal、watchdog self-message、续期、心跳。
+
+读操作（status）**走** mailbox（§2.1.3 的 `cast RefreshHint`），沿用房规 `Some(5s)` 读超时（A7f）——它不排队等 guard，gate 非空闲时立即回缓存。watch 化是 C1 的端态。
+
+### RQ-02 — engine revision 的 app 侧处理与 `expected_revision` CAS
+
+**表示法（不新增 app 镜像类型）。** design §4.1 禁止在 app 侧复制 `EngineRevision`。两侧结构完全同构：
+
+- Local：`RevisionId { epoch, generation, effective_hash }`（R9），完整信息在 `ConfigRevision`（比 `ConfigRevisionInfo` 多一个 `runtime_path`）。**`runtime_path` 一律丢弃**，理由是保持与 IPC 侧同构的单一表示、并且不把 runtime 内部路径泄进 app 状态——**不是**因为读不到：Local manager 与 app 同进程同用户，那个路径 app 是能读的。真正 app 不可访问的是 **Service** 侧 daemon 的 0o700 私有目录，所以 IPC 的 `ConfigRevisionInfo` 本来就不带它；
+- Service：`RevisionIdInfo { epoch, generation, effective_hash }`（R25），完整信息在 `ConfigRevisionInfo`。
+
+**结论：统一采用 IPC 的 `RevisionIdInfo` / `ConfigRevisionInfo` 作为 app 侧唯一表示**，理由：(a) 它已经是 app 依赖的 wire 类型且已 derive specta，C1 要 additive 暴露时零成本；(b) `LocalBackend` 内做一次 `RevisionId → RevisionIdInfo` 的字段搬运即可，转换点收敛在 backend 内部，符合 §4.1"在 backend 内转换"。
+
+**存储。** actor state 持有 `last_revision: Option<ConfigRevisionInfo>`，作为 `CoreStatusView` 的一个字段。它是**观察到的事实缓存**，不是权威——权威永远在 runtime 那边。
+
+**刷新来源（两条）：**
+
+| 来源            | Local                                                 | Service                                       |
+| --------------- | ----------------------------------------------------- | --------------------------------------------- |
+| 操作返回值      | `run`/`stop`/`recover` 后的 `observe_status()`（R10） | 同左，经 `/status`（R21）                     |
+| `RefreshStatus` | `CoreManager::status().revision`（R10）               | `Client::status().core_infos.revision`（R21） |
+
+**重连/对账：5a 不存在这个问题。** 没有持久连接就没有断线，也没有陈旧帧——Service 侧每次 `run()` / `RefreshStatus` 都从 `/status` 重新学习当前 revision（§2.1）。`Client::events()` 的重连循环、连接身份、乱序栅栏全部移出 5a，由 **C1** 随 watch 投影一并交付。
+
+**竞态：构造上没有。** 需要新鲜度的调用方在**持 `CoreOperationGuard` 时**刷新，而 `OperationGate` 保证同一时刻只有一个 active operation——详见 §2.1.2。
+
+**冲突处理。** `expected_revision` 语义：
+
+- `None` = 无条件应用（R7/R20）。**只允许在一种情况下出现：actor 尚未观察到任何 revision**——而 `apply` 要求核心已在跑（R7 `Error::NotStarted`），核心跑起来必然产生 revision，所以正常路径下 `None` 不会出现。因此规则是：**apply 一律传 `Some(last_revision.id())`；若 `last_revision` 为 `None`，视为内部不变量被破坏，返回错误而不是降级为无条件应用。**
+- CAS 失败：Local `Error::RevisionConflict { expected, actual }`（R8），Service `error_kind = "revision_conflict"`（R20）。两侧都**没有应用任何东西**，所以处理方式是：用 `actual`（或重新查一次 status）刷新 `last_revision`，然后把冲突作为可重试错误上报。
+
+**5a / 5b 分工（重要）：**
+
+- **5a 只做"观察与存储"**：表示法、两个观察来源（§2.1.1）、操作返回值的同处理提交，由 **T-RV-01/02/03a/03b/05/06/07/08** 钉住。
+- **5b 才做"CAS 应用"**：因为 5a 不改 apply 管线（决策点 D3），`expected_revision` 在 5a 没有生产调用点。上面的冲突规则属于 B1 的实现契约，5a 只负责让 `last_revision` 在那时是可信的。
+
+> **前向引用（不在本阶段作答）：** RQ-01 完整 post-commit 失败矩阵、RQ-03 apply parity 含 `Noop`——均由 **PR-5b 计划**回答。事实 R11/R23 已为其备好素材。
+
+---
+
+## 2.1 观察模型（5a 范围内）
+
+> **范围裁定（2026-08-02，leader）：5a 不做推送式观察。** v3–v6 曾围绕"订阅流 + 陈旧帧栅栏"反复迭代（`ConnectionId`、`subscription_epoch`、握手、重连循环、乱序判定），六轮审查全部集中在这套机制上。依据 task.md：**"backend status/events 投影到 actor watch snapshot；status read 不走 mailbox RPC" 明确写在 C1（PR-5c）卡上**，而 A1–A3 与 A-Exit（operation 语义、Local/Service parity、seam 迁移）**没有一条需要实时推送流**。因此该机制整体移出 5a。
+>
+> **陈旧帧问题在没有推送流时不存在**——这不是把 bug 藏起来，是把产生 bug 的结构删掉。
+
+### 2.1.1 读路径：actor→client watch 投影（裁定 A-v2，2026-08-02）
+
+**为什么 watch 必须回来。** v8 让 `status()` 走 mailbox RPC，八审指出这会破坏活性：ractor 顺序处理消息，`Run` 的 handler 可能 await 30–80 s（runtime 的 `startup_timeout` 30 s + `reconcile_timeout` 30 s，R1/R13），期间**排在它后面的每一个读都要等**，5 s 读超时必然失败。**这正是 design.md §6 当初指定 watch 读的原因。**
+
+区分两件被混为一谈的事：
+
+| 机制                          | 5a 是否有 | 说明                                                                 |
+| ----------------------------- | --------- | -------------------------------------------------------------------- |
+| backend → actor **推送流**    | **否**    | 订阅任务 / 连接身份 / 重连 / 陈旧帧栅栏，全部归 **C1**（第七轮裁定） |
+| actor → client **watch 投影** | **是**    | **单一写入者 = actor**，无并发写、无栅栏需求，约 30 行               |
+
+被砍掉的是前者。后者从来不是有争议的机制。
+
+**规则：**
+
+- actor 持有 `watch::Sender<CoreStatusView>`；**每一次提交都发布投影**——操作返回观察、`RefreshStatus` 结果、槽位转换（含 `Failed` / `None` 瞬态）、`shutdown`；
+- `CoreClient` 持 `watch::Receiver`，`status()` 是**同步的 watch 克隆**，**完全不碰 mailbox**；
+- 因此"读永不阻塞"成为**结构性事实**，不再需要 5 s 读超时（该常量随之删除）。
+
+> 这提前交付了 task.md C1 卡 "status read 不走 mailbox RPC" 的**读半边**；C1 仍负责 backend→actor 推送与 `LogFrame` ring。已在处置表记账。
+
+### 2.1.2 写路径：两个观察来源
+
+| 来源                | 触发                                               | 竞态处理                                               |
+| ------------------- | -------------------------------------------------- | ------------------------------------------------------ |
+| **操作返回值**      | `run` / `stop` / `recover` 的 `BackendObservation` | actor 在**同一消息处理内**提交并发布 watch，然后才回复 |
+| **`RefreshStatus`** | 守卫调用方按需查询                                 | 必填 `OperationId`，须等于 active（见 2.1.3）          |
+
+`apply` **不是**观察来源：D3=A 下它仍走 lease 内的 `api::put_configs`，不经过 actor。
+
+### 2.1.3 刷新的两种调用形态
+
+```rust
+/// 守卫刷新（5b 的事务内刷新）。**必填** operation——调用方必然持有 guard。
+RefreshStatus {
+    operation: OperationId,
+    reply: RpcReplyPort<Result<BackendObservation, CoreActorError>>,
+},
+
+/// UI 提示（fire-and-forget，`cast` 而非 `call`）。无 operation、无 reply。
+/// 仅在**出队时 gate 空闲**才执行刷新；否则**直接丢弃**——
+/// 因为此刻必有一个 active operation，它结束时会提交并发布新状态，
+/// 再刷一次既多余又会排在慢操作后面。
+RefreshHint,
+```
+
+`CoreActorError` 的**定义见 A.1b**（四个变体 + `thiserror` 派生）。
+
+**为什么 hint 用 `cast`：** 它没有返回值需求（结果通过 watch 到达），也就不该占用调用方的等待。丢弃是安全的——丢弃的前提正是"有操作在飞"，而那个操作的提交马上就会发布。
+
+### 2.1.4 UI 读路径与 D5
+
+`NyanpasuClient::core_status()` = **watch 读**（立即返回）+ **`cast RefreshHint`**（不等待），再投影成既有元组 wire。
+
+D5 的"UI 读取观察到耗尽"因此是**最终一致**的：hint 在 gate 空闲时出队 → 刷新 → 提交并发布 watch → **下一次读取/渲染**看到耗尽并发布一次 degradation。T-RV-09 逐步钉住这个序列。
+
+> 前端 `useCoreStatus` 用 react-query，invalidate/重新挂载都会再读一次，因此"下一次读取"在真实交互中很快到来。
+
+### 2.1.5 观察载荷与忠实生命周期
+
+观察载荷 `BackendObservation`（含忠实 `lifecycle`）与 `FaithfulLifecycle` 的**声明见 A.1**。此处只说明存在理由：`CoreStatusView.state` 是两值投影，看不见 `Starting` / `Restarting`，而 D5 的 latch 必须在**投影之前**区分它们，否则"启动→再次耗尽"无法复位。
+
+两侧映射（**必须逐条实现**）：
+
+| `FaithfulLifecycle`  | Local（`nyanpasu_core_manager::CoreState`，R10/state.rs:106-131）    | Service（`CoreInfos.detail`，R5d/status.rs:107-122） |
+| -------------------- | -------------------------------------------------------------------- | ---------------------------------------------------- |
+| `Stopped { reason }` | `Stopped { reason }`（`StopReason` 转字符串，D5 的耗尽前缀在此判定） | `Stopped { reason }`                                 |
+| `Starting`           | `Starting { .. }`                                                    | `Starting { .. }`                                    |
+| `Running`            | `Running { .. }`                                                     | `Running { .. }`                                     |
+| `Restarting`         | `Restarting { .. }`                                                  | `Restarting { .. }`                                  |
+| `Switching`          | `Switching { .. }`                                                   | `Switching { .. }`                                   |
+| `Stopping`           | `Stopping { .. }`                                                    | `Stopping { .. }`                                    |
+
+**Service 侧 `detail` 缺失时**（老 daemon 或字段未送达）：按两值 `CoreState` 保守映射——`Running → Running`，`Stopped(reason) → Stopped { reason }`。此时看不见过渡态，D5 的 latch 会退化为"只在 `Running` 复位"，**这是可接受的降级**（v1 daemon 本就进不了 Service backend，见 PR-5-pre 兼容门）。
+
+### 2.1.6 `RefreshHint` 的合流（round-9 #3）
+
+UI 每次渲染都可能调 `core_status()`，若每次都 `cast` 一条 hint，空闲期会积压出 N 次 backend 查询。**用一个共享 pending 位合流**：
+
+```rust
+// CoreClientInner 增加：hint 是否已在途。
+hint_pending: Arc<AtomicBool>,
+```
+
+- client 侧 `hint_refresh()`：`compare_exchange(false, true)` 成功才 `cast`；失败说明已有一条在途，**直接返回**；
+- actor 侧处理 `RefreshHint` 时**第一件事**就是把该位清回 `false`，然后再判 gate、再决定是否查 backend。
+
+于是**任意时刻至多一条 hint 在途**。清位发生在处理开始处，因此清位之后到达的读会重新排一条，不会丢失"最新一次读也想要新鲜值"的意图。
+
+> 该原子位由 client 与 actor 共享（`Arc<AtomicBool>`），是本设计中**唯一**跨 actor 边界的共享可变量。它不承载任何状态、只做去重，因此不违反"actor 状态不得经 `Arc<Mutex>` 外泄"（CLAUDE.md §8）——在此显式登记为窄用途例外。
+
+### 2.1.6.1 最终一致性的一个例外（round-9 #4）
+
+§2.1.4 说 D5 是最终一致的，但有一个**必须写明的例外**：D3=A 下 `apply_promoted` 仍走 lease 内的 `api::put_configs`，它**不经过 actor，因此不产生观察、也不发布 watch**。所以：
+
+- 一次外部 apply 改变了运行态之后，watch 里的视图**在下一次观察之前是陈旧的**；
+- 恢复新鲜的路径就是下一次 idle hint（或下一次经 actor 的 mutation）；
+- 这条例外随 **B3** 消失——届时 apply 统一走 `CoreBackend::apply`，本身就是观察来源。
+
+T-RV-13 钉住这条：外部 apply 期间读到旧值，随后 idle hint 到达 → watch 更新。
+
+### 2.1.7 watch 通道的具体接线（编译级，round-9 #1）
+
+**类型与构造顺序见附录 A（A.1 / A.3）——此处不复述字段。** 本节只讲行为契约。
+
+- watch 通道与 `hint_pending` 都在 `CoreClient::new` **内部**创建（A.3 第 5 步），`Sender` 与共享位随 `CoreActorArgs` 进 actor，`Receiver` 与同一个 `Arc` 留在 `CoreClientInner`——两端同源；
+- `status()`：`self.inner.status_rx.borrow().clone()`，同步、零 mailbox；
+- `refresh_status(&guard)`：`call` 发 `RefreshStatus { operation: guard.id(), reply }`。`CallResult::SenderError` 与 `Err(_)`（actor 已终止）**都映射成** `CoreActorError::ShuttingDown`；不传超时，故 `CallResult::Timeout` 不可达；
+- `hint_refresh()`：`hint_pending.compare_exchange(false, true, AcqRel, Acquire)` 成功才 `cast`；**`cast` 失败必须把该位重置回 `false`**，否则 actor 已死时会永久阻断后续 hint；
+- actor 处理 `RefreshHint` 的**第一条语句**是 `hint_pending.store(false, Release)`，然后才判 gate。
+
+初值语义见 A.5。
+
+**唯一的提交路径。** actor 内所有状态变更都走同一个 helper，杜绝"改了缓存忘了发布"或"发布了但没过 latch"：
+
+```rust
+impl CoreActorState {
+    /// 提交一次观察：latch 判定（**投影前**吃 `lifecycle`，D5）→ 更新缓存 → 发布 watch。
+    /// 所有调用点：run/stop/recover 的返回值、RefreshStatus/RefreshHint 的结果、
+    /// 槽位转换（`None` 瞬态与 `Failed`）、shutdown。
+    fn commit(&mut self, observation: BackendObservation) {
+        self.evaluate_recovery_latch(&observation.lifecycle);   // D5，投影前
+        self.observed = observation;
+        let _ = self.status_tx.send_replace(self.observed.view.clone());
+    }
+}
+```
+
+**没有 backend 时的观察合成**（换槽瞬态 `None` / `Failed` / shutdown）：**取值表见 A.5**。三者都经 `commit()`，因此**都会发布 watch**——T-RV-11 / T-RV-12 分别钉住瞬态与关停。
+
+> 类型的 `Clone` 派生、可见性与模块路径统一见 A.1 / A.6（typed client 在 `APP/client/core.rs`；`actor/mod.rs` 不声明 `client` 子模块）。
+
+### 2.1.8 转出到 C1 的内容（前向指针）
+
+以下**明确不在 5a**，由 **PR-5c / C1** 交付：backend→actor 的 status/events **推送订阅**；100 条 `LogFrame` ring。**注意：watch 投影的读半边（`status()` 不走 mailbox）已在 5a 交付**（§2.1.1，裁定 A-v2），C1 只需把推送源接到 actor 的 `commit()` 上——投影与读路径无需再改。
+
+---
+
+## 3. 需 leader 裁定的决策点
+
+> 未另行裁定则按推荐项执行。
+>
+> **Leader 裁定（2026-08-02）：D1=A、D2=A、D3=A、D4=A、D5=A、D6=120s。** 全部按推荐项执行。D5 附带建议（上游 `StopReason` 加 `RestartBudgetExhausted` typed 变体）**不并入已收口的 R0 分支**——记入待用户授权的上游事项，授权后作独立小 PR；本阶段按字符串前缀实现。
+
+### D1 — workspace 依赖加哪几个 crate？
+
+PR-5-pre 的 D1=A 把 `nyanpasu-core-manager` / `nyanpasu-core-metadata` 推迟到"首个真实消费者"，那就是本阶段。
+
+- **推荐 A**：只加 `nyanpasu-core-manager` 与 `nyanpasu-core-metadata` 两条。前者是 `LocalBackend` 的直接依赖；后者提供 `LogFrame` / `ClashCoreKind`，且 R0 之后的 `CoreErrorKind` 也在其中——虽然 5a 的日志 ring 是 C1 范围，`ClashCoreKind`（= `CoreKind`）在构造 `CoreSpec` 时就要用到，属真实消费。
+- **选项 B**：再加 `clash-api`。**不推荐**——app 侧无直接消费者（`clash_api::Host` 只在 `CoreStatus.controller` 里出现，5a 不读它），加了就是死条目。
+
+### D2 — backend 的构造时机
+
+`CoreManager::new()` 会取运行目录独占锁（R2），所以"两个 backend 都常驻"不可行。
+
+**裁定 A：pre_start 只构造当前模式匹配的那一个；`SetBackend` 时换槽。** `SetBackend` 必须在 operation guard 下执行（design §3.4 已列入必须持 guard 的清单）。
+
+**换槽协议（必须逐字实现——`shutdown()` 并不释放目录锁）。** 事实 R6b：锁是 `atomic_fs::DirLock`，挂在 `Inner` 的最后一个字段上，**只在最后一个 `Arc<Inner>` drop 时才释放**。所以"shutdown 旧的 → 构造新的"如果还有任何一个 `Arc<CoreManager>` 存活（例如订阅任务里那份 clone），新 manager 会拿不到锁并以 `Error::RuntimeDirectoryOwned` 失败。因此：
+
+1. **槽位建模为 `BackendSlot::{Ready, Failed{error}}`**——换槽期间必然存在一个短暂空位，状态里必须能表达它，并且失败诊断要能被后续 mutation 复现；
+2. 调 `backend.shutdown()`（优雅停核 + 归档 sink）；
+3. **显式 drop 掉 backend 值本身以及所有 `Arc<CoreManager>` 克隆**，让 `Inner` 的引用计数归零、目录锁释放；
+4. 再构造替换 backend；
+5. 成功则写回 `Ready(new)`，失败则写回 `Failed { error }`。
+
+> **比 v6 简单了一步**：5a 不起订阅任务（§2.1），因此**没有需要 cancel + join 的后台任务**，也就不存在 v6 里那个"`SetBackend` 在 join 任务、任务在等同一个 handler 回复"的死锁风险。持有 `Arc<CoreManager>` 的只有 backend 自身，drop 它即释放。
+
+**无 backend 失败态。** 槽位为 `Failed { error }` 时：所有 mutation 返回 **`CoreActorError::NoBackend { last_error }`**（`Arc` 克隆自槽位——注意它是 **`CoreActorError`** 的变体，不是 `CoreBackendError` 的，见 A.1b）；`status()` 经 watch 仍可读且 `state == Stopped`。后续 `SetBackend` 可以重试装载。**不做**自动重试循环。
+
+配套顺序事实：组合根（`setup.rs`）先于 `init_service()` 运行，此时 `IpcState` 仍是 `Disconnected`，`RunType::classify` 必然给出 `Normal`（A12f）。所以**启动时总是先建 Local backend**，随后健康检查若判定兼容再发 `SetBackend(Service)`。这与 fail-closed 语义一致，是期望行为。
+
+### D3 — 5a 是否把 apply 改道到 `CoreBackend::apply`？（**本计划最关键的范围裁定**）
+
+- **推荐 A：不改道。** `check_and_promote` / `apply_candidate` / `apply_promoted` 在新的 lease 适配器里**保持现有实现**（候选检查 + 原子 promote + `api::put_configs` 推送）。理由：(1) task.md A3 列的是 "start/stop/restart/status 改走 actor"，apply **不在其中**；(2) 统一 full-config apply 是 design §7 白纸黑字的 **5b/B3** 范围；(3) `put_configs` 是对核心 external-controller 的 HTTP 调用，与"谁拉起了进程"无关，因此 CoreActor 接管进程所有权后它照常工作；(4) 让 5a 保持"纯所有权搬移"，diff 可审。
+  - 代价：5a 结束时短暂存在两条配置应用路径（legacy PUT 用于生产，`CoreBackend::apply` 仅被测试覆盖）。这正是 B3 要消灭的。
+- **选项 B**：5a 就改道。会把 B1（Promoted/Applied 入 actor）和 B3（删补偿层）的一部分提前，且 `expected_revision` 的失败矩阵（RQ-01）尚未定义，风险明显更高。
+
+### D4 — `CoreBackend::apply` 是否在 5a 实现？
+
+与 D3 配套。task.md A1 明确写了 "只实现 check/start/apply/stop/restart/recover"。
+
+- **推荐 A：实现，但只被 Test backend 与 parity 测试消费，生产不接线。** 依据是 A1 卡的显式要求；同时它让 R12 的 outcome 映射（`DurabilityUncertain` 拆 warning、可嵌套两层）在 5a 就被测试钉住，5b 接线时只剩接线。
+- **选项 B**：5a 不实现 apply，5b 再加。更严格地遵守 CLAUDE.md §2（不写投机代码），但违反 A1 卡的字面要求，且把 outcome 映射的风险全压到 5b。
+
+### D5 — `core_recovery_exhausted` 怎么判定？
+
+事实 R14：没有 typed 信号，只有 `StopReason::Error` 里的字符串前缀。
+
+**裁定 A：常量 + 纯函数集中一处字符串匹配，并用测试钉住前缀。** Local 从 `CoreStatus.state` 取，Service 从 `CoreState::Stopped(Some(msg))` / `CoreStatusChanged` 的 detail 取（同一字符串，因为 daemon 内跑的是同一个 manager）。
+
+```rust
+/// 上游 `instance.rs:631-641` 在重启预算耗尽时写入的前缀。
+/// 这是目前唯一的机器可读线索——上游没有 typed 信号（见计划 §1.1 R14）。
+/// 若上游后续加了 typed 变体，这里连同 `is_recovery_exhausted` 一并删除。
+const RECOVERY_EXHAUSTED_PREFIX: &str = "core kept crashing; restart budget exhausted";
+```
+
+**但"算出一个 flag"不等于满足 design §5。** design.md:227 的原文要求是"Supervisor/daemon 最终放弃后，**发布一次** `core_recovery_exhausted` degradation"——这是一个**恰好一次的发布行为**，不是一个可反复读取的布尔位。而状态推送是幂等重放的（R24 明确说 `CoreStatusChanged` 可能因重连/丢事件恢复而重复），朴素实现会对同一次耗尽事件重复发布。因此必须补两样东西：
+
+**（a）注入式 degradation sink + 具体生产实现。** 既有 `UiEventSink`（`APP/client/event_sink.rs:11-31`）只有 `state_changed` / `notice_message` / `update_systray*`，**没有** degradation 通道，不要往里塞。事实 A23f 还确认了：`Degradation` 是挂在 **mutation 响应体**上的字段（前端在 `provider/index.tsx:46-53` 从 mutation 结果里取 `degradations` 数组），**没有现成的推送通道可继承**——而 `core_recovery_exhausted` 是无人调用时自发产生的事件。
+
+`CoreDegradationSink` 的**声明见 A.1**（单方法、可 mock）。
+
+**完整 DTO 取值**（复用既有 `Degradation`，`APP/client/runtime.rs:448-470`，四个字段全部定死）：
+
+| 字段        | 值                                                                                                                                                                                                                                                                             | 理由                                                                                                                                                                                                                                                                                                                 |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `phase`     | **`DegradationPhase::CoreLifecycle`（本阶段新增的变体）**                                                                                                                                                                                                                      | **leader 裁定（2026-08-02）**：现有 10 个变体没有核心生命周期项，用 `RuntimeApply` 承载"监督重启预算耗尽"是**语义谎言**，且会直接显示成 UI 上的相位标签。零 diff 闸门的目的是拦**非预期**的 wire 变化，而一个**声明在案、精确、纯新增**的期望同样达成该目的。C1 无论如何都要这个变体，推迟只会先发一段时间的错标事件 |
+| `code`      | `"core_recovery_exhausted"`                                                                                                                                                                                                                                                    | design §5 指定的稳定 snake_case 码                                                                                                                                                                                                                                                                                   |
+| `message`   | `format!("core restart budget exhausted; the core is not running ({reason})")`，`reason` 取自 `StopReason::Error` 原文。**整条最终 `message`（前缀 + reason + 后缀）上限 512 字节**——超限时**只截断 reason 段**，且必须按 UTF-8 字符边界截断（不得切出半个码点），截断处补 `…` | 面向支持排查，保留 runtime 原始诊断；512 与上游 `CoreHealthInfo.last_error` 的上限一致                                                                                                                                                                                                                               |
+| `retryable` | `true`                                                                                                                                                                                                                                                                         | 用户可显式 `restart` / `recover` 重试                                                                                                                                                                                                                                                                                |
+
+**生产实现（`TauriCoreDegradationSink`）：** 放在 `APP/client/event_sink.rs` 旁，与 `TauriUiEventSink` 同层（都是 Tauri 边界适配器）。它持有 `Arc<dyn UiEventSink>`，`publish` 时做两件事：
+
+1. `tracing::warn!(code = %d.code, phase = ?d.phase, message = %d.message, "core degradation")` —— 结构化日志，进 `collect_logs` 的支持包；
+2. `ui_sink.notice_message(&Message::SetConfig(Err(d.message.clone())))` —— 复用**既有**的用户可见通知通道（`core/handle.rs:25-27` 只有这一个变体），让用户当场看到"核心反复崩溃已放弃重启"。
+
+> 为什么不新开一条推送 wire：那需要新 event URI + 新 wire 类型 + 前端订阅，属于 **C1**（status/event 投影）的范围。当前实现让**协议义务**（恰好一次、可注入、可 mock）在 5a 完整成立，**传输**在 C1 升级——sink trait 不变，只换实现。
+
+**新增 `DegradationPhase::CoreLifecycle` 的具体改动（backend-only，leader 裁定）：**
+
+- `APP/client/runtime.rs:459-470` 的 `DegradationPhase` 加一个变体 `CoreLifecycle`（serde/specta 为 `snake_case`，即 `'core_lifecycle'`）；
+- **不动前端**：`localizeDegradationPhase`（`frontend/nyanpasu/src/pages/__root.tsx:123-145`）有 `default` 分支兜底显示，本阶段**不加**本地化条目——它随 C1 一并补；
+- roadmap §9 的 `DegradationPhase` 列表是"至少覆盖"，新增变体不违反它；
+- bindings 因此**有且仅有这一处**新增，S13 已把期望从"零变化"改成"恰好这一处"。
+
+**注入路径：** `ClientSetupArgs` 新增 `degradation: Arc<dyn CoreDegradationSink>` 字段（**5 个字面构造点全部要改**，事实 A22f）；生产在 `setup.rs` 传 `Arc::new(TauriCoreDegradationSink::new(ui_sink.clone()))`，测试传 `Arc::new(MockCoreDegradationSink::new())`。
+
+**（b）per-episode latch。** actor state 持 `recovery_exhausted_published: bool`：
+
+- 观察到耗尽且 latch 为 `false` → `publish()` 一次并置 `true`；
+- latch 为 `true` 时再观察到同一状态 → **不发布**；
+- **latch 复位条件（只有两条）**：观察到核心重新进入非耗尽的**活跃**状态，或 backend 身份变化（`SetBackend` 换槽）。**`recover` 成功本身不复位**——它只清 quarantine、不拉起核心，若复位则重放的同一耗尽快照会二次发布同一 episode。
+
+**观察时机（裁定 A 之后已有确定机制）。** 没有推送流，耗尽状态在**有人观察时**被发现，来源是 §2.1 的两条：任一 mutation 的返回值，或一次 `RefreshStatus`。**UI 的 `core_status()` 走 `cast RefreshHint`（§2.1.3），gate 空闲时会真正查询 backend**（§2.1.2 规则 (d)），因此：
+
+- Local 核心在最后一次操作之后耗尽重启预算 → **下一次 UI status 读取**即观察到并发布一次（T-RV-09 钉住）；
+- 无需周期性自消息，也无需依赖 service 健康轮询（那查的是 daemon 状态，不是核心状态）；
+- latch 保证同一 episode 只发一次，复位条件见上。
+
+**（c）latch 必须在投影之前判定（round-3 #5）。** `CoreStatusView.state` 是**有损两值** `CoreState`，看不见 `Starting`（事实 R5d）。若在投影后判定，一次"启动→再次崩溃耗尽"的失败重试会因为从没观察到 `Running` 而无法复位 latch，第二次耗尽就不会发布。因此：
+
+- backend 的观察结构里携带一个 **crate-private 的忠实生命周期视图**（Local 用 `nyanpasu_core_manager::CoreState`，Service 用 `CoreInfos.detail`），**不进** `CoreStatusView`、不上 wire；
+- latch 的判定与复位**读这个忠实视图**：`Starting` / `Running` / `Restarting` / `Switching` 均视为"活跃"，复位 latch；
+- 投影成两值 `CoreStatusView` 是判定**之后**的最后一步。
+
+测试见 T-BK-06 / T-BK-07 / T-BK-12。
+
+**附带建议（需用户授权，不在本阶段执行）**：给上游提一个小改动，在 `StopReason` 上加 `RestartBudgetExhausted` 变体。**Leader 已裁定不并入已收口的 R0 分支**，授权后作独立小 PR。
+
+### D6 — `CORE_ACQUIRE_TIMEOUT` 取值
+
+推荐 **120 s**，依据见 RQ-04。若 leader 认为应更激进（例如 60 s），需同时接受"前序 apply 跑满 runtime 超时时后续操作可能误超时"的代价。
+
+---
+
+## 4. 实施步骤
+
+> 每步给出编辑内容 → 验证命令 → 通过判据。全程**不要**跑 `cargo clippy -- -D warnings`（仓库本就红）。
+> 记忆事项：本仓共享 target 曾出现 kache 污染导致本地 clippy 假红；若遇到，用独立 target 目录复验再判定。
+
+### S1 — workspace 依赖（按 D1=A）
+
+`backend/Cargo.toml` 的 `[workspace.dependencies]` `# --- nyanpasu ---` 段追加两条，沿用既有注释风格：
+
+```toml
+nyanpasu-core-manager = { path = "nyanpasu-runtime/crates/nyanpasu-core-manager" }
+nyanpasu-core-metadata = { path = "nyanpasu-runtime/crates/nyanpasu-core-metadata" }
+```
+
+`backend/tauri/Cargo.toml` 的 `# Local Dependencies` 段追加：
+
+```toml
+nyanpasu-core-manager = { workspace = true }
+nyanpasu-core-metadata = { workspace = true }
+```
+
+**验证：**
+
+```powershell
+cargo metadata --manifest-path .\backend\Cargo.toml --format-version 1 | Out-Null; $LASTEXITCODE
+Select-String -Path .\backend\Cargo.lock -Pattern '^name = "nyanpasu-core-manager"' -Context 0,2
+cargo tree --manifest-path .\backend\Cargo.toml --duplicates --edges normal | Out-String
+```
+
+**通过判据：** exit 0；两个 crate 以 path 依赖入 lock（无 `source =` 行）；`--duplicates` **没有新增重复组**（出现新重复组 → 停止并上报，不要自行改 feature）。
+
+### S2 — 请求与状态投影类型（纯类型，零行为）
+
+新文件 `APP/core/actor/types.rs`（模块树见 S5）。
+
+```rust
+/// 一次核心操作的完整输入。两个 backend 各自把它翻译成自己的形状：
+/// Local → `InstanceSpec`（事实 R7），Service → `CoreStartReq` / `CoreApplyReq`（R20）。
+#[derive(Debug, Clone)]
+pub struct CoreRequest {
+    pub core_type: nyanpasu_utils::core::CoreType,
+    pub binary_path: camino::Utf8PathBuf,
+    pub config_path: camino::Utf8PathBuf,
+    pub working_dir: camino::Utf8PathBuf,
+    pub pid_path: Option<camino::Utf8PathBuf>,
+}
+
+/// 给 UI 的最小状态投影。刻意**不**镜像 runtime 的 `CoreStatus`：
+/// 只保留 5a 的调用点真正需要的字段（见事实 A5f 的四个读取点）。
+#[derive(Debug, Clone)]
+pub struct CoreStatusView {
+    pub state: nyanpasu_ipc::api::status::CoreState,
+    pub state_changed_at: i64,
+    pub run_type: crate::core::RunType,
+    /// 观察到的运行配置 revision（RQ-02）。权威在 runtime，这里只是缓存。
+    pub revision: Option<nyanpasu_ipc::api::status::ConfigRevisionInfo>,
+    /// runtime 侧重启预算耗尽（事实 R14）。
+    pub recovery_exhausted: bool,
+}
+```
+
+**`CoreRequest` 的构造需要一个显式的工厂（round-6 #7 / round-7 #4）。** 注入 `RuntimePaths` **不够**——它只有 `product` 与 `candidate_dir`（`APP/client/runtime.rs:193-221`），而 `CoreRequest` 还需要 `binary_path` / `working_dir` / `pid_path`。**注入 `PathResolver` 也不够**：它的 `app_install_dir()` 直接委托 `dirs::app_install_dir()`（`APP/utils/path.rs:82-84`），测试无法重定向。因此二进制查找必须是**独立可注入的策略**：
+
+`CoreBinaryResolver` 与 `CoreRequestFactory` 的**声明见 A.1**；`for_product(core)` 的取值规则：`core` 来自 typed 快照的 **`core`** 字段（`clash_core` 只是 serde alias），显式转 `CoreType`，`binary_path` 经注入的 resolver，其余路径取自工厂构造时固化的值——**全程无 `dirs::*()`**。
+
+**归属：** 工厂存进 `NyanpasuClientInner`（`core_mode_reconciler()`、`restart_core()`、facade 的 service 方法、以及 S9.1 的 Updater 都要用它）。`ClientSetupArgs` 增加 `binary_resolver: Arc<dyn CoreBinaryResolver>`，生产在 `setup.rs` 传 OS 实现，测试传固定路径实现。
+
+**Updater 的路径（round-9 #2 修正，推翻 round-7 的预构造裁定）。** v8/v9 让 facade 在 `update_core()` **调用时**构造 `CoreRequest` 再交给 Updater——**那是一个陈旧竞态**：`replace_core` 发生在**下载与解压之后**（`UpdaterState` 序列 Downloading → Decompressing → Replacing，`APP/core/updater/instance.rs:139,200,291`），大文件下载可能持续数分钟，期间用户完全可能换核。用调用时刻的快照去比较/重启，会**重启一个用户已经切走的核**，或**漏停一个下载期间才变成活跃的核**。
+
+**正确做法：运行身份在替换 guard 内向 actor 查询。** Updater 只携带**目标核类型**，通过 A.4 的守卫消息 `RunningIdentity` 拿到当前实际在跑的 `CoreRequest`——不预构造、不读 typed desired。
+
+**改用守卫消息，不引入 trait**（round-11 裁定）：`RunningIdentity { operation, reply }` + `CoreClient::running(&guard)`，定义见 **A.4**。
+
+**可见性约定（round-8 #4）：** 5a 新增的实现面统一 `pub(crate)`——`CoreRequest` / `CoreStatusView` / `BackendObservation` / `FaithfulLifecycle` / `CoreBackend` / `BackendSlot` / `CoreActorError` / `CoreRequestFactory` / `CoreBinaryResolver` / `CoreModeReconciler`。只有 `CoreClient`、`CoreOperationGuard`、`CoreDegradationSink`、`ServiceControlOps` 需要 `pub`（前二者被 client 层引用，后二者是注入点）。
+
+**验证：** `cargo check -p nyanpasu --all-features`（或 `pnpm lint:clippy`）。
+
+### S3 — `CoreBackend` 封闭 enum
+
+新文件 `APP/core/actor/backend.rs`。
+
+```rust
+pub enum CoreBackend {
+    Local(LocalBackend),
+    Service(ServiceBackend),
+    #[cfg(test)]
+    Test(TestBackend),
+}
+
+impl CoreBackend {
+    pub async fn check(&self, request: &CoreRequest) -> Result<(), CoreBackendError>;
+
+    /// **唯一的 request-bearing 运行迁移原语**（DV-F）。语义 = legacy `run_core_from`：
+    /// 核心未跑就按 `request` 启动；已在跑就迁移到 `request` 指定的 spec。
+    /// 刻意**不**暴露 `start` / `restart` 两个平级方法——它们各自只在半边状态空间有效
+    /// （R5c），把选择权交给调用方就是把 bug 交给调用方。
+    pub async fn run(&self, request: &CoreRequest) -> Result<BackendObservation, CoreBackendError>;
+    pub async fn stop(&self) -> Result<BackendObservation, CoreBackendError>;
+    /// 清除 runtime 的 quarantine 闩锁。**不是**"重启核心"——
+    /// Local 走 `recover_quarantine()`、Service 走 `recover_core()`（R6/R22/DV-A）。
+    pub async fn recover(&self) -> Result<BackendObservation, CoreBackendError>;
+
+    /// **async**：Service 需要一次 IPC roundtrip（Local 读 `CoreManager::status()` 是同步的，
+    /// 但签名统一为 async 才能装进同一个封闭 enum）。返回**忠实**观察，不是投影后的视图。
+    pub async fn observe_status(&self) -> Result<BackendObservation, CoreBackendError>;
+
+    /// D4=A：实现但**生产不接线**（B3 才改道）。因此它**不是** §2.1 的观察来源——
+    /// 5a 里只有测试调用它，actor 不会用它的返回值提交状态。
+    pub async fn apply(&self, request: &CoreRequest, expected: Option<RevisionIdInfo>)
+        -> Result<CoreApplyData, CoreBackendError>;
+
+    /// 优雅停核 + 归档 sink。调用后此值必须被立即 drop（D2 换槽协议）——5a 没有订阅任务需要 join。
+    pub async fn shutdown(self) -> Result<(), CoreBackendError>;
+}
+```
+
+**`run()` 的两侧实现（不对称，且必须如此）：**
+
+| backend   | 实现                                                                                                                                                                       | 依据                                                                                           |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `Local`   | **一次** `CoreManager::switch(spec)` 调用即可 —— `switch_locked` 自己判 running：未跑则清理 stale epoch 后 `start_locked`；在跑则按能力做 graceful（零停机）或 hard switch | R5b（`switching.rs:52,58-103`）                                                                |
+| `Service` | IPC **没有** `/core/switch`，只能组合：判定"是否需要先停" → 需要则 `stop_core()` → `start_core(CoreStartReq)`                                                              | R21；`api/core/apply.rs` 的文档说明 switch 语义只存在于 `/core/apply`，而 apply 要求核心已在跑 |
+
+**Service 的"是否在跑"判定必须读 `detail`，不能读 `state`（事实 R5d）。** wire 上的 `CoreState` 是有损两值投影，把 `Starting` 和 `Restarting` 都压成 `Stopped(None)`——若按它判定，一个正在启动/重启中的核心会被误判为"已停"，于是跳过 `stop_core()` 直接 `start_core()`，而 daemon 侧仍会返回 already-running，`run()` 就失败了。正确判定：
+
+```rust
+/// 只有 `Stopped` 是终止态；其余五个 detail 变体都意味着"有东西在跑或正在动"，
+/// 必须先 stop。`detail` 缺失（老 daemon 或字段未送达）时**保守当作在跑**——
+/// 多发一次 stop 是幂等的，漏发会导致 start 失败。
+fn service_needs_stop(infos: &CoreInfos) -> bool {
+    match infos.detail.as_ref() {
+        Some(CoreStateDetail::Stopped { .. }) => false,
+        Some(_) => true,
+        None => true,   // fail-safe
+    }
+}
+```
+
+**兜底：`stop_core()` 的 not-started 错误必须被吞掉。** 即便判定正确，daemon 侧仍可能在两次 RPC 之间自行停掉核心。因此 `stop_core()` 返回 typed `not_started`（`error_kind` 常量表，R16）时视为成功继续；**只抑制这一种 kind**，其余错误照常上报。
+
+两侧 `run()` 成功后都必须**同步刷新一次状态**——`switch` 返回 `SwitchOutcome`、`start_core` 返回 `()`，都不带 revision。`run()` 因此**返回刷新后的 `CoreStatusView`**（提交规则见 RQ-02 的 post-run 段），而不是 `Result<()>`。
+
+`LocalBackend`：
+
+- 持 `Arc<nyanpasu_core_manager::CoreManager>`（事实 R4：非 Clone）+ `watch::Receiver<CoreStatus>`（R10）；
+- 构造时 `ManagerOptions` **显式写出** `local_ipc_policy: LocalIpcPolicy::Disable`，并加注释说明"上游默认值已是 Disable（`spec.rs:114`），显式化是为了让这条安全门在 app 侧可见可审"（A1 卡要求，事实 R3）；
+- `runtime_dir` 来自注入的 `RuntimePaths`，**不得**用 `dirs::*` 自行解析（roadmap §1.6 测试禁真实目录）；
+- `apply` 把本地 `ApplyOutcome`（7 分支，R11）映射成 `CoreApplyData`，映射规则**照抄** `manager_bridge.rs:605-639`（R12），含 `DurabilityUncertain` 可嵌套两层、warning 用 `"; "` 拼接。
+
+`ServiceBackend`：
+
+- 持 `nyanpasu_ipc::client::Client`（实例，`Client::new(SERVICE_PLACEHOLDER)`，**禁止 `service_default()`**——A1 卡要求，事实 R18/R19）；
+- 状态经 `observe_status()` 走 `/status`（R21）；`/ws/events` 订阅归 C1。
+
+**5a 不起订阅任务（§2.1 范围裁定）。** 因此 backend 内**没有** `SubscriptionHandle`、没有可取消重连循环、没有需要 join 的后台任务。两个 backend 都只需提供 `status()`（按需查询）与各 mutation 的返回观察，并产出 §2.1 的 `BackendObservation`（含忠实 `lifecycle`）。runtime 侧已有的 `subscribe()` / `subscribe_logs()` 保持可达但**不消费**——C1 接线时无需改 backend 形状。
+
+- Local：`CoreManager::status()` 按需查询（`subscribe()` 保持可达但 5a 不消费）；
+- Service：`Client::status()` 按需查询（`events()` 的订阅/重连整体移出 5a，归 C1）。
+
+`TestBackend`（`#[cfg(test)]`）：脚本化返回值 + 调用计数 + oneshot barrier 钩子，供 A2/A3 的**并发与 gate 语义**测试使用。**注意范围：`TestBackend` 不得用于 A-Exit 要求的 Local/Service parity**（见 S12 的说明）。
+
+**验证：** `cargo check`；`rg 'service_default' backend/tauri/src` 只命中 legacy `core/clash/core.rs`（5a 不动那 5 处，见 §0）。
+
+### S4 — error kind 分类（R0 条件化，隔离在一个模块）
+
+新文件 `APP/core/actor/error_kind.rs`，**整个文件就是 R0 的适配层**。
+
+```rust
+//! 机器可读的核心错误分类。
+//!
+//! 当前 submodule pin（v2.0.0-rc.1）**没有** `Error::kind()`（见计划 §1.1 R16）；
+//! 上游的映射函数 `map_error_kind` 是 `nyanpasu-service-runtime` 的私有函数，
+//! 本 app 不依赖该 crate。因此这里维护一份等价映射作为过渡。
+//!
+//! TODO(actor-migration): 过渡实现，等 R0 合并并 bump submodule。
+//! Reason: `nyanpasu_core_manager::Error::kind()` 在 v2.0.0-rc.1 不存在。
+//! Remove when: submodule 指向含 R0 的 tag —— 届时本文件退化为
+//! `err.kind()` 的一次调用，Service 侧的字符串解析也改成解析 typed kind。
+```
+
+- Local：`fn local_error_kind(err: &nyanpasu_core_manager::Error) -> Option<&'static str>`，逐条对齐 `nyanpasu_ipc::api::error_kind` 的 12 个常量（R16），并像上游一样递归进 `DurabilityUncertain`；
+- Service：直接读 `ClientError` 的 `error_kind: Option<String>`（R26）。
+
+**R0 落地后的替换步骤（一步，独立提交）：** 删除 `local_error_kind` 的 match 体，改为 `err.kind()`；Service 侧把字符串解析成同一个 enum。**本计划不执行该步**（见 §0 与 out-of-scope）。
+
+**验证：** 单测断言 12 个常量的映射与 `nyanpasu_ipc::api::error_kind` 一一对应（用常量本身而非字面量，防止上游改字符串时静默漂移）。
+
+### S5 — `OperationId` / `OperationGate` / actor 骨架
+
+新文件 `APP/core/actor/mod.rs`（`pub(crate) mod backend; pub(crate) mod types; mod error_kind;`——**不含 `client`**：唯一的 typed client 在 `APP/client/core.rs`，与其它四个 client 同层，见 §2.1.7）与 `APP/core/actor/gate.rs`。
+
+按 design §3.1–§3.3 逐字实现：
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct OperationId(NonZeroU64);   // 0 保留为无效值
+
+struct OperationGate { active: Option<ActiveOperation>, waiters: VecDeque<OperationWaiter> }
+struct ActiveOperation { id: OperationId, acquired_at: Instant }
+struct OperationWaiter { id: OperationId, reply: RpcReplyPort<Result<(), OperationError>> }
+```
+
+消息枚举（**5a 只放本阶段用得到的**，design §3.2 里属于 B1 的 `CheckAndPromote` / `ApplyPromoted` / `StartPromoted` **不在 5a**）：
+
+消息枚举的**完整定义（含真实 reply 类型）见 A.1e**——本节只说明 gate 规则。
+
+actor state **见附录 A.1 的 `CoreActorState`**（对照 DV-E：**不含** runtime lifecycle 与 log ring——那是 B1 / C1 的字段）。
+
+gate 规则（design §3.3，逐条）：无 active → 立即登记并回复成功；有 active → 入 FIFO，**handler 立即返回，绝不等待**；`ReleaseOperation(active_id)` → 清 active 并放行下一个仍有接收方的 waiter；`ReleaseOperation(waiting_id)` → 从 waiters 删除；未知 ID → 幂等 no-op + debug 日志；mutation 的 ID 与 active 不符 → `StaleOperation`；shutdown → 拒绝全部 waiters、清 active、关 backend。
+
+**验证：** S12 的 T-OP-01…07。
+
+### S6 — `CoreClient` + `CoreOperationGuard`
+
+新文件 `APP/client/core.rs`（与 `application.rs` / `profiles.rs` 同级，遵循 A7f 房规）。
+
+`CoreClientInner` 的字段**见 A.1**。
+
+关键实现点：
+
+- `begin_operation()` **先分配 ID、先构造 pending guard、再发 `AcquireOperation`**（design §3.1 的取消窗口论证）：
+  ```rust
+  async fn begin_operation(&self) -> Result<CoreOperationGuard> {
+      let mut operation = CoreOperationGuard::pending(self.clone(), self.allocate_operation_id()?);
+      operation.acquire().await?;   // 内部用 Some(CORE_ACQUIRE_TIMEOUT)
+      Ok(operation)
+  }
+  ```
+- `Drop for CoreOperationGuard` 用 **`cast`**（fire-and-forget）发 `ReleaseOperation { id }`——`Drop` 是同步的，不能 await；发送失败只意味着 actor 已终止，此时不存在需要让位的 active operation（design §3.3 原文）；
+- 正常路径允许显式 `release().await`，`Drop` 只作兜底；
+- `allocate_operation_id` 用 `fetch_add`，`0` 视为无效；溢出 → 进程生命周期内不可恢复的内部错误（design §3.1），**不持久化、不跨进程**；
+- `status()` 是**同步 watch 克隆**（`watch::Receiver::borrow().clone()`），不发消息、无超时——读的活性因此是结构性的（§2.1.1）；原计划的 `CORE_READ_TIMEOUT` 常量**删除**；
+- `core_status()`（facade）= watch 读 + `cast RefreshHint`，两步都不等待；
+- `Drop for CoreClientInner` 调 `actor_ref.stop(None)`（房规）。
+
+### S7 — A3 兼容 seam 适配
+
+在 `APP/client/core.rs` 里定义 **`CoreLifecycleAdapter`** 并由它实现 `CoreLifecyclePort`（**不是**直接给 `CoreClient` 实现——适配器还需要 `ApplicationClient` 与 `RuntimePaths` 两个依赖，见下），再为一个包住 `CoreOperationGuard` 的 lease 适配器实现 `CoreLifecycleLease`。
+
+约束（来自 A1f/A4f，**编译期硬约束，不可妥协**）：
+
+- `CoreLifecycleLease: Send`（不要求 Sync）→ `CoreOperationGuard` 必须 `Send`；
+- lease 以 `&mut dyn` 跨 4 处函数签名传递，并被 **move 进 `async move` 闭包**（`patch_running_config`）→ 适配器必须是 `Box<dyn CoreLifecycleLease>` 且可移动进 boxed future；
+- `begin()` 返回的 `Box<dyn CoreLifecycleLease>` 拥有 guard，作用域结束即 drop → 自动 `ReleaseOperation`。这正好把"借用式 lease"与"RAII guard"对上，**不需要改任何调用点**。
+
+**适配器的运行身份来源（round-10 NEW-1，重要修正）。** `CoreLifecycleLease::restart(&mut self)` **不带参数**（`core_bridge.rs:71`），而 `Run` 需要完整 `CoreRequest`。v10 让适配器读 typed 快照取 core type——**那是错的**。
+
+`change_core` 的真实时序（`APP/client/rebuild.rs:281-317`）：取 lease → **只在 legacy `Config::verge().draft()` 里写新核** → `regenerate_for_legacy_inner` 用新核构建并校验 → **`lease.restart()`** → 成功后才 `Config::verge().apply()`，typed 重播更晚（`APP/bridge/verge.rs:257-303`）。因此在 `restart()` 那一刻读 typed 快照拿到的是**旧核**——适配器会在"换到新核"的事务里**重启旧核**。
+
+**修法（A.4 的 lease 那一行）：让 lease 记住本事务的目标核。**
+
+```rust
+// 字段声明见 A.1；此处只写行为。
+impl CoreLifecycleLease for CoreLeaseAdapter {
+    async fn check_and_promote(
+        &mut self,
+        candidate: &CandidateFile,
+        target_core: ClashCore,
+        product: &Utf8Path,
+    ) -> anyhow::Result<[u8; 32]> {
+        self.target_core = Some(target_core);   // 记住本事务的意图
+        /* 其余维持现有实现（D3=A） */
+    }
+
+    async fn restart(&mut self) -> anyhow::Result<()> {
+        // 优先用本事务记住的核；只有"纯 restart、无 promote"的流程
+        // （如 `restart_sidecar`）才回落到 typed 快照。
+        let core = match self.target_core {
+            Some(core) => core,
+            None => self.application.get().await?.state.core,
+        };
+        let request = self.requests.for_product(core)?;
+        self.core.run(&self.guard, &request).await?;
+        Ok(())
+    }
+}
+```
+
+`change_core` 的回滚分支（`rebuild.rs:333`、`:377`）在重启旧核**之前**必须把 `target_core` 覆写为恢复后的核——否则回滚会再次拉起新核。**T-AD-01 / T-AD-02** 分别钉住成功路径与回滚路径**实际请求的 core type**。
+
+> 备选（**不推荐**）：保留一个 legacy bridge 专门供 seam 取 core type 并显式 allowlist。它会让 `config_calls` 指标不降反留，且把一个本可立即消除的全局依赖延寿到 B2/B3，收益为负。
+
+五个 lease 方法在 5a 的路由（按 D3=A）：
+
+| 方法                | 5a 路由                                                                                                                                                                                                                                                                | 去向 |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| `check_and_promote` | 维持现有实现（候选校验 + 原子 promote），核心检查改调 `CoreBackend::check`                                                                                                                                                                                             | B1   |
+| `apply_candidate`   | 维持现有实现                                                                                                                                                                                                                                                           | B3   |
+| `apply_promoted`    | 维持现有实现（`api::put_configs`）                                                                                                                                                                                                                                     | B3   |
+| `restart`           | **改走 `Run { request }`**（**不是** `CoreBackend::start`）。legacy `run_core_from(product)` 的语义就是"在跑先停、再按 product 启动"，恰好等于 `run()`（DV-F / R5b）。`request` 由 lease 适配器按 A13f 的既有取值方式就地构造，`config_path = runtime_paths.product()` | —    |
+| `stop`              | **改走** `CoreBackend::stop`                                                                                                                                                                                                                                           | —    |
+
+> **注意**：`CoreLifecycleLease::restart` 这个**名字**保持不变（A3 要求兼容 seam 不动），但它背后是 `Run` 而非任何 "restart" 原语。适配器上必须写明这一点，否则后续读者会误以为可以直接映射到 `CoreManager::restart()`。
+
+`CoreLifecyclePort::status()` 在 5a **第一次有了生产实现**（A5f 此前无生产调用者），返回值由 `CoreStatusView` 投影成既有 `CoreStatusSnapshot`，**wire 与结构都不变**。
+
+`on_profile_change()` 维持现有实现（连接中断服务，PR-6 范围）。
+
+**顺序不变式（必须在代码注释里写明）：** A3f 已确认 `rebuild_gate` 在全部 10 处都先于 `core.begin()`，`patch_running_config` 是 `clash_patch_gate → rebuild_gate → begin()`。5a 引入 `OperationGate` 后变成**三层嵌套且全局顺序一致**，因此不产生死锁。B2 会把前两层吸收掉。
+
+### S8 — 组合根接线
+
+**不能**沿用"在 `setup.rs` 里构造好再从 `ClientSetupArgs.core` 传进去"的写法：事实 A17f——`try_new_with_args` 在进入 `block_on` **之前**就解构了 `core`（`client/mod.rs:255-264`），而 `CoreClient` 需要的 `enable_service_mode` 来自 typed `application` client，后者到 block 内第 279 行才存在。
+
+**正确的所有权图（三步）：**
+
+**（1）`CoreClient` 在 block 内、typed 快照之后构造。** 位置紧跟 `new_typed_config_clients(...)`（`client/mod.rs:279`）之后：
+
+**完整构造序列见 A.3（7 步，编号）——此处不复述。** 要点只有一条：`CoreRequestFactory` 必须在 `CoreClient` **之前**构造（A.3 第 4 步先于第 5 步），因为 `CoreClientArgs` 要按值收下它的 clone。
+
+按 D2 的顺序事实此刻必然是 `Normal`（`init_service()` 尚未跑），先建 Local backend；健康检查随后再发 `SetBackend(Service)`。
+
+**（2）`CoreClient` 成为 `NyanpasuClientInner` 的 typed 字段；legacy trait 适配器内部产出。**
+
+```rust
+struct NyanpasuClientInner {
+    // ...
+    core_client: CoreClient,              // 新增 typed 依赖
+    core: Arc<dyn CoreLifecyclePort>,     // 保留，但生产路径由 core_client 内部产出
+}
+```
+
+`ClientSetupArgs.core` 由 `Arc<dyn CoreLifecyclePort>` 改为 **`Option<Arc<dyn CoreLifecyclePort>>`**：
+
+- 生产（`setup.rs`）传 `None` → block 内构造完整适配器并作为生产 port：
+  **构造代码见 A.3 第 4/6 步。** 适配器的三个参数缺一不可：少 `application` 就回到"无参 `restart()` 拿不到 core type"的死结（且 A.4 已说明它只用于纯 restart 回落）；少 `CoreRequestFactory` 就凑不齐 `binary_path` / `working_dir` / `pid_path`，只能退回会调 `dirs::*()` 的 `find_binary_path`——那正是被禁止的；
+  三个参数**缺一不可**：少 `application` 就回到"无参 `restart()` 拿不到 core type"的死结；少 `CoreRequestFactory` 就凑不齐 `binary_path` / `working_dir` / `pid_path`（`RuntimePaths` 只有 product 与 candidate_dir），只能退回会调 `dirs::*()` 的 `find_binary_path`——那正是被禁止的；
+- 测试传 `Some(mock)` → 沿用既有 `test_client_args_with_lifecycle`（A8f），**测试图零改动**。
+
+这**完全复刻**同文件既有的 `clash_patch: Option<...>` 分阶段注入模式（`client/mod.rs:265-268`），是本仓已确立的房规而非新发明。`setup.rs` 相应删掉 `core: Arc::new(LegacyCoreBridge::new(runtime_paths))` 一行，并新增 degradation sink 的注入。
+
+**（3）无注入点的消费者——显式 clone 穿线。** 这些 `pub fn` 既没有参数也拿不到 Tauri state。**共 6 个入口**（v2/v3 只列了 2 个，遗漏了 `spawn_health_check` 的三个直接调用者，事实 A21f）：
+
+| #   | 消费者                                                                 | 现状                                                                                  | 5a 穿线方式                                                                                                                                    |
+| --- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `APP/feat.rs:56 restart_clash_core()`                                  | 无参 `pub fn`，`spawn` 后调 `CoreManager::global().run_core()`；调用方是托盘/菜单动作 | 改签名为 `restart_clash_core(client: NyanpasuClient)`，由托盘调用点传入已 `manage` 的 clone（`NyanpasuClient` 是 `Arc` newtype，clone 零开销） |
+| 2   | `APP/core/service/ipc.rs:74 on_ipc_state_changed(state)`               | 健康检查线程内调用                                                                    | 由 `spawn_health_check` 往下传（见 3–6）                                                                                                       |
+| 3   | `APP/core/service/mod.rs:32` `init_service()` → `spawn_health_check()` | 启动路径                                                                              | `init_service(reconciler: CoreModeReconciler)`；上游 `APP/utils/init/mod.rs::init_service` 同步加参数                                          |
+| 4   | `APP/core/service/control.rs:97`（`install_service()` 内）             | 安装成功后拉起健康检查                                                                | `OsServiceControlOps::install(reconciler)` 内部持有并下传；IPC 入口 `APP/ipc.rs:937` 改调 facade                                               |
+| 5   | `APP/core/service/control.rs:225`（`start_service()` 内）              | 同上                                                                                  | `OsServiceControlOps::start(reconciler)`；IPC 入口 `APP/ipc.rs:951` 改调 facade                                                                |
+| 6   | `APP/core/service/control.rs:320`（`restart_service()` 内）            | 同上                                                                                  | `OsServiceControlOps::restart(reconciler)`；IPC 入口 `APP/ipc.rs:985` 改调 facade                                                              |
+
+**穿的不是裸 `CoreClient`，而是 `CoreModeReconciler`（round-6 #8）。** `on_ipc_state_changed` 要做的是完整事务——读 typed 快照、构造 `CoreRequest`、在 guard 下 `SetBackend` + `Run`——只给 `CoreClient` 三样依赖缺两样。因此定义：
+
+`CoreModeReconciler` 的**声明见 A.1**；它的 `reconcile(ipc_state)` 做完整事务：读 typed 快照 → 取 guard → `SetBackend` → 用工厂构造 `CoreRequest` → `Run`。
+
+`spawn_health_check(reconciler: CoreModeReconciler)`，四个调用者各自把手里的 reconciler 传进去。
+
+**健康检查的注入根在 `resolve.rs:152`（round-8 #3）。** 现状是 `resolve.rs:152` 调 `init::init_service()`，后者（`APP/utils/init/mod.rs:231-269`）与 `APP/core/service/mod.rs:17-36` **各自**读一次 `Config::verge().enable_service_mode`，再决定是否 `spawn_health_check()`。5a 改为：
+
+1. facade 提供入口 `NyanpasuClient::init_service_health()`——它**自己**从 `ApplicationClient` 读一次 typed 快照， 并构造 `CoreModeReconciler`；
+2. `resolve.rs:152` 改调该 facade 方法（此处 `NyanpasuClient` 已 `manage`，拿得到）；
+3. 下游两处 `Config::verge()` 读取**改为接收传入的值**——`init::init_service(enable_service: bool, reconciler: CoreModeReconciler)` 与 `service::init_service(enable_service: bool, reconciler: CoreModeReconciler)`，它们不再自己查配置；
+4. 初次 `spawn_health_check(reconciler)` 由第 3 步传下去的 reconciler 供给。
+
+这样**启动路径上的两处 `Config::verge()` 一并消除**（ledger `config_calls` 应下降 2），且健康检查线程从诞生起就持有完整依赖。
+
+**四个** service IPC 命令（install / start / stop / restart）改为转调 facade 领域方法（见下 (4)），另有 `get_core_status` / `restart_sidecar` / `update_core` 三个也改走 facade（S9 表）。新增的 `tauri::State` 参数**不进 TS 签名**（managed state 在 specta 导出时被跳过）；验证判据是 **bindings 除已声明的 `core_lifecycle` 联合成员外无其它 diff**（S13）。
+
+**（4）所有需要 `CoreClient` 的 Tauri 命令都必须走 facade 领域方法（round-4 #4 / round-5 #3、#4）。** 它们拿到的是 `State<NyanpasuClient>`，而 `NyanpasuClient.inner` 是**私有**字段（`client/mod.rs:93-96`）——命令层既够不到 `CoreClient`，计划又（正确地）禁止加 `core_client()` 访问器。按 `update_core` 的先例（S9.1），facade 补齐**六个**领域方法：
+
+| facade 方法         | 承接的命令                     | 内容                                       |
+| ------------------- | ------------------------------ | ------------------------------------------ |
+| `install_service()` | `ipc.rs:937`                   | 控制操作 + 健康检查穿线                    |
+| `start_service()`   | `ipc.rs:951`                   | 完整 typed 事务（见下）                    |
+| `stop_service()`    | `ipc.rs:968`                   | 完整 typed 事务（**v5 遗漏了这一个**）     |
+| `restart_service()` | `ipc.rs:985`                   | 完整 typed 事务                            |
+| `core_status()`     | `ipc.rs:399` `get_core_status` | 读缓存快照（§2.1 R5），投影成既有元组 wire |
+| `restart_core()`    | `ipc.rs:502` `restart_sidecar` | guard + `Run { request }`                  |
+
+**三个 service 方法的完整 typed 事务**（不是 `control::*` 直通）。**关键是错误次序（round-6 #9）**：整个对账块必须作为**一个被捕获的 `Result`** 执行，块内**任何**失败（快照读取、取 guard、`SetBackend`、构造请求、`Run`）都只记录日志，**绝不 `?`**——否则会用对账错误顶替掉原本要返回的控制结果，把"控制成功但对账失败"变成 `Err`，或把"控制失败"的原因替换掉。
+
+```rust
+impl NyanpasuClient {
+    /// `start_service` / `stop_service` / `restart_service` 同形，只有 `control::*` 那一步不同。
+    pub async fn start_service(&self) -> Result<()> {
+        // 1) 控制操作。结果**存起来不 `?`**。
+        let control = self.inner.service_control.start(self.core_mode_reconciler()).await;
+
+        // 2) 整个对账块捕获成一个 Result —— 内部一律不 `?` 逃逸出去。
+        let reconcile: anyhow::Result<()> = async {
+            let app = self.inner.application.get().await?.state;
+            if app.enable_service_mode {
+                self.core_mode_reconciler()
+                    .reconcile(crate::core::service::ipc::get_ipc_state())
+                    .await?;
+            }
+            Ok(())
+        }
+        .await;
+        if let Err(e) = reconcile {
+            log::error!(target: "app", "{e}");   // 与既有实现一致：只记录
+        }
+
+        // 3) 控制操作的错误在**最后**才抛
+        Ok(control?)
+    }
+}
+```
+
+> **保留的既有语义（round-5 #3，leader 裁定：不改行为）。** 现有三个命令都是 `let res = control::X().await;` … 中间无条件尝试 `run_core()` … 最后才 `Ok(res?)`（`ipc.rs:951-997`）。也就是说**控制操作失败时仍然会尝试拉起核心**。这不是笔误，而是 **fail-open-to-Local**：控制操作失败 → daemon 没起来 → 健康检查不会把 `IpcState` 置为 `Connected` → `RunType::classify` 给出 `Normal` → 于是拉起的是**本地核心**。用户至少有一个能用的核心，与 PR-5-pre 兼容门"失败一律退回 Local"的哲学一致。
+>
+> **因此 `control?` 必须留在最后**，对账块的任何错误都只记录不上抛。实施时**不得**"顺手改成先判 `control?` 再对账"——那会静默改变行为：控制失败时用户从"有本地核心"变成"什么都没有"。T-FA-01…05 逐点钉住。
+
+**可注入的控制 seam `ServiceControlOps`（round-6 #9 / round-7 #5）。** 不能靠真的执行 OS service 命令来制造控制失败，因此把四个控制函数抽成窄 trait 并**接入对象图**：
+
+`ServiceControlOps` 的**声明见 A.1**（四个方法；`pub(crate)`，因为参数含 crate-private 的 `CoreModeReconciler`——见 A.6）。
+
+注入链（**四处都要改**）：
+
+1. `ClientSetupArgs` 增加 `service_control: Arc<dyn ServiceControlOps>`（**5 个字面构造点全部要动**，A22f）；
+2. `NyanpasuClientInner` 增加同名字段；
+3. `setup.rs` 构造生产适配器 `Arc::new(OsServiceControlOps)`——它内部就是现有的 `control::{install,start,stop,restart}_service`；
+4. facade 方法**调注入的 ops**（`self.inner.service_control.start(...)`），**不再**直接 `control::start_service(...)`。
+
+这才是 T-FA-01/05 能注入失败的前提——测试传 `MockServiceControlOps`，不碰任何 OS 命令。
+
+> **这是 5a 唯一新增的 port。** design §9 说的"不引入完整 `ServiceControlPort`"针对的是把 service 管理**迁进 CoreActor**；这里只给既有函数加一层可测边界，所有权仍在 `core::service::control`，不迁移。
+
+> `uninstall_service`（`ipc.rs:944`）**不加** facade 方法——它只置 `KILL_FLAG`，不需要 `CoreClient`。
+
+> `uninstall_service`（`ipc.rs:944`）**不需要**改——它只置 `KILL_FLAG`，不调 `spawn_health_check`。
+> 这两处都**不是**"再加一个全局"——是把已有的实例显式传下去。若某个调用点确实拿不到 client（例如极早期启动路径），**停下来上报**，不要退回全局查找。
+
+**（4）`LegacyCoreBridge` 删除**（`core_bridge.rs:107-153`，含其 `CoreManager::global()` 两处与那条 TODO 标记）。
+
+**（5）IpcState 翻转的处理**（`core/service/ipc.rs:83-91`）改为在**同一个** `CoreOperationGuard` 下顺序执行 `SetBackend(mode)` 然后 `Run { request }`——**不是** `Restart`（新 backend 没有 `last_spec`，R5c）。
+
+### S9 — 迁移直接调用点
+
+按 A3 卡"start/stop/restart/status 改走 actor"逐点替换。**命令层一律只调 facade 领域方法（round-6 #10）**——
+`ipc.rs` / `feat.rs` 拿不到私有的 `NyanpasuClientInner`，T-FA-04 也断言 `ipc.rs` 里不得出现 `CoreClient` 类型名。
+
+| 调用点                                         | 现状                             | 5a 改为（**全部经 facade**）                                                                     |
+| ---------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `APP/ipc.rs:399` `get_core_status`             | `CoreManager::global().status()` | `client.core_status()` —— facade 内部 `CoreClient::status()` 后投影成既有元组 wire，**形状不变** |
+| `APP/ipc.rs:502` `restart_sidecar`             | `run_core()`                     | `client.restart_core()` —— facade 内部 guard + `Run`                                             |
+| `APP/ipc.rs:937/951/968/985` 四个 service 命令 | `control::*` + `run_core()`      | `client.{install,start,stop,restart}_service()`（S8(4)）                                         |
+| `APP/ipc.rs:639` `update_core`                 | `UpdaterManager::global()`       | `client.update_core(core_type)`（S9.1）                                                          |
+| `APP/feat.rs:56` `restart_clash_core()`        | `run_core()`                     | 改签名收 `NyanpasuClient`，调 `client.restart_core()`                                            |
+| `APP/feat.rs:292,385`                          | `status()`                       | `client.core_status()`                                                                           |
+| `APP/core/service/ipc.rs:83,88`                | `status()` + `run_core()`        | `CoreModeReconciler::reconcile()`（S8(3)）                                                       |
+| `APP/utils/help.rs:268`                        | `stop_core()`                    | `client.shutdown()` 已覆盖（S11），**删除该行**                                                  |
+| `APP/utils/resolve.rs:288`                     | `stop_core()`                    | **删除该行停核**（S11：`resolve_reset` 只留 `reset_sysproxy()`）                                 |
+| `APP/feat.rs:392` macOS DNS                    | `change_default_network_dns`     | **不动，但必须 allowlist**（S9.2）                                                               |
+| `APP/core/updater/instance.rs:201,205,216,279` | `begin_lifecycle` + lease 方法   | **必须迁移**（S9.1）                                                                             |
+
+> facade 领域方法总表见 S8(4)：`core_status` / `restart_core` / `install_service` / `start_service` / `stop_service` / `restart_service` / `update_core`，共 **7 个**。
+
+#### S9.1 — Updater 必须在 5a 迁移（原计划此处有错）
+
+事实 A16f：`replace_core()` 依赖的是 **S10 要删掉的那一整套 API**——`CoreManager::global().begin_lifecycle()`、`lifecycle.stop_core()`、`lifecycle.run_core_from(product)`。原计划"Updater 不动 + S10 删 lease"两条**互相矛盾，会直接编译失败**。而且即便设法保住编译，legacy 单例也停不掉 CoreActor 拥有的新 manager 实例——那是**两个不同的进程所有者**，会出现"更新器以为停了核、实际没停"的静默损坏。
+
+**Leader 裁定：在 5a 用显式注入的 `CoreClient` + operation guard 改造 `replace_core`，不加 `attach_core_port` 全局桥，UpdaterActor 的完整迁移仍归 PR-6d。**
+
+**注入必须穿透真实的四段构造链**（事实 A16g；v2 计划把类型名写成了不存在的 `UpdaterInstance`，且只说"构造点会接受它"，不够可执行）：
+
+```text
+ipc::update_core(core_type)                                   ← Tauri 命令，注入起点
+  → NyanpasuClient::update_core(core_type)                    ← facade 领域方法
+  → UpdaterManager::update_core(&core_type, core)  ← **两个**参数；core 不存入 manager 自身
+    → UpdaterBuilder::set_core(core).build()      ← builder 只加一个 Option 字段
+      → Updater { core, .. }                     ← 只需 CoreClient；运行身份经 A.4 的守卫消息查询
+```
+
+**逐点签名（四处，全部要改）：**
+
+```rust
+// 1) APP/ipc.rs:639 — 薄适配器，只转调 facade 的领域方法
+#[tauri::command]
+#[specta::specta]
+pub async fn update_core(
+    client: tauri::State<'_, crate::client::NyanpasuClient>,
+    core_type: nyanpasu::ClashCore,
+) -> Result<usize> {
+    Ok(client.update_core(core_type).await?)
+}
+
+// 1b) APP/client/mod.rs — facade 上的**领域方法**（leader 裁定，round-3 #10）。
+//     不提供 `core_client()` 这类内部 client 访问器：那会把 typed actor 边界泄给命令层，
+//     即使不暴露裸 `ActorRef` 也违反 CLAUDE.md §7 的 facade 约束。
+//     依赖穿线全部发生在**这一个方法体内**，命令层看不到 CoreClient。
+impl NyanpasuClient {
+    pub async fn update_core(&self, core_type: ClashCore) -> Result<usize> {
+        let core = self.inner.core_client.clone();          // 私有字段，不外泄
+        Ok(crate::core::updater::UpdaterManager::global()
+            .write().await
+            .update_core(&core_type, core).await?)
+    }
+}
+
+// 2) APP/core/updater/mod.rs:222
+pub async fn update_core(&mut self, core_type: &ClashCore, core: CoreClient) -> Result<usize>
+
+// 3) APP/core/updater/instance.rs — builder 新增字段与 setter
+pub(super) struct UpdaterBuilder {
+    client: Option<reqwest::Client>,
+    core_type: Option<ClashCore>,
+    mirror: Option<String>,
+    artifact: Option<String>,
+    tag: Option<CoreTypeMeta>,
+    core: Option<CoreClient>,        // 新增
+    // round-11：不再需要 provider 字段——运行身份由 `CoreClient::running(&guard)` 查询
+}
+impl UpdaterBuilder {
+    pub fn set_core(mut self, core: CoreClient) -> Self { self.core = Some(core); self }
+    // round-11：`set_request_provider` 删除
+    // build() 里 `core` 缺失时按既有风格 bail
+}
+
+// 4) APP/core/updater/instance.rs:31 — Updater 持有它
+pub(super) struct Updater {
+    // ...既有字段不动...
+    core: CoreClient,
+    /// 在**替换时刻**解析请求（round-9 #2）——不是 `update_core()` 调用时刻。
+    // round-11：无额外字段——`core: CoreClient` 已足够
+}
+
+async fn replace_core(&self) -> anyhow::Result<()> {
+    self.dispatch_state(UpdaterState::Replacing);
+    // 整个 stop → swap binary → run 事务持有同一个 guard，
+    // 与 rebuild/change-core 互斥（这正是 legacy begin_lifecycle 原本提供的保证）。
+    let operation = self.core.begin_operation().await?;
+
+    // **在 guard 内解析当前意图**（round-9 #2）——下载可能已经跑了几分钟，
+    // 期间用户可能换核，因此绝不能用 `update_core()` 调用时刻的快照。
+    // **查 actor 拥有的运行身份**（A.4 的守卫消息）——不读 typed desired：typed 快照在
+    // legacy `change_core` 的重播窗口内可能仍是旧核。三种处置见 A.4 末表。
+    let running = self.core.running(&operation).await?;   // Err ⇒ 直接中止替换
+    let restart_target = running
+        .filter(|r| r.core_type == (&self.core_type).into());
+
+    if restart_target.is_some() {
+        tracing::debug!("stopping core to replace");
+        self.core.stop(&operation).await?;             // 取代 lifecycle.stop_core()
+    }
+
+    /* 现有的下载 / 校验 / 复制二进制逻辑逐字不动 */
+
+    if let Some(request) = restart_target.as_ref() {
+        self.dispatch_state(UpdaterState::Restarting);
+        // 用**刚才查到的**运行身份重启（同一个核、同一份路径）。
+        self.core.run(&operation, request).await?;   // 取代 lifecycle.run_core_from()
+    }
+    Ok(())
+}
+```
+
+**注入原则（三条，逐条约束）：**
+
+1. **`CoreClient` 只随调用传递，绝不存进 `UpdaterManager`。** 把它挂到全局 manager 上等同于新建一个全局服务定位器（CLAUDE.md §7 禁止），也正是 design §9 拒绝的 `attach_core_port` 半迁移桥。它只从 `update_core` 的参数流向 builder 再流向 `Updater` 实例。
+2. **领域 facade 方法，不是内部 client 访问器**（leader 裁定，round-3 #10）：`NyanpasuClient` 新增 `pub async fn update_core(&self, core_type) -> Result<usize>`，**不**新增 `core_client()` 访问器。`CoreClient` 的 clone 只在该方法体内发生，命令层完全看不到它——既不暴露裸 `ActorRef`，也不暴露 typed client（CLAUDE.md §7）。
+3. `UpdaterManager::global()` 本身仍是 PR-6d 的 residual——**本阶段只把 core 依赖显式化，不动 updater 自身的全局性**。
+
+原来那条 `TODO(actor-migration): temporary bridge to the legacy global core manager`（instance.rs:202-204）**删除**。
+
+> **`update_core` 的 Tauri 命令签名变化不应影响 TS**：新增的 `client: tauri::State<'_, NyanpasuClient>` 参数**不进入** TS 签名（Tauri 的 managed state 参数在 specta 导出时被跳过，与既有 `patch_verge_config` 等命令同理）。因此 `updateCore` 的 TS 形状不变——但**实施时必须核对**：bindings 的 diff **除已声明的 `core_lifecycle` 联合成员外应为空**（S13），不要假设。
+
+#### S9.2 — macOS DNS residual allowlist（leader 裁定）
+
+`feat.rs:392` 的 `CoreManager::global().change_default_network_dns(...)` 是**第二个** core residual（原计划 §5 的"仅剩 Updater residual"断言因此是错的）。**Leader 裁定：不在 5a 迁移，allowlist 到 PR-5c / C3**，补标记：
+
+```rust
+// TODO(actor-migration): macOS DNS 仍走 legacy CoreManager。
+// Reason: DNS 归位（MacosDnsGuard，与 start/stop 保序）是 PR-5c / C3 的范围；
+//         在 5a 迁移它会把平台副作用编排提前带进本阶段。
+// Remove when: PR-5c 把 MacosDnsGuard 移入 CoreActor。
+```
+
+于是 5a 结束后 `CoreManager::global()` 的**生产代码**残留恰好 **1 处**（`feat.rs:392`，且带 `#[cfg(target_os = "macos")]`），另有 1 处出现在 `process_core_bridge.rs:4` 的**文档注释**里（内容是"禁止调用"的告诫，不是调用）。S13 的 grep 判据按此写。
+
+### S10 — 删除 legacy 生命周期
+
+- 删除 `CoreManager::lifecycle_lock` 字段、`begin_lifecycle()`、`CoreLifecycleLease<'a>`（legacy 的那个）以及所有 `*_with_lease` 变体（`APP/core/clash/core.rs:386-422,428,444-449,486-651`）；
+- **删除两条裸线程递归恢复路径**（design §5 禁止的第二层恢复，缺一不可）：
+  1. `core.rs:577-582`——`recover_core()` 失败后 `sleep(5s)` + `std::thread::spawn` + 自调用；
+  2. **`core.rs:228-238`**——`Instance` 事件循环里核心异常退出且 `tx.send` 失败时 `std::thread::spawn` → `CoreManager::global().recover_core()`（事实 A20f。原计划**遗漏**了这一条）。
+
+  两条删完后 `recover_core()` 本身若失去调用者也一并删除；恢复完全交给 runtime 的 Supervisor（R13）。
+
+- **保留**：`Instance`、`RunType`、`find_binary_path`、`change_default_network_dns`、`status()`（S9.2 的 DNS allowlist 仍需要）。
+
+> 判定原则：只删"被 CoreActor 取代的排他与恢复机制"，不删"尚有 owner 的功能代码"。
+
+### S11 — shutdown 接线（原计划的顺序描述有错）
+
+事实 A18f：`cleanup_processes` 的**真实**顺序是 `save_window_state` → **`resolve_reset()`** → `client.shutdown()` → widget stop → `CoreManager::global().stop_core()`。而 `resolve_reset()` 内部**已经停了一次核**（`resolve.rs:288`）。所以现状是**核被停两次，且第一次发生在 `client.shutdown()` 之前**——原计划"顺序保持 client.shutdown() → widget stop → 停核"的描述是错的。
+
+**改法（reviewer 建议，已核实可行）：**
+
+1. **从 `resolve_reset()` 里移除停核**，只留 `reset_sysproxy()`。可行性已验证：`resolve_reset` 全仓**只有一个调用者**（`help.rs:251`），移除后不影响任何其它路径；
+2. `NyanpasuClient::shutdown()` 追加：rebuild worker 关闭**之后**调 `CoreClient::shutdown()`（`Shutdown` 消息 → 拒绝全部 waiters → 关 backend；5a 无订阅任务需要 join）；
+3. 删除 `help.rs:268` 的 `CoreManager::global().stop_core()`——停核已由第 2 步完成；
+4. 最终顺序：`save_window_state` → `resolve_reset()`（现在只重置系统代理）→ `client.shutdown()`（rebuild worker + CoreActor + backend）→ widget stop；
+5. 更新 `shutdown()` 的契约 doc comment（`client/mod.rs:392-401` 现在明写"不停 CoreManager globals"，5a 后不再成立）。
+
+> 顺序理由：系统代理必须在核心停止**之前**恢复，否则会留下一段"代理指向已死核心"的窗口——这正是现状把 `resolve_reset` 放在最前的原因，保留该位置。
+
+### S12 — 测试
+
+全部 TempDir + barrier/RPC 同步，**零 sleep 断言**（A10f）。
+
+#### A2 gate 测试（对应 A-Exit 六项）
+
+| ID      | 名称                                                 | 断言                                                                                                                                                              | A-Exit 项         |
+| ------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| T-OP-01 | `waiters_are_granted_in_fifo_order`                  | 三个 waiter 依次入队；释放 active 后按入队顺序放行（用 oneshot 记录放行次序）                                                                                     | FIFO              |
+| T-OP-02 | `dropping_a_waiting_guard_cancels_it`                | waiter guard drop → 从 waiters 移除；后续 release 不会把它误认为 active                                                                                           | 等待取消          |
+| T-OP-03 | `guard_dropped_right_after_grant_releases_active`    | 用 barrier 让 release 与 grant 竞争：guard 在刚被提升为 active 后 drop → active 清空且下一个 waiter 被放行                                                        | 刚获批取消        |
+| T-OP-04 | `stale_release_is_idempotent_noop`                   | 对已完成/未知 ID 发 `ReleaseOperation` → 不影响当前 active，不 panic                                                                                              | stale release     |
+| T-OP-05 | `mutation_with_wrong_id_returns_stale`               | 持 A 的 id 时用 B 的 id 发 `Run` → `StaleOperation`，且 backend **零调用**（TestBackend 计数）                                                                    | wrong-id mutation |
+| T-OP-06 | `shutdown_drains_all_waiters`                        | 一个 active + 两个 waiter 时 shutdown → 两个 waiter 都收到错误，backend 收到 stop                                                                                 | shutdown drain    |
+| T-OP-07 | `acquire_times_out_and_releases_the_waiter`（RQ-04） | 用 `tokio::time::pause()` 推进到 `CORE_ACQUIRE_TIMEOUT` → `begin_operation` 返回 `AcquireTimeout`，且 waiter 已从队列移除（后续 release active 时直接放行第三个） | RQ-04             |
+
+#### A1 backend parity 测试
+
+| ID      | 断言                                                                                                                                                                                                                                                                                                            |
+| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T-BK-01 | **真实 parity**：`CoreBackend::{Local, Service}` 对 check / run / stop / recover 的成功路径产生一致的 `CoreStatusView` 转换。Local = TempDir + manager-compatible 探针核（见下 §S12.1）；Service = 真实 IPC roundtrip harness（见下 §S12.2）。**不得用 `TestBackend` 顶替**（A-Exit 明写 Local/Service parity） |
+| T-BK-02 | `LocalBackend` 构造出的 `ManagerOptions.local_ipc_policy == LocalIpcPolicy::Disable`（显式化的回归钉）                                                                                                                                                                                                          |
+| T-BK-03 | apply outcome 映射：7 个本地 `ApplyOutcome` 分支 → `CoreApplyData`，含 `DurabilityUncertain` 单层与**双层嵌套**（warning 以 `"; "` 拼接），`Noop` 不丢失                                                                                                                                                        |
+| T-BK-04 | `local_error_kind` 对 12 个 `nyanpasu_ipc::api::error_kind` 常量的映射（断言用常量而非字面量）                                                                                                                                                                                                                  |
+| T-BK-05 | `is_recovery_exhausted` 对上游前缀命中/不命中（纯函数层）                                                                                                                                                                                                                                                       |
+| T-BK-06 | **`core_recovery_exhausted` 恰好发布一次**（D5 / design §5）：注入 `MockCoreDegradationSink`，重复投递同一个耗尽状态 → `publish` 调用次数 `== 1`。**并含 recover-重放分支**：耗尽 → 发布 1 次 → `recover` 成功（核心**未**拉起）→ 重放同一耗尽快照 → `publish` 仍 `== 1`（`recover` 不复位 latch）              |
+| T-BK-07 | **latch 复位后可再次发布**：耗尽 → 发布 1 次 → 核心重新 `Running`（或 `SetBackend` 换槽）→ 再次耗尽 → 累计 `publish` 次数 `== 2`                                                                                                                                                                                |
+| T-BK-12 | **latch 在投影前判定**（round-3 #5 回归钉）：构造 `Starting → 耗尽 → Starting → 再耗尽` 序列（**全程从未到达 `Running`**）→ `publish` 次数 `== 2`。若实现改成读投影后的两值 `CoreStatusView`，`Starting` 不可见、latch 无法复位，第二次不会发布，本用例即刻失败                                                 |
+| T-BK-13 | **`Degradation` DTO 取值**：`phase == DegradationPhase::CoreLifecycle`、`code == "core_recovery_exhausted"`、`retryable == true`、`message` 含 runtime 原始 reason 且**长度 ≤ 512 字节**（超长 reason 被截断）                                                                                                  |
+
+#### facade 编排测试
+
+| ID      | 断言                                                                                                                                                                                                                                                                                                              |
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T-FA-01 | **控制失败仍尝试拉核**（S8(4) 保留的既有语义）：让 `control::start_service` 返回 `Err` → facade **仍然**走 `SetBackend` + `Run`（fail-open-to-Local），最终返回的是控制操作的 `Err`。若实现被"优化"成先 `res?` 再 run，本用例即失败。故障通过注入的 `ServiceControlOps` mock 制造，**不执行任何 OS service 命令** |
+| T-FA-02 | **`enable_service_mode == false` 时不碰核心**：typed 快照为 false → 不取 guard、不发 `SetBackend`/`Run`（backend 零调用），只返回控制操作结果                                                                                                                                                                     |
+| T-FA-03 | **对账块任一环节失败都不改变返回值**：分别注入"快照读取失败"/"取 guard 超时"/"`SetBackend` 失败"/"构造请求失败"/"`Run` 失败"五种故障 → 每种都只记录日志，facade 仍返回**控制操作**的结果（成功则 `Ok`，失败则原始 `Err`）                                                                                         |
+| T-FA-04 | **四个 service 方法 + `core_status` / `restart_core` 都不需要命令层接触 `CoreClient`**：编译期保证——`ipc.rs` 内不出现 `CoreClient` 类型名（用 `rg` 断言）                                                                                                                                                         |
+| T-FA-05 | **控制失败的错误不被顶替**：控制返回 `Err(A)` 且对账也失败 `Err(B)` → facade 返回的是 **A**，B 只进日志                                                                                                                                                                                                           |
+
+#### 生产适配器测试（round-10 NEW-1）
+
+| ID      | 断言                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T-AD-01 | **换核成功路径请求的是新核**：走 `check_and_promote(_, 新核, _)` → `restart()` → 断言 backend 收到的 `CoreRequest.core_type` 是**新核**（而非 typed 快照里的旧核）                                                                                                                                                                                                                                                                                                                                               |
+| T-AD-02 | **回滚路径请求的是旧核**：新核 `restart()` 失败 → 回滚分支覆写 `target_core` 为恢复后的核 → 断言第二次 `run` 的 `core_type` 是**旧核**                                                                                                                                                                                                                                                                                                                                                                           |
+| T-AD-03 | **纯 restart 回落 typed**：未经 `check_and_promote` 的 `restart()`（`restart_sidecar` 路径）→ 用 typed 快照的 `core` 构造请求                                                                                                                                                                                                                                                                                                                                                                                    |
+| T-AD-04 | **`SetBackend` 后运行身份清空**（A.4）：`Run` 成功 → `running == Some` → `SetBackend` 换槽 → `running(&guard)` 返回 **`Ok(None)`**（旧 backend 已 drop，身份失效），Updater 因此只换二进制、不停不启                                                                                                                                                                                                                                                                                                             |
+| T-AD-05 | **`Failed` 槽位查询**：换槽构造失败 → 槽位 `Failed` → `running(&guard)` 返回 **`Err(NoBackend{..})`** → Updater **中止替换**并上抛该错误（**不**回退 typed desired）                                                                                                                                                                                                                                                                                                                                             |
+| T-AD-06 | **观察到终止态后清空**（round-11 NEW-1）：`Run` 成功 → 提交一次 `lifecycle == Stopped` 的观察（模拟核崩溃）→ `running(&guard)` 返回 `Ok(None)`，不再是陈旧的旧身份                                                                                                                                                                                                                                                                                                                                               |
+| T-AD-07 | **未持 guard 查询被拒**：用错误 / 过期的 `OperationId` 发 `RunningIdentity` → `Err(StaleOperation)`，且 actor **不读** `state.running`                                                                                                                                                                                                                                                                                                                                                                           |
+| T-BK-08 | **换槽后目录锁可重新获取**（D2 协议回归钉）。**必须走 Local → Service → Local**，不能用同模式换槽：同模式 `SetBackend` 的行为未定义，合理实现可以直接 no-op，那样测试会在什么都没释放的情况下通过（假阳性）。断言两点：(a) 第二次 Local 的 `CoreManager` 构造**成功**（不出现 `Error::RuntimeDirectoryOwned`）；(b) backend **身份确实变了**——用 `LocalBackend` 里递增的构造计数器（或 `Arc::ptr_eq` 判否）证明是新实例而非复用。等效替代：直接 consume/drop 第一个 `LocalBackend` 再在同一 `runtime_dir` 上重建 |
+| T-BK-09 | **无 backend 失败态**：让替换构造失败 → 槽位为 **`Some(BackendSlot::Failed { error })`**（不是 `None`——`None` 只在换槽**瞬态**出现）→ mutation 返回 `CoreActorError::NoBackend { last_error }`（`Arc` 克隆自槽位）；`status()` 经 watch 仍可读且 `state == Stopped`；随后一次成功的 `SetBackend` 能恢复                                                                                                                                                                                                          |
+| T-BK-10 | **`service_needs_stop` 表驱动**（对应 R5d）：遍历 `CoreStateDetail` **全部 6 个变体** —— `Stopped` → `false`；`Starting` / `Running` / `Restarting` / `Switching` / `Stopping` → `true`；外加 `detail == None` → `true`（fail-safe）。共 7 个用例，用表驱动写法保证新增变体时会因不穷尽而被发现                                                                                                                                                                                                                  |
+| T-BK-11 | **stop 竞态到 not_started**：`status` 判定需要先停，但 `stop_core()` 返回 `error_kind = "not_started"` → `run()` 仍**成功**并继续 `start_core`；换成任意**其它** `error_kind`（例如 `quarantined`）则 `run()` **失败**且不调 `start_core`（断言 harness 的调用序列）                                                                                                                                                                                                                                             |
+
+#### RQ-02 revision 测试
+
+| ID       | 断言                                                                                                                                                                                                                                                                                                                                                      |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T-RV-01  | **两个观察来源都能更新 `last_revision`**（§2.1.1）：操作返回值、`RefreshStatus` 结果                                                                                                                                                                                                                                                                      |
+| T-RV-02  | **Service 每次操作/刷新重新学习 revision**：无持久连接，`run()` 与 `RefreshStatus` 各自从 `/status` 取回当前 revision（取代 v6 的重连对账用例）                                                                                                                                                                                                           |
+| T-RV-03a | `ConfigRevision → ConfigRevisionInfo`：`epoch` / `generation` / `source_hash` / `effective_hash` 保真，**`runtime_path` 被丢弃**                                                                                                                                                                                                                          |
+| T-RV-03b | `RevisionId → RevisionIdInfo`：三字段（`epoch` / `generation` / `effective_hash`）直拷。**这是两个不同的转换**——`RevisionId` 本来就没有 `runtime_path`，原 T-RV-03 把两者混为一谈，语句不成立                                                                                                                                                             |
+| T-RV-05  | **start 后同步回填**：Service `run()` 成功（`start_core` 返回 `()`，不带 revision）后 `last_revision` 已非空；Local `switch()` 同理                                                                                                                                                                                                                       |
+| T-RV-06  | **两种刷新形态**（§2.1.3）：(a) `RefreshStatus { operation: active_id }` → 查 backend 并提交、发布 watch；(b) `RefreshStatus { operation: wrong_id }` → `Err(CoreActorError::StaleOperation)` 且 **backend 零调用**；(c) `cast RefreshHint` 且 gate **有** active → 出队时**丢弃**，backend 零调用；(d) `RefreshHint` 且 gate 空闲 → 执行刷新并发布 watch |
+| T-RV-07  | **操作返回值在回复前已提交**：`run()` 的 RPC 一返回，`CoreClient::status()` 立即可见新 revision，**无需**任何后续刷新或推送                                                                                                                                                                                                                               |
+| T-RV-08  | **`RefreshStatus` 失败不污染缓存**：backend 查询返回 `Err` → actor 保留上一次成功的 `CoreStatusView`，把错误回给调用方                                                                                                                                                                                                                                    |
+| T-RV-09  | **UI 读路径最终观察到耗尽并只发布一次**（§2.1.4 / D5）：最后一次操作后注入耗尽 → `core_status()`（watch 读 + `cast RefreshHint`）→ hint 出队（gate 空闲）→ 刷新 → 提交并发布 watch → **下一次** `core_status()` 读到耗尽，`publish` 次数 **== 1**；再读一次仍 **== 1**（latch）                                                                           |
+| T-RV-10  | **读的活性**（八审发现，watch 回归的核心理由）：让一次 **`Run`** 阻塞在 backend barrier 上（**不是 `apply`**——D3=A 下 apply 不占 actor handler）→ 期间调 `CoreClient::status()` → **立即返回**（watch 克隆，零 mailbox）。若实现回退成 mailbox RPC 读，本用例会等到超时而失败                                                                             |
+| T-RV-11  | **换槽瞬态也发布**（§2.1.7）：`SetBackend` 期间取出旧 backend 后、构造新 backend 前，用 barrier 卡住 → 此刻 `status()` 读到 `state == Stopped`（合成观察已 `commit()` 并发布），而不是旧的 `Running`                                                                                                                                                      |
+| T-RV-12  | **shutdown 发布终态**（去空泛版，round-10 #75）：先 `Run` 成功提交一个**可区分的** running 观察（`state == Running`、`state_changed_at` 非 0）→ 取一份 `watch::Receiver` → `CoreClient::shutdown()` → 断言 `receiver.changed().await` **返回 Ok**（确有新发布）且新值 `state == Stopped`。旧写法从初值 `Stopped` 出发，即使 shutdown 从不发布也会通过     |
+| T-RV-13  | **外部 apply 的最终一致例外**（§2.1.6.1）：lease 内 `api::put_configs` 改变运行态 → watch **不更新**（该路径不经 actor）→ 随后一次 idle `RefreshHint` 到达 → watch 更新到新状态                                                                                                                                                                           |
+| T-RV-14  | **hint 合流**（§2.1.6）：gate 空闲时连发 N=10 次 `core_status()` → backend 的 `observe_status` 调用**至多 1 次在途**，总调用数 ≪ N（断言 ≤ 2：一次在途 + 一次清位后重排）                                                                                                                                                                                 |
+| T-RV-15  | **Updater 用的是运行身份而非 typed desired**（round-10 #71）：模拟 legacy `change_core` 的重播窗口——typed 快照仍是旧核 A、actor 已提交新核 B 为 running → Updater 在 guard 内 `running()` 拿到 **B** → 因此不会误停/误启 A                                                                                                                                |
+| T-RV-16  | **watch 初值与 legacy 等价**（A.5）：`CoreStatusView::initial()` 投影出的三元组与 legacy `CoreManager::status()` 在无 instance 时的返回**逐字段相等**（含 `run_type == RunType::default()`）                                                                                                                                                              |
+
+#### seam 回归
+
+| ID      | 断言                                                                                                                                                                                         |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T-SM-01 | 既有 `client/mod.rs` 与 `rebuild.rs` 的全部 lease 测试在 6 个替身更新后**继续通过**（A9f 列的替身逐个适配，不改测试语义）                                                                    |
+| T-SM-02 | `rebuild.rs:930-1000` 的 `s04_concurrent_restart_waits_until_change_core_rollback_completes` 在三层嵌套（clash_patch_gate → rebuild_gate → OperationGate）下仍然通过——这是顺序不变式的回归钉 |
+
+**Local backend 测试的 fake core 问题（事实 R17）。** 两侧的 fake core 都**不能**靠 `CARGO_BIN_EXE_*` 拿到：
+
+- `nyanpasu-core-manager` 的 fake core 是**它自己 package 的 `[[bin]]`**，`CARGO_BIN_EXE_*` 只在同 package 内可见，app 侧取不到（R17）；
+- 本仓的 `backend/fake-core` 对 `backend/tauri` 是 **dev-dependency**，而 dev-dependency **既不构建该 binary 也不设置 `CARGO_BIN_EXE_fake-core`**——这一点在 `backend/tauri/Cargo.toml:275-280` 有明确注释。既有做法是**预构建 + 运行时定位**：`cargo build -p fake-core`（或 `cargo test -p fake-core`），然后 `fake_core::require_bin_path()` 按 `current_exe` 的 profile/triple 查找，支持非空 `NYANPASU_FAKE_CORE` 覆盖，最后回退 target 目录（`backend/fake-core/src/lib.rs:399-418`）。现成消费者示例：`APP/client/process_core_bridge.rs:18-20`。
+
+**因此：** 用真实 `LocalBackend` 驱动真实 `CoreManager` 时必须预构建 + 运行时定位。**但既有的 `fake_core::require_bin_path()` 不能用于探针核**——它解析的是 `BIN_NAME = "fake-core"`（`backend/fake-core/src/lib.rs:48,384-418`），找不到 `manager-probe-core`。因此 `backend/fake-core/src/lib.rs` 需要**新增一个同构的具名 resolver**：
+
+```rust
+pub const PROBE_BIN_NAME: &str = "manager-probe-core";
+pub const PROBE_PATH_ENV: &str = "NYANPASU_MANAGER_PROBE_CORE";
+/// 与 `resolve_bin_path` 同样的三段发现顺序，只是目标 bin 名与覆盖环境变量不同。
+pub fn resolve_probe_bin_path() -> PathBuf { /* env 覆盖 → current_exe 同目录 → target 回退 */ }
+pub fn require_probe_bin_path() -> io::Result<PathBuf> { /* 缺失时给出可操作的错误 */ }
+```
+
+解析出的路径直接喂给 `CoreRequest.binary_path`（**不经过** `find_binary_path`——那会去找真实核心）。
+
+#### S12.1 — Local parity 的探针核（**不允许降级为 TestBackend**）
+
+两个**互相独立**的门槛，缺一不可：
+
+1. **manager 的默认 readiness 是 `ControllerVersionProbe`**——"healthy iff `GET /version` succeeds"（`RT/.../health/probe.rs:109`）。本仓 fake-core 的内置 HTTP 只对精确 `PUT /configs` / `PATCH /configs` 作答，其余 404（`backend/fake-core/src/main.rs:22-23,305-344`）。
+2. **fake-core 自己要求父进程 barrier**：长驻启动必须有 `FAKE_CORE_READY_ADDR`，否则 exit 2（事实 A24f，`main.rs:13-18,137-147`）。
+
+第 2 条是关键麻烦：**spawn 子进程的是 manager，不是测试**，所以测试无法逐次给子进程注入环境变量，只能设**父进程全局环境**让 manager 的子进程继承——这会强制所有并发测试串行化。
+
+**推荐路径：新增第二个 `[[bin]]`——一个不需要父进程 barrier 的 manager 兼容探针核。**
+
+```toml
+# backend/fake-core/Cargo.toml
+[[bin]]
+name = "manager-probe-core"
+path = "src/bin/manager_probe_core.rs"
+```
+
+契约（刻意做到最小）：
+
+- argv 与真实核心一致（复用既有 `fake_core::parse_args`：`-t -d <dir> -f <config>` 干跑；`-d <dir> -f <config>` 长驻）；
+- `-t` 干跑：读 config、退出码 0（失败注入用**自己的**环境键，与 `FAKE_CORE_*` 不共享命名空间）；
+- 长驻：**不需要任何 barrier**，直接在 config 的 `external-controller` 端口上起 HTTP，`GET /version` 返回 `200 {"version":"manager-probe"}`，其余路径 404；
+- 端口来源**只从 config 文件读**，不读环境变量——于是"端口对齐"变成结构性保证而非约定。
+
+**为什么端口能对齐：** `LocalIpcPolicy::Disable` 下 manager **不重写** source config 的 `external-controller`（R3 / `spec.rs:65-77`）。所以测试写入 config 的端口 = 探针核监听的端口 = manager 探针访问的端口，三者天然一致。测试用 `tests/common` 风格的 `free_port()` 先取一个空闲端口再写进 config。
+
+> **为什么不提供"复用 fake-core"的备选路径（leader 裁定，round-4 #6）：那条路径是错的。** fake-core 的 barrier 语义不是"放行后继续跑"，而是"收到 RELEASE 即收摊退出"——`signal_ready_and_wait_release` 返回后它立刻 `stop.store(true)`、join HTTP 线程并 `return ExitCode`（`backend/fake-core/src/main.rs:233-249`；release 实现 `lib.rs:490-493`）。所以"accept → release → 让 manager 去探针"根本不成立：release 的那一刻 HTTP 服务就没了。要让它活到断言结束就必须**全程不 release**，那又与"barrier 是同步点"的设计相悖，还得把 ready 连接的所有权一路带到 teardown。**一条好路径胜过两条半路径**——`manager-probe-core` 是唯一 parity 路径。
+
+**S13 必须加对应的预构建命令**（dev-dependency 不会构建 bin，事实 A15f）。
+
+#### S12.2 — Service parity 需要真实 IPC roundtrip harness
+
+`ServiceBackend` 走命名管道 / Unix socket（端点形态见事实 R19）。parity 测试**不能**打真实 daemon（端点是全局固定路径，PR-5-pre 已确认），因此：
+
+- 测试内起一个**进程内最小 IPC 服务端**，绑到**测试专用 placeholder**（如 `nyanpasu_ipc_test_{pid}_{n}`，避开生产的 `nyanpasu_ipc`），实现 parity 所需端点：`/status`、`/core/start`、`/core/stop`、`/core/recover`；
+- `ServiceBackend` 用 `Client::new(<测试 placeholder>)` 构造——这正是 A1 卡"禁止 `service_default()`、必须实例化 client"带来的**可测性收益**；
+- Windows 命名管道与 Unix socket 绑定方式不同，harness 用 `#[cfg]` 分支。
+
+**禁止裸 `#[ignore]`（round-3 #6）。** 允许某平台跳过就等于允许 parity 从常规验证里静默消失。规则：
+
+- **CI 支持的平台上 parity 必须作为常规测试运行**，不加任何 `#[ignore]`；
+- 某目标确实无法实现 harness 时，该测试标 `#[ignore = "<具体原因> — 由 <命令> 显式运行"]`，并且**必须**在 `package.json` 增加一条显式门禁脚本（例如 `test:backend:parity` = `cargo test --manifest-path ./backend/Cargo.toml --all-features -- --ignored parity`）；
+- 该脚本**必须进 CI**（与 `pnpm test` 并列的一个 job），否则视为未实现——"有个命令可以跑"不等于"有人在跑"。
+
+### S13 — 门禁
+
+```powershell
+pnpm fmt:backend
+pnpm lint:rustfmt
+pnpm lint:clippy
+cargo build --manifest-path .\backend\Cargo.toml -p fake-core --bin manager-probe-core   # T-BK-01 前置：仓库根**没有** Cargo.toml，必须带 --manifest-path（A15f / round-5 #6）
+pnpm test:backend
+git diff frontend/interface/src/ipc/bindings.ts   # 期望：恰好一处新增（见下），其余零变化
+pnpm lint:ts
+pnpm architecture-ledger
+pnpm lint:architecture-ledger
+```
+
+**bindings 预期：差异恰好等于 `DegradationPhase` 新增 `CoreLifecycle` 变体**（Rust 侧一个 enum 变体 + TS 侧联合类型多一个成员 `'core_lifecycle'`），**其余零变化**。`get_core_status` 保持元组形状（S9）；四个 service 命令与 `update_core` 新增的 `tauri::State` 参数不进 TS 签名（S8 / S9.1）。若 diff 超出这一处 → 说明范围溢出，停下核查。
+
+**ledger 基线（已于 2026-08-02 实测，`--mode=gate` 当前通过）：**
+
+```
+config_calls 116 · service_globals 74 · migration_markers 19 · legacy_dto_refs 300 · test_real_dirs 0
+```
+
+> 注意：这是 **PR-5-pre 落地后**的实测值，与本计划初稿引用的 120/80/18 不同（初稿误用了 5-pre 之前的快照）。以本节为准。
+
+**ledger 预期变化（必须逐条核对后再 `--write-snapshot`）：**
+
+| 指标                                       | 方向                                    | 原因                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------------------------------------ | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `service_globals["CoreManager::global()"]` | **显著下降**（基线 16 条计数）          | S9 迁移 + S9.1 Updater 迁移 + S10 删两条恢复路径 + S8 删 `LegacyCoreBridge`。**5a 后生产代码仅剩 `feat.rs:392` 一处**（macOS DNS，allowlist 到 5c），另有 `process_core_bridge.rs:4` 的文档注释文本命中                                                                                                                                                                                                                |
+| `migration_markers`                        | 基线 19 → **预期 17**                   | **+2**：S4 的 R0 过渡标记、S9.2 的 macOS DNS allowlist 标记。**−4**：`core_bridge.rs` 的 `CoreManager::global()` 桥（随 `LegacyCoreBridge` 删）、`core/clash/core.rs` 的 legacy lifecycle 桥、`updater/instance.rs` 的 legacy core manager 桥（S9.1 迁移）、`ipc.rs` 的 core manager status 桥（S9 迁移）。**±0（相对迁移）**：`core_bridge.rs` 的 connection-interruption 标记随 `on_profile_change` 一起搬到新实现处 |
+| `config_calls`                             | 基线 116，**预期下降 ≥ 2**              | 新代码禁调 `Config::*()`；S8(3) 的健康检查注入根把 `init/mod.rs:235` 与 `service/mod.rs:19` 两处 `Config::verge().enable_service_mode` 改为传值 → 至少 −2。实际降幅可能更大（S9 迁移的调用点），照实记录                                                                                                                                                                                                               |
+| `test_real_dirs`                           | **必须仍为 0**                          | 新测试只用 TempDir + 注入的 `RuntimePaths`；S12.2 的 IPC harness 用测试专用 placeholder，不碰生产端点                                                                                                                                                                                                                                                                                                                  |
+| `bridgeFiles`                              | 8 → 7（若 `core_bridge.rs` 整文件删除） | 该文件同时还装着 `RunningConfigPatchPort` / `LegacyRunningConfigPatchBridge`（B3 才删）与 `restore_product`，**大概率保留**。以实际删除结果为准，不要为了凑数字而搬移代码                                                                                                                                                                                                                                              |
+
+> **两条硬规则**：(1) `config_calls` 或 `test_real_dirs` 变差 → **回头改代码，不要靠改 snapshot 掩盖**；(2) `migration_markers` 若不等于 17，**逐条比对上表列出的加减项**找出差异来源再决定，**不要盲目 `--write-snapshot`**。
+
+---
+
+## 5. Exit 判据映射
+
+task.md A-Exit 三条：
+
+| Exit                                                                                              | 交付步骤    | 验证                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| operation 测试：FIFO / 等待取消 / 刚获批取消 / stale release / wrong-id mutation / shutdown drain | S5、S6、S12 | T-OP-01…06 全绿                                                                                                                                                                    |
+| Local/Service 基本生命周期 parity 测试                                                            | S3、S12     | T-BK-01…13 全绿；生产适配器由 **T-AD-01…03** 覆盖，其中 **T-BK-01 必须是真实 Local/Service 双端**（S12.1 探针核 + S12.2 IPC harness），不接受 TestBackend 顶替                     |
+| legacy core 生命周期不再被新调用点使用                                                            | S9、S10     | `rg 'begin_lifecycle\|lifecycle_lock\|_with_lease' backend/tauri/src` 为 0；`CoreManager::global()` 的**生产代码**命中仅剩 `feat.rs:392`（macOS DNS，带 allowlist 标记，owner=5c） |
+| 既有 lease 调用点与并发契约不回归                                                                 | S7、S12     | **T-SM-01**（6 个测试替身适配后既有 lease 测试全绿）、**T-SM-02**（三层嵌套顺序不变式回归钉）                                                                                      |
+
+roadmap §6.1 附加项：
+
+| §6.1 判据                                                    | 对应                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 封闭 enum，不定义 `CoreEngine` trait/factory                 | S3；`rg 'CoreEngine\|EngineFactory' backend/tauri/src` 为 0                                                                                                                                                                                           |
+| `LocalIpcPolicy::Disable` 显式写出                           | S3 + T-BK-02                                                                                                                                                                                                                                          |
+| 禁用 `service_default()`                                     | S3；ServiceBackend 用 `Client::new`                                                                                                                                                                                                                   |
+| client 预分配 `OperationId` + pending guard                  | S6 + T-OP-03/07                                                                                                                                                                                                                                       |
+| 不实现 TTL / auto-steal / watchdog                           | S5；`rg 'ttl\|auto_steal\|watchdog' backend/tauri/src/core/actor` 为 0                                                                                                                                                                                |
+| actor 无第二层恢复，只**发布一次** `core_recovery_exhausted` | S3(D5) + S10（删两条裸线程路径） + T-BK-05/06/07                                                                                                                                                                                                      |
+| A3 兼容 seam 保留，旧 trait 名不扩散                         | S7；新代码里 `CoreLifecycle*` 只出现在适配 impl 中                                                                                                                                                                                                    |
+| RQ-02 / RQ-04 已作答                                         | 本计划 §2 + **§2.1（读/写模型，含 2.1.6 合流与 2.1.7 接线）**；测试 **T-RV-01…16**（06 两种刷新形态；09 UI 最终一致 + 只发一次；10 读的活性；11/12 瞬态与关停发布；13 外部 apply 例外；14 hint 合流；15 Updater 换核竞态），RQ-04 由 **T-OP-07** 覆盖 |
+
+---
+
+## 6. 风险与回滚
+
+| 风险                                                       | 概率 | 影响                                  | 缓解                                                                                                                                                            |
+| ---------------------------------------------------------- | ---- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CoreManager::new()` 的运行目录独占锁与 daemon 冲突        | 中   | Service 模式下建 Local backend 会失败 | D2=A 只建当前模式匹配的那个；且 app 与 daemon 的 runtime_dir 本就不同（daemon 用 `service_data_dir`）。**S3 开工时先写一个断言两路径不相等的测试**，不要假设    |
+| lease 被 move 进 `async move` 闭包导致 guard 不满足 `Send` | 中   | 编译失败                              | A4f 已定位为编译期硬约束；`CoreOperationGuard` 的字段（`OperationId` + `CoreClient` + `bool`）全部 `Send`，`ActorRef` 亦然                                      |
+| 三层嵌套锁引入死锁                                         | 低   | 挂起                                  | A3f 证明全局顺序一致（10/10 处 `rebuild_gate` 先于 `begin`）；T-SM-02 作回归钉                                                                                  |
+| 6 个 lease 测试替身适配引发大面积测试改动                  | 高   | diff 变大、review 困难                | 适配只改**构造**不改**语义**；`MockRunningCoreBridge` 的 4 方法 mockall 面保持不变，只在 lease 侧多包一层 guard                                                 |
+| 上游"重启预算耗尽"字符串前缀漂移                           | 中   | `recovery_exhausted` 静默失效         | D5 集中在一处 + T-BK-05 钉住；typed 变体作**独立上游小 PR**（leader 已裁定不并入已收口的 R0 分支）                                                              |
+| 本地 clippy 假红（共享 target kache 污染）                 | 中   | 误判                                  | 已知问题：用独立 `--target-dir` 复验再下结论                                                                                                                    |
+| `apply` 实现但不接线被审查判为投机代码                     | 中   | review 争议                           | D4=A 已裁定：实现并由 T-BK-03 钉住 outcome 映射，生产接线留给 B3                                                                                                |
+| **换槽时目录锁未释放**（漏 drop `Arc`）                    | 中   | `SetBackend` 后新 manager 构造失败    | R6b 明确锁只在最后一个 `Arc<Inner>` drop 时释放；D2 换槽协议逐步写死；**T-BK-08 是专门的回归钉**。5a 无订阅任务，持有 `Arc` 的只有 backend 自身，风险面比 v6 小 |
+| 观察值陈旧（无推送流）                                     | 中   | 状态显示滞后于实际                    | **已知的范围取舍**：5a 的观察是"操作驱动 + 按需刷新"，不是实时。需要新鲜度的路径持 guard 刷新（§2.1.2）；实时性由 C1 的 watch 投影交付                          |
+| 新增 `manager-probe-core` bin 影响既有 fake-core 测试      | 低   | 既有 S09 进程矩阵测试红               | 它是**独立的第二个 `[[bin]]`**，与 `fake-core` 不共享源文件、不共享 `FAKE_CORE_*` 环境命名空间，对既有测试是纯新增；commit 1 单独打头即为验证该前提             |
+| Updater 迁移触及下载/替换事务                              | 中   | 更新流程回归                          | S9.1 只替换 3 个生命周期调用点，下载/校验/复制逻辑**逐字不动**；guard 覆盖范围与原 `begin_lifecycle` 完全一致                                                   |
+
+**回滚：** 改动集中在——新增 `APP/core/actor/`（目录）、`APP/client/core.rs`；新增 `backend/fake-core/src/bin/manager_probe_core.rs` 与 `backend/fake-core/Cargo.toml` 的 `[[bin]]` 条目、**`backend/fake-core/src/lib.rs`**（具名 probe resolver，round-6 #12）（S12.1）；定点修改 `setup.rs` / `ipc.rs` / `feat.rs` / `utils/{help,resolve,init}.rs` / `core/clash/core.rs` / `core/service/{ipc,mod,control}.rs` / `core/updater/{mod,instance}.rs` / `client/{mod,core_bridge,runtime,event_sink}.rs`；以及 `backend/Cargo.toml` + `backend/tauri/Cargo.toml`（S1）。第一个 commit 单独回滚不影响生产路径。
+
+---
+
+## 7. 提交切分建议
+
+1. `test(fake-core): add manager-compatible probe core binary` —— S12.1 的 `manager-probe-core`（新 `[[bin]]` + `Cargo.toml` 条目 + `src/lib.rs` 的 `resolve_probe_bin_path` / `require_probe_bin_path`）。**单独打头**：它是 T-BK-01 的前置，且对既有 S09 进程矩阵测试是纯新增，先独立验证不污染既有测试；
+2. `feat(core): add CoreBackend enum and cancellation-safe OperationId protocol` —— S1–S6 + T-OP / T-BK / T-RV（纯新增，生产路径未变）；
+3. `refactor(core): own the core lifecycle in CoreActor` —— S7–S11 + T-SM 回归 + S13。其中 S9.1（Updater）与 S10（删 legacy lease）**必须在同一个 commit 内**——拆开任一半都无法编译。
+
+---
+
+## 9. 附录 A — 接线单点声明（normative；**其它小节只引用，不复述**）
+
+> **存在理由**：v3 起反复出现同一类缺陷——同一个类型／字段／参数在不同小节写成不同名字或不同成员，逐轮打补丁只会再生。本附录是 5a 全部新增类型与构造顺序的**唯一声明处**。§2.1、S2、S3、S5、S6、S7、S8 一律以"见附录 A"引用；**任何小节不得重复列字段**。
+
+### A.1 全部类型（一次性声明）
+
+```rust
+// APP/core/actor/types.rs
+#[derive(Clone)]
+pub(crate) struct CoreRequest {
+    pub(crate) core_type: nyanpasu_utils::core::CoreType,
+    pub(crate) binary_path: Utf8PathBuf,
+    pub(crate) config_path: Utf8PathBuf,
+    pub(crate) working_dir: Utf8PathBuf,
+    pub(crate) pid_path: Option<Utf8PathBuf>,
+}
+
+#[derive(Clone)]
+pub(crate) struct CoreStatusView {
+    pub(crate) state: nyanpasu_ipc::api::status::CoreState,
+    pub(crate) state_changed_at: i64,
+    pub(crate) run_type: crate::core::RunType,
+    pub(crate) revision: Option<nyanpasu_ipc::api::status::ConfigRevisionInfo>,
+    pub(crate) recovery_exhausted: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct BackendObservation {
+    pub(crate) view: CoreStatusView,
+    pub(crate) lifecycle: FaithfulLifecycle,
+}
+
+#[derive(Clone)]
+pub(crate) enum FaithfulLifecycle {
+    Stopped { reason: Option<String> },
+    Starting,
+    Running,
+    Restarting,
+    Switching,
+    Stopping,
+}
+
+// `CoreActorError` / `CoreBackendError` / `OperationError` 的定义见 A.1b
+
+// APP/core/actor/backend.rs
+pub(crate) enum CoreBackend {
+    Local(LocalBackend),
+    Service(ServiceBackend),
+    #[cfg(test)]
+    Test(TestBackend),
+}
+pub(crate) enum BackendSlot {
+    Ready(CoreBackend),
+    Failed { error: Arc<CoreBackendError> },
+}
+
+// 注入用 trait：出现在 `ClientSetupArgs` 的公开签名里，因此是 `pub`
+pub trait CoreBinaryResolver: Send + Sync + 'static {
+    fn resolve(&self, kind: &CoreType) -> anyhow::Result<Utf8PathBuf>;
+}
+pub trait CoreDegradationSink: Send + Sync + 'static {
+    fn publish(&self, degradation: crate::client::runtime::Degradation);
+}
+#[async_trait]
+pub(crate) trait ServiceControlOps: Send + Sync + 'static {
+    async fn install(&self, reconciler: CoreModeReconciler) -> anyhow::Result<()>;
+    async fn start(&self, reconciler: CoreModeReconciler) -> anyhow::Result<()>;
+    async fn stop(&self) -> anyhow::Result<()>;
+    async fn restart(&self, reconciler: CoreModeReconciler) -> anyhow::Result<()>;
+}
+
+// APP/core/actor/mod.rs
+pub(crate) struct CoreActorArgs {
+    pub(crate) mode: crate::core::RunType,
+    pub(crate) requests: CoreRequestFactory,
+    pub(crate) degradation: Arc<dyn CoreDegradationSink>,
+    pub(crate) status_tx: watch::Sender<CoreStatusView>,
+    pub(crate) hint_pending: Arc<AtomicBool>,
+}
+
+pub(crate) struct CoreActorState {
+    pub(crate) backend: Option<BackendSlot>,
+    pub(crate) mode: crate::core::RunType,
+    pub(crate) operation: OperationGate,
+    pub(crate) observed: BackendObservation,
+    /// 最后一次成功提交的运行身份（A.4）。Updater 查它，不查 typed desired。
+    pub(crate) running: Option<CoreRequest>,
+    pub(crate) status_tx: watch::Sender<CoreStatusView>,
+    pub(crate) hint_pending: Arc<AtomicBool>,
+    pub(crate) recovery_exhausted_published: bool,
+    pub(crate) degradation: Arc<dyn CoreDegradationSink>,
+    pub(crate) requests: CoreRequestFactory,
+}
+
+// APP/client/core.rs
+pub(crate) struct CoreClientArgs {
+    pub(crate) mode: crate::core::RunType,
+    pub(crate) requests: CoreRequestFactory,
+    pub(crate) degradation: Arc<dyn CoreDegradationSink>,
+}
+
+struct CoreClientInner {
+    actor_ref: ActorRef<CoreActorMessage>,
+    next_operation: AtomicU64,
+    status_rx: watch::Receiver<CoreStatusView>,
+    hint_pending: Arc<AtomicBool>,
+}
+
+// APP/core/actor/request.rs
+#[derive(Clone)]
+pub(crate) struct CoreRequestFactory {
+    data_dir: Utf8PathBuf,
+    pid_path: Utf8PathBuf,
+    runtime_paths: crate::client::RuntimePaths,
+    binary: Arc<dyn CoreBinaryResolver>,
+}
+
+#[derive(Clone)]
+pub(crate) struct CoreModeReconciler {
+    core: CoreClient,
+    application: ApplicationClient,
+    requests: CoreRequestFactory,
+}
+```
+
+### A.1b 错误类型（round-11 #77：此前被引用但从未定义）
+
+```rust
+// APP/core/actor/backend.rs —— backend 层错误
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CoreBackendError {
+    /// Local：`nyanpasu_core_manager::Error` 的全部变体（含 RevisionConflict / Quarantined / StartupTimeout…）
+    #[error("local core manager: {0}")]
+    Local(#[from] nyanpasu_core_manager::Error),
+    /// Service：`nyanpasu_ipc::client::ClientError`（含 error_kind 字符串）
+    #[error("service ipc: {0}")]
+    Service(#[from] nyanpasu_ipc::client::ClientError),
+    /// 探针核 / 二进制解析失败（`CoreBinaryResolver` 或 `CoreRequestFactory` 的取值阶段）
+    #[error("core binary: {0}")]
+    Binary(#[source] anyhow::Error),
+    /// backend 构造失败（`CoreManager::new` / `Client::new`），用于 `BackendSlot::Failed`
+    #[error("backend construction: {0}")]
+    Construct(#[source] anyhow::Error),
+}
+
+// APP/core/actor/gate.rs —— operation gate 的错误
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum OperationError {
+    /// 等待 operation 超时（`CORE_ACQUIRE_TIMEOUT`，RQ-04）
+    #[error("timed out acquiring the core operation")]
+    AcquireTimeout,
+    /// actor 已关停，waiter 被拒
+    #[error("core actor is shutting down")]
+    ShuttingDown,
+}
+
+// APP/core/actor/types.rs —— actor 对外的统一错误
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CoreActorError {
+    #[error("operation id does not match the active operation")]
+    StaleOperation,
+    #[error("no core backend is available: {last_error}")]
+    NoBackend { last_error: Arc<CoreBackendError> },
+    #[error(transparent)]
+    Backend(Arc<CoreBackendError>),
+    #[error("core actor is shutting down")]
+    ShuttingDown,
+}
+```
+
+**可转换性（round-11 #77；本轮已用最小编译探针实测）**：三个枚举都 `#[derive(Debug, thiserror::Error)]`，因此都实现 `std::error::Error + Send + Sync + 'static`，`anyhow::Error: From<CoreActorError>` 自动成立——Updater 里的 `self.core.running(&operation).await?` 能直接 `?` 进 `anyhow::Result`。`Backend(Arc<CoreBackendError>)` 的 `#[error(transparent)]` **可用**：标准库有 `impl<T: Error + ?Sized> Error for Arc<T>`，已用 `rustc` 探针验证通过（v12 曾写"std 没有该 impl"，**那是错的**，已更正）。
+
+### A.1c 模块树与可见性（round-11 #77）
+
+```rust
+// APP/core/actor/mod.rs
+pub(crate) mod backend;    // CoreBackend / BackendSlot / CoreBackendError / Local/Service/Test
+pub(crate) mod types;      // CoreRequest / CoreStatusView / BackendObservation / FaithfulLifecycle / CoreActorError
+pub(crate) mod request;    // CoreRequestFactory / CoreBinaryResolver
+mod error_kind;            // R0 过渡映射（S4），仅本模块内使用
+mod gate;                  // OperationGate / OperationError
+
+use gate::OperationGate;                 // 私有：仅 actor 主体使用
+pub(crate) use gate::OperationError;      // 需出现在 `begin_operation` 的返回类型里
+```
+
+`gate.rs` 内 `OperationGate` 及其成员声明为 `pub(super)`（父模块 `actor` 可见即可，不外泄到 `crate`）；`OperationError` 需要出现在 `CoreClient::begin_operation` 的返回类型里，因此 `pub(crate)` 并在 `mod.rs` 重导出。**没有 `pub mod client`** —— typed client 在 `APP/client/core.rs`。
+
+### A.1d client 与适配器类型（round-12 #86：此前只在正文出现，未进附录）
+
+```rust
+// APP/client/core.rs
+#[derive(Clone)]
+pub struct CoreClient { inner: Arc<CoreClientInner> }   // 字段见 A.1 的 CoreClientInner
+
+/// RAII guard。`pending()` 先构造、再 `acquire()`，取消窗口见 design §3.1。
+pub struct CoreOperationGuard {
+    id: OperationId,
+    client: CoreClient,
+    acquired: bool,
+}
+
+// 返回或接收 crate-private 类型的方法一律 pub(crate)（A.6）
+impl CoreClient {
+    pub(crate) async fn new(args: CoreClientArgs) -> anyhow::Result<Self>;
+    pub(crate) fn status(&self) -> CoreStatusView;                    // 同步 watch 克隆
+    pub(crate) async fn begin_operation(&self) -> Result<CoreOperationGuard, OperationError>;
+    pub(crate) async fn refresh_status(&self, op: &CoreOperationGuard)
+        -> Result<BackendObservation, CoreActorError>;
+    pub(crate) async fn running(&self, op: &CoreOperationGuard)
+        -> Result<Option<CoreRequest>, CoreActorError>;
+    pub(crate) async fn run(&self, op: &CoreOperationGuard, req: &CoreRequest)
+        -> Result<(), CoreActorError>;
+    pub(crate) async fn stop(&self, op: &CoreOperationGuard) -> Result<(), CoreActorError>;
+    pub(crate) async fn set_backend(&self, op: &CoreOperationGuard, mode: RunType)
+        -> Result<(), CoreActorError>;
+    pub(crate) async fn shutdown(&self);
+    pub fn hint_refresh(&self);      // 无参无返，可 pub
+}
+
+/// `CoreLifecyclePort` 的生产实现（A.4 的 lease 那一行）。
+pub(crate) struct CoreLifecycleAdapter {
+    core: CoreClient,
+    application: ApplicationClient,   // 仅用于"纯 restart、无 promote"的回落
+    requests: CoreRequestFactory,
+}
+
+/// `begin()` 返回的 lease。拥有 guard，作用域结束即 `ReleaseOperation`。
+pub(crate) struct CoreLeaseAdapter {
+    guard: CoreOperationGuard,
+    core: CoreClient,
+    application: ApplicationClient,
+    requests: CoreRequestFactory,
+    runtime_paths: crate::client::RuntimePaths,
+    /// 本事务的目标核：`check_and_promote` 写入、`restart()` 消费、回滚覆写（A.4）。
+    target_core: Option<ClashCore>,
+}
+```
+
+### A.1e `CoreActorMessage` 完整定义（含真实 reply 类型）
+
+```rust
+pub(crate) enum CoreActorMessage {
+    // ── operation gate（design §3.2）────────────────────────────────────────
+    AcquireOperation { id: OperationId, reply: RpcReplyPort<Result<(), OperationError>> },
+    ReleaseOperation { id: OperationId },
+
+    // ── mutation：全部校验 active OperationId，不匹配回 StaleOperation ───────
+    Check   { operation: OperationId, request: CoreRequest,
+              reply: RpcReplyPort<Result<(), CoreActorError>> },
+    Run     { operation: OperationId, request: CoreRequest,
+              reply: RpcReplyPort<Result<(), CoreActorError>> },
+    Stop    { operation: OperationId, reply: RpcReplyPort<Result<(), CoreActorError>> },
+    Recover { operation: OperationId, reply: RpcReplyPort<Result<(), CoreActorError>> },
+    SetBackend { operation: OperationId, mode: crate::core::RunType,
+                 reply: RpcReplyPort<Result<(), CoreActorError>> },
+
+    // ── 观察（§2.1）─────────────────────────────────────────────────────────
+    RefreshStatus { operation: OperationId,
+                    reply: RpcReplyPort<Result<BackendObservation, CoreActorError>> },
+    RefreshHint,                       // cast，无 reply；出队时 gate 空闲才执行
+    RunningIdentity { operation: OperationId,
+                      reply: RpcReplyPort<Result<Option<CoreRequest>, CoreActorError>> },
+
+    Shutdown(RpcReplyPort<()>),
+}
+```
+
+**没有 `Status` 消息**——读走 watch 克隆（§2.1.1）。`Run` / `Stop` / `Recover` 的 `Ok(())` 表示"已提交并发布"；调用方要新鲜值就读 watch 或用 `RefreshStatus`。
+
+### A.2 `ClientSetupArgs` 的新增字段
+
+```rust
+pub struct ClientSetupArgs {
+    // 既有字段不动
+    pub core: Option<Arc<dyn CoreLifecyclePort>>,   // None = 生产（内部构造）；Some = 测试注入
+    pub binary_resolver: Arc<dyn CoreBinaryResolver>,
+    pub degradation: Arc<dyn CoreDegradationSink>,
+    pub(crate) service_control: Arc<dyn ServiceControlOps>,   // 见 A.6：随 trait 收窄
+}
+```
+
+**5 个字面构造点全部要改**（A22f）：`setup.rs:42`、`bridge/verge.rs:1072`、`client/mod.rs:2093`、`client/mod.rs:2325`、`client/rebuild.rs:955`。
+
+### A.3 构造顺序（编号；在 `try_new_with_args` 的 `block_on` 内、typed clients 之后）
+
+1. `let (application, session_state, clash_config) = new_typed_config_clients(..).await?;`
+2. `let app = application.get().await?.state;`
+3. `let mode = RunType::classify(app.enable_service_mode, get_ipc_state());`
+4. `let requests = CoreRequestFactory::new(&paths, runtime_paths_for_setup.clone(), args.binary_resolver)?;` —— **工厂先于 client**
+5. `let core_client = CoreClient::new(CoreClientArgs { mode, requests: requests.clone(), degradation: args.degradation.clone() }).await?;`
+   - `CoreClient::new` **内部**：`let (status_tx, status_rx) = watch::channel(CoreStatusView::initial());`；`let hint_pending = Arc::new(AtomicBool::new(false));`；`Actor::spawn(None, CoreActor, CoreActorArgs { mode, requests, degradation, status_tx, hint_pending: hint_pending.clone() })`；→ `CoreClientInner { actor_ref, next_operation: AtomicU64::new(1), status_rx, hint_pending }`
+6. `let core = args.core.unwrap_or_else(|| Arc::new(CoreLifecycleAdapter::new(core_client.clone(), application.clone(), requests.clone())) as Arc<dyn CoreLifecyclePort>);`
+7. `NyanpasuClientInner { ..., core_client, core, requests, application, service_control: args.service_control, ... }`
+
+> watch 通道与 `hint_pending` **都在第 5 步内部创建**，两端同源，不存在"某一侧忘了拿"的可能。
+
+### A.4 运行身份归 actor（round-10 #71 / NEW-1；round-11 简化）
+
+**问题**：typed desired 快照**不等于**当前实际在跑的核。`change_core` 只在 legacy `Config::verge().draft()` 里改核，`lease.restart()` 之后才 `apply()`，typed 重播更晚（`APP/client/rebuild.rs:299-317`；`APP/bridge/verge.rs:257-303`）。在 `restart()` 那一刻读 typed 快照会拿到**旧核**——v10 的适配器正是这么写的，会在换新核的事务里重启**旧核**。
+
+**两条互补的修法：**
+
+| 谁                   | 需要哪种身份                    | 怎么拿                                                                                                                                                                                                                           |
+| -------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| lease 的 `restart()` | **本事务要运行的核**（desired） | `check_and_promote(candidate, target_core, product)` **已经收到** `target_core`——lease 记在自身，随后的 `restart()` 消费；回滚分支用恢复后的核**覆写**。只有"纯 restart、无 promote"的流程（`restart_sidecar`）才回落 typed 快照 |
+| Updater 的替换步骤   | **当前实际在跑的核**（actual）  | 守卫消息 `RunningIdentity`（下）。**不读 typed desired**                                                                                                                                                                         |
+
+**不引入 `CoreRequestProvider` 抽象**（round-11 裁定）：它既要带 `OperationId` 又只有一个实现，多一层 trait 只是把守卫语义藏起来。直接用消息 + client 方法：
+
+```rust
+// CoreActorMessage 增加（守卫消息，与其它 mutation 同等准入）
+RunningIdentity {
+    operation: OperationId,
+    reply: RpcReplyPort<Result<Option<CoreRequest>, CoreActorError>>,
+},
+```
+
+```rust
+// APP/client/core.rs
+impl CoreClient {
+    /// 查询**当前已提交的运行身份**。必须持 guard——它与 mutation 同属一个事务，
+    /// 否则查到的结果可能在使用前就被别人改掉。
+    /// `Ok(None)` = 当前没有核在跑（不是错误）；`Err(NoBackend)` = 槽位坏了。
+    pub(crate) async fn running(
+        &self,
+        operation: &CoreOperationGuard,
+    ) -> Result<Option<CoreRequest>, CoreActorError>;
+}
+```
+
+**`state.running` 的生命周期（round-11 NEW-1 逐条封口）：**
+
+| 事件                                                     | `state.running` 的变化     | 理由                                                                            |
+| -------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `Run` **成功提交**                                       | `= Some(该次 CoreRequest)` | 这是唯一的赋值点：已提交 ⇒ 确实跑起来了                                         |
+| `Run` **失败**（含 Service start 后刷新失败）            | **不变**（失败不写）       | 失败没有产生新的运行事实                                                        |
+| `Stop` / `shutdown` 成功                                 | `= None`                   | 明确停了                                                                        |
+| `SetBackend`（换槽）                                     | `= None`                   | 旧 backend 已 shutdown 并 drop，**旧身份立即失效**；新身份要等下一次 `Run` 提交 |
+| 槽位变成 `Failed`                                        | `= None`                   | 没有 backend 就没有运行身份                                                     |
+| 提交的观察显示**终止态**（`FaithfulLifecycle::Stopped`） | `= None`                   | 核崩了/被外部停了——`running` 必须跟着失效，否则会陈旧                           |
+
+> 最后一行是 NEW-1 点名的"runtime 崩溃后仍陈旧"的封口：`commit()` 在写缓存的同时检查 `observation.lifecycle`，若是 `Stopped` 就清空 `running`。因此 `running` 的含义严格是"**最后一次成功提交、且此后未被观察为停止**的运行身份"。
+
+**查询结果的三种处置（Updater 侧）：**
+
+| 返回                                         | Updater 行为                                                                                                                |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `Ok(Some(req))` 且 `req.core_type` == 目标核 | 停核 → 换二进制 → 用**同一个 `req`** 重启                                                                                   |
+| `Ok(Some(req))` 且 `req.core_type` != 目标核 | 不停不启，只换二进制（用户在跑的是别的核）                                                                                  |
+| `Ok(None)`                                   | 不停不启，只换二进制——**当前没核在跑，这是正常路径**（与 legacy 行为一致：legacy 的 `stop_core` 在无 instance 时直接 `Ok`） |
+| `Err(NoBackend{..})` / `Err(_)`              | **中止替换**并上抛该错误。**不回退到 typed desired**                                                                        |
+
+### A.5 合成观察的完整取值（round-10 NEW-2）
+
+统一规则：**克隆上一次 `view`，只改下表列出的字段**，其余（含 `revision`、`run_type`、`recovery_exhausted`）一律**保留**。
+
+| 场景            | `lifecycle`                                   | `view.state`       | 其它改动                   |
+| --------------- | --------------------------------------------- | ------------------ | -------------------------- |
+| 换槽瞬态 `None` | `Stopped { reason: None }`                    | `Stopped(None)`    | `state_changed_at = now()` |
+| `Failed{error}` | `Stopped { reason: Some(error.to_string()) }` | `Stopped(Some(…))` | `state_changed_at = now()` |
+| `shutdown`      | `Stopped { reason: None }`                    | `Stopped(None)`    | `state_changed_at = now()` |
+
+`CoreStatusView::initial()`（watch 初值）：`state: Stopped(None)`、`state_changed_at: 0`、**`run_type: RunType::default()`**、`revision: None`、`recovery_exhausted: false`——与 legacy `CoreManager::status()` 在无 instance 时返回的三元组逐字段一致（`APP/core/clash/core.rs:451-466`）。**T-RV-16** 断言该等价性。
+
+### A.6 可见性规则（round-10 NEW-3）
+
+- **`pub(crate)`**：全部实现类型与其字段——`CoreRequest`、`CoreStatusView`、`BackendObservation`、`FaithfulLifecycle`、`CoreActorError`、`CoreBackend`、`BackendSlot`、`CoreActorMessage`、`CoreActorArgs`、`CoreActorState`、`CoreClientArgs`、`CoreRequestFactory`、`CoreModeReconciler`；
+- **`pub`**：`CoreBinaryResolver`、`CoreDegradationSink`——它们的方法签名里**不出现** crate-private 类型（前者收 `CoreType`、返 `Utf8PathBuf`；后者收 `Degradation`），因此可以保持 `pub`；
+- **`pub(crate)`（round-11 #82 收窄）**：`ServiceControlOps` 的方法收 `CoreModeReconciler`（crate-private），因此 trait 与 `ClientSetupArgs.service_control` 字段一并收窄为 `pub(crate)`。`CoreRequestProvider` 已随 A.4 删除，其可见性冲突自然消失；
+- `CoreClient` / `CoreOperationGuard` 本身 `pub`，但**返回或接收 crate-private 类型的方法一律 `pub(crate)`**（`status()`、`refresh_status()`、`running()`、`run()` 等）；仅 `hint_refresh()`（无参无返）可 `pub`；
+
+> 判定口径：**一个类型的可见性必须 ≥ 它出现的最宽签名的可见性**。实施时按此逐个检查，不要凭直觉。
+
+---
+
+## 8. 明确 out-of-scope（登记去向）
+
+| 项                                                             | 去向                                                                                                |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| typed `CoreErrorKind` 消费（替换 S4 的过渡映射）               | R0 合并 + submodule bump 之后的**独立一步**；bump 本身待用户授权                                    |
+| `StopReason::RestartBudgetExhausted` typed 变体                | **独立上游小 PR**，待用户授权推送（leader 已裁定不并入已收口的 R0 分支）                            |
+| apply 管线统一到 `CoreBackend::apply`                          | **PR-5b / B3**（D3=A）                                                                              |
+| Promoted / Applied 入 actor、删 `RuntimeLifecycleStore`        | **PR-5b / B1**                                                                                      |
+| 删 `rebuild_gate` / `clash_patch_gate`                         | **PR-5b / B2**                                                                                      |
+| `change_core` 简化为 commit-first                              | **PR-5b / B4**                                                                                      |
+| post-commit 失败矩阵（RQ-01）、apply parity 含 `Noop`（RQ-03） | **PR-5b 计划**                                                                                      |
+| 100 条 `LogFrame` ring、删 `Logger` global                     | **PR-5c / C1**                                                                                      |
+| `set_mode` / `reconcile_mode`、删 5 s 轮询线程与 statics       | **PR-5c / C2**                                                                                      |
+| macOS DNS 归入 actor（`MacosDnsGuard`）                        | **PR-5c / C3**                                                                                      |
+| UpdaterActor 完整迁移、`UpdaterManager::global()`              | **PR-6d**。5a 只把 Updater 的 **core 依赖**显式注入（S9.1，编译必要条件），updater 自身的全局性不动 |
+| `clash-api` workspace 条目                                     | 无 app 侧消费者，暂不加（D1=A）                                                                     |

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -778,6 +778,7 @@ export type DegradationPhase =
   | 'core_rollback'
   | 'system_effect'
   | 'ui_effect'
+  | 'core_lifecycle'
 
 export type DelayRes = {
   delay: number

--- a/frontend/nyanpasu/src/pages/__root.tsx
+++ b/frontend/nyanpasu/src/pages/__root.tsx
@@ -142,6 +142,8 @@ function localizeDegradationPhase(phase: DegradationPhase): string {
       return m.mutation_degradation_phase_system_effect()
     case 'ui_effect':
       return m.mutation_degradation_phase_ui_effect()
+    case 'core_lifecycle':
+      return String(phase)
     default: {
       const _exhaustive: never = phase
       return String(_exhaustive)

--- a/scripts/architecture-ledger.snapshot.json
+++ b/scripts/architecture-ledger.snapshot.json
@@ -4,16 +4,15 @@
   ],
   "metrics": {
     "config_calls": {
-      "total": 116,
+      "total": 109,
       "byKey": {
-        "Config::verge()": 90,
+        "Config::verge()": 83,
         "Config::clash()": 26
       }
     },
     "service_globals": {
-      "total": 74,
+      "total": 59,
       "byKey": {
-        "CoreManager::global()": 16,
         "ProxiesGuard::global()": 14,
         "Handle::global()": 11,
         "Self::global()": 9,
@@ -21,13 +20,14 @@
         "WindowManager::global()": 8,
         "Hotkey::global()": 3,
         "UpdaterManager::global()": 3,
-        "Logger::global()": 2
+        "Logger::global()": 2,
+        "CoreManager::global()": 1
       }
     },
     "migration_markers": {
-      "total": 19,
+      "total": 17,
       "byKey": {
-        "TODO(actor-migration)": 17,
+        "TODO(actor-migration)": 15,
         "FIXME(actor-migration)": 2
       }
     },


### PR DESCRIPTION
Second of five stacked PRs. **Base is `pr5/1-pre` (#5070), not `main`** — review the base first.

## What this does

Replaces the `CoreManager` global with a ractor actor owning the core process lifecycle behind a typed client.

## Three design decisions worth reviewing

**`CoreBackend` is a closed enum, not a trait.** The core has exactly two shapes (Local, Service). A sealed enum keeps the match exhaustive and avoids a trait object whose only implementors are known at compile time. This is a deliberate, recorded deviation from ports-and-adapters, approved during design review.

**Operations are serialised by an `OperationId` protocol rather than a mutex.** The id is preallocated by the caller, which makes two failures distinguishable that a mutex conflates: "acquire timed out" and "acquire succeeded but the caller vanished". Dropping the guard releases the gate, so the protocol is cancellation-safe.

**`OperationGate` is not actor-wide exclusion — do not read it as one.** It hands out FIFO ids and validates guarded messages; the actor keeps serving other messages while a permit is held. A consequence worth knowing before extending this: acquiring the gate *inside* a handler deadlocks by construction, because the grant only happens when a later `ReleaseOperation` is processed, and ractor processes messages serially.

## Also included

A manager-compatible probe binary so the fake-core harness can exercise the backend without a real daemon.

## Verification

50/50 plan tests, 437/438 library tests. Architecture ledger: `CoreManager::global` 16 → 1 (the remaining one is the macOS DNS path, migrated in a later stage).

Stage review closed at 96/100 after five findings were fixed.