### PR TITLE
PR-5b: route runtime config through a single commit-first apply pipeline

### DIFF
--- a/backend/tauri/src/bridge/verge.rs
+++ b/backend/tauri/src/bridge/verge.rs
@@ -730,10 +730,9 @@ mod tests {
     use super::*;
     use crate::{
         client::{
-            ClientError, ClientSetupArgs, CompensationFailure, LegacyBridgeSet,
-            LegacyRunningConfigPatchBridge, LegacyVergeDomain, MockRunningCoreBridge,
-            NoopUiEventSink, NyanpasuClient, test_binary_resolver, test_degradation_sink,
-            test_service_control,
+            ClientError, ClientSetupArgs, CompensationFailure, LegacyBridgeSet, LegacyVergeDomain,
+            MockRunningCoreBridge, NoopUiEventSink, NyanpasuClient, test_binary_resolver,
+            test_degradation_sink, test_service_control,
         },
         config::{
             IClashTemp,
@@ -1083,7 +1082,6 @@ mod tests {
             binary_resolver: test_binary_resolver(dir),
             degradation: test_degradation_sink(),
             service_control: test_service_control(),
-            clash_patch: Some(Arc::new(LegacyRunningConfigPatchBridge)),
             system_dns: Arc::new(crate::client::NoopSystemDnsCache),
         })
         .expect("client should construct with typed config actors");

--- a/backend/tauri/src/client/core.rs
+++ b/backend/tauri/src/client/core.rs
@@ -9,12 +9,16 @@ use std::{
 use anyhow::Context as _;
 use async_trait::async_trait;
 use nyanpasu_config::application::ClashCore;
+use nyanpasu_ipc::api::{core::apply::CoreApplyData, status::RevisionIdInfo};
 use ractor::{Actor, ActorRef, RpcReplyPort, rpc::CallResult};
 use tokio::sync::watch;
 
 use super::{
     ApplicationClient, CoreLifecycleLease, CoreLifecyclePort, RuntimePaths,
-    core_bridge::{CoreStatusSnapshot, restore_product},
+    core_bridge::{
+        CheckAndPromoteError, CheckAndPromoteFailure, CheckAndPromotePhase, CoreStatusSnapshot,
+        RestartFailure, restore_product,
+    },
     runtime::CandidateFile,
 };
 use crate::core::{
@@ -23,7 +27,10 @@ use crate::core::{
         CoreActor, CoreActorArgs, CoreActorMessage, OperationError, OperationId,
         backend::CoreDegradationSink,
         request::CoreRequestFactory,
-        types::{BackendObservation, CoreActorError, CoreRequest, CoreStatusView},
+        runtime::{RuntimeLifecycleState, RuntimeSnapshot},
+        types::{
+            BackendObservation, CoreActorError, CoreRequest, CoreStatusView, FaithfulLifecycle,
+        },
     },
 };
 
@@ -39,6 +46,7 @@ struct CoreClientInner {
     actor_ref: ActorRef<CoreActorMessage>,
     next_operation: AtomicU64,
     status_rx: watch::Receiver<CoreStatusView>,
+    lifecycle_rx: watch::Receiver<RuntimeLifecycleState>,
     hint_pending: Arc<AtomicBool>,
 }
 
@@ -101,6 +109,7 @@ impl CoreClient {
         #[cfg(test)] replacement_backend: Option<crate::core::actor::backend::TestBackend>,
     ) -> anyhow::Result<Self> {
         let (status_tx, status_rx) = watch::channel(CoreStatusView::initial());
+        let (lifecycle_tx, lifecycle_rx) = watch::channel(RuntimeLifecycleState::default());
         let hint_pending = Arc::new(AtomicBool::new(false));
         let actor_ref = Actor::spawn(
             None,
@@ -110,6 +119,7 @@ impl CoreClient {
                 requests: args.requests,
                 degradation: args.degradation,
                 status_tx,
+                lifecycle_tx,
                 hint_pending: hint_pending.clone(),
                 #[cfg(test)]
                 backend,
@@ -127,6 +137,7 @@ impl CoreClient {
                 actor_ref,
                 next_operation: AtomicU64::new(1),
                 status_rx,
+                lifecycle_rx,
                 hint_pending,
             }),
         })
@@ -134,6 +145,10 @@ impl CoreClient {
 
     pub(crate) fn status(&self) -> CoreStatusView {
         self.inner.status_rx.borrow().clone()
+    }
+
+    pub(crate) fn lifecycle(&self) -> RuntimeLifecycleState {
+        self.inner.lifecycle_rx.borrow().clone()
     }
 
     #[cfg(test)]
@@ -161,9 +176,52 @@ impl CoreClient {
     pub(crate) async fn running(
         &self,
         operation: &CoreOperationGuard,
-    ) -> Result<Option<CoreRequest>, CoreActorError> {
+    ) -> Result<(Option<CoreRequest>, FaithfulLifecycle), CoreActorError> {
         self.call(|reply| CoreActorMessage::RunningIdentity {
             operation: operation.id(),
+            reply,
+        })
+        .await
+    }
+
+    pub(crate) async fn publish_promoted(
+        &self,
+        operation: &CoreOperationGuard,
+        snapshot: Arc<RuntimeSnapshot>,
+    ) -> Result<(), CoreActorError> {
+        self.call(|reply| CoreActorMessage::PublishPromoted {
+            operation: operation.id(),
+            snapshot,
+            reply,
+        })
+        .await
+    }
+
+    pub(crate) async fn publish_applied(
+        &self,
+        operation: &CoreOperationGuard,
+        snapshot: Arc<RuntimeSnapshot>,
+    ) -> Result<(), CoreActorError> {
+        self.call(|reply| CoreActorMessage::PublishApplied {
+            operation: operation.id(),
+            snapshot,
+            reply,
+        })
+        .await
+    }
+
+    pub(crate) async fn apply_promoted(
+        &self,
+        operation: &CoreOperationGuard,
+        request: &CoreRequest,
+        expected: Option<RevisionIdInfo>,
+        snapshot: Arc<RuntimeSnapshot>,
+    ) -> Result<CoreApplyData, CoreActorError> {
+        self.call(|reply| CoreActorMessage::ApplyPromoted {
+            operation: operation.id(),
+            request: request.clone(),
+            expected,
+            snapshot,
             reply,
         })
         .await
@@ -354,8 +412,6 @@ impl CoreLifecycleAdapter {
 #[async_trait]
 impl CoreLifecyclePort for CoreLifecycleAdapter {
     async fn begin(&self) -> anyhow::Result<Box<dyn CoreLifecycleLease>> {
-        // Lock order: clash_patch_gate -> rebuild_gate -> OperationGate. Every lifecycle caller
-        // follows this order; PR-5b will absorb the first two gates.
         let guard = self.core.begin_operation().await?;
         Ok(Box::new(CoreLeaseAdapter {
             guard,
@@ -394,79 +450,141 @@ impl CoreLifecycleLease for CoreLeaseAdapter {
         candidate: &CandidateFile,
         target_core: ClashCore,
         product: &camino::Utf8Path,
-    ) -> anyhow::Result<[u8; 32]> {
+    ) -> Result<[u8; 32], CheckAndPromoteFailure> {
         use sha2::Digest as _;
 
         self.target_core = Some(target_core);
-        anyhow::ensure!(
-            product == self.runtime_paths.product(),
-            "product path must match the lifecycle adapter runtime product"
-        );
-        let bytes = tokio::fs::read(candidate.path()).await?;
-        let mut request = self.requests.for_product(target_core)?;
+        if product != self.runtime_paths.product() {
+            return Err(check_and_promote_operation_error(
+                CheckAndPromotePhase::Promote,
+                anyhow::anyhow!("product path must match the lifecycle adapter runtime product"),
+            ));
+        }
+        let bytes = tokio::fs::read(candidate.path()).await.map_err(|error| {
+            check_and_promote_operation_error(CheckAndPromotePhase::Promote, error.into())
+        })?;
+        let mut request = self.requests.for_product(target_core).map_err(|error| {
+            check_and_promote_operation_error(
+                CheckAndPromotePhase::Check,
+                anyhow::Error::new(error),
+            )
+        })?;
         request.config_path = candidate.path().to_owned();
-        self.core.check(&self.guard, &request).await?;
+        self.core
+            .check(&self.guard, &request)
+            .await
+            .map_err(CheckAndPromoteFailure::Actor)?;
 
-        let after = tokio::fs::read(candidate.path()).await?;
-        anyhow::ensure!(
-            after == bytes,
-            "candidate config changed between check and promote"
-        );
+        let after = tokio::fs::read(candidate.path()).await.map_err(|error| {
+            check_and_promote_operation_error(CheckAndPromotePhase::Promote, error.into())
+        })?;
+        if after != bytes {
+            return Err(check_and_promote_operation_error(
+                CheckAndPromotePhase::Promote,
+                anyhow::anyhow!("candidate config changed between check and promote"),
+            ));
+        }
         let candidate_hash: [u8; 32] = sha2::Sha256::digest(&bytes).into();
-        anyhow::ensure!(
-            candidate_hash == candidate.bytes_sha256(),
-            "candidate config hash changed before promotion"
-        );
+        if candidate_hash != candidate.bytes_sha256() {
+            return Err(check_and_promote_operation_error(
+                CheckAndPromotePhase::Promote,
+                anyhow::anyhow!("candidate config hash changed before promotion"),
+            ));
+        }
 
-        restore_product(product.as_std_path(), &bytes).await?;
-        let promoted = tokio::fs::read(product).await?;
+        restore_product(product.as_std_path(), &bytes)
+            .await
+            .map_err(|error| {
+                check_and_promote_operation_error(CheckAndPromotePhase::Promote, error)
+            })?;
+        let promoted = tokio::fs::read(product).await.map_err(|error| {
+            check_and_promote_operation_error(CheckAndPromotePhase::Promote, error.into())
+        })?;
         let promoted_hash: [u8; 32] = sha2::Sha256::digest(&promoted).into();
-        anyhow::ensure!(
-            promoted_hash == candidate.bytes_sha256(),
-            "promoted runtime product hash does not match candidate"
-        );
+        if promoted_hash != candidate.bytes_sha256() {
+            return Err(check_and_promote_operation_error(
+                CheckAndPromotePhase::Promote,
+                anyhow::anyhow!("promoted runtime product hash does not match candidate"),
+            ));
+        }
         Ok(promoted_hash)
     }
 
-    async fn apply_candidate(
+    async fn publish_promoted(
         &mut self,
-        candidate: &CandidateFile,
-        target_core: ClashCore,
-    ) -> anyhow::Result<()> {
-        use sha2::Digest as _;
-
-        let bytes = tokio::fs::read(candidate.path()).await?;
-        let candidate_hash: [u8; 32] = sha2::Sha256::digest(&bytes).into();
-        anyhow::ensure!(
-            candidate_hash == candidate.bytes_sha256(),
-            "candidate config hash changed before check"
-        );
-        let mut request = self.requests.for_product(target_core)?;
-        request.config_path = candidate.path().to_owned();
-        self.core.check(&self.guard, &request).await?;
-        let after = tokio::fs::read(candidate.path()).await?;
-        anyhow::ensure!(
-            after == bytes,
-            "candidate config changed between check and apply"
-        );
-        apply_config_from(candidate.path()).await
+        snapshot: Arc<RuntimeSnapshot>,
+    ) -> Result<(), CoreActorError> {
+        self.core.publish_promoted(&self.guard, snapshot).await
     }
 
-    async fn apply_promoted(&mut self, product: &camino::Utf8Path) -> anyhow::Result<()> {
-        anyhow::ensure!(
-            product == self.runtime_paths.product(),
-            "product path must match the lifecycle adapter runtime product"
-        );
-        apply_config_from(product).await
+    async fn publish_applied(
+        &mut self,
+        snapshot: Arc<RuntimeSnapshot>,
+    ) -> Result<(), CoreActorError> {
+        self.core.publish_applied(&self.guard, snapshot).await
     }
 
-    async fn restart(&mut self) -> anyhow::Result<()> {
+    async fn running_identity(
+        &mut self,
+    ) -> Result<(Option<CoreRequest>, FaithfulLifecycle), CoreActorError> {
+        self.core.running(&self.guard).await
+    }
+
+    async fn apply_promoted(
+        &mut self,
+        snapshot: Arc<RuntimeSnapshot>,
+    ) -> Result<CoreApplyData, CoreActorError> {
+        let target_core = self
+            .target_core
+            .expect("apply_promoted requires check_and_promote on the same lease");
+        let request = self
+            .requests
+            .for_product(target_core)
+            .map_err(|error| CoreActorError::Backend(Arc::new(error)))?;
+        let expected = self
+            .core
+            .status()
+            .revision
+            .as_ref()
+            .map(|revision| revision.id());
+        for attempt in 0..5 {
+            match self
+                .core
+                .apply_promoted(&self.guard, &request, expected.clone(), snapshot.clone())
+                .await
+            {
+                Ok(data) => return Ok(data),
+                Err(CoreActorError::Backend(error))
+                    if attempt < 4 && is_apply_transport_failure(error.as_ref()) =>
+                {
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        unreachable!("bounded apply retry loop always returns")
+    }
+
+    async fn restart(&mut self) -> Result<(), RestartFailure> {
         let core = match self.target_core.take() {
             Some(core) => core,
-            None => self.application.get().await?.state.core,
+            None => {
+                self.application
+                    .get()
+                    .await
+                    .map_err(RestartFailure::Operation)?
+                    .state
+                    .core
+            }
         };
-        let request = self.requests.for_product(core)?;
-        self.core.run(&self.guard, &request).await?;
+        let request = self
+            .requests
+            .for_product(core)
+            .map_err(|error| RestartFailure::Operation(error.into()))?;
+        self.core
+            .run(&self.guard, &request)
+            .await
+            .map_err(RestartFailure::Actor)?;
         Ok(())
     }
 
@@ -476,16 +594,23 @@ impl CoreLifecycleLease for CoreLeaseAdapter {
     }
 }
 
-async fn apply_config_from(product: &camino::Utf8Path) -> anyhow::Result<()> {
-    for attempt in 0..5 {
-        match crate::core::clash::api::put_configs(product.as_str()).await {
-            Ok(()) => break,
-            Err(error) if attempt < 4 => log::info!(target: "app", "{error:?}"),
-            Err(error) => return Err(error),
-        }
-        tokio::time::sleep(Duration::from_millis(250)).await;
-    }
-    Ok(())
+fn check_and_promote_operation_error(
+    phase: CheckAndPromotePhase,
+    source: anyhow::Error,
+) -> CheckAndPromoteFailure {
+    CheckAndPromoteFailure::Operation(CheckAndPromoteError { phase, source })
+}
+
+fn is_apply_transport_failure(error: &crate::core::actor::backend::CoreBackendError) -> bool {
+    matches!(
+        error,
+        crate::core::actor::backend::CoreBackendError::Service(
+            nyanpasu_ipc::client::ClientError::BuildClient(_)
+                | nyanpasu_ipc::client::ClientError::Request { .. }
+                | nyanpasu_ipc::client::ClientError::WebSocket { .. }
+                | nyanpasu_ipc::client::ClientError::HttpStatus { .. }
+        )
+    )
 }
 
 #[cfg(test)]
@@ -498,7 +623,10 @@ mod tests {
     };
 
     use camino::Utf8PathBuf;
-    use nyanpasu_ipc::api::status::{ConfigRevisionInfo, CoreState};
+    use nyanpasu_ipc::api::{
+        core::apply::ApplyOutcomeKind,
+        status::{ConfigRevisionInfo, CoreState},
+    };
     use nyanpasu_utils::core::{ClashCoreType, CoreType};
     use tempfile::TempDir;
 
@@ -509,8 +637,10 @@ mod tests {
             ReplaceBarrier,
             backend::{BackendSlot, CoreBackend, LocalBackend, TestBackend},
             request::CoreBinaryResolver,
-            types::FaithfulLifecycle,
+            runtime::{RuntimeRevision, RuntimeSnapshot, RuntimeSnapshotData},
+            types::{FaithfulLifecycle, LifecycleInvariantKind},
         },
+        enhance::PostProcessingOutput,
         utils::path::PathResolver,
     };
 
@@ -544,7 +674,7 @@ mod tests {
 
     async fn running_request(client: &CoreClient) -> CoreRequest {
         let operation = client.begin_operation().await.unwrap();
-        client.running(&operation).await.unwrap().unwrap()
+        client.running(&operation).await.unwrap().0.unwrap()
     }
 
     async fn poll_once_pending<F: Future>(mut future: Pin<&mut F>) {
@@ -665,6 +795,168 @@ mod tests {
 
     fn request(factory: &CoreRequestFactory, core: ClashCore) -> CoreRequest {
         factory.for_product(core).unwrap()
+    }
+
+    fn runtime_snapshot(revision: u64, core: ClashCore) -> Arc<RuntimeSnapshot> {
+        Arc::new(RuntimeSnapshot::from_data(
+            RuntimeRevision(revision),
+            core,
+            Arc::from([]),
+            RuntimeSnapshotData {
+                config: Default::default(),
+                exists_keys: Vec::new(),
+                postprocessing_output: PostProcessingOutput::default(),
+            },
+        ))
+    }
+
+    #[tokio::test]
+    async fn promoted_revision_must_advance_monotonically() {
+        let test = test_client(stopped(None)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        let snapshot = runtime_snapshot(1, ClashCore::Mihomo);
+        test.client
+            .publish_promoted(&operation, snapshot.clone())
+            .await
+            .unwrap();
+        let error = test
+            .client
+            .publish_promoted(&operation, snapshot.clone())
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            CoreActorError::LifecycleInvariant(LifecycleInvariantKind::PromotedRegression)
+        ));
+        assert!(Arc::ptr_eq(
+            test.client.lifecycle().promoted.as_ref().unwrap(),
+            &snapshot
+        ));
+    }
+
+    #[tokio::test]
+    async fn applied_requires_the_matching_promoted_snapshot() {
+        let test = test_client(stopped(None)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        let promoted = runtime_snapshot(1, ClashCore::Mihomo);
+        let other = runtime_snapshot(2, ClashCore::Mihomo);
+
+        let missing = test
+            .client
+            .publish_applied(&operation, promoted.clone())
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            missing,
+            CoreActorError::LifecycleInvariant(LifecycleInvariantKind::AppliedWithoutPromoted)
+        ));
+
+        test.client
+            .publish_promoted(&operation, promoted.clone())
+            .await
+            .unwrap();
+        let mismatched = test
+            .client
+            .publish_applied(&operation, other)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            mismatched,
+            CoreActorError::LifecycleInvariant(LifecycleInvariantKind::AppliedWithoutPromoted)
+        ));
+
+        test.client
+            .publish_applied(&operation, promoted.clone())
+            .await
+            .unwrap();
+        assert!(Arc::ptr_eq(
+            test.client.lifecycle().applied.as_ref().unwrap(),
+            &promoted
+        ));
+    }
+
+    #[tokio::test]
+    async fn actor_apply_advances_applied_for_all_outcomes_except_rollback() {
+        let outcomes = [
+            ApplyOutcomeKind::Noop,
+            ApplyOutcomeKind::Patched,
+            ApplyOutcomeKind::Reloaded,
+            ApplyOutcomeKind::Restarted,
+            ApplyOutcomeKind::Switched,
+            ApplyOutcomeKind::RolledBack,
+        ];
+        for outcome in outcomes {
+            for warning in [None, Some("durability uncertain".to_owned())] {
+                let test = test_client(running(5)).await;
+                let operation = test.client.begin_operation().await.unwrap();
+                let promoted = runtime_snapshot(10, ClashCore::Mihomo);
+                test.client
+                    .publish_promoted(&operation, promoted.clone())
+                    .await
+                    .unwrap();
+                test.backend.push_apply_result(Ok(CoreApplyData {
+                    outcome,
+                    revision: ConfigRevisionInfo {
+                        epoch: 1,
+                        generation: 6,
+                        source_hash: "source-6".into(),
+                        effective_hash: "effective-6".into(),
+                    },
+                    warning,
+                    failed_apply: (outcome == ApplyOutcomeKind::RolledBack)
+                        .then(|| "rejected".into()),
+                }));
+                let request = request(&test.requests, ClashCore::Mihomo);
+                let data = test
+                    .client
+                    .apply_promoted(
+                        &operation,
+                        &request,
+                        test.client
+                            .status()
+                            .revision
+                            .as_ref()
+                            .map(|revision| revision.id()),
+                        promoted.clone(),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(data.outcome, outcome);
+                assert_eq!(test.backend.apply_calls(), 1);
+                let applied = test.client.lifecycle().applied;
+                if outcome == ApplyOutcomeKind::RolledBack {
+                    assert!(applied.is_none());
+                } else {
+                    assert!(Arc::ptr_eq(applied.as_ref().unwrap(), &promoted));
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn lifecycle_read_remains_live_while_run_is_blocked() {
+        let test = test_client(stopped(None)).await;
+        let operation = test.client.begin_operation().await.unwrap();
+        let snapshot = runtime_snapshot(1, ClashCore::Mihomo);
+        test.client
+            .publish_promoted(&operation, snapshot.clone())
+            .await
+            .unwrap();
+        let (started, release) = test.backend.block_next_run();
+        let client = test.client.clone();
+        let request = request(&test.requests, ClashCore::Mihomo);
+        let run = tokio::spawn(async move {
+            let result = client.run(&operation, &request).await;
+            drop(operation);
+            result
+        });
+        started.await.unwrap();
+        assert!(Arc::ptr_eq(
+            test.client.lifecycle().promoted.as_ref().unwrap(),
+            &snapshot
+        ));
+        release.send(()).unwrap();
+        run.await.unwrap().unwrap();
     }
 
     #[tokio::test]
@@ -907,7 +1199,7 @@ mod tests {
         test.backend.set_observation(running(1));
         let request_b = request(&test.requests, ClashCore::ClashRs);
         test.client.run(&operation, &request_b).await.unwrap();
-        let actual = test.client.running(&operation).await.unwrap().unwrap();
+        let actual = test.client.running(&operation).await.unwrap().0.unwrap();
         assert_eq!(actual.core_type, CoreType::Clash(ClashCoreType::ClashRust));
     }
 
@@ -997,9 +1289,9 @@ mod tests {
             .run(&operation, &request(&test.requests, ClashCore::Mihomo))
             .await
             .unwrap();
-        assert!(test.client.running(&operation).await.unwrap().is_some());
+        assert!(test.client.running(&operation).await.unwrap().0.is_some());
         let _ = test.client.set_backend(&operation, RunType::Service).await;
-        assert!(test.client.running(&operation).await.unwrap().is_none());
+        assert!(test.client.running(&operation).await.unwrap().0.is_none());
     }
 
     #[tokio::test]
@@ -1048,7 +1340,7 @@ mod tests {
             .set_backend(&operation, RunType::Normal)
             .await
             .unwrap();
-        assert!(test.client.running(&operation).await.unwrap().is_none());
+        assert!(test.client.running(&operation).await.unwrap().0.is_none());
         operation.release().await;
         test.client.shutdown().await;
     }
@@ -1086,7 +1378,7 @@ mod tests {
         test.backend
             .set_observation(stopped(Some("crashed".to_owned())));
         test.client.refresh_status(&operation).await.unwrap();
-        assert!(test.client.running(&operation).await.unwrap().is_none());
+        assert!(test.client.running(&operation).await.unwrap().0.is_none());
     }
 
     #[tokio::test]
@@ -1137,7 +1429,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_target_restart_falls_back_to_the_rollback_core() {
+    async fn restart_consumes_transaction_target_once_then_uses_typed_core() {
         let test = test_client(stopped(None)).await;
         let application =
             crate::client::tests::test_application_client(&test._dir, ClashCore::Mihomo).await;
@@ -1158,22 +1450,18 @@ mod tests {
             )
             .await
             .unwrap();
-        test.backend.fail_next_run();
-        assert!(lease.restart().await.is_err());
-        lease
-            .check_and_promote(
-                &candidate,
-                ClashCore::Mihomo,
-                test.requests.runtime_paths().product(),
-            )
-            .await
-            .unwrap();
-        test.backend.set_observation(running(2));
+        lease.restart().await.unwrap();
         lease.restart().await.unwrap();
         drop(lease);
 
+        let requests = test.backend.run_requests();
+        assert_eq!(requests.len(), 2);
         assert_eq!(
-            running_request(&test.client).await.core_type,
+            requests[0].core_type,
+            CoreType::Clash(ClashCoreType::ClashRust)
+        );
+        assert_eq!(
+            requests[1].core_type,
             CoreType::Clash(ClashCoreType::Mihomo)
         );
     }

--- a/backend/tauri/src/client/core_bridge.rs
+++ b/backend/tauri/src/client/core_bridge.rs
@@ -1,27 +1,58 @@
 //! Core lifecycle port (S04): exclusive lease over check/promote/apply/restart/stop.
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use super::runtime::CandidateFile;
 use async_trait::async_trait;
 use camino::Utf8Path;
 use nyanpasu_config::application::ClashCore;
-use nyanpasu_ipc::api::status::CoreState;
+use nyanpasu_ipc::api::{core::apply::CoreApplyData, status::CoreState};
 
-/// Narrow boundary for API-first updates to the running core configuration.
-#[cfg_attr(test, mockall::automock)]
-#[async_trait]
-pub trait RunningConfigPatchPort: Send + Sync + 'static {
-    async fn patch(&self, patch: &serde_yaml::Mapping) -> anyhow::Result<()>;
+use crate::core::actor::types::{CoreActorError, CoreRequest, FaithfulLifecycle};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CheckAndPromoteFailure {
+    #[error(transparent)]
+    Actor(CoreActorError),
+    #[error(transparent)]
+    Operation(CheckAndPromoteError),
 }
 
-pub struct LegacyRunningConfigPatchBridge;
-
-#[async_trait]
-impl RunningConfigPatchPort for LegacyRunningConfigPatchBridge {
-    async fn patch(&self, patch: &serde_yaml::Mapping) -> anyhow::Result<()> {
-        crate::core::clash::api::patch_configs(patch).await
+#[cfg(test)]
+impl From<anyhow::Error> for CheckAndPromoteFailure {
+    fn from(source: anyhow::Error) -> Self {
+        // Test doubles use this convenience only for failures that occur before
+        // promotion. Production adapters must tag Check/Promote at the exact
+        // construction site instead of relying on this default.
+        Self::Operation(CheckAndPromoteError {
+            phase: CheckAndPromotePhase::Check,
+            source,
+        })
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CheckAndPromotePhase {
+    Check,
+    Promote,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{phase:?} failed: {source:#}")]
+pub(crate) struct CheckAndPromoteError {
+    pub(crate) phase: CheckAndPromotePhase,
+    pub(crate) source: anyhow::Error,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum RestartFailure {
+    #[error(transparent)]
+    Actor(CoreActorError),
+    #[error(transparent)]
+    Operation(anyhow::Error),
 }
 
 #[allow(dead_code)]
@@ -53,21 +84,147 @@ pub trait CoreLifecycleLease: Send {
         candidate: &CandidateFile,
         target_core: ClashCore,
         product: &Utf8Path,
-    ) -> anyhow::Result<[u8; 32]>;
-    /// Check and apply exact candidate bytes without promoting them to product.
-    async fn apply_candidate(
+    ) -> Result<[u8; 32], CheckAndPromoteFailure>;
+    async fn publish_promoted(
         &mut self,
-        candidate: &CandidateFile,
-        target_core: ClashCore,
-    ) -> anyhow::Result<()>;
-    async fn apply_promoted(&mut self, product: &Utf8Path) -> anyhow::Result<()>;
-    async fn restart(&mut self) -> anyhow::Result<()>;
+        _snapshot: Arc<crate::core::actor::runtime::RuntimeSnapshot>,
+    ) -> Result<(), crate::core::actor::types::CoreActorError> {
+        Ok(())
+    }
+    async fn publish_applied(
+        &mut self,
+        _snapshot: Arc<crate::core::actor::runtime::RuntimeSnapshot>,
+    ) -> Result<(), crate::core::actor::types::CoreActorError> {
+        Ok(())
+    }
+    async fn running_identity(
+        &mut self,
+    ) -> Result<(Option<CoreRequest>, FaithfulLifecycle), CoreActorError>;
+    async fn apply_promoted(
+        &mut self,
+        snapshot: Arc<crate::core::actor::runtime::RuntimeSnapshot>,
+    ) -> Result<CoreApplyData, CoreActorError>;
+    async fn restart(&mut self) -> Result<(), RestartFailure>;
     #[allow(dead_code)]
     async fn stop(&mut self) -> anyhow::Result<()>;
 }
 
-/// Atomically write known-good product bytes back: the sole promote path and
-/// the change-core last-resort rollback path.
+#[cfg(test)]
+pub(crate) struct ActorBackedTestCoreLifecyclePort {
+    inner: Arc<dyn CoreLifecyclePort>,
+    core: super::core::CoreClient,
+}
+
+#[cfg(test)]
+impl ActorBackedTestCoreLifecyclePort {
+    pub(crate) fn new(inner: Arc<dyn CoreLifecyclePort>, core: super::core::CoreClient) -> Self {
+        Self { inner, core }
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl CoreLifecyclePort for ActorBackedTestCoreLifecyclePort {
+    async fn begin(&self) -> anyhow::Result<Box<dyn CoreLifecycleLease>> {
+        let inner = self.inner.begin().await?;
+        let operation = self.core.begin_operation().await?;
+        Ok(Box::new(ActorBackedTestCoreLifecycleLease {
+            inner,
+            core: self.core.clone(),
+            operation,
+        }))
+    }
+
+    async fn status(&self) -> anyhow::Result<CoreStatusSnapshot> {
+        self.inner.status().await
+    }
+
+    async fn on_profile_change(&self) {
+        self.inner.on_profile_change().await;
+    }
+}
+
+#[cfg(test)]
+struct ActorBackedTestCoreLifecycleLease {
+    inner: Box<dyn CoreLifecycleLease>,
+    core: super::core::CoreClient,
+    operation: super::core::CoreOperationGuard,
+}
+
+#[cfg(test)]
+#[async_trait]
+impl CoreLifecycleLease for ActorBackedTestCoreLifecycleLease {
+    async fn check_and_promote(
+        &mut self,
+        candidate: &CandidateFile,
+        target_core: ClashCore,
+        product: &Utf8Path,
+    ) -> Result<[u8; 32], CheckAndPromoteFailure> {
+        self.inner
+            .check_and_promote(candidate, target_core, product)
+            .await
+    }
+
+    async fn publish_promoted(
+        &mut self,
+        snapshot: Arc<crate::core::actor::runtime::RuntimeSnapshot>,
+    ) -> Result<(), crate::core::actor::types::CoreActorError> {
+        self.inner.publish_promoted(snapshot.clone()).await?;
+        self.core.publish_promoted(&self.operation, snapshot).await
+    }
+
+    async fn publish_applied(
+        &mut self,
+        snapshot: Arc<crate::core::actor::runtime::RuntimeSnapshot>,
+    ) -> Result<(), crate::core::actor::types::CoreActorError> {
+        self.inner.publish_applied(snapshot.clone()).await?;
+        self.core.publish_applied(&self.operation, snapshot).await
+    }
+
+    async fn running_identity(
+        &mut self,
+    ) -> Result<(Option<CoreRequest>, FaithfulLifecycle), CoreActorError> {
+        self.inner.running_identity().await
+    }
+
+    async fn apply_promoted(
+        &mut self,
+        snapshot: Arc<crate::core::actor::runtime::RuntimeSnapshot>,
+    ) -> Result<CoreApplyData, CoreActorError> {
+        let data = self.inner.apply_promoted(snapshot.clone()).await?;
+        if crate::core::actor::runtime::advances_applied(data.outcome) {
+            self.core.publish_applied(&self.operation, snapshot).await?;
+        }
+        Ok(data)
+    }
+
+    async fn restart(&mut self) -> Result<(), RestartFailure> {
+        self.inner.restart().await
+    }
+
+    async fn stop(&mut self) -> anyhow::Result<()> {
+        self.inner.stop().await
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_apply_data(
+    snapshot: &crate::core::actor::runtime::RuntimeSnapshot,
+) -> CoreApplyData {
+    CoreApplyData {
+        outcome: nyanpasu_ipc::api::core::apply::ApplyOutcomeKind::Reloaded,
+        revision: nyanpasu_ipc::api::status::ConfigRevisionInfo {
+            epoch: 1,
+            generation: snapshot.revision.get(),
+            source_hash: String::new(),
+            effective_hash: String::new(),
+        },
+        warning: None,
+        failed_apply: None,
+    }
+}
+
+/// Atomically write known-good product bytes into the runtime product path.
 pub(crate) async fn restore_product(product: &Path, bytes: &[u8]) -> anyhow::Result<()> {
     if let Some(parent) = product.parent() {
         tokio::fs::create_dir_all(parent).await?;

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -16,6 +16,7 @@ mod system_dns;
 pub(crate) use self::application::ApplicationClient;
 use self::{clash_config::ClashConfigClient, session_state::SessionStateClient};
 use crate::{
+    core::actor::runtime as core_runtime,
     enhance::{
         EnhanceScriptRunner, FsProfileContentSource, RuntimeBuildInput, RuntimeBuilder,
         runtime_snapshot_data_from_artifact,
@@ -50,7 +51,6 @@ use nyanpasu_config::{
     runtime::executor::ResolvedPortBindings,
     state::{PersistentState, PersistentStatePatch},
 };
-use sha2::{Digest, Sha256};
 use std::{path::PathBuf, sync::Arc};
 use struct_patch::Patch as _;
 
@@ -58,9 +58,7 @@ use struct_patch::Patch as _;
 pub(crate) use core::CoreClientArgs;
 #[allow(unused_imports)]
 pub use core::{CoreClient, CoreOperationGuard};
-pub use core_bridge::{
-    CoreLifecycleLease, CoreLifecyclePort, LegacyRunningConfigPatchBridge, RunningConfigPatchPort,
-};
+pub use core_bridge::{CoreLifecycleLease, CoreLifecyclePort};
 pub use error::{ClientError, Result};
 pub(crate) use error::{CompensationFailure, LegacyVergeDomain, PartialCommit};
 #[cfg(test)]
@@ -85,8 +83,6 @@ pub struct ClientSetupArgs {
     pub binary_resolver: Arc<dyn crate::core::actor::request::CoreBinaryResolver>,
     pub degradation: Arc<dyn crate::core::actor::backend::CoreDegradationSink>,
     pub(crate) service_control: Arc<dyn crate::core::actor::backend::ServiceControlOps>,
-    /// Optional during the staged caller migration; setup always injects it.
-    pub clash_patch: Option<Arc<dyn RunningConfigPatchPort>>,
     pub system_dns: Arc<dyn SystemDnsCache>,
 }
 
@@ -124,6 +120,22 @@ enum PreparedConfigDomain {
         forward: PreparedTypedReplace<ClashConfig>,
         rollback: PreparedTypedReplace<ClashConfig>,
     },
+}
+
+#[derive(Debug, thiserror::Error)]
+enum RuntimeRebuildError {
+    #[error(transparent)]
+    Build(ClientError),
+    #[error(transparent)]
+    CheckAndPromote(core_bridge::CheckAndPromoteFailure),
+    #[error(transparent)]
+    Publish(crate::core::actor::types::CoreActorError),
+}
+
+impl From<RuntimeRebuildError> for ClientError {
+    fn from(error: RuntimeRebuildError) -> Self {
+        Self::Anyhow(anyhow::Error::new(error))
+    }
 }
 
 enum CommittedConfigDomain {
@@ -243,21 +255,12 @@ struct NyanpasuClientInner {
     core: Arc<dyn CoreLifecyclePort>,
     requests: crate::core::actor::request::CoreRequestFactory,
     service_control: Arc<dyn crate::core::actor::backend::ServiceControlOps>,
-    clash_patch: Arc<dyn RunningConfigPatchPort>,
-    /// Serializes API-first running-core patches through desired-state rebuild
-    /// and any revision-fenced compensation.
-    clash_patch_gate: tokio::sync::Mutex<()>,
+    degradation: Arc<dyn crate::core::actor::backend::CoreDegradationSink>,
     system_dns: Arc<dyn SystemDnsCache>,
-    /// Serializes runtime regeneration (snapshot -> build -> runtime draft ->
-    /// core apply). The profiles actor only orders commits; without this gate
-    /// a slow rebuild started for an older commit can finish after a newer
-    /// one and overwrite the runtime with a stale snapshot.
-    rebuild_gate: tokio::sync::Mutex<()>,
     /// Instance-owned background dirty coordinator (capacity-1 coalesce).
     /// Request/reply regeneration calls typed facade methods directly.
     rebuild: rebuild::RebuildCoordinator,
     runtime_revisions: runtime::RuntimeRevisionAllocator,
-    runtime: runtime::RuntimeLifecycleStore,
 }
 
 #[allow(dead_code)]
@@ -272,13 +275,9 @@ impl NyanpasuClient {
             binary_resolver,
             degradation,
             service_control,
-            clash_patch,
             system_dns,
         } = args;
-        // TODO(actor-migration): temporary default for legacy test/caller construction.
-        // Reason: bridge callers migrate to the explicit patch port after S05.
-        // Remove when: all ClientSetupArgs callers provide clash_patch.
-        let clash_patch = clash_patch.unwrap_or_else(|| Arc::new(LegacyRunningConfigPatchBridge));
+        let client_degradation = degradation.clone();
         let profiles_dir = paths.app_profiles_dir();
         let profiles_path = utf8_path(paths.profiles_path())?;
         let runtime_paths_for_setup = runtime_paths.clone();
@@ -287,7 +286,6 @@ impl NyanpasuClient {
             session_state,
             clash_config,
             profiles,
-            runtime_store,
             ports,
             fs,
             rebuild,
@@ -317,13 +315,26 @@ impl NyanpasuClient {
                 degradation,
             })
             .await?;
-            let core = core.unwrap_or_else(|| {
-                Arc::new(core::CoreLifecycleAdapter::new(
+            let core = match core {
+                Some(core) => {
+                    #[cfg(test)]
+                    {
+                        Arc::new(core_bridge::ActorBackedTestCoreLifecyclePort::new(
+                            core,
+                            core_client.clone(),
+                        )) as Arc<dyn CoreLifecyclePort>
+                    }
+                    #[cfg(not(test))]
+                    {
+                        core
+                    }
+                }
+                None => Arc::new(core::CoreLifecycleAdapter::new(
                     core_client.clone(),
                     application.clone(),
                     requests.clone(),
-                )) as Arc<dyn CoreLifecyclePort>
-            });
+                )) as Arc<dyn CoreLifecyclePort>,
+            };
 
             // Eager session port resolution: the core is not running yet,
             // so probing strategies is race-free (design §19.2 caller duty).
@@ -346,13 +357,11 @@ impl NyanpasuClient {
                 Arc::new(rebuild.notifier()),
             )
             .await?;
-            let runtime_store = runtime::new_runtime_lifecycle_store().await?;
             anyhow::Ok((
                 application,
                 session_state,
                 clash_config,
                 profiles,
-                runtime_store,
                 ports,
                 file_service as Arc<dyn ProfileFsPort>,
                 rebuild,
@@ -375,9 +384,8 @@ impl NyanpasuClient {
             core,
             requests,
             service_control,
-            clash_patch,
+            client_degradation,
             system_dns,
-            runtime_store,
             rebuild,
         );
         client.start_rebuild_worker();
@@ -399,9 +407,8 @@ impl NyanpasuClient {
         core: Arc<dyn CoreLifecyclePort>,
         requests: crate::core::actor::request::CoreRequestFactory,
         service_control: Arc<dyn crate::core::actor::backend::ServiceControlOps>,
-        clash_patch: Arc<dyn RunningConfigPatchPort>,
+        degradation: Arc<dyn crate::core::actor::backend::CoreDegradationSink>,
         system_dns: Arc<dyn SystemDnsCache>,
-        runtime: runtime::RuntimeLifecycleStore,
         rebuild: rebuild::RebuildCoordinator,
     ) -> Self {
         Self {
@@ -419,13 +426,10 @@ impl NyanpasuClient {
                 core,
                 requests,
                 service_control,
-                clash_patch,
-                clash_patch_gate: tokio::sync::Mutex::new(()),
+                degradation,
                 system_dns,
-                rebuild_gate: tokio::sync::Mutex::new(()),
                 rebuild,
                 runtime_revisions: runtime::RuntimeRevisionAllocator::new(),
-                runtime,
             }),
         }
     }
@@ -441,9 +445,8 @@ impl NyanpasuClient {
                     return Ok(());
                 };
                 NyanpasuClient { inner }
-                    .rebuild_running_config()
+                    .rebuild_running_config_in_background()
                     .await
-                    .map_err(anyhow::Error::from)
             }
         });
     }
@@ -976,21 +979,10 @@ impl NyanpasuClient {
         }
     }
 
-    /// Post-commit rebuild has a single opaque `Result` today; do not invent
-    /// RuntimeCheck/Promote/Apply precision the error surface cannot support.
-    fn map_runtime_rebuild_degradation(error: &ClientError) -> runtime::Degradation {
-        runtime::Degradation {
-            phase: runtime::DegradationPhase::RuntimeBuild,
-            code: "runtime_rebuild_failed".into(),
-            message: error.to_string(),
-            retryable: true,
-        }
-    }
-
     async fn collect_post_commit_degradations(
         &self,
         report: &CommitReport,
-    ) -> Vec<runtime::Degradation> {
+    ) -> Result<Vec<runtime::Degradation>> {
         // Post-commit side-effect failures are degraded results, not transaction
         // failures (T04 contract): state is already persisted, so surface them.
         let mut degradations: Vec<runtime::Degradation> = report
@@ -1008,20 +1000,49 @@ impl NyanpasuClient {
             })
             .collect();
 
-        if report.affects_current
-            && let Err(error) = self.rebuild_running_config().await
-        {
-            tracing::warn!(%error, "post-commit rebuild failed; state stays committed (degraded)");
-            degradations.push(Self::map_runtime_rebuild_degradation(&error));
+        if report.affects_current {
+            let mut lease = match self.inner.core.begin().await {
+                Ok(lease) => lease,
+                Err(error) => {
+                    let degradation = Self::core_operation_unavailable(error.to_string());
+                    tracing::warn!(
+                        phase = ?degradation.phase,
+                        code = %degradation.code,
+                        retryable = degradation.retryable,
+                        message = %degradation.message,
+                        "post-commit core operation could not be acquired (degraded)",
+                    );
+                    degradations.push(degradation);
+                    return Ok(degradations);
+                }
+            };
+            let (result, mut runtime_degradations) =
+                self.rebuild_pipeline_with_lease(&mut *lease).await;
+            result?;
+            if runtime_degradations.is_empty() {
+                drop(lease);
+                self.inner.ui_sink.refresh_clash();
+                self.inner.core.on_profile_change().await;
+            }
+            for degradation in &runtime_degradations {
+                tracing::warn!(
+                    phase = ?degradation.phase,
+                    code = %degradation.code,
+                    retryable = degradation.retryable,
+                    message = %degradation.message,
+                    "post-commit rebuild failed; state stays committed (degraded)",
+                );
+            }
+            degradations.append(&mut runtime_degradations);
         }
-        degradations
+        Ok(degradations)
     }
 
-    async fn after_commit(&self, report: &CommitReport) -> runtime::MutationOutcome<()> {
-        runtime::MutationOutcome::from_parts(
+    async fn after_commit(&self, report: &CommitReport) -> Result<runtime::MutationOutcome<()>> {
+        Ok(runtime::MutationOutcome::from_parts(
             (),
-            self.collect_post_commit_degradations(report).await,
-        )
+            self.collect_post_commit_degradations(report).await?,
+        ))
     }
 
     /// Public wire for a post-commit auto-activation hard failure. Create/import
@@ -1046,11 +1067,11 @@ impl NyanpasuClient {
     /// - `Ok(Some(report))` → merge report (and rebuild) degradations
     /// - `Ok(None)` → existing current won; no degradation
     /// - `Err(_)` → committed degradation, profile id retained by the caller
-    async fn try_auto_activate_if_none(&self, uid: ProfileId) -> Vec<runtime::Degradation> {
+    async fn try_auto_activate_if_none(&self, uid: ProfileId) -> Result<Vec<runtime::Degradation>> {
         match self.inner.profiles.set_current_if_none(uid).await {
             Ok(Some(report)) => self.collect_post_commit_degradations(&report).await,
-            Ok(None) => Vec::new(),
-            Err(error) => vec![Self::auto_activation_failure_degradation(&error)],
+            Ok(None) => Ok(Vec::new()),
+            Err(error) => Ok(vec![Self::auto_activation_failure_degradation(&error)]),
         }
     }
 
@@ -1078,7 +1099,7 @@ impl NyanpasuClient {
             .ok_or_else(|| ClientError::Custom("add committed without a created uid".into()))?;
         Ok(runtime::MutationOutcome::from_parts(
             created,
-            self.collect_post_commit_degradations(&report).await,
+            self.collect_post_commit_degradations(&report).await?,
         ))
     }
 
@@ -1100,7 +1121,7 @@ impl NyanpasuClient {
         // check-and-set atomic so a concurrent selection is not overwritten.
         if is_config {
             let uid = outcome.value().clone();
-            outcome = outcome.extend_degradations(self.try_auto_activate_if_none(uid).await);
+            outcome = outcome.extend_degradations(self.try_auto_activate_if_none(uid).await?);
         }
         Ok(outcome)
     }
@@ -1154,16 +1175,16 @@ impl NyanpasuClient {
             .created
             .clone()
             .ok_or_else(|| ClientError::Custom("import committed without a created uid".into()))?;
-        let mut degradations = self.collect_post_commit_degradations(&report).await;
+        let mut degradations = self.collect_post_commit_degradations(&report).await?;
         // Atomically activate only when nothing was selected during the download
         // window. Failures degrade; they must not erase the committed ProfileId.
-        degradations.extend(self.try_auto_activate_if_none(created.clone()).await);
+        degradations.extend(self.try_auto_activate_if_none(created.clone()).await?);
         Ok(runtime::MutationOutcome::from_parts(created, degradations))
     }
 
     pub async fn delete_profile(&self, uid: ProfileId) -> Result<runtime::MutationOutcome<()>> {
         let report = self.inner.profiles.delete(uid).await?;
-        Ok(self.after_commit(&report).await)
+        self.after_commit(&report).await
     }
 
     pub async fn reorder_profile(
@@ -1176,7 +1197,7 @@ impl NyanpasuClient {
             .profiles
             .reorder(ReorderOp::Move { active, over })
             .await?;
-        Ok(self.after_commit(&report).await)
+        self.after_commit(&report).await
     }
 
     pub async fn reorder_profiles_by_list(
@@ -1184,7 +1205,7 @@ impl NyanpasuClient {
         list: Vec<ProfileId>,
     ) -> Result<runtime::MutationOutcome<()>> {
         let report = self.inner.profiles.reorder(ReorderOp::ByList(list)).await?;
-        Ok(self.after_commit(&report).await)
+        self.after_commit(&report).await
     }
 
     pub async fn refresh_profile(
@@ -1193,7 +1214,7 @@ impl NyanpasuClient {
         patch: Option<RemoteProfileOptionsPatch>,
     ) -> Result<runtime::MutationOutcome<()>> {
         let report = self.inner.profiles.refresh(uid, patch).await?;
-        Ok(self.after_commit(&report).await)
+        self.after_commit(&report).await
     }
 
     pub async fn patch_profile_metadata(
@@ -1202,7 +1223,7 @@ impl NyanpasuClient {
         patch: ProfileMetadataPatch,
     ) -> Result<runtime::MutationOutcome<()>> {
         let report = self.inner.profiles.patch_metadata(uid, patch).await?;
-        Ok(self.after_commit(&report).await)
+        self.after_commit(&report).await
     }
 
     pub async fn patch_remote_profile_options(
@@ -1211,7 +1232,7 @@ impl NyanpasuClient {
         patch: RemoteProfileOptionsPatch,
     ) -> Result<runtime::MutationOutcome<()>> {
         let report = self.inner.profiles.patch_remote_options(uid, patch).await?;
-        Ok(self.after_commit(&report).await)
+        self.after_commit(&report).await
     }
 
     pub async fn replace_profile_definition(
@@ -1224,7 +1245,7 @@ impl NyanpasuClient {
             .profiles
             .replace_definition(uid, definition)
             .await?;
-        Ok(self.after_commit(&report).await)
+        self.after_commit(&report).await
     }
 
     pub async fn activate_profile(
@@ -1232,7 +1253,7 @@ impl NyanpasuClient {
         uid: Option<ProfileId>,
     ) -> Result<runtime::MutationOutcome<()>> {
         let report = self.inner.profiles.set_current(uid).await?;
-        Ok(self.after_commit(&report).await)
+        self.after_commit(&report).await
     }
 
     pub async fn set_global_transforms(
@@ -1240,7 +1261,7 @@ impl NyanpasuClient {
         ids: Vec<ProfileId>,
     ) -> Result<runtime::MutationOutcome<()>> {
         let report = self.inner.profiles.set_global_transforms(ids).await?;
-        Ok(self.after_commit(&report).await)
+        self.after_commit(&report).await
     }
 
     pub async fn set_profile_valid_fields(
@@ -1248,7 +1269,7 @@ impl NyanpasuClient {
         fields: Vec<String>,
     ) -> Result<runtime::MutationOutcome<()>> {
         let report = self.inner.profiles.set_valid_fields(fields).await?;
-        Ok(self.after_commit(&report).await)
+        self.after_commit(&report).await
     }
 
     pub async fn get_profile_materialized_path(&self, uid: ProfileId) -> Result<PathBuf> {
@@ -1331,54 +1352,8 @@ impl NyanpasuClient {
         self.inner.ports.cached_ports()
     }
 
-    pub async fn promoted_runtime(&self) -> Option<Arc<runtime::RuntimeSnapshot>> {
-        self.inner.runtime.read().await.promoted.clone()
-    }
-
-    pub(crate) async fn runtime_lifecycle_state(&self) -> runtime::RuntimeLifecycleState {
-        self.inner.runtime.read().await.clone()
-    }
-
-    async fn publish_promoted(&self, snapshot: Arc<runtime::RuntimeSnapshot>) -> Result<()> {
-        let mut lifecycle = self.inner.runtime.write().await;
-        if lifecycle
-            .promoted
-            .as_ref()
-            .is_some_and(|current| current.revision >= snapshot.revision)
-        {
-            return Err(ClientError::Custom(format!(
-                "runtime promoted revision must advance (current: {:?}, next: {})",
-                lifecycle.promoted.as_ref().map(|item| item.revision.get()),
-                snapshot.revision.get()
-            )));
-        }
-        lifecycle.promoted = Some(snapshot);
-        Ok(())
-    }
-
-    async fn publish_applied(&self, snapshot: Arc<runtime::RuntimeSnapshot>) -> Result<()> {
-        let mut lifecycle = self.inner.runtime.write().await;
-        let Some(promoted) = lifecycle.promoted.as_ref() else {
-            return Err(ClientError::Custom(
-                "cannot publish applied runtime without promoted runtime".into(),
-            ));
-        };
-        if !promoted.identity_eq(&snapshot) {
-            return Err(ClientError::Custom(format!(
-                "cannot publish stale applied runtime revision {}",
-                snapshot.revision.get()
-            )));
-        }
-        lifecycle.applied = Some(snapshot);
-        Ok(())
-    }
-
-    async fn restore_promoted(
-        &self,
-        promoted: Option<Arc<runtime::RuntimeSnapshot>>,
-    ) -> Result<()> {
-        self.inner.runtime.write().await.promoted = promoted;
-        Ok(())
+    pub async fn promoted_runtime(&self) -> Option<Arc<core_runtime::RuntimeSnapshot>> {
+        self.inner.core_client.lifecycle().promoted
     }
 
     pub(crate) fn runtime_product_path(&self) -> &camino::Utf8Path {
@@ -1387,24 +1362,24 @@ impl NyanpasuClient {
 
     pub(crate) async fn promote_existing_runtime_product(
         &self,
-    ) -> Result<Arc<runtime::RuntimeSnapshot>> {
-        let _rebuild = self.inner.rebuild_gate.lock().await;
+    ) -> Result<Arc<core_runtime::RuntimeSnapshot>> {
+        let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
         let revision = self
             .inner
             .runtime_revisions
             .allocate()
-            .map_err(ClientError::Anyhow)?;
+            .map_err(|error| ClientError::Anyhow(error.into()))?;
         let bytes = tokio::fs::read(self.inner.runtime_paths.product())
             .await
             .map_err(ClientError::Io)?;
         let config: serde_yaml::Mapping =
             serde_yaml::from_slice(&bytes).map_err(ClientError::SerdeYaml)?;
         let app = self.get_app_config().await?;
-        let snapshot = Arc::new(runtime::RuntimeSnapshot::from_data(
+        let snapshot = Arc::new(core_runtime::RuntimeSnapshot::from_data(
             revision,
             app.core,
             Arc::from(bytes.clone()),
-            runtime::RuntimeSnapshotData {
+            core_runtime::RuntimeSnapshotData {
                 exists_keys: config
                     .keys()
                     .filter_map(serde_yaml::Value::as_str)
@@ -1420,165 +1395,263 @@ impl NyanpasuClient {
             .create_candidate(&bytes)
             .await
             .map_err(ClientError::Anyhow)?;
-        let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
         let checked = lease
             .check_and_promote(&candidate, app.core, self.inner.runtime_paths.product())
             .await;
         if let Err(error) = candidate.cleanup().await {
             tracing::warn!(%error, "failed to remove existing-product candidate config");
         }
-        checked.map_err(ClientError::Anyhow)?;
-        self.publish_promoted(snapshot.clone()).await?;
+        checked.map_err(|error| ClientError::Anyhow(error.into()))?;
+        lease
+            .publish_promoted(snapshot.clone())
+            .await
+            .map_err(|error| ClientError::Anyhow(error.into()))?;
         Ok(snapshot)
     }
 
     pub(crate) async fn start_promoted_runtime(&self) -> Result<()> {
-        let _rebuild = self.inner.rebuild_gate.lock().await;
+        let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
         let promoted = self.promoted_runtime().await.ok_or_else(|| {
             ClientError::Custom("cannot start core without a promoted runtime".into())
         })?;
-        let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
-        lease.restart().await.map_err(ClientError::Anyhow)?;
-        self.publish_applied(promoted).await
+        lease
+            .restart()
+            .await
+            .map_err(|error| ClientError::Anyhow(error.into()))?;
+        lease
+            .publish_applied(promoted)
+            .await
+            .map_err(|error| ClientError::Anyhow(error.into()))
     }
 
-    async fn restore_applied_after_patch_failure(
-        &self,
-        lease: &mut dyn CoreLifecycleLease,
-        captured: runtime::RuntimeLifecycleState,
-        compensation: runtime::PatchCompensationPlan,
-        primary: String,
-    ) -> anyhow::Result<Arc<runtime::RuntimeSnapshot>> {
-        let current_applied = self.inner.runtime.read().await.applied.clone();
-        let expected_revision = compensation.expected_applied_revision();
-        if !compensation.fence_matches(current_applied.as_deref()) {
-            anyhow::bail!(
-                "desired clash patch failed: {primary}; compensation refused because Applied revision changed (expected {}, actual {:?})",
-                expected_revision.get(),
-                current_applied
-                    .as_ref()
-                    .map(|snapshot| snapshot.revision.get()),
-            );
+    fn post_commit_actor_error(error: crate::core::actor::types::CoreActorError) -> ClientError {
+        if matches!(
+            error,
+            crate::core::actor::types::CoreActorError::StaleOperation
+                | crate::core::actor::types::CoreActorError::LifecycleInvariant(_)
+        ) {
+            tracing::error!(%error, "core lifecycle invariant failed after desired-state commit");
         }
-        let Some(applied) = captured.applied.as_ref() else {
-            anyhow::bail!(
-                "desired clash patch failed: {primary}; compensation refused because Applied runtime was unknown"
-            );
-        };
+        ClientError::Anyhow(anyhow::Error::new(error))
+    }
 
-        let candidate = self
-            .inner
-            .runtime_paths
-            .create_candidate(applied.product_bytes())
-            .await?;
-        anyhow::ensure!(
-            candidate.bytes_sha256() == applied.product_sha256,
-            "compensation candidate hash does not match Applied snapshot"
-        );
-        let restore = lease.apply_candidate(&candidate, applied.target_core).await;
-        if let Err(error) = candidate.cleanup().await {
-            tracing::warn!(%error, "failed to remove compensation candidate config");
+    fn not_applied_report(revision: core_runtime::RuntimeRevision) -> runtime::RuntimeApplyReport {
+        runtime::RuntimeApplyReport {
+            outcome: runtime::RuntimeApplyOutcome::NotApplied,
+            desired_revision: revision.get(),
+            applied_revision: None,
         }
-        restore.map_err(|error| {
-            anyhow::anyhow!(
-                "desired clash patch failed: {primary}; Applied snapshot restore also failed: {error:#}"
-            )
-        })?;
+    }
 
-        let product = tokio::fs::read(self.inner.runtime_paths.product()).await?;
-        let current_promoted = self
-            .inner
-            .runtime
-            .read()
-            .await
-            .promoted
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("compensation completed without a Promoted runtime"))?;
-        anyhow::ensure!(
-            <[u8; 32]>::from(Sha256::digest(&product)) == current_promoted.product_sha256,
-            "compensation refused to publish Applied because product no longer matches Promoted"
-        );
-        self.inner.runtime.write().await.applied = Some(applied.clone());
-        anyhow::bail!(
-            "desired clash patch failed after the running core was patched; Applied snapshot restored: {primary}"
+    fn runtime_degradation(
+        phase: runtime::DegradationPhase,
+        code: &'static str,
+        message: String,
+    ) -> runtime::Degradation {
+        runtime::Degradation {
+            phase,
+            code: code.into(),
+            message,
+            retryable: true,
+        }
+    }
+
+    fn core_operation_unavailable(message: String) -> runtime::Degradation {
+        Self::runtime_degradation(
+            runtime::DegradationPhase::CoreLifecycle,
+            "core_operation_unavailable",
+            message,
         )
     }
 
-    /// Apply a running-core patch first, then commit it to desired state and
-    /// rebuild. A failed desired mutation is compensated only while the
-    /// captured Applied revision is still current.
-    pub async fn patch_running_config(&self, patch: serde_yaml::Mapping) -> Result<()> {
-        let _patch = self.inner.clash_patch_gate.lock().await;
-        let _rebuild = self.inner.rebuild_gate.lock().await;
-        let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
-        let captured_lifecycle = self.runtime_lifecycle_state().await;
-        let applied = captured_lifecycle.applied.as_ref().ok_or_else(|| {
-            ClientError::Custom(
-                "running-core patch requires a known Applied runtime; retry after core startup"
-                    .into(),
-            )
-        })?;
-        let Some(compensation) = runtime::compensation_for(&patch, Some(applied)) else {
-            return Ok(());
-        };
+    fn publish_background_degradation(&self, degradation: runtime::Degradation) {
+        tracing::warn!(
+            phase = ?degradation.phase,
+            code = %degradation.code,
+            retryable = degradation.retryable,
+            message = %degradation.message,
+            "background-driven rebuild failed (degraded)",
+        );
+        self.inner.degradation.publish(degradation);
+    }
 
-        self.inner
-            .clash_patch
-            .patch(&patch)
-            .await
-            .map_err(ClientError::Anyhow)?;
-
-        let client = self.clone();
-        let result =
-            crate::feat::patch_clash_with_rebuild(self.clone(), patch, |restart| async move {
-                let operation = async {
-                    let snapshot = client
-                        .regenerate_for_legacy_inner(&mut *lease)
-                        .await
-                        .map_err(anyhow::Error::from)?;
-                    if restart {
-                        lease.restart().await?;
-                    } else {
-                        lease
-                            .apply_promoted(client.inner.runtime_paths.product())
-                            .await?;
-                    }
-                    Ok::<_, anyhow::Error>(snapshot)
+    fn rebuild_failure_degradation(
+        error: RuntimeRebuildError,
+    ) -> std::result::Result<runtime::Degradation, ClientError> {
+        match error {
+            RuntimeRebuildError::Build(error) => Ok(Self::runtime_degradation(
+                runtime::DegradationPhase::RuntimeBuild,
+                "runtime_build_failed",
+                error.to_string(),
+            )),
+            RuntimeRebuildError::CheckAndPromote(
+                core_bridge::CheckAndPromoteFailure::Operation(error),
+            ) => {
+                let (phase, code) = match error.phase {
+                    core_bridge::CheckAndPromotePhase::Check => (
+                        runtime::DegradationPhase::RuntimeCheck,
+                        "runtime_check_failed",
+                    ),
+                    core_bridge::CheckAndPromotePhase::Promote => (
+                        runtime::DegradationPhase::RuntimePromote,
+                        "runtime_promote_failed",
+                    ),
                 };
-                match operation.await {
-                    Ok(snapshot) => Ok(snapshot),
-                    Err(primary) => {
-                        client
-                            .restore_applied_after_patch_failure(
-                                &mut *lease,
-                                captured_lifecycle,
-                                compensation,
-                                primary.to_string(),
-                            )
-                            .await
-                    }
-                }
-            })
-            .await;
-        match result {
-            Ok(snapshot) => {
-                self.publish_applied(snapshot).await?;
-                crate::feat::update_proxies_buff(None);
-                Ok(())
+                Ok(Self::runtime_degradation(phase, code, error.to_string()))
             }
-            Err(error) => Err(error.into()),
+            RuntimeRebuildError::CheckAndPromote(core_bridge::CheckAndPromoteFailure::Actor(
+                error,
+            )) => {
+                if rebuild::actor_error_is_post_commit_exempt(&error) {
+                    return Err(Self::post_commit_actor_error(error));
+                }
+                let (phase, code) = match &error {
+                    crate::core::actor::types::CoreActorError::NoBackend { .. } => (
+                        runtime::DegradationPhase::RuntimeApply,
+                        "core_backend_unavailable",
+                    ),
+                    _ => (
+                        runtime::DegradationPhase::RuntimeCheck,
+                        "runtime_check_failed",
+                    ),
+                };
+                Ok(Self::runtime_degradation(phase, code, error.to_string()))
+            }
+            RuntimeRebuildError::Publish(error) => {
+                if rebuild::actor_error_is_post_commit_exempt(&error) {
+                    return Err(Self::post_commit_actor_error(error));
+                }
+                let (phase, code) = match &error {
+                    crate::core::actor::types::CoreActorError::NoBackend { .. } => (
+                        runtime::DegradationPhase::RuntimeApply,
+                        "core_backend_unavailable",
+                    ),
+                    _ => (
+                        runtime::DegradationPhase::RuntimePromote,
+                        "runtime_promote_failed",
+                    ),
+                };
+                Ok(Self::runtime_degradation(phase, code, error.to_string()))
+            }
         }
     }
 
-    pub async fn rebuild_running_config(&self) -> Result<()> {
-        let _rebuild = self.inner.rebuild_gate.lock().await;
+    fn apply_failure_degradation(
+        error: crate::core::actor::types::CoreActorError,
+    ) -> std::result::Result<runtime::Degradation, ClientError> {
+        if rebuild::actor_error_is_post_commit_exempt(&error) {
+            return Err(Self::post_commit_actor_error(error));
+        }
+        let (code, message) = match error {
+            crate::core::actor::types::CoreActorError::NoBackend { last_error } => {
+                ("core_backend_unavailable", last_error.to_string())
+            }
+            crate::core::actor::types::CoreActorError::Backend(error) => {
+                use crate::core::actor::backend::BackendFailureClass;
+                let code = match crate::core::actor::backend::classify_apply_backend_failure(
+                    error.as_ref(),
+                ) {
+                    BackendFailureClass::RevisionConflict => "revision_conflict",
+                    BackendFailureClass::NotRunning => "core_not_running",
+                    BackendFailureClass::TransportLost => "core_transport_lost",
+                    BackendFailureClass::Other => "runtime_apply_failed",
+                };
+                (code, error.to_string())
+            }
+            error => ("runtime_apply_failed", error.to_string()),
+        };
+        Ok(Self::runtime_degradation(
+            runtime::DegradationPhase::RuntimeApply,
+            code,
+            message,
+        ))
+    }
+
+    async fn rebuild_pipeline_with_lease(
+        &self,
+        lease: &mut dyn CoreLifecycleLease,
+    ) -> (
+        Result<runtime::RuntimeApplyReport>,
+        Vec<runtime::Degradation>,
+    ) {
+        let revision = match self.inner.runtime_revisions.allocate() {
+            Ok(revision) => revision,
+            Err(error) => return (Err(ClientError::Anyhow(error.into())), Vec::new()),
+        };
+        let promoted = match self.regenerate_runtime_at_revision(lease, revision).await {
+            Ok(promoted) => promoted,
+            Err(error) => {
+                return match Self::rebuild_failure_degradation(error) {
+                    Ok(degradation) => (Ok(Self::not_applied_report(revision)), vec![degradation]),
+                    Err(error) => (Err(error), Vec::new()),
+                };
+            }
+        };
+        match lease.apply_promoted(promoted).await {
+            Ok(data) => {
+                let (report, degradations) =
+                    runtime::runtime_outcome_from_apply_data(&data, revision.get());
+                (Ok(report), degradations)
+            }
+            Err(error) => match Self::apply_failure_degradation(error) {
+                Ok(degradation) => (Ok(Self::not_applied_report(revision)), vec![degradation]),
+                Err(error) => (Err(error), Vec::new()),
+            },
+        }
+    }
+
+    fn require_clean_pipeline(
+        result: Result<runtime::RuntimeApplyReport>,
+        degradations: Vec<runtime::Degradation>,
+    ) -> Result<runtime::RuntimeApplyReport> {
+        let report = result?;
+        if degradations.is_empty() {
+            return Ok(report);
+        }
+        Err(ClientError::Custom(
+            degradations
+                .iter()
+                .map(|degradation| format!("{}: {}", degradation.code, degradation.message))
+                .collect::<Vec<_>>()
+                .join("; "),
+        ))
+    }
+
+    pub async fn patch_running_config(
+        &self,
+        patch: serde_yaml::Mapping,
+    ) -> Result<runtime::MutationOutcome<runtime::RuntimeApplyReport>> {
         let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
-        let promoted = self.regenerate_runtime_inner(&mut *lease).await?;
-        lease
-            .apply_promoted(self.inner.runtime_paths.product())
-            .await
-            .map_err(ClientError::Anyhow)?;
-        self.publish_applied(promoted).await?;
+        let overrides_patch: nyanpasu_config::clash::config::overrides::ClashGuardOverridesPatch =
+            serde_yaml::from_value(serde_yaml::Value::Mapping(patch.clone()))
+                .map_err(ClientError::SerdeYaml)?;
+        let mut overrides = self.inner.clash_config.get().await?.state.overrides.clone();
+        overrides.apply(overrides_patch);
+        let mut desired = ClashConfig::new_empty_patch();
+        desired.overrides = Some(overrides);
+        let client = self.clone();
+        let outcome = crate::feat::patch_clash_with_rebuild(
+            self.clone(),
+            patch,
+            move |_restart| async move {
+                client.inner.clash_config.patch(desired).await?;
+                let (report, degradations) = client.rebuild_pipeline_with_lease(&mut *lease).await;
+                Ok(runtime::MutationOutcome::from_parts(
+                    report.map_err(anyhow::Error::from)?,
+                    degradations,
+                ))
+            },
+        )
+        .await
+        .map_err(ClientError::Anyhow)?;
+        crate::feat::update_proxies_buff(None);
+        Ok(outcome)
+    }
+
+    pub async fn rebuild_running_config(&self) -> Result<()> {
+        let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
+        let (report, degradations) = self.rebuild_pipeline_with_lease(&mut *lease).await;
+        Self::require_clean_pipeline(report, degradations)?;
         drop(lease);
         self.inner.ui_sink.refresh_clash();
         // 用户决策 2026-07-06:所有 rebuild 统一触发(选项默认 false 门控)。
@@ -1586,26 +1659,82 @@ impl NyanpasuClient {
         Ok(())
     }
 
+    async fn rebuild_running_config_in_background(&self) -> Result<()> {
+        let mut lease = match self.inner.core.begin().await {
+            Ok(lease) => lease,
+            Err(error) => {
+                self.publish_background_degradation(Self::core_operation_unavailable(
+                    error.to_string(),
+                ));
+                return Ok(());
+            }
+        };
+        let (report, degradations) = self.rebuild_pipeline_with_lease(&mut *lease).await;
+        if let Err(error) = report {
+            if rebuild::client_error_is_post_commit_exempt(&error) {
+                return Err(error);
+            }
+            for degradation in degradations {
+                self.publish_background_degradation(degradation);
+            }
+            self.publish_background_degradation(Self::core_operation_unavailable(
+                error.to_string(),
+            ));
+            return Ok(());
+        }
+        if degradations.is_empty() {
+            drop(lease);
+            self.inner.ui_sink.refresh_clash();
+            self.inner.core.on_profile_change().await;
+            return Ok(());
+        }
+        for degradation in degradations {
+            self.publish_background_degradation(degradation);
+        }
+        Ok(())
+    }
+
     pub(crate) async fn regenerate_runtime(&self) -> Result<()> {
-        let _rebuild = self.inner.rebuild_gate.lock().await;
         let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
         self.regenerate_runtime_inner(&mut *lease).await.map(|_| ())
     }
 
-    /// Must only run while holding `rebuild_gate`: revision allocation happens
-    /// before desired snapshots are read, and failed attempts never reuse it.
+    /// Must only run while holding the core operation guard: revision allocation
+    /// happens before desired snapshots are read, and failed attempts never reuse it.
     async fn regenerate_runtime_inner(
         &self,
         lease: &mut dyn CoreLifecycleLease,
-    ) -> Result<Arc<runtime::RuntimeSnapshot>> {
+    ) -> Result<Arc<core_runtime::RuntimeSnapshot>> {
         let revision = self
             .inner
             .runtime_revisions
             .allocate()
-            .map_err(ClientError::Anyhow)?;
-        let profiles = self.inner.profiles.get().await?;
-        let clash = self.get_clash_config().await?;
-        let app = self.get_app_config().await?;
+            .map_err(|error| ClientError::Anyhow(error.into()))?;
+        self.regenerate_runtime_at_revision(lease, revision)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn regenerate_runtime_at_revision(
+        &self,
+        lease: &mut dyn CoreLifecycleLease,
+        revision: core_runtime::RuntimeRevision,
+    ) -> std::result::Result<Arc<core_runtime::RuntimeSnapshot>, RuntimeRebuildError> {
+        let profiles = self
+            .inner
+            .profiles
+            .get()
+            .await
+            .map_err(ClientError::from)
+            .map_err(RuntimeRebuildError::Build)?;
+        let clash = self
+            .get_clash_config()
+            .await
+            .map_err(RuntimeRebuildError::Build)?;
+        let app = self
+            .get_app_config()
+            .await
+            .map_err(RuntimeRebuildError::Build)?;
         self.regenerate_runtime_with(lease, revision, profiles, clash, app)
             .await
     }
@@ -1613,21 +1742,22 @@ impl NyanpasuClient {
     async fn regenerate_runtime_with(
         &self,
         lease: &mut dyn CoreLifecycleLease,
-        revision: runtime::RuntimeRevision,
+        revision: core_runtime::RuntimeRevision,
         profiles: Arc<Profiles>,
         clash: ClashConfig,
         app: NyanpasuAppConfig,
-    ) -> Result<Arc<runtime::RuntimeSnapshot>> {
+    ) -> std::result::Result<Arc<core_runtime::RuntimeSnapshot>, RuntimeRebuildError> {
         let resolved_ports = self
             .inner
             .ports
             .resolve(&clash)
-            .map_err(ClientError::Anyhow)?;
+            .map_err(ClientError::Anyhow)
+            .map_err(RuntimeRebuildError::Build)?;
         let profiles_dir = self.inner.profiles_dir.clone();
         let core = app.core;
         let builtin_enabled = app.enable_builtin_enhanced;
         let (data, yaml) = tokio::task::spawn_blocking(
-            move || -> anyhow::Result<(runtime::RuntimeSnapshotData, String)> {
+            move || -> anyhow::Result<(core_runtime::RuntimeSnapshotData, String)> {
                 let content = FsProfileContentSource::new(profiles_dir);
                 let scripts = EnhanceScriptRunner::new()?;
                 let input = RuntimeBuildInput {
@@ -1651,10 +1781,12 @@ impl NyanpasuClient {
             },
         )
         .await
-        .map_err(|error| ClientError::Custom(format!("runtime build task failed: {error}")))?
-        .map_err(ClientError::Anyhow)?;
+        .map_err(|error| ClientError::Custom(format!("runtime build task failed: {error}")))
+        .map_err(RuntimeRebuildError::Build)?
+        .map_err(ClientError::Anyhow)
+        .map_err(RuntimeRebuildError::Build)?;
         let product_bytes: Arc<[u8]> = Arc::from(yaml.into_bytes());
-        let snapshot = Arc::new(runtime::RuntimeSnapshot::from_data(
+        let snapshot = Arc::new(core_runtime::RuntimeSnapshot::from_data(
             revision,
             core,
             product_bytes.clone(),
@@ -1669,10 +1801,22 @@ impl NyanpasuClient {
             .runtime_paths
             .create_candidate(&product_bytes)
             .await
-            .map_err(ClientError::Anyhow)?;
+            .map_err(|source| {
+                RuntimeRebuildError::CheckAndPromote(
+                    core_bridge::CheckAndPromoteFailure::Operation(
+                        core_bridge::CheckAndPromoteError {
+                            phase: core_bridge::CheckAndPromotePhase::Promote,
+                            source,
+                        },
+                    ),
+                )
+            })?;
         if candidate.bytes_sha256() != snapshot.product_sha256 {
-            return Err(ClientError::Custom(
-                "runtime snapshot hash does not match candidate bytes".into(),
+            return Err(RuntimeRebuildError::CheckAndPromote(
+                core_bridge::CheckAndPromoteFailure::Operation(core_bridge::CheckAndPromoteError {
+                    phase: core_bridge::CheckAndPromotePhase::Promote,
+                    source: anyhow::anyhow!("runtime snapshot hash does not match candidate bytes"),
+                }),
             ));
         }
         let checked = lease
@@ -1681,8 +1825,11 @@ impl NyanpasuClient {
         if let Err(error) = candidate.cleanup().await {
             tracing::warn!(%error, "failed to remove candidate config");
         }
-        checked.map_err(ClientError::Anyhow)?;
-        self.publish_promoted(snapshot.clone()).await?;
+        checked.map_err(RuntimeRebuildError::CheckAndPromote)?;
+        lease
+            .publish_promoted(snapshot.clone())
+            .await
+            .map_err(RuntimeRebuildError::Publish)?;
         Ok(snapshot)
     }
 }
@@ -1703,7 +1850,7 @@ mod tests {
         profiles::ports::{
             CleanupOutcome, MaterializationReconcileReport, MockProfileFsPort,
             MockProfileMaterializationPort, MockRebuildNotifier, MockSubscriptionFetcher,
-            PreparedCleanup, PreparedMaterialization, ProfileMaterializationPort,
+            PreparedCleanup, PreparedMaterialization, ProfileMaterializationPort, RebuildNotifier,
         },
     };
     use async_trait::async_trait;
@@ -1715,6 +1862,7 @@ mod tests {
         },
         state::window::{WindowLabel, WindowState},
     };
+    use sha2::{Digest, Sha256};
     use std::{
         collections::BTreeMap,
         sync::{
@@ -1828,25 +1976,43 @@ mod tests {
             candidate: &runtime::CandidateFile,
             target_core: nyanpasu_config::application::ClashCore,
             _product: &camino::Utf8Path,
-        ) -> anyhow::Result<[u8; 32]> {
+        ) -> std::result::Result<[u8; 32], core_bridge::CheckAndPromoteFailure> {
             self.inner.check_and_promote(candidate, target_core).await?;
             Ok(candidate.bytes_sha256())
         }
 
-        async fn apply_candidate(
+        async fn apply_promoted(
             &mut self,
-            candidate: &runtime::CandidateFile,
-            target_core: nyanpasu_config::application::ClashCore,
-        ) -> anyhow::Result<()> {
-            self.inner.check_and_promote(candidate, target_core).await
+            snapshot: Arc<core_runtime::RuntimeSnapshot>,
+        ) -> std::result::Result<
+            nyanpasu_ipc::api::core::apply::CoreApplyData,
+            crate::core::actor::types::CoreActorError,
+        > {
+            self.inner.apply_config().await.map_err(|error| {
+                crate::core::actor::types::CoreActorError::Backend(Arc::new(
+                    crate::core::actor::backend::CoreBackendError::Construct(error),
+                ))
+            })?;
+            Ok(core_bridge::test_apply_data(&snapshot))
         }
 
-        async fn apply_promoted(&mut self, _product: &camino::Utf8Path) -> anyhow::Result<()> {
-            self.inner.apply_config().await
+        async fn running_identity(
+            &mut self,
+        ) -> std::result::Result<
+            (
+                Option<crate::core::actor::types::CoreRequest>,
+                crate::core::actor::types::FaithfulLifecycle,
+            ),
+            crate::core::actor::types::CoreActorError,
+        > {
+            Ok((None, crate::core::actor::types::FaithfulLifecycle::Running))
         }
 
-        async fn restart(&mut self) -> anyhow::Result<()> {
-            self.inner.restart_core().await
+        async fn restart(&mut self) -> std::result::Result<(), core_bridge::RestartFailure> {
+            self.inner
+                .restart_core()
+                .await
+                .map_err(core_bridge::RestartFailure::Operation)
         }
 
         async fn stop(&mut self) -> anyhow::Result<()> {
@@ -1860,6 +2026,422 @@ mod tests {
 
     struct TestCoreLease {
         inner: Arc<dyn TestRunningCoreBridge>,
+    }
+
+    struct OperationProbeCore {
+        gate: Arc<tokio::sync::Mutex<()>>,
+        state: Arc<OperationProbeState>,
+    }
+
+    struct OperationProbeState {
+        begin_calls: AtomicUsize,
+        check_calls: AtomicUsize,
+        active_checks: AtomicUsize,
+        max_active_checks: AtomicUsize,
+        candidates: StdMutex<Vec<Vec<u8>>>,
+        begin_entered_tx: StdMutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        release_begin_rx: StdMutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+        first_check_entered_tx: StdMutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        release_first_check_rx: StdMutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+        second_begin_attempted_tx: StdMutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        applied_revisions: StdMutex<Vec<u64>>,
+    }
+
+    struct OperationProbeLease {
+        state: Arc<OperationProbeState>,
+        _guard: tokio::sync::OwnedMutexGuard<()>,
+    }
+
+    #[derive(Clone, Copy)]
+    enum PromoteFailurePoint {
+        BeforeWrite,
+        AfterWrite,
+    }
+
+    struct PromoteFailureCore {
+        failure: PromoteFailurePoint,
+        check_calls: Arc<AtomicUsize>,
+    }
+
+    struct PromoteFailureLease {
+        failure: PromoteFailurePoint,
+        check_calls: Arc<AtomicUsize>,
+    }
+
+    struct ExemptRestartCore;
+
+    struct ExemptRestartLease;
+
+    struct ExemptCheckCore;
+
+    struct ExemptCheckLease;
+
+    struct BeginFailureCore;
+
+    #[async_trait]
+    impl CoreLifecyclePort for BeginFailureCore {
+        async fn begin(&self) -> anyhow::Result<Box<dyn CoreLifecycleLease>> {
+            anyhow::bail!("scripted acquire timeout")
+        }
+
+        async fn status(&self) -> anyhow::Result<core_bridge::CoreStatusSnapshot> {
+            anyhow::bail!("status is not used")
+        }
+
+        async fn on_profile_change(&self) {}
+    }
+
+    #[async_trait]
+    impl CoreLifecyclePort for ExemptCheckCore {
+        async fn begin(&self) -> anyhow::Result<Box<dyn CoreLifecycleLease>> {
+            Ok(Box::new(ExemptCheckLease))
+        }
+
+        async fn status(&self) -> anyhow::Result<core_bridge::CoreStatusSnapshot> {
+            anyhow::bail!("status is not used by the exempt check test")
+        }
+
+        async fn on_profile_change(&self) {}
+    }
+
+    #[async_trait]
+    impl CoreLifecycleLease for ExemptCheckLease {
+        async fn check_and_promote(
+            &mut self,
+            _candidate: &runtime::CandidateFile,
+            _target_core: nyanpasu_config::application::ClashCore,
+            _product: &camino::Utf8Path,
+        ) -> std::result::Result<[u8; 32], core_bridge::CheckAndPromoteFailure> {
+            Err(core_bridge::CheckAndPromoteFailure::Actor(
+                crate::core::actor::types::CoreActorError::StaleOperation,
+            ))
+        }
+
+        async fn running_identity(
+            &mut self,
+        ) -> std::result::Result<
+            (
+                Option<crate::core::actor::types::CoreRequest>,
+                crate::core::actor::types::FaithfulLifecycle,
+            ),
+            crate::core::actor::types::CoreActorError,
+        > {
+            Err(crate::core::actor::types::CoreActorError::StaleOperation)
+        }
+
+        async fn apply_promoted(
+            &mut self,
+            _snapshot: Arc<core_runtime::RuntimeSnapshot>,
+        ) -> std::result::Result<
+            nyanpasu_ipc::api::core::apply::CoreApplyData,
+            crate::core::actor::types::CoreActorError,
+        > {
+            Err(crate::core::actor::types::CoreActorError::StaleOperation)
+        }
+
+        async fn restart(&mut self) -> std::result::Result<(), core_bridge::RestartFailure> {
+            Err(core_bridge::RestartFailure::Actor(
+                crate::core::actor::types::CoreActorError::StaleOperation,
+            ))
+        }
+
+        async fn stop(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl CoreLifecyclePort for ExemptRestartCore {
+        async fn begin(&self) -> anyhow::Result<Box<dyn CoreLifecycleLease>> {
+            Ok(Box::new(ExemptRestartLease))
+        }
+
+        async fn status(&self) -> anyhow::Result<core_bridge::CoreStatusSnapshot> {
+            anyhow::bail!("status is not used by the exempt restart test")
+        }
+
+        async fn on_profile_change(&self) {}
+    }
+
+    #[async_trait]
+    impl CoreLifecycleLease for ExemptRestartLease {
+        async fn check_and_promote(
+            &mut self,
+            candidate: &runtime::CandidateFile,
+            _target_core: nyanpasu_config::application::ClashCore,
+            _product: &camino::Utf8Path,
+        ) -> std::result::Result<[u8; 32], core_bridge::CheckAndPromoteFailure> {
+            Ok(candidate.bytes_sha256())
+        }
+
+        async fn running_identity(
+            &mut self,
+        ) -> std::result::Result<
+            (
+                Option<crate::core::actor::types::CoreRequest>,
+                crate::core::actor::types::FaithfulLifecycle,
+            ),
+            crate::core::actor::types::CoreActorError,
+        > {
+            Ok((
+                None,
+                crate::core::actor::types::FaithfulLifecycle::Stopped { reason: None },
+            ))
+        }
+
+        async fn apply_promoted(
+            &mut self,
+            _snapshot: Arc<core_runtime::RuntimeSnapshot>,
+        ) -> std::result::Result<
+            nyanpasu_ipc::api::core::apply::CoreApplyData,
+            crate::core::actor::types::CoreActorError,
+        > {
+            Err(crate::core::actor::types::CoreActorError::StaleOperation)
+        }
+
+        async fn restart(&mut self) -> std::result::Result<(), core_bridge::RestartFailure> {
+            Err(core_bridge::RestartFailure::Actor(
+                crate::core::actor::types::CoreActorError::StaleOperation,
+            ))
+        }
+
+        async fn stop(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl CoreLifecyclePort for PromoteFailureCore {
+        async fn begin(&self) -> anyhow::Result<Box<dyn CoreLifecycleLease>> {
+            Ok(Box::new(PromoteFailureLease {
+                failure: self.failure,
+                check_calls: self.check_calls.clone(),
+            }))
+        }
+
+        async fn status(&self) -> anyhow::Result<core_bridge::CoreStatusSnapshot> {
+            anyhow::bail!("status is not used by promote failure tests")
+        }
+
+        async fn on_profile_change(&self) {}
+    }
+
+    #[async_trait]
+    impl CoreLifecycleLease for PromoteFailureLease {
+        async fn check_and_promote(
+            &mut self,
+            candidate: &runtime::CandidateFile,
+            _target_core: nyanpasu_config::application::ClashCore,
+            product: &camino::Utf8Path,
+        ) -> std::result::Result<[u8; 32], core_bridge::CheckAndPromoteFailure> {
+            let call = self.check_calls.fetch_add(1, Ordering::SeqCst);
+            if call == 1 && matches!(self.failure, PromoteFailurePoint::BeforeWrite) {
+                return Err(core_bridge::CheckAndPromoteFailure::Operation(
+                    core_bridge::CheckAndPromoteError {
+                        phase: core_bridge::CheckAndPromotePhase::Promote,
+                        source: anyhow::anyhow!("candidate hash mismatch before product write"),
+                    },
+                ));
+            }
+
+            let bytes = tokio::fs::read(candidate.path()).await.map_err(|source| {
+                core_bridge::CheckAndPromoteFailure::Operation(core_bridge::CheckAndPromoteError {
+                    phase: core_bridge::CheckAndPromotePhase::Promote,
+                    source: source.into(),
+                })
+            })?;
+            if let Some(parent) = product.parent() {
+                tokio::fs::create_dir_all(parent).await.map_err(|source| {
+                    core_bridge::CheckAndPromoteFailure::Operation(
+                        core_bridge::CheckAndPromoteError {
+                            phase: core_bridge::CheckAndPromotePhase::Promote,
+                            source: source.into(),
+                        },
+                    )
+                })?;
+            }
+            tokio::fs::write(product, bytes).await.map_err(|source| {
+                core_bridge::CheckAndPromoteFailure::Operation(core_bridge::CheckAndPromoteError {
+                    phase: core_bridge::CheckAndPromotePhase::Promote,
+                    source: source.into(),
+                })
+            })?;
+            if call == 1 && matches!(self.failure, PromoteFailurePoint::AfterWrite) {
+                return Err(core_bridge::CheckAndPromoteFailure::Operation(
+                    core_bridge::CheckAndPromoteError {
+                        phase: core_bridge::CheckAndPromotePhase::Promote,
+                        source: anyhow::anyhow!("product hash mismatch after product write"),
+                    },
+                ));
+            }
+            Ok(candidate.bytes_sha256())
+        }
+
+        async fn apply_promoted(
+            &mut self,
+            snapshot: Arc<core_runtime::RuntimeSnapshot>,
+        ) -> std::result::Result<
+            nyanpasu_ipc::api::core::apply::CoreApplyData,
+            crate::core::actor::types::CoreActorError,
+        > {
+            Ok(core_bridge::test_apply_data(&snapshot))
+        }
+
+        async fn running_identity(
+            &mut self,
+        ) -> std::result::Result<
+            (
+                Option<crate::core::actor::types::CoreRequest>,
+                crate::core::actor::types::FaithfulLifecycle,
+            ),
+            crate::core::actor::types::CoreActorError,
+        > {
+            Ok((None, crate::core::actor::types::FaithfulLifecycle::Running))
+        }
+
+        async fn restart(&mut self) -> std::result::Result<(), core_bridge::RestartFailure> {
+            Ok(())
+        }
+
+        async fn stop(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn promote_failure_core(failure: PromoteFailurePoint) -> Arc<dyn CoreLifecyclePort> {
+        Arc::new(PromoteFailureCore {
+            failure,
+            check_calls: Arc::new(AtomicUsize::new(0)),
+        })
+    }
+
+    impl OperationProbeState {
+        fn new() -> Self {
+            Self {
+                begin_calls: AtomicUsize::new(0),
+                check_calls: AtomicUsize::new(0),
+                active_checks: AtomicUsize::new(0),
+                max_active_checks: AtomicUsize::new(0),
+                candidates: StdMutex::new(Vec::new()),
+                begin_entered_tx: StdMutex::new(None),
+                release_begin_rx: StdMutex::new(None),
+                first_check_entered_tx: StdMutex::new(None),
+                release_first_check_rx: StdMutex::new(None),
+                second_begin_attempted_tx: StdMutex::new(None),
+                applied_revisions: StdMutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CoreLifecyclePort for OperationProbeCore {
+        async fn begin(&self) -> anyhow::Result<Box<dyn CoreLifecycleLease>> {
+            let call = self.state.begin_calls.fetch_add(1, Ordering::SeqCst);
+            if call == 0 {
+                if let Some(tx) = self.state.begin_entered_tx.lock().unwrap().take() {
+                    let _ = tx.send(());
+                }
+                let release = self.state.release_begin_rx.lock().unwrap().take();
+                if let Some(release) = release {
+                    let _ = release.await;
+                }
+            } else if call == 1
+                && let Some(tx) = self.state.second_begin_attempted_tx.lock().unwrap().take()
+            {
+                let _ = tx.send(());
+            }
+            let guard = self.gate.clone().lock_owned().await;
+            Ok(Box::new(OperationProbeLease {
+                state: self.state.clone(),
+                _guard: guard,
+            }))
+        }
+
+        async fn status(&self) -> anyhow::Result<core_bridge::CoreStatusSnapshot> {
+            anyhow::bail!("status is not used by operation ordering tests")
+        }
+
+        async fn on_profile_change(&self) {}
+    }
+
+    #[async_trait]
+    impl CoreLifecycleLease for OperationProbeLease {
+        async fn check_and_promote(
+            &mut self,
+            candidate: &runtime::CandidateFile,
+            _target_core: nyanpasu_config::application::ClashCore,
+            _product: &camino::Utf8Path,
+        ) -> std::result::Result<[u8; 32], core_bridge::CheckAndPromoteFailure> {
+            let call = self.state.check_calls.fetch_add(1, Ordering::SeqCst);
+            let active = self.state.active_checks.fetch_add(1, Ordering::SeqCst) + 1;
+            self.state
+                .max_active_checks
+                .fetch_max(active, Ordering::SeqCst);
+            let bytes = tokio::fs::read(candidate.path())
+                .await
+                .map_err(anyhow::Error::from)?;
+            self.state.candidates.lock().unwrap().push(bytes);
+            if call == 0 {
+                if let Some(tx) = self.state.first_check_entered_tx.lock().unwrap().take() {
+                    let _ = tx.send(());
+                }
+                let release = self.state.release_first_check_rx.lock().unwrap().take();
+                if let Some(release) = release {
+                    let _ = release.await;
+                }
+            }
+            self.state.active_checks.fetch_sub(1, Ordering::SeqCst);
+            Ok(candidate.bytes_sha256())
+        }
+
+        async fn apply_promoted(
+            &mut self,
+            snapshot: Arc<core_runtime::RuntimeSnapshot>,
+        ) -> std::result::Result<
+            nyanpasu_ipc::api::core::apply::CoreApplyData,
+            crate::core::actor::types::CoreActorError,
+        > {
+            Ok(core_bridge::test_apply_data(&snapshot))
+        }
+
+        async fn running_identity(
+            &mut self,
+        ) -> std::result::Result<
+            (
+                Option<crate::core::actor::types::CoreRequest>,
+                crate::core::actor::types::FaithfulLifecycle,
+            ),
+            crate::core::actor::types::CoreActorError,
+        > {
+            Ok((None, crate::core::actor::types::FaithfulLifecycle::Running))
+        }
+
+        async fn restart(&mut self) -> std::result::Result<(), core_bridge::RestartFailure> {
+            Ok(())
+        }
+
+        async fn stop(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn publish_applied(
+            &mut self,
+            snapshot: Arc<core_runtime::RuntimeSnapshot>,
+        ) -> std::result::Result<(), crate::core::actor::types::CoreActorError> {
+            self.state
+                .applied_revisions
+                .lock()
+                .unwrap()
+                .push(snapshot.revision.get());
+            Ok(())
+        }
+    }
+
+    fn operation_probe_core(state: Arc<OperationProbeState>) -> Arc<dyn CoreLifecyclePort> {
+        Arc::new(OperationProbeCore {
+            gate: Arc::new(tokio::sync::Mutex::new(())),
+            state,
+        })
     }
 
     #[async_trait]
@@ -1886,25 +2468,43 @@ mod tests {
             candidate: &runtime::CandidateFile,
             target_core: nyanpasu_config::application::ClashCore,
             _product: &camino::Utf8Path,
-        ) -> anyhow::Result<[u8; 32]> {
+        ) -> std::result::Result<[u8; 32], core_bridge::CheckAndPromoteFailure> {
             self.inner.check_and_promote(candidate, target_core).await?;
             Ok(candidate.bytes_sha256())
         }
 
-        async fn apply_candidate(
+        async fn apply_promoted(
             &mut self,
-            candidate: &runtime::CandidateFile,
-            target_core: nyanpasu_config::application::ClashCore,
-        ) -> anyhow::Result<()> {
-            self.inner.check_and_promote(candidate, target_core).await
+            snapshot: Arc<core_runtime::RuntimeSnapshot>,
+        ) -> std::result::Result<
+            nyanpasu_ipc::api::core::apply::CoreApplyData,
+            crate::core::actor::types::CoreActorError,
+        > {
+            self.inner.apply_config().await.map_err(|error| {
+                crate::core::actor::types::CoreActorError::Backend(Arc::new(
+                    crate::core::actor::backend::CoreBackendError::Construct(error),
+                ))
+            })?;
+            Ok(core_bridge::test_apply_data(&snapshot))
         }
 
-        async fn apply_promoted(&mut self, _product: &camino::Utf8Path) -> anyhow::Result<()> {
-            self.inner.apply_config().await
+        async fn running_identity(
+            &mut self,
+        ) -> std::result::Result<
+            (
+                Option<crate::core::actor::types::CoreRequest>,
+                crate::core::actor::types::FaithfulLifecycle,
+            ),
+            crate::core::actor::types::CoreActorError,
+        > {
+            Ok((None, crate::core::actor::types::FaithfulLifecycle::Running))
         }
 
-        async fn restart(&mut self) -> anyhow::Result<()> {
-            self.inner.restart_core().await
+        async fn restart(&mut self) -> std::result::Result<(), core_bridge::RestartFailure> {
+            self.inner
+                .restart_core()
+                .await
+                .map_err(core_bridge::RestartFailure::Operation)
         }
 
         async fn stop(&mut self) -> anyhow::Result<()> {
@@ -1999,15 +2599,6 @@ mod tests {
         }
     }
 
-    struct NoopRunningConfigPatchPort;
-
-    #[async_trait]
-    impl RunningConfigPatchPort for NoopRunningConfigPatchPort {
-        async fn patch(&self, _patch: &serde_yaml::Mapping) -> anyhow::Result<()> {
-            Ok(())
-        }
-    }
-
     struct FixedCoreBinaryResolver(Utf8PathBuf);
 
     impl crate::core::actor::request::CoreBinaryResolver for FixedCoreBinaryResolver {
@@ -2029,6 +2620,14 @@ mod tests {
     impl crate::core::actor::backend::CoreDegradationSink for RecordingCoreDegradationSink {
         fn publish(&self, degradation: runtime::Degradation) {
             self.0.lock().unwrap().push(degradation);
+        }
+    }
+
+    struct NotifyingCoreDegradationSink(tokio::sync::mpsc::UnboundedSender<runtime::Degradation>);
+
+    impl crate::core::actor::backend::CoreDegradationSink for NotifyingCoreDegradationSink {
+        fn publish(&self, degradation: runtime::Degradation) {
+            let _ = self.0.send(degradation);
         }
     }
 
@@ -2226,7 +2825,7 @@ mod tests {
             core::CoreClientArgs {
                 mode: crate::core::RunType::Normal,
                 requests: requests.clone(),
-                degradation,
+                degradation: degradation.clone(),
             },
             backend,
         )
@@ -2251,11 +2850,8 @@ mod tests {
             core,
             requests,
             test_service_control(),
-            Arc::new(NoopRunningConfigPatchPort),
+            degradation,
             Arc::new(NoopSystemDnsCache),
-            crate::client::runtime::new_runtime_lifecycle_store()
-                .await
-                .unwrap(),
             rebuild,
         )
     }
@@ -2296,11 +2892,12 @@ mod tests {
             binary,
         )
         .unwrap();
+        let degradation = test_degradation_sink();
         let core_client = CoreClient::new_with_reconciled_backend(
             core::CoreClientArgs {
                 mode: crate::core::RunType::Normal,
                 requests: requests.clone(),
-                degradation: test_degradation_sink(),
+                degradation: degradation.clone(),
             },
             backend,
         )
@@ -2322,28 +2919,45 @@ mod tests {
             test_core_port(Arc::new(MockRunningCoreBridge::new())),
             requests,
             service_control,
-            Arc::new(NoopRunningConfigPatchPort),
+            degradation,
             Arc::new(NoopSystemDnsCache),
-            crate::client::runtime::new_runtime_lifecycle_store()
-                .await
-                .unwrap(),
             rebuild::RebuildCoordinator::new(),
         )
     }
 
-    fn facade_backend() -> crate::core::actor::backend::TestBackend {
-        crate::core::actor::backend::TestBackend::new(
-            crate::core::actor::types::BackendObservation {
-                view: crate::core::actor::types::CoreStatusView {
-                    state: nyanpasu_ipc::api::status::CoreState::Running,
-                    state_changed_at: 1,
-                    run_type: crate::core::RunType::Normal,
-                    revision: None,
-                    recovery_exhausted: false,
-                },
-                lifecycle: crate::core::actor::types::FaithfulLifecycle::Running,
+    fn facade_observation(
+        lifecycle: crate::core::actor::types::FaithfulLifecycle,
+    ) -> crate::core::actor::types::BackendObservation {
+        let state = match lifecycle {
+            crate::core::actor::types::FaithfulLifecycle::Stopped { ref reason } => {
+                nyanpasu_ipc::api::status::CoreState::Stopped(reason.clone())
+            }
+            crate::core::actor::types::FaithfulLifecycle::Starting
+            | crate::core::actor::types::FaithfulLifecycle::Restarting => {
+                nyanpasu_ipc::api::status::CoreState::Stopped(None)
+            }
+            crate::core::actor::types::FaithfulLifecycle::Running
+            | crate::core::actor::types::FaithfulLifecycle::Switching
+            | crate::core::actor::types::FaithfulLifecycle::Stopping => {
+                nyanpasu_ipc::api::status::CoreState::Running
+            }
+        };
+        crate::core::actor::types::BackendObservation {
+            view: crate::core::actor::types::CoreStatusView {
+                state,
+                state_changed_at: 1,
+                run_type: crate::core::RunType::Normal,
+                revision: None,
+                recovery_exhausted: false,
             },
-        )
+            lifecycle,
+        }
+    }
+
+    fn facade_backend() -> crate::core::actor::backend::TestBackend {
+        crate::core::actor::backend::TestBackend::new(facade_observation(
+            crate::core::actor::types::FaithfulLifecycle::Running,
+        ))
     }
 
     #[tokio::test]
@@ -2380,102 +2994,6 @@ mod tests {
         status.changed().await.unwrap();
         assert_eq!(degradation.0.lock().unwrap().len(), 1);
         client.shutdown().await;
-    }
-
-    #[derive(Default)]
-    struct CompensationLease {
-        checked: Vec<Vec<u8>>,
-        apply_calls: usize,
-    }
-
-    #[async_trait]
-    impl CoreLifecycleLease for CompensationLease {
-        async fn check_and_promote(
-            &mut self,
-            candidate: &runtime::CandidateFile,
-            _target_core: nyanpasu_config::application::ClashCore,
-            product: &camino::Utf8Path,
-        ) -> anyhow::Result<[u8; 32]> {
-            let bytes = tokio::fs::read(candidate.path()).await?;
-            core_bridge::restore_product(product.as_std_path(), &bytes).await?;
-            self.checked.push(bytes);
-            Ok(candidate.bytes_sha256())
-        }
-
-        async fn apply_candidate(
-            &mut self,
-            candidate: &runtime::CandidateFile,
-            _target_core: nyanpasu_config::application::ClashCore,
-        ) -> anyhow::Result<()> {
-            self.checked.push(tokio::fs::read(candidate.path()).await?);
-            self.apply_calls += 1;
-            Ok(())
-        }
-
-        async fn apply_promoted(&mut self, _product: &camino::Utf8Path) -> anyhow::Result<()> {
-            self.apply_calls += 1;
-            Ok(())
-        }
-
-        async fn restart(&mut self) -> anyhow::Result<()> {
-            Ok(())
-        }
-
-        async fn stop(&mut self) -> anyhow::Result<()> {
-            Ok(())
-        }
-    }
-
-    struct BarrierCompensationLease {
-        _guard: tokio::sync::OwnedMutexGuard<()>,
-        check_entered: Option<tokio::sync::oneshot::Sender<()>>,
-        release_check: Option<tokio::sync::oneshot::Receiver<()>>,
-    }
-
-    #[async_trait]
-    impl CoreLifecycleLease for BarrierCompensationLease {
-        async fn check_and_promote(
-            &mut self,
-            candidate: &runtime::CandidateFile,
-            _target_core: nyanpasu_config::application::ClashCore,
-            product: &camino::Utf8Path,
-        ) -> anyhow::Result<[u8; 32]> {
-            if let Some(sender) = self.check_entered.take() {
-                let _ = sender.send(());
-            }
-            if let Some(receiver) = self.release_check.take() {
-                let _ = receiver.await;
-            }
-            let bytes = tokio::fs::read(candidate.path()).await?;
-            core_bridge::restore_product(product.as_std_path(), &bytes).await?;
-            Ok(candidate.bytes_sha256())
-        }
-
-        async fn apply_candidate(
-            &mut self,
-            _candidate: &runtime::CandidateFile,
-            _target_core: nyanpasu_config::application::ClashCore,
-        ) -> anyhow::Result<()> {
-            if let Some(sender) = self.check_entered.take() {
-                let _ = sender.send(());
-            }
-            if let Some(receiver) = self.release_check.take() {
-                let _ = receiver.await;
-            }
-            Ok(())
-        }
-
-        async fn apply_promoted(&mut self, _product: &camino::Utf8Path) -> anyhow::Result<()> {
-            Ok(())
-        }
-
-        async fn restart(&mut self) -> anyhow::Result<()> {
-            Ok(())
-        }
-
-        async fn stop(&mut self) -> anyhow::Result<()> {
-            Ok(())
-        }
     }
 
     struct NoopClashBridge;
@@ -2607,11 +3125,8 @@ mod tests {
             test_core_port(Arc::new(MockRunningCoreBridge::new())),
             requests,
             test_service_control(),
-            Arc::new(NoopRunningConfigPatchPort),
+            test_degradation_sink(),
             system_dns,
-            crate::client::runtime::new_runtime_lifecycle_store()
-                .await
-                .expect("runtime state store"),
             rebuild::RebuildCoordinator::new(),
         )
     }
@@ -2842,7 +3357,6 @@ mod tests {
             binary_resolver: test_binary_resolver(dir),
             degradation: test_degradation_sink(),
             service_control: test_service_control(),
-            clash_patch: Some(Arc::new(NoopRunningConfigPatchPort)),
             system_dns: Arc::new(NoopSystemDnsCache),
         }
     }
@@ -2923,11 +3437,8 @@ mod tests {
             test_core_port(core),
             requests,
             test_service_control(),
-            Arc::new(NoopRunningConfigPatchPort),
+            test_degradation_sink(),
             Arc::new(NoopSystemDnsCache),
-            crate::client::runtime::new_runtime_lifecycle_store()
-                .await
-                .expect("runtime state store"),
             rebuild,
         );
         client.start_rebuild_worker();
@@ -3082,7 +3593,6 @@ mod tests {
             binary_resolver: test_binary_resolver(&dir),
             degradation: test_degradation_sink(),
             service_control: test_service_control(),
-            clash_patch: Some(Arc::new(NoopRunningConfigPatchPort)),
             system_dns: Arc::new(NoopSystemDnsCache),
         })
         .expect("client should construct with typed config actors");
@@ -3103,273 +3613,11 @@ mod tests {
         let dir = tempdir().unwrap();
         let client = tauri::async_runtime::block_on(test_client(&dir));
         let promoted = tauri::async_runtime::block_on(client.promoted_runtime());
-        let lifecycle = tauri::async_runtime::block_on(client.runtime_lifecycle_state());
+        let lifecycle = client.inner.core_client.lifecycle();
 
         assert!(promoted.is_none());
         assert!(lifecycle.promoted.is_none());
         assert!(lifecycle.applied.is_none());
-    }
-
-    fn compensation_snapshot(
-        client: &NyanpasuClient,
-        config: serde_yaml::Mapping,
-    ) -> Arc<runtime::RuntimeSnapshot> {
-        let product_bytes = serde_yaml::to_string(&config).unwrap().into_bytes();
-        compensation_snapshot_with_bytes(client, config, product_bytes)
-    }
-
-    fn compensation_snapshot_with_bytes(
-        client: &NyanpasuClient,
-        config: serde_yaml::Mapping,
-        product_bytes: Vec<u8>,
-    ) -> Arc<runtime::RuntimeSnapshot> {
-        let revision = tauri::async_runtime::block_on(async {
-            client.inner.runtime_revisions.allocate().unwrap()
-        });
-        Arc::new(runtime::RuntimeSnapshot::from_data(
-            revision,
-            nyanpasu_config::application::ClashCore::default(),
-            Arc::from(product_bytes),
-            runtime::RuntimeSnapshotData {
-                exists_keys: config
-                    .keys()
-                    .filter_map(serde_yaml::Value::as_str)
-                    .map(ToOwned::to_owned)
-                    .collect(),
-                config,
-                postprocessing_output: Default::default(),
-            },
-        ))
-    }
-
-    #[test]
-    fn s05_remove_compensation_applies_p1_without_replacing_promoted_p2_product() {
-        let dir = tempdir().unwrap();
-        let client = tauri::async_runtime::block_on(test_client(&dir));
-        let p1_bytes =
-            b"# exact applied P1\nmode: rule\nproxy-groups: [] # formatting must survive\n";
-        let p2_bytes = b"# promoted P2 product\nmode: direct\nproxy-groups: [new]\n";
-        let applied = compensation_snapshot_with_bytes(
-            &client,
-            serde_yaml::from_slice(p1_bytes).unwrap(),
-            p1_bytes.to_vec(),
-        );
-        let promoted = compensation_snapshot_with_bytes(
-            &client,
-            serde_yaml::from_slice(p2_bytes).unwrap(),
-            p2_bytes.to_vec(),
-        );
-        assert!(promoted.revision > applied.revision);
-        std::fs::create_dir_all(client.runtime_product_path().parent().unwrap()).unwrap();
-        std::fs::write(client.runtime_product_path(), p2_bytes).unwrap();
-        tauri::async_runtime::block_on(async {
-            *client.inner.runtime.write().await = runtime::RuntimeLifecycleState {
-                promoted: Some(promoted.clone()),
-                applied: Some(applied.clone()),
-            };
-        });
-        let mut patch = serde_yaml::Mapping::new();
-        patch.insert("ipv6".into(), true.into());
-        let plan = runtime::compensation_for(&patch, Some(&applied)).unwrap();
-        assert!(matches!(
-            plan.ops(),
-            [runtime::PatchCompensationOp::Remove { .. }]
-        ));
-        let captured = runtime::RuntimeLifecycleState {
-            promoted: Some(promoted.clone()),
-            applied: Some(applied.clone()),
-        };
-        let mut lease = CompensationLease::default();
-        let result = tauri::async_runtime::block_on(client.restore_applied_after_patch_failure(
-            &mut lease,
-            captured,
-            plan,
-            "primary".into(),
-        ));
-        assert!(result.is_err());
-        assert_eq!(lease.checked, vec![p1_bytes.to_vec()]);
-        assert_eq!(lease.apply_calls, 1);
-        let product = std::fs::read(client.runtime_product_path()).unwrap();
-        assert_eq!(product, p2_bytes);
-        assert_eq!(
-            <[u8; 32]>::from(Sha256::digest(&product)),
-            promoted.product_sha256
-        );
-        let lifecycle = tauri::async_runtime::block_on(client.runtime_lifecycle_state());
-        assert!(Arc::ptr_eq(&lifecycle.promoted.unwrap(), &promoted));
-        assert!(Arc::ptr_eq(&lifecycle.applied.unwrap(), &applied));
-    }
-
-    #[test]
-    fn s05_compensation_preserves_new_promoted_and_restores_only_applied() {
-        let dir = tempdir().unwrap();
-        let client = tauri::async_runtime::block_on(test_client(&dir));
-        let p1_bytes = b"# exact applied P1\nmode: rule\n";
-        let p2_bytes = b"# captured promoted P2\nmode: direct\n";
-        let p3_bytes = b"# current promoted P3\nmode: global\n";
-        let applied = compensation_snapshot_with_bytes(
-            &client,
-            serde_yaml::from_slice(p1_bytes).unwrap(),
-            p1_bytes.to_vec(),
-        );
-        let captured_promoted = compensation_snapshot_with_bytes(
-            &client,
-            serde_yaml::from_slice(p2_bytes).unwrap(),
-            p2_bytes.to_vec(),
-        );
-        let current_promoted = compensation_snapshot_with_bytes(
-            &client,
-            serde_yaml::from_slice(p3_bytes).unwrap(),
-            p3_bytes.to_vec(),
-        );
-        assert!(captured_promoted.revision < current_promoted.revision);
-        std::fs::create_dir_all(client.runtime_product_path().parent().unwrap()).unwrap();
-        std::fs::write(client.runtime_product_path(), p3_bytes).unwrap();
-        tauri::async_runtime::block_on(async {
-            *client.inner.runtime.write().await = runtime::RuntimeLifecycleState {
-                promoted: Some(current_promoted.clone()),
-                applied: Some(applied.clone()),
-            };
-        });
-        let mut patch = serde_yaml::Mapping::new();
-        patch.insert("ipv6".into(), true.into());
-        let plan = runtime::compensation_for(&patch, Some(&applied)).unwrap();
-        let mut lease = CompensationLease::default();
-        let result = tauri::async_runtime::block_on(client.restore_applied_after_patch_failure(
-            &mut lease,
-            runtime::RuntimeLifecycleState {
-                promoted: Some(captured_promoted),
-                applied: Some(applied.clone()),
-            },
-            plan,
-            "primary".into(),
-        ));
-        assert!(result.is_err());
-        assert_eq!(lease.checked, vec![p1_bytes.to_vec()]);
-        let product = std::fs::read(client.runtime_product_path()).unwrap();
-        assert_eq!(product, p3_bytes);
-        assert_eq!(
-            <[u8; 32]>::from(Sha256::digest(&product)),
-            current_promoted.product_sha256
-        );
-        let lifecycle = tauri::async_runtime::block_on(client.runtime_lifecycle_state());
-        assert!(Arc::ptr_eq(
-            lifecycle.promoted.as_ref().unwrap(),
-            &current_promoted
-        ));
-        assert!(Arc::ptr_eq(lifecycle.applied.as_ref().unwrap(), &applied));
-    }
-
-    #[test]
-    fn s05_revision_conflict_performs_no_restore() {
-        let dir = tempdir().unwrap();
-        let client = tauri::async_runtime::block_on(test_client(&dir));
-        let applied = compensation_snapshot(&client, serde_yaml::Mapping::new());
-        let current = compensation_snapshot(&client, serde_yaml::Mapping::new());
-        tauri::async_runtime::block_on(async {
-            client.inner.runtime.write().await.applied = Some(current);
-        });
-        let mut patch = serde_yaml::Mapping::new();
-        patch.insert("ipv6".into(), true.into());
-        let plan = runtime::compensation_for(&patch, Some(&applied)).unwrap();
-        let mut lease = CompensationLease::default();
-        let result = tauri::async_runtime::block_on(client.restore_applied_after_patch_failure(
-            &mut lease,
-            runtime::RuntimeLifecycleState {
-                promoted: Some(applied.clone()),
-                applied: Some(applied),
-            },
-            plan,
-            "primary".into(),
-        ));
-        assert!(result.is_err());
-        assert!(lease.checked.is_empty());
-        assert_eq!(lease.apply_calls, 0);
-    }
-
-    #[test]
-    fn s05_lifecycle_waiter_cannot_enter_during_compensation_restore() {
-        let dir = tempdir().unwrap();
-        let client = tauri::async_runtime::block_on(test_client(&dir));
-        let applied = compensation_snapshot(&client, serde_yaml::Mapping::new());
-        tauri::async_runtime::block_on(async {
-            client.inner.runtime.write().await.applied = Some(applied.clone());
-            let lifecycle = Arc::new(tokio::sync::Mutex::new(()));
-            let guard = lifecycle.clone().lock_owned().await;
-            let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
-            let (release_tx, release_rx) = tokio::sync::oneshot::channel();
-            let lease = BarrierCompensationLease {
-                _guard: guard,
-                check_entered: Some(entered_tx),
-                release_check: Some(release_rx),
-            };
-            let mut patch = serde_yaml::Mapping::new();
-            patch.insert("ipv6".into(), true.into());
-            let plan = runtime::compensation_for(&patch, Some(&applied)).unwrap();
-            let restore = tauri::async_runtime::spawn({
-                let client = client.clone();
-                async move {
-                    let mut lease = lease;
-                    client
-                        .restore_applied_after_patch_failure(
-                            &mut lease,
-                            runtime::RuntimeLifecycleState {
-                                promoted: Some(applied.clone()),
-                                applied: Some(applied),
-                            },
-                            plan,
-                            "primary".into(),
-                        )
-                        .await
-                }
-            });
-            entered_rx.await.unwrap();
-            let (attempted_tx, attempted_rx) = tokio::sync::oneshot::channel();
-            let (waiter_tx, mut waiter_rx) = tokio::sync::oneshot::channel();
-            let waiter = tauri::async_runtime::spawn({
-                let lifecycle = lifecycle.clone();
-                async move {
-                    let _ = attempted_tx.send(());
-                    let _guard = lifecycle.lock_owned().await;
-                    let _ = waiter_tx.send(());
-                }
-            });
-            attempted_rx.await.unwrap();
-            assert!(waiter_rx.try_recv().is_err());
-            let _ = release_tx.send(());
-            restore.await.unwrap().unwrap_err();
-            waiter.await.unwrap();
-            waiter_rx.await.unwrap();
-        });
-    }
-
-    #[test]
-    fn s05_compensation_preserves_exact_applied_identity() {
-        let dir = tempdir().unwrap();
-        let client = tauri::async_runtime::block_on(test_client(&dir));
-        let mut config = serde_yaml::Mapping::new();
-        config.insert("mode".into(), "rule".into());
-        let applied = compensation_snapshot(&client, config);
-        tauri::async_runtime::block_on(async {
-            let mut lifecycle = client.inner.runtime.write().await;
-            lifecycle.promoted = Some(applied.clone());
-            lifecycle.applied = Some(applied.clone());
-        });
-        let mut patch = serde_yaml::Mapping::new();
-        patch.insert("mode".into(), "direct".into());
-        let plan = runtime::compensation_for(&patch, Some(&applied)).unwrap();
-        let mut lease = CompensationLease::default();
-        let _ = tauri::async_runtime::block_on(client.restore_applied_after_patch_failure(
-            &mut lease,
-            runtime::RuntimeLifecycleState {
-                promoted: Some(applied.clone()),
-                applied: Some(applied.clone()),
-            },
-            plan,
-            "primary".into(),
-        ));
-        let lifecycle = tauri::async_runtime::block_on(client.runtime_lifecycle_state());
-        assert!(Arc::ptr_eq(&lifecycle.applied.unwrap(), &applied));
     }
 
     #[test]
@@ -3407,7 +3655,7 @@ mod tests {
             );
             let _ = promoted.postprocessing_output.clone();
 
-            let lifecycle = client.runtime_lifecycle_state().await;
+            let lifecycle = client.inner.core_client.lifecycle();
             let applied = lifecycle
                 .applied
                 .as_ref()
@@ -3465,9 +3713,9 @@ mod tests {
             assert_eq!(degradations.len(), 1);
             assert_eq!(
                 degradations[0].phase,
-                crate::client::runtime::DegradationPhase::RuntimeBuild
+                crate::client::runtime::DegradationPhase::RuntimeCheck
             );
-            assert_eq!(degradations[0].code, "runtime_rebuild_failed");
+            assert_eq!(degradations[0].code, "runtime_check_failed");
             assert!(degradations[0].retryable);
             assert!(degradations[0].message.contains("check boom"));
             let profiles = client.get_profiles().await.unwrap();
@@ -3475,6 +3723,168 @@ mod tests {
                 profiles.current.as_ref(),
                 Some(&uid),
                 "state stays committed"
+            );
+        });
+    }
+
+    #[test]
+    fn background_rebuild_degradation_reaches_sink_and_sync_caller_keeps_it_in_outcome() {
+        let dir = tempdir().unwrap();
+        let (degradation_tx, mut degradation_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut core = MockRunningCoreBridge::new();
+        core.expect_check_and_promote()
+            .returning(|_, _| Err(anyhow::anyhow!("background check failure")));
+        let mut args = test_profiles_client_args(&dir, Arc::new(core));
+        args.degradation = Arc::new(NotifyingCoreDegradationSink(degradation_tx));
+        let client = NyanpasuClient::try_new_with_args(args).unwrap();
+
+        tauri::async_runtime::block_on(async {
+            client.rebuild_coordinator().notifier().request_rebuild();
+            let degradation = tokio::time::timeout(Duration::from_secs(2), degradation_rx.recv())
+                .await
+                .expect("background rebuild must publish without polling sleeps")
+                .expect("degradation sink must stay connected");
+            assert_eq!(degradation.phase, runtime::DegradationPhase::RuntimeCheck);
+            assert_eq!(degradation.code, "runtime_check_failed");
+            assert!(degradation.message.contains("background check failure"));
+
+            let uid = client
+                .add_profile(
+                    minimal_file_profile_request(),
+                    Some("proxies: []\nmode: rule\n".into()),
+                )
+                .await
+                .unwrap()
+                .into_value();
+            let outcome = client.activate_profile(Some(uid)).await.unwrap();
+            assert!(matches!(
+                outcome,
+                runtime::MutationOutcome::CommittedDegraded { .. }
+            ));
+            assert_eq!(outcome.degradations().len(), 1);
+            assert_eq!(outcome.degradations()[0].code, "runtime_check_failed");
+            assert!(degradation_rx.try_recv().is_err());
+            client.shutdown().await;
+        });
+    }
+
+    #[test]
+    fn background_acquire_errors_degrade_but_stale_operations_do_not() {
+        fn client_with_sink(
+            dir: &TempDir,
+            core: Arc<dyn CoreLifecyclePort>,
+        ) -> (
+            NyanpasuClient,
+            tokio::sync::mpsc::UnboundedReceiver<runtime::Degradation>,
+        ) {
+            let (degradation_tx, degradation_rx) = tokio::sync::mpsc::unbounded_channel();
+            let mut args = test_client_args_with_lifecycle(dir, core);
+            args.degradation = Arc::new(NotifyingCoreDegradationSink(degradation_tx));
+            (
+                NyanpasuClient::try_new_with_args(args).unwrap(),
+                degradation_rx,
+            )
+        }
+
+        {
+            let dir = tempdir().unwrap();
+            let (client, mut degradation_rx) = client_with_sink(
+                &dir,
+                Arc::new(BeginFailureCore) as Arc<dyn CoreLifecyclePort>,
+            );
+            tauri::async_runtime::block_on(async {
+                client.rebuild_coordinator().notifier().request_rebuild();
+                let degradation =
+                    tokio::time::timeout(Duration::from_secs(2), degradation_rx.recv())
+                        .await
+                        .expect("background error must publish without polling sleeps")
+                        .expect("degradation sink must stay connected");
+                assert_eq!(degradation.phase, runtime::DegradationPhase::CoreLifecycle);
+                assert_eq!(degradation.code, "core_operation_unavailable");
+                assert!(degradation.retryable);
+                assert!(degradation.message.contains("acquire timeout"));
+                client.shutdown().await;
+            });
+        }
+
+        {
+            let dir = tempdir().unwrap();
+            let (client, mut degradation_rx) = client_with_sink(
+                &dir,
+                Arc::new(ExemptCheckCore) as Arc<dyn CoreLifecyclePort>,
+            );
+            tauri::async_runtime::block_on(async {
+                let error = client
+                    .rebuild_running_config_in_background()
+                    .await
+                    .expect_err("stale operation must remain a plain invariant error");
+                assert!(rebuild::client_error_is_post_commit_exempt(&error));
+                assert!(
+                    degradation_rx.try_recv().is_err(),
+                    "E-b errors must never publish a degradation"
+                );
+                client.shutdown().await;
+            });
+        }
+    }
+
+    #[test]
+    fn background_revision_exhaustion_is_plain_error_without_degradation() {
+        let dir = tempdir().unwrap();
+        let degradation = Arc::new(RecordingCoreDegradationSink::default());
+        let mut args = test_profiles_client_args(&dir, Arc::new(MockRunningCoreBridge::new()));
+        args.degradation = degradation.clone();
+        let client = NyanpasuClient::try_new_with_args(args).unwrap();
+        client.inner.runtime_revisions.exhaust();
+
+        tauri::async_runtime::block_on(async {
+            let error = client
+                .rebuild_running_config_in_background()
+                .await
+                .expect_err(
+                    "allocator exhaustion must be plain Err, never CommittedDegraded or Ok",
+                );
+            assert!(matches!(
+                error,
+                ClientError::Anyhow(source)
+                    if source.downcast_ref::<runtime::RuntimeRevisionExhausted>().is_some()
+            ));
+            assert!(
+                degradation.0.lock().unwrap().is_empty(),
+                "revision exhaustion is E-b and must not publish a degradation"
+            );
+            client.shutdown().await;
+        });
+    }
+
+    #[test]
+    fn profile_commit_acquire_failure_is_committed_degraded() {
+        let dir = tempdir().unwrap();
+        let client = NyanpasuClient::try_new_with_args(test_client_args_with_lifecycle(
+            &dir,
+            Arc::new(BeginFailureCore),
+        ))
+        .unwrap();
+
+        tauri::async_runtime::block_on(async {
+            let outcome = client
+                .create_profile(minimal_file_profile_request(), Some("proxies: []".into()))
+                .await
+                .unwrap();
+            assert!(matches!(
+                outcome,
+                runtime::MutationOutcome::CommittedDegraded { .. }
+            ));
+            assert_eq!(outcome.degradations().len(), 1);
+            assert_eq!(
+                outcome.degradations()[0].phase,
+                runtime::DegradationPhase::CoreLifecycle
+            );
+            assert_eq!(outcome.degradations()[0].code, "core_operation_unavailable");
+            assert!(outcome.degradations()[0].retryable);
+            assert_eq!(
+                client.get_profiles().await.unwrap().current.as_ref(),
+                Some(outcome.value())
             );
         });
     }
@@ -3551,13 +3961,1084 @@ mod tests {
             // T8: a failed rebuild degrades (commit stays) instead of erroring;
             // the rejected candidate must still never reach readers.
             let _ = client.activate_profile(Some(uid)).await;
-            let lifecycle = client.runtime_lifecycle_state().await;
+            let lifecycle = client.inner.core_client.lifecycle();
             assert!(
                 client.promoted_runtime().await.is_none(),
                 "a rejected candidate must never be published to readers"
             );
             assert!(lifecycle.promoted.is_none());
             assert!(lifecycle.applied.is_none());
+        });
+    }
+
+    async fn seed_active_runtime(client: &NyanpasuClient) -> Arc<core_runtime::RuntimeSnapshot> {
+        let uid = client
+            .add_profile(
+                minimal_file_profile_request(),
+                Some("proxies: []\nmode: rule\n".into()),
+            )
+            .await
+            .expect("add profile")
+            .into_value();
+        client
+            .activate_profile(Some(uid))
+            .await
+            .expect("activate profile");
+        client
+            .inner
+            .core_client
+            .lifecycle()
+            .applied
+            .expect("initial rebuild must publish Applied")
+    }
+
+    fn allow_lan_patch() -> serde_yaml::Mapping {
+        serde_yaml::from_str("allow-lan: true\n").unwrap()
+    }
+
+    fn assert_not_applied_degradation(
+        outcome: &runtime::MutationOutcome<runtime::RuntimeApplyReport>,
+        allocated_revision: core_runtime::RuntimeRevision,
+        phase: runtime::DegradationPhase,
+        code: &str,
+    ) {
+        assert!(matches!(
+            outcome,
+            runtime::MutationOutcome::CommittedDegraded { .. }
+        ));
+        assert_eq!(
+            outcome.value().outcome,
+            runtime::RuntimeApplyOutcome::NotApplied
+        );
+        assert_eq!(outcome.value().desired_revision, allocated_revision.get());
+        assert_eq!(outcome.value().applied_revision, None);
+        assert_eq!(outcome.degradations().len(), 1);
+        assert_eq!(outcome.degradations()[0].phase, phase);
+        assert_eq!(outcome.degradations()[0].code, code);
+    }
+
+    fn scripted_apply(
+        outcome: nyanpasu_ipc::api::core::apply::ApplyOutcomeKind,
+        generation: u64,
+    ) -> nyanpasu_ipc::api::core::apply::CoreApplyData {
+        nyanpasu_ipc::api::core::apply::CoreApplyData {
+            outcome,
+            revision: nyanpasu_ipc::api::status::ConfigRevisionInfo {
+                epoch: 1,
+                generation,
+                source_hash: "source".into(),
+                effective_hash: "effective".into(),
+            },
+            warning: None,
+            failed_apply: None,
+        }
+    }
+
+    #[test]
+    fn change_core_acquire_failure_does_not_commit_desired_core() {
+        let dir = tempdir().unwrap();
+        let client = NyanpasuClient::try_new_with_args(test_client_args_with_lifecycle(
+            &dir,
+            Arc::new(BeginFailureCore),
+        ))
+        .unwrap();
+        tauri::async_runtime::block_on(async {
+            let before = client.get_app_config().await.unwrap().core;
+            let error = client
+                .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+                .await
+                .unwrap_err();
+
+            assert!(error.to_string().contains("acquire timeout"));
+            assert_eq!(client.get_app_config().await.unwrap().core, before);
+        });
+    }
+
+    #[tokio::test]
+    async fn change_core_build_failure_commits_desired_and_reports_not_applied() {
+        let dir = tempdir().unwrap();
+        let client =
+            actor_backed_test_client(&dir, facade_backend(), Arc::new(NoopCoreDegradationSink))
+                .await;
+        let uid = client
+            .add_profile(minimal_file_profile_request(), Some("proxies: [".into()))
+            .await
+            .unwrap()
+            .into_value();
+        let activation = client.activate_profile(Some(uid)).await.unwrap();
+        assert!(matches!(
+            activation,
+            runtime::MutationOutcome::CommittedDegraded { .. }
+        ));
+
+        let outcome = client
+            .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+            .await
+            .unwrap();
+        let allocated_revision = client.inner.runtime_revisions.last_allocated();
+
+        assert_eq!(
+            client.get_app_config().await.unwrap().core,
+            nyanpasu_config::application::ClashCore::ClashRs
+        );
+        assert_not_applied_degradation(
+            &outcome,
+            allocated_revision,
+            runtime::DegradationPhase::RuntimeBuild,
+            "runtime_build_failed",
+        );
+    }
+
+    #[test]
+    fn change_core_check_failure_commits_desired_without_promoting() {
+        let dir = tempdir().unwrap();
+        let mut core = MockRunningCoreBridge::new();
+        core.expect_check_and_promote()
+            .once()
+            .returning(|_, _| Err(anyhow::anyhow!("scripted change-core check failure")));
+        let client =
+            NyanpasuClient::try_new_with_args(test_profiles_client_args(&dir, Arc::new(core)))
+                .unwrap();
+        tauri::async_runtime::block_on(async {
+            let outcome = client
+                .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+                .await
+                .unwrap();
+            let allocated_revision = client.inner.runtime_revisions.last_allocated();
+
+            assert_eq!(
+                client.get_app_config().await.unwrap().core,
+                nyanpasu_config::application::ClashCore::ClashRs
+            );
+            assert_not_applied_degradation(
+                &outcome,
+                allocated_revision,
+                runtime::DegradationPhase::RuntimeCheck,
+                "runtime_check_failed",
+            );
+            assert!(client.inner.core_client.lifecycle().promoted.is_none());
+        });
+    }
+
+    #[tokio::test]
+    async fn change_core_transport_loss_is_committed_degraded_and_preserves_applied() {
+        let dir = tempdir().unwrap();
+        let backend = facade_backend();
+        let client =
+            actor_backed_test_client(&dir, backend.clone(), Arc::new(NoopCoreDegradationSink))
+                .await;
+        let old_applied = seed_active_runtime(&client).await;
+        let ipc = nyanpasu_ipc::client::Client::new("change-core-transport-test").unwrap();
+        for _ in 0..5 {
+            let source = ipc.http_client().get("::::").build().unwrap_err();
+            backend.push_apply_result(Err(crate::core::actor::backend::CoreBackendError::Service(
+                nyanpasu_ipc::client::ClientError::Request {
+                    operation: "apply",
+                    source,
+                },
+            )));
+        }
+
+        let outcome = client
+            .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+            .await
+            .unwrap();
+        let allocated_revision = client.inner.runtime_revisions.last_allocated();
+
+        assert_not_applied_degradation(
+            &outcome,
+            allocated_revision,
+            runtime::DegradationPhase::RuntimeApply,
+            "core_transport_lost",
+        );
+        assert_eq!(
+            client.get_app_config().await.unwrap().core,
+            nyanpasu_config::application::ClashCore::ClashRs
+        );
+        let lifecycle = client.inner.core_client.lifecycle();
+        assert!(lifecycle.applied.unwrap().identity_eq(&old_applied));
+        assert!(lifecycle.promoted.unwrap().revision > old_applied.revision);
+    }
+
+    #[tokio::test]
+    async fn change_core_rolled_back_keeps_old_applied_without_application_rollback() {
+        let dir = tempdir().unwrap();
+        let backend = facade_backend();
+        let client =
+            actor_backed_test_client(&dir, backend.clone(), Arc::new(NoopCoreDegradationSink))
+                .await;
+        let old_applied = seed_active_runtime(&client).await;
+        backend.push_apply_result(Ok(scripted_apply(
+            nyanpasu_ipc::api::core::apply::ApplyOutcomeKind::RolledBack,
+            old_applied.revision.get(),
+        )));
+
+        let outcome = client
+            .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            outcome,
+            runtime::MutationOutcome::CommittedDegraded { .. }
+        ));
+        assert_eq!(
+            outcome.value().outcome,
+            runtime::RuntimeApplyOutcome::RolledBack
+        );
+        assert_eq!(
+            outcome.value().applied_revision,
+            Some(old_applied.revision.get())
+        );
+        assert_eq!(outcome.degradations()[0].code, "core_rollback");
+        assert_eq!(
+            client.get_app_config().await.unwrap().core,
+            nyanpasu_config::application::ClashCore::ClashRs
+        );
+        let lifecycle = client.inner.core_client.lifecycle();
+        let promoted = lifecycle.promoted.unwrap();
+        let applied = lifecycle.applied.unwrap();
+        assert_eq!(
+            promoted.target_core,
+            nyanpasu_config::application::ClashCore::ClashRs
+        );
+        assert!(promoted.revision > old_applied.revision);
+        assert!(applied.identity_eq(&old_applied));
+    }
+
+    #[tokio::test]
+    async fn change_core_running_switches_via_apply_without_restart() {
+        let dir = tempdir().unwrap();
+        let backend = facade_backend();
+        let client =
+            actor_backed_test_client(&dir, backend.clone(), Arc::new(NoopCoreDegradationSink))
+                .await;
+        seed_active_runtime(&client).await;
+        client.restart_core().await.unwrap();
+        let prior_runs = backend.run_calls();
+        let prior_applies = backend.apply_calls();
+        backend.push_apply_result(Ok(scripted_apply(
+            nyanpasu_ipc::api::core::apply::ApplyOutcomeKind::Switched,
+            2,
+        )));
+
+        let outcome = client
+            .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, runtime::MutationOutcome::Applied { .. }));
+        assert_eq!(
+            outcome.value().outcome,
+            runtime::RuntimeApplyOutcome::Switched
+        );
+        assert_eq!(backend.run_calls(), prior_runs);
+        assert_eq!(backend.apply_calls(), prior_applies + 1);
+        let lifecycle = client.inner.core_client.lifecycle();
+        let promoted = lifecycle.promoted.unwrap();
+        let applied = lifecycle.applied.unwrap();
+        assert!(applied.identity_eq(&promoted));
+        assert_eq!(
+            promoted.target_core,
+            nyanpasu_config::application::ClashCore::ClashRs
+        );
+        assert_eq!(
+            outcome.value().applied_revision,
+            Some(promoted.revision.get())
+        );
+    }
+
+    #[tokio::test]
+    async fn change_core_stopped_starts_promoted_core_once() {
+        let dir = tempdir().unwrap();
+        let backend = crate::core::actor::backend::TestBackend::new(facade_observation(
+            crate::core::actor::types::FaithfulLifecycle::Stopped { reason: None },
+        ));
+        let client =
+            actor_backed_test_client(&dir, backend.clone(), Arc::new(NoopCoreDegradationSink))
+                .await;
+
+        let outcome = client
+            .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, runtime::MutationOutcome::Applied { .. }));
+        assert_eq!(
+            outcome.value().outcome,
+            runtime::RuntimeApplyOutcome::Started
+        );
+        assert_eq!(backend.apply_calls(), 0);
+        assert_eq!(backend.run_calls(), 1);
+        assert_eq!(
+            backend.run_requests()[0].core_type,
+            nyanpasu_utils::core::CoreType::Clash(nyanpasu_utils::core::ClashCoreType::ClashRust)
+        );
+        let lifecycle = client.inner.core_client.lifecycle();
+        let promoted = lifecycle.promoted.unwrap();
+        let applied = lifecycle.applied.unwrap();
+        assert!(applied.identity_eq(&promoted));
+        assert_eq!(
+            outcome.value().applied_revision,
+            Some(promoted.revision.get())
+        );
+    }
+
+    #[tokio::test]
+    async fn change_core_stopped_start_failure_is_committed_degraded() {
+        let dir = tempdir().unwrap();
+        let backend = crate::core::actor::backend::TestBackend::new(facade_observation(
+            crate::core::actor::types::FaithfulLifecycle::Stopped { reason: None },
+        ));
+        backend.fail_next_run();
+        let client =
+            actor_backed_test_client(&dir, backend.clone(), Arc::new(NoopCoreDegradationSink))
+                .await;
+
+        let outcome = client
+            .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            outcome,
+            runtime::MutationOutcome::CommittedDegraded { .. }
+        ));
+        assert_eq!(
+            outcome.value().outcome,
+            runtime::RuntimeApplyOutcome::NotApplied
+        );
+        assert_eq!(outcome.value().applied_revision, None);
+        assert_eq!(outcome.degradations().len(), 1);
+        assert_eq!(
+            outcome.degradations()[0].phase,
+            runtime::DegradationPhase::CoreLifecycle
+        );
+        assert_eq!(outcome.degradations()[0].code, "core_start_failed");
+        assert_eq!(
+            client.get_app_config().await.unwrap().core,
+            nyanpasu_config::application::ClashCore::ClashRs
+        );
+        let lifecycle = client.inner.core_client.lifecycle();
+        let promoted = lifecycle.promoted.unwrap();
+        assert_eq!(outcome.value().desired_revision, promoted.revision.get());
+        assert_eq!(
+            promoted.target_core,
+            nyanpasu_config::application::ClashCore::ClashRs
+        );
+        assert!(lifecycle.applied.is_none());
+    }
+
+    #[test]
+    fn change_core_stopped_exempt_restart_failure_returns_plain_error() {
+        let dir = tempdir().unwrap();
+        let client = NyanpasuClient::try_new_with_args(test_client_args_with_lifecycle(
+            &dir,
+            Arc::new(ExemptRestartCore),
+        ))
+        .unwrap();
+        tauri::async_runtime::block_on(async {
+            let error = client
+                .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+                .await
+                .expect_err("stale operation must stay a plain error");
+
+            let ClientError::Anyhow(error) = error else {
+                panic!("stale operation must stay an actor-backed error");
+            };
+            assert!(matches!(
+                error.downcast_ref(),
+                Some(crate::core::actor::types::CoreActorError::StaleOperation)
+            ));
+        });
+    }
+
+    #[tokio::test]
+    async fn change_core_uses_faithful_lifecycle_for_attach_and_transition_states() {
+        use crate::core::actor::types::FaithfulLifecycle;
+
+        let cases = [
+            (FaithfulLifecycle::Running, true),
+            (FaithfulLifecycle::Starting, true),
+            (FaithfulLifecycle::Restarting, true),
+            (FaithfulLifecycle::Stopping, false),
+        ];
+        for (lifecycle, should_apply) in cases {
+            let dir = tempdir().unwrap();
+            let backend =
+                crate::core::actor::backend::TestBackend::new(facade_observation(lifecycle));
+            if should_apply {
+                backend.push_apply_result(Ok(scripted_apply(
+                    nyanpasu_ipc::api::core::apply::ApplyOutcomeKind::Switched,
+                    1,
+                )));
+            }
+            let client =
+                actor_backed_test_client(&dir, backend.clone(), Arc::new(NoopCoreDegradationSink))
+                    .await;
+
+            let outcome = client
+                .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+                .await
+                .unwrap();
+
+            if should_apply {
+                assert_eq!(backend.apply_calls(), 1);
+                assert_eq!(backend.run_calls(), 0);
+                assert_eq!(
+                    outcome.value().outcome,
+                    runtime::RuntimeApplyOutcome::Switched
+                );
+            } else {
+                assert_eq!(backend.apply_calls(), 0);
+                assert_eq!(backend.run_calls(), 1);
+                assert_eq!(
+                    outcome.value().outcome,
+                    runtime::RuntimeApplyOutcome::Started
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn patch_promote_prewrite_failure_keeps_product_and_reports_not_applied() {
+        let dir = tempdir().unwrap();
+        let client = NyanpasuClient::try_new_with_args(test_client_args_with_lifecycle(
+            &dir,
+            promote_failure_core(PromoteFailurePoint::BeforeWrite),
+        ))
+        .unwrap();
+        tauri::async_runtime::block_on(async {
+            let old_applied = seed_active_runtime(&client).await;
+            let old_product = tokio::fs::read(client.runtime_product_path())
+                .await
+                .unwrap();
+
+            let outcome = client
+                .patch_running_config(allow_lan_patch())
+                .await
+                .unwrap();
+            let allocated_revision = client.inner.runtime_revisions.last_allocated();
+
+            assert_not_applied_degradation(
+                &outcome,
+                allocated_revision,
+                runtime::DegradationPhase::RuntimePromote,
+                "runtime_promote_failed",
+            );
+            assert_eq!(
+                tokio::fs::read(client.runtime_product_path())
+                    .await
+                    .unwrap(),
+                old_product
+            );
+            let lifecycle = client.inner.core_client.lifecycle();
+            assert!(
+                lifecycle
+                    .promoted
+                    .as_ref()
+                    .is_some_and(|promoted| promoted.identity_eq(&old_applied))
+            );
+            assert!(
+                lifecycle
+                    .applied
+                    .as_ref()
+                    .is_some_and(|applied| applied.identity_eq(&old_applied))
+            );
+            assert!(
+                outcome.degradations()[0]
+                    .message
+                    .contains("before product write")
+            );
+        });
+    }
+
+    #[test]
+    fn patch_promote_postwrite_failure_self_heals_on_next_rebuild() {
+        let dir = tempdir().unwrap();
+        let client = NyanpasuClient::try_new_with_args(test_client_args_with_lifecycle(
+            &dir,
+            promote_failure_core(PromoteFailurePoint::AfterWrite),
+        ))
+        .unwrap();
+        tauri::async_runtime::block_on(async {
+            let old_applied = seed_active_runtime(&client).await;
+            let old_product = tokio::fs::read(client.runtime_product_path())
+                .await
+                .unwrap();
+
+            let outcome = client
+                .patch_running_config(allow_lan_patch())
+                .await
+                .unwrap();
+            let allocated_revision = client.inner.runtime_revisions.last_allocated();
+
+            assert_not_applied_degradation(
+                &outcome,
+                allocated_revision,
+                runtime::DegradationPhase::RuntimePromote,
+                "runtime_promote_failed",
+            );
+            let written_product = tokio::fs::read(client.runtime_product_path())
+                .await
+                .unwrap();
+            assert_ne!(written_product, old_product);
+            let split_lifecycle = client.inner.core_client.lifecycle();
+            assert!(
+                split_lifecycle
+                    .promoted
+                    .as_ref()
+                    .is_some_and(|promoted| promoted.identity_eq(&old_applied))
+            );
+            assert!(
+                outcome.degradations()[0]
+                    .message
+                    .contains("after product write")
+            );
+
+            client.rebuild_running_config().await.unwrap();
+
+            let healed = client.inner.core_client.lifecycle();
+            let promoted = healed.promoted.expect("self-heal must publish Promoted");
+            let applied = healed.applied.expect("self-heal must publish Applied");
+            assert!(applied.identity_eq(&promoted));
+            assert_eq!(promoted.product_bytes(), written_product);
+            assert_eq!(
+                tokio::fs::read(client.runtime_product_path())
+                    .await
+                    .unwrap(),
+                promoted.product_bytes()
+            );
+        });
+    }
+
+    async fn assert_patch_apply_backend_failure(
+        errors: Vec<crate::core::actor::backend::CoreBackendError>,
+        expected_code: &str,
+    ) {
+        let dir = tempdir().unwrap();
+        let backend = facade_backend();
+        let client =
+            actor_backed_test_client(&dir, backend.clone(), Arc::new(NoopCoreDegradationSink))
+                .await;
+        let old_applied = seed_active_runtime(&client).await;
+        for error in errors {
+            backend.push_apply_result(Err(error));
+        }
+
+        let outcome = client
+            .patch_running_config(allow_lan_patch())
+            .await
+            .unwrap();
+        let allocated_revision = client.inner.runtime_revisions.last_allocated();
+
+        assert_not_applied_degradation(
+            &outcome,
+            allocated_revision,
+            runtime::DegradationPhase::RuntimeApply,
+            expected_code,
+        );
+        let lifecycle = client.inner.core_client.lifecycle();
+        let promoted = lifecycle.promoted.expect("candidate must stay Promoted");
+        let applied = lifecycle.applied.expect("old Applied must be retained");
+        assert_eq!(promoted.revision.get(), outcome.value().desired_revision);
+        assert!(promoted.revision > old_applied.revision);
+        assert!(applied.identity_eq(&old_applied));
+    }
+
+    #[test]
+    fn patch_revision_conflict_is_committed_degraded_and_preserves_applied() {
+        tauri::async_runtime::block_on(async {
+            let expected = nyanpasu_core_manager::RevisionId {
+                epoch: 1,
+                generation: 2,
+                effective_hash: "expected".into(),
+            };
+            assert_patch_apply_backend_failure(
+                vec![crate::core::actor::backend::CoreBackendError::Local(
+                    nyanpasu_core_manager::Error::RevisionConflict {
+                        expected,
+                        actual: None,
+                    },
+                )],
+                "revision_conflict",
+            )
+            .await;
+        });
+    }
+
+    #[test]
+    fn patch_transport_loss_is_committed_degraded_and_preserves_applied() {
+        tauri::async_runtime::block_on(async {
+            let ipc = nyanpasu_ipc::client::Client::new("post-commit-transport-test").unwrap();
+            let transport_failures = (0..5)
+                .map(|_| {
+                    let source = ipc.http_client().get("::::").build().unwrap_err();
+                    crate::core::actor::backend::CoreBackendError::Service(
+                        nyanpasu_ipc::client::ClientError::Request {
+                            operation: "apply",
+                            source,
+                        },
+                    )
+                })
+                .collect();
+            assert_patch_apply_backend_failure(transport_failures, "core_transport_lost").await;
+        });
+    }
+
+    #[test]
+    fn patch_backend_apply_error_is_committed_degraded_and_preserves_applied() {
+        tauri::async_runtime::block_on(async {
+            assert_patch_apply_backend_failure(
+                vec![crate::core::actor::backend::CoreBackendError::Construct(
+                    anyhow::anyhow!("scripted apply failure"),
+                )],
+                "runtime_apply_failed",
+            )
+            .await;
+        });
+    }
+
+    #[test]
+    fn post_commit_exemption_boundary_keeps_backend_failures_degraded() {
+        struct ErrorEventCounter(Arc<AtomicUsize>);
+
+        impl<S> tracing_subscriber::Layer<S> for ErrorEventCounter
+        where
+            S: tracing::Subscriber,
+        {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _context: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                if *event.metadata().level() == tracing::Level::ERROR {
+                    self.0.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }
+
+        let shutting_down = NyanpasuClient::apply_failure_degradation(
+            crate::core::actor::types::CoreActorError::ShuttingDown,
+        );
+        assert!(shutting_down.is_err());
+
+        let errors = Arc::new(AtomicUsize::new(0));
+        let subscriber = {
+            use tracing_subscriber::prelude::*;
+            tracing_subscriber::registry().with(ErrorEventCounter(errors.clone()))
+        };
+        let invariant = tracing::subscriber::with_default(subscriber, || {
+            NyanpasuClient::apply_failure_degradation(
+                crate::core::actor::types::CoreActorError::LifecycleInvariant(
+                    crate::core::actor::types::LifecycleInvariantKind::PromotedRegression,
+                ),
+            )
+        });
+        assert!(invariant.is_err());
+        assert_eq!(errors.load(Ordering::SeqCst), 1);
+
+        let backend = NyanpasuClient::apply_failure_degradation(
+            crate::core::actor::types::CoreActorError::Backend(Arc::new(
+                crate::core::actor::backend::CoreBackendError::Construct(anyhow::anyhow!(
+                    "backend apply failure"
+                )),
+            )),
+        )
+        .unwrap();
+        let backend_outcome = runtime::MutationOutcome::from_parts(
+            NyanpasuClient::not_applied_report(core_runtime::RuntimeRevision(41)),
+            vec![backend],
+        );
+        assert!(matches!(
+            backend_outcome,
+            runtime::MutationOutcome::CommittedDegraded { .. }
+        ));
+        assert_eq!(
+            backend_outcome.value().outcome,
+            runtime::RuntimeApplyOutcome::NotApplied
+        );
+
+        let no_backend = NyanpasuClient::apply_failure_degradation(
+            crate::core::actor::types::CoreActorError::NoBackend {
+                last_error: Arc::new(crate::core::actor::backend::CoreBackendError::Construct(
+                    anyhow::anyhow!("backend unavailable"),
+                )),
+            },
+        )
+        .unwrap();
+        let no_backend_outcome = runtime::MutationOutcome::from_parts(
+            NyanpasuClient::not_applied_report(core_runtime::RuntimeRevision(42)),
+            vec![no_backend],
+        );
+        assert!(matches!(
+            no_backend_outcome,
+            runtime::MutationOutcome::CommittedDegraded { .. }
+        ));
+        assert_eq!(
+            no_backend_outcome.degradations()[0].code,
+            "core_backend_unavailable"
+        );
+        assert_eq!(
+            no_backend_outcome.value().outcome,
+            runtime::RuntimeApplyOutcome::NotApplied
+        );
+    }
+
+    #[test]
+    fn default_promotion_check_failure_is_plain_error_without_degradation() {
+        let dir = tempdir().unwrap();
+        let sink = Arc::new(RecordingCoreDegradationSink::default());
+        let mut core = MockRunningCoreBridge::new();
+        core.expect_check_and_promote()
+            .times(1)
+            .returning(|_, _| Err(anyhow::anyhow!("scripted startup check failure")));
+        let mut args = test_profiles_client_args(&dir, Arc::new(core));
+        args.degradation = sink.clone();
+        let client = NyanpasuClient::try_new_with_args(args).unwrap();
+
+        let error = tauri::async_runtime::block_on(client.promote_default_runtime_config())
+            .expect_err("startup check failure has no prior commit and must stay an error");
+
+        assert!(error.to_string().contains("scripted startup check failure"));
+        assert!(sink.0.lock().unwrap().is_empty());
+        let lifecycle = client.inner.core_client.lifecycle();
+        assert!(lifecycle.promoted.is_none());
+        assert!(lifecycle.applied.is_none());
+        tauri::async_runtime::block_on(client.shutdown());
+    }
+
+    #[test]
+    fn enhance_profiles_failures_are_plain_errors_and_do_not_publish_degradations() {
+        let build_dir = tempdir().unwrap();
+        let build_sink = Arc::new(RecordingCoreDegradationSink::default());
+        let build_client = tauri::async_runtime::block_on(actor_backed_test_client(
+            &build_dir,
+            facade_backend(),
+            build_sink.clone(),
+        ));
+        tauri::async_runtime::block_on(async {
+            let uid = build_client
+                .add_profile(
+                    minimal_file_profile_request(),
+                    Some("proxies: []\nmode: rule\n".into()),
+                )
+                .await
+                .unwrap()
+                .into_value();
+            build_client
+                .activate_profile(Some(uid.clone()))
+                .await
+                .unwrap();
+            let materialized = build_client
+                .get_profile_materialized_path(uid)
+                .await
+                .unwrap();
+            tokio::fs::remove_file(materialized).await.unwrap();
+            assert!(build_client.rebuild_running_config().await.is_err());
+        });
+        assert!(build_sink.0.lock().unwrap().is_empty());
+
+        let check_dir = tempdir().unwrap();
+        let check_sink = Arc::new(RecordingCoreDegradationSink::default());
+        let mut check_core = MockRunningCoreBridge::new();
+        check_core
+            .expect_check_and_promote()
+            .times(1)
+            .returning(|_, _| Err(anyhow::anyhow!("scripted check failure")));
+        let mut check_args = test_profiles_client_args(&check_dir, Arc::new(check_core));
+        check_args.degradation = check_sink.clone();
+        let check_client = NyanpasuClient::try_new_with_args(check_args).unwrap();
+        assert!(tauri::async_runtime::block_on(check_client.rebuild_running_config()).is_err());
+        assert!(check_sink.0.lock().unwrap().is_empty());
+
+        let apply_dir = tempdir().unwrap();
+        let apply_sink = Arc::new(RecordingCoreDegradationSink::default());
+        let mut apply_core = MockRunningCoreBridge::new();
+        apply_core
+            .expect_check_and_promote()
+            .times(1)
+            .returning(|_, _| Ok(()));
+        apply_core
+            .expect_apply_config()
+            .times(1)
+            .returning(|| Err(anyhow::anyhow!("scripted apply failure")));
+        let mut apply_args = test_profiles_client_args(&apply_dir, Arc::new(apply_core));
+        apply_args.degradation = apply_sink.clone();
+        let apply_client = NyanpasuClient::try_new_with_args(apply_args).unwrap();
+        assert!(tauri::async_runtime::block_on(apply_client.rebuild_running_config()).is_err());
+        assert!(apply_sink.0.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn legacy_apply_rolled_back_is_a_plain_error_without_sink_degradation() {
+        let dir = tempdir().unwrap();
+        let sink = Arc::new(RecordingCoreDegradationSink::default());
+        let backend = facade_backend();
+        backend.push_apply_result(Ok(nyanpasu_ipc::api::core::apply::CoreApplyData {
+            outcome: nyanpasu_ipc::api::core::apply::ApplyOutcomeKind::RolledBack,
+            revision: nyanpasu_ipc::api::status::ConfigRevisionInfo {
+                epoch: 1,
+                generation: 17,
+                source_hash: "source".into(),
+                effective_hash: "effective".into(),
+            },
+            warning: None,
+            failed_apply: None,
+        }));
+        let client = actor_backed_test_client(&dir, backend, sink.clone()).await;
+
+        let error = client
+            .regenerate_and_apply_for_legacy()
+            .await
+            .expect_err("RolledBack must make legacy draft callers discard");
+
+        assert!(error.to_string().contains("rolled back"));
+        assert!(sink.0.lock().unwrap().is_empty());
+        let lifecycle = client.inner.core_client.lifecycle();
+        assert!(lifecycle.promoted.is_some());
+        assert!(lifecycle.applied.is_none());
+    }
+
+    fn test_runtime_snapshot(
+        revision: u64,
+        bytes: &'static [u8],
+    ) -> Arc<core_runtime::RuntimeSnapshot> {
+        let config = serde_yaml::from_slice(bytes).expect("test runtime must be valid YAML");
+        Arc::new(core_runtime::RuntimeSnapshot::from_data(
+            core_runtime::RuntimeRevision(revision),
+            nyanpasu_config::application::ClashCore::Mihomo,
+            Arc::from(bytes),
+            core_runtime::RuntimeSnapshotData {
+                config,
+                exists_keys: Vec::new(),
+                postprocessing_output: Default::default(),
+            },
+        ))
+    }
+
+    fn candidate_tun_enabled(bytes: &[u8]) -> Option<bool> {
+        let config: serde_yaml::Mapping =
+            serde_yaml::from_slice(bytes).expect("candidate must be valid YAML");
+        let tun = config
+            .get(serde_yaml::Value::String("tun".into()))
+            .and_then(serde_yaml::Value::as_mapping)?;
+        tun.get(serde_yaml::Value::String("enable".into()))
+            .and_then(serde_yaml::Value::as_bool)
+    }
+
+    #[test]
+    fn concurrent_rebuilds_serialize_and_second_reads_latest_snapshot() {
+        let dir = tempdir().unwrap();
+        let state = Arc::new(OperationProbeState::new());
+        let (first_check_entered_tx, first_check_entered_rx) = tokio::sync::oneshot::channel();
+        let (release_first_check_tx, release_first_check_rx) = tokio::sync::oneshot::channel();
+        let (second_begin_attempted_tx, second_begin_attempted_rx) =
+            tokio::sync::oneshot::channel();
+        *state.first_check_entered_tx.lock().unwrap() = Some(first_check_entered_tx);
+        *state.release_first_check_rx.lock().unwrap() = Some(release_first_check_rx);
+        *state.second_begin_attempted_tx.lock().unwrap() = Some(second_begin_attempted_tx);
+        let client = NyanpasuClient::try_new_with_args(test_client_args_with_lifecycle(
+            &dir,
+            operation_probe_core(state.clone()),
+        ))
+        .unwrap();
+
+        tauri::async_runtime::block_on(async {
+            let uid = client
+                .add_profile(
+                    minimal_file_profile_request(),
+                    Some("proxies: []\nmode: rule\n".into()),
+                )
+                .await
+                .expect("add")
+                .into_value();
+            let first = tauri::async_runtime::spawn({
+                let client = client.clone();
+                async move { client.activate_profile(Some(uid)).await }
+            });
+            first_check_entered_rx
+                .await
+                .expect("first rebuild must reach its check while holding the operation guard");
+
+            let mut latest = client.get_clash_config().await.unwrap();
+            assert!(!latest.enable_tun_mode);
+            latest.enable_tun_mode = true;
+            client
+                .replace_clash_config(latest)
+                .await
+                .expect("new desired snapshot must commit while the first rebuild is blocked");
+
+            let second = tauri::async_runtime::spawn({
+                let client = client.clone();
+                async move { client.rebuild_running_config().await }
+            });
+            second_begin_attempted_rx
+                .await
+                .expect("second rebuild must queue on the operation guard");
+            assert_eq!(state.check_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(state.candidates.lock().unwrap().len(), 1);
+
+            let _ = release_first_check_tx.send(());
+            first
+                .await
+                .expect("first rebuild task must join")
+                .expect("first rebuild must succeed");
+            second
+                .await
+                .expect("second rebuild task must join")
+                .expect("second rebuild must succeed");
+
+            assert_eq!(state.max_active_checks.load(Ordering::SeqCst), 1);
+            let candidates = state.candidates.lock().unwrap();
+            assert_eq!(candidates.len(), 2);
+            assert_ne!(candidate_tun_enabled(&candidates[0]), Some(true));
+            assert_eq!(
+                candidate_tun_enabled(&candidates[1]),
+                Some(true),
+                "the queued rebuild must read the post-queue desired snapshot"
+            );
+        });
+    }
+
+    #[test]
+    fn promote_default_builds_candidate_after_operation_guard() {
+        let dir = tempdir().unwrap();
+        let state = Arc::new(OperationProbeState::new());
+        let (begin_entered_tx, begin_entered_rx) = tokio::sync::oneshot::channel();
+        let (release_begin_tx, release_begin_rx) = tokio::sync::oneshot::channel();
+        *state.begin_entered_tx.lock().unwrap() = Some(begin_entered_tx);
+        *state.release_begin_rx.lock().unwrap() = Some(release_begin_rx);
+        let client = NyanpasuClient::try_new_with_args(test_client_args_with_lifecycle(
+            &dir,
+            operation_probe_core(state.clone()),
+        ))
+        .unwrap();
+        let candidate_dir = client.inner.runtime_paths.candidate_dir().to_owned();
+
+        tauri::async_runtime::block_on(async {
+            let promote = tauri::async_runtime::spawn({
+                let client = client.clone();
+                async move { client.promote_default_runtime_config().await }
+            });
+            begin_entered_rx
+                .await
+                .expect("default promotion must begin the operation first");
+            let candidates_before_release = std::fs::read_dir(&candidate_dir)
+                .map(|entries| {
+                    entries
+                        .filter_map(std::result::Result::ok)
+                        .filter(|entry| {
+                            entry
+                                .file_name()
+                                .to_string_lossy()
+                                .starts_with("candidate-")
+                        })
+                        .count()
+                })
+                .unwrap_or(0);
+            assert_eq!(candidates_before_release, 0);
+            assert_eq!(state.check_calls.load(Ordering::SeqCst), 0);
+            let _ = release_begin_tx.send(());
+            promote
+                .await
+                .expect("default promotion task must join")
+                .expect("default promotion must succeed");
+            assert_eq!(state.check_calls.load(Ordering::SeqCst), 1);
+        });
+    }
+
+    #[test]
+    fn promote_existing_reads_product_after_operation_guard() {
+        let dir = tempdir().unwrap();
+        let state = Arc::new(OperationProbeState::new());
+        let (begin_entered_tx, begin_entered_rx) = tokio::sync::oneshot::channel();
+        let (release_begin_tx, release_begin_rx) = tokio::sync::oneshot::channel();
+        *state.begin_entered_tx.lock().unwrap() = Some(begin_entered_tx);
+        *state.release_begin_rx.lock().unwrap() = Some(release_begin_rx);
+        let client = NyanpasuClient::try_new_with_args(test_client_args_with_lifecycle(
+            &dir,
+            operation_probe_core(state.clone()),
+        ))
+        .unwrap();
+        let product = client.runtime_product_path().to_owned();
+
+        tauri::async_runtime::block_on(async {
+            let promote = tauri::async_runtime::spawn({
+                let client = client.clone();
+                async move { client.promote_existing_runtime_product().await }
+            });
+            begin_entered_rx
+                .await
+                .expect("existing-product promotion must begin the operation first");
+            assert!(!product.exists());
+            tokio::fs::create_dir_all(product.parent().unwrap())
+                .await
+                .unwrap();
+            tokio::fs::write(&product, b"mode: rule\n").await.unwrap();
+            let _ = release_begin_tx.send(());
+            let promoted = promote
+                .await
+                .expect("existing-product promotion task must join")
+                .expect("product created after begin must be observed");
+            assert_eq!(promoted.product_bytes(), b"mode: rule\n");
+            assert_eq!(state.check_calls.load(Ordering::SeqCst), 1);
+        });
+    }
+
+    #[test]
+    fn start_promoted_reads_latest_snapshot_after_operation_guard() {
+        let dir = tempdir().unwrap();
+        let state = Arc::new(OperationProbeState::new());
+        let (begin_entered_tx, begin_entered_rx) = tokio::sync::oneshot::channel();
+        let (release_begin_tx, release_begin_rx) = tokio::sync::oneshot::channel();
+        *state.begin_entered_tx.lock().unwrap() = Some(begin_entered_tx);
+        *state.release_begin_rx.lock().unwrap() = Some(release_begin_rx);
+        let client = NyanpasuClient::try_new_with_args(test_client_args_with_lifecycle(
+            &dir,
+            operation_probe_core(state.clone()),
+        ))
+        .unwrap();
+
+        tauri::async_runtime::block_on(async {
+            let old = test_runtime_snapshot(1, b"mode: rule\n");
+            let operation = client.inner.core_client.begin_operation().await.unwrap();
+            client
+                .inner
+                .core_client
+                .publish_promoted(&operation, old)
+                .await
+                .unwrap();
+            operation.release().await;
+
+            let start = tauri::async_runtime::spawn({
+                let client = client.clone();
+                async move { client.start_promoted_runtime().await }
+            });
+            begin_entered_rx
+                .await
+                .expect("start must begin the operation before reading Promoted");
+
+            let newest = test_runtime_snapshot(2, b"mode: global\n");
+            let operation = client.inner.core_client.begin_operation().await.unwrap();
+            client
+                .inner
+                .core_client
+                .publish_promoted(&operation, newest)
+                .await
+                .unwrap();
+            operation.release().await;
+            let _ = release_begin_tx.send(());
+            start
+                .await
+                .expect("start task must join")
+                .expect("start must succeed");
+
+            assert_eq!(
+                state.applied_revisions.lock().unwrap().as_slice(),
+                &[2],
+                "start must associate Applied with the Promoted snapshot read after begin"
+            );
         });
     }
 
@@ -3601,7 +5082,7 @@ mod tests {
                 .await
                 .expect("initial apply");
 
-            let before = client.runtime_lifecycle_state().await;
+            let before = client.inner.core_client.lifecycle();
             let old_applied = before.applied.expect("initial Applied");
             assert!(old_applied.identity_eq(before.promoted.as_deref().expect("initial Promoted")));
 
@@ -3611,7 +5092,7 @@ mod tests {
                 .expect_err("second apply must fail");
             assert!(error.to_string().contains("apply boom"));
 
-            let after = client.runtime_lifecycle_state().await;
+            let after = client.inner.core_client.lifecycle();
             let promoted = after.promoted.expect("second Promoted");
             let applied = after.applied.expect("previous Applied retained");
             assert!(promoted.revision > old_applied.revision);
@@ -3651,7 +5132,7 @@ mod tests {
 
             client.start_promoted_runtime().await.unwrap();
 
-            let lifecycle = client.runtime_lifecycle_state().await;
+            let lifecycle = client.inner.core_client.lifecycle();
             assert!(
                 lifecycle
                     .applied
@@ -3963,6 +5444,9 @@ mod tests {
             ports
                 .resolve(&ClashConfig::default())
                 .expect("default ports");
+            let paths = PathResolver::with_base_dirs(dir.path().into(), dir.path().join("data"));
+            let runtime_paths = RuntimePaths::from_resolver(&paths).unwrap();
+            let (core_client, requests) = test_actor_parts(&paths, runtime_paths.clone()).await;
             let client = NyanpasuClient::with_parts(
                 application,
                 session_state,
@@ -3971,18 +5455,14 @@ mod tests {
                 Arc::new(MockProfileFsPort::new()),
                 ports,
                 dir.path().join("profiles"),
-                RuntimePaths::from_resolver(&PathResolver::with_base_dirs(
-                    dir.path().into(),
-                    dir.path().join("data"),
-                ))
-                .unwrap(),
+                runtime_paths,
                 Arc::new(crate::client::event_sink::NoopUiEventSink),
+                core_client,
                 test_core_port(Arc::new(MockRunningCoreBridge::new())),
-                Arc::new(NoopRunningConfigPatchPort),
+                requests,
+                test_service_control(),
+                test_degradation_sink(),
                 Arc::new(NoopSystemDnsCache),
-                crate::client::runtime::new_runtime_lifecycle_store()
-                    .await
-                    .expect("runtime state store"),
                 rebuild::RebuildCoordinator::new(),
             );
 

--- a/backend/tauri/src/client/process_core_bridge.rs
+++ b/backend/tauri/src/client/process_core_bridge.rs
@@ -19,14 +19,18 @@ use fake_core::{
     FakeCoreCommand, ReadyBarrier, ReadyConnection, ScopedChild, env_keys, require_bin_path,
 };
 use nyanpasu_config::application::ClashCore;
-use nyanpasu_ipc::api::status::CoreState;
+use nyanpasu_ipc::api::{core::apply::CoreApplyData, status::CoreState};
 use sha2::Digest;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use super::{
-    core_bridge::{CoreLifecycleLease, CoreLifecyclePort, CoreStatusSnapshot, restore_product},
+    core_bridge::{
+        CheckAndPromoteError, CheckAndPromoteFailure, CheckAndPromotePhase, CoreLifecycleLease,
+        CoreLifecyclePort, CoreStatusSnapshot, RestartFailure, restore_product,
+    },
     runtime::{CandidateFile, RuntimePaths},
 };
+use crate::core::actor::types::{CoreRequest, FaithfulLifecycle};
 
 const READY_OR_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 const CHILD_DRAIN_TIMEOUT: Duration = Duration::from_secs(3);
@@ -100,6 +104,7 @@ struct ProcessCoreState {
     hold_port: Option<u16>,
     http_port: Option<u16>,
     target_core: ClashCore,
+    running_core: Option<ClashCore>,
     state_changed_at: i64,
 }
 
@@ -111,6 +116,7 @@ impl Default for ProcessCoreState {
             hold_port: None,
             http_port: None,
             target_core: ClashCore::Mihomo,
+            running_core: None,
             state_changed_at: unix_now(),
         }
     }
@@ -259,75 +265,115 @@ impl CoreLifecycleLease for ProcessCoreLifecycleLease {
         candidate: &CandidateFile,
         target_core: ClashCore,
         product: &Utf8Path,
-    ) -> anyhow::Result<[u8; 32]> {
-        anyhow::ensure!(
-            product == self.runtime_paths.product(),
-            "product path must match the lifecycle adapter runtime product"
-        );
-        let bytes = tokio::fs::read(candidate.path()).await?;
+    ) -> Result<[u8; 32], CheckAndPromoteFailure> {
+        if product != self.runtime_paths.product() {
+            return Err(process_operation_error(
+                CheckAndPromotePhase::Promote,
+                anyhow::anyhow!("product path must match the lifecycle adapter runtime product"),
+            ));
+        }
+        let bytes = tokio::fs::read(candidate.path()).await.map_err(|error| {
+            process_operation_error(CheckAndPromotePhase::Promote, error.into())
+        })?;
         let candidate_hash: [u8; 32] = sha2::Sha256::digest(&bytes).into();
-        anyhow::ensure!(
-            candidate_hash == candidate.bytes_sha256(),
-            "candidate config hash changed before check"
-        );
+        if candidate_hash != candidate.bytes_sha256() {
+            return Err(process_operation_error(
+                CheckAndPromotePhase::Promote,
+                anyhow::anyhow!("candidate config hash changed before check"),
+            ));
+        }
 
-        self.run_check(candidate.path()).await?;
+        self.run_check(candidate.path())
+            .await
+            .map_err(|error| process_operation_error(CheckAndPromotePhase::Check, error))?;
 
-        let after = tokio::fs::read(candidate.path().as_std_path()).await?;
+        let after = tokio::fs::read(candidate.path().as_std_path())
+            .await
+            .map_err(|error| {
+                process_operation_error(CheckAndPromotePhase::Promote, error.into())
+            })?;
         if after != bytes {
-            anyhow::bail!("candidate config changed between check and promote");
+            return Err(process_operation_error(
+                CheckAndPromotePhase::Promote,
+                anyhow::anyhow!("candidate config changed between check and promote"),
+            ));
         }
         let after_hash: [u8; 32] = sha2::Sha256::digest(&after).into();
         if after_hash != candidate.bytes_sha256() {
-            anyhow::bail!("candidate config hash changed before promotion");
+            return Err(process_operation_error(
+                CheckAndPromotePhase::Promote,
+                anyhow::anyhow!("candidate config hash changed before promotion"),
+            ));
         }
 
-        restore_product(product.as_std_path(), &bytes).await?;
-        let promoted = tokio::fs::read(product.as_std_path()).await?;
+        restore_product(product.as_std_path(), &bytes)
+            .await
+            .map_err(|error| process_operation_error(CheckAndPromotePhase::Promote, error))?;
+        let promoted = tokio::fs::read(product.as_std_path())
+            .await
+            .map_err(|error| {
+                process_operation_error(CheckAndPromotePhase::Promote, error.into())
+            })?;
         let promoted_hash: [u8; 32] = sha2::Sha256::digest(&promoted).into();
         if promoted_hash != candidate.bytes_sha256() {
-            anyhow::bail!("promoted runtime product hash does not match candidate");
+            return Err(process_operation_error(
+                CheckAndPromotePhase::Promote,
+                anyhow::anyhow!("promoted runtime product hash does not match candidate"),
+            ));
         }
         self.state.target_core = target_core;
         Ok(promoted_hash)
     }
 
-    async fn apply_candidate(
+    async fn apply_promoted(
         &mut self,
-        candidate: &CandidateFile,
-        target_core: ClashCore,
-    ) -> anyhow::Result<()> {
-        let bytes = tokio::fs::read(candidate.path()).await?;
-        let candidate_hash: [u8; 32] = sha2::Sha256::digest(&bytes).into();
-        anyhow::ensure!(
-            candidate_hash == candidate.bytes_sha256(),
-            "candidate config hash changed before check"
-        );
-        self.run_check(candidate.path()).await?;
-        let after = tokio::fs::read(candidate.path()).await?;
-        anyhow::ensure!(
-            after == bytes,
-            "candidate config changed between check and apply"
-        );
-        self.state.target_core = target_core;
-        self.put_configs(candidate.path().as_str()).await
+        snapshot: Arc<crate::core::actor::runtime::RuntimeSnapshot>,
+    ) -> Result<CoreApplyData, crate::core::actor::types::CoreActorError> {
+        let outcome = if self
+            .state
+            .running_core
+            .is_some_and(|core| core != snapshot.target_core)
+        {
+            nyanpasu_ipc::api::core::apply::ApplyOutcomeKind::Switched
+        } else {
+            nyanpasu_ipc::api::core::apply::ApplyOutcomeKind::Reloaded
+        };
+        let product = self.runtime_paths.product().to_owned();
+        self.apply_runtime_config(product.as_str())
+            .await
+            .map_err(|error| {
+                crate::core::actor::types::CoreActorError::Backend(Arc::new(
+                    crate::core::actor::backend::CoreBackendError::Construct(error),
+                ))
+            })?;
+        self.state.running_core = Some(snapshot.target_core);
+        let mut data = super::core_bridge::test_apply_data(&snapshot);
+        data.outcome = outcome;
+        Ok(data)
     }
 
-    async fn apply_promoted(&mut self, product: &Utf8Path) -> anyhow::Result<()> {
-        anyhow::ensure!(
-            product == self.runtime_paths.product(),
-            "product path must match the lifecycle adapter runtime product"
-        );
-        self.put_configs(product.as_str()).await
+    async fn running_identity(
+        &mut self,
+    ) -> Result<(Option<CoreRequest>, FaithfulLifecycle), crate::core::actor::types::CoreActorError>
+    {
+        reap_if_exited(&mut self.state);
+        let lifecycle = if self.state.child.is_some() {
+            FaithfulLifecycle::Running
+        } else {
+            FaithfulLifecycle::Stopped { reason: None }
+        };
+        Ok((None, lifecycle))
     }
 
-    async fn restart(&mut self) -> anyhow::Result<()> {
-        self.stop_inner().await?;
+    async fn restart(&mut self) -> Result<(), RestartFailure> {
+        self.stop_inner().await.map_err(RestartFailure::Operation)?;
 
         let product = self.runtime_paths.product().to_owned();
         // Never invent a placeholder product — promote/seed must write real bytes.
         if !product.as_std_path().is_file() {
-            anyhow::bail!("runtime product is missing; cannot restart");
+            return Err(RestartFailure::Operation(anyhow::anyhow!(
+                "runtime product is missing; cannot restart"
+            )));
         }
 
         // Atomic snapshot: one lock covers start-mode pop + ports/apply fields so
@@ -335,15 +381,27 @@ impl CoreLifecycleLease for ProcessCoreLifecycleLease {
         let (start_exit, policy) = self.take_restart_policy();
 
         if let Some(code) = start_exit {
-            return self.spawn_immediate_start_exit(&product, code).await;
+            return self
+                .spawn_immediate_start_exit(&product, code)
+                .await
+                .map_err(RestartFailure::Operation);
         }
 
-        self.spawn_long_running(&product, &policy).await
+        self.spawn_long_running(&product, &policy)
+            .await
+            .map_err(RestartFailure::Operation)
     }
 
     async fn stop(&mut self) -> anyhow::Result<()> {
         self.stop_inner().await
     }
+}
+
+fn process_operation_error(
+    phase: CheckAndPromotePhase,
+    source: anyhow::Error,
+) -> CheckAndPromoteFailure {
+    CheckAndPromoteFailure::Operation(CheckAndPromoteError { phase, source })
 }
 
 impl ProcessCoreLifecycleLease {
@@ -415,13 +473,13 @@ impl ProcessCoreLifecycleLease {
         }
     }
 
-    async fn put_configs(&mut self, config_path: &str) -> anyhow::Result<()> {
+    async fn apply_runtime_config(&mut self, config_path: &str) -> anyhow::Result<()> {
         self.ensure_core_running()?;
         let http_port = self
             .state
             .http_port
             .expect("http_port present after ensure_core_running");
-        match put_configs_direct(http_port, config_path).await {
+        match apply_runtime_config_direct(http_port, config_path).await {
             Ok(()) => Ok(()),
             Err(error) => {
                 // Child may die between ensure and I/O completion. Re-reap under
@@ -530,6 +588,7 @@ impl ProcessCoreLifecycleLease {
         self.state.http_port = ready.announcement.http_port;
         self.state.ready = Some(ready);
         self.state.child = Some(child);
+        self.state.running_core = Some(target);
         self.state.state_changed_at = unix_now();
         Ok(())
     }
@@ -561,6 +620,7 @@ impl ProcessCoreLifecycleLease {
 
         self.state.hold_port = None;
         self.state.http_port = None;
+        self.state.running_core = None;
         self.state.state_changed_at = unix_now();
         Ok(())
     }
@@ -583,6 +643,7 @@ fn clear_running(state: &mut ProcessCoreState) {
     state.ready = None;
     state.hold_port = None;
     state.http_port = None;
+    state.running_core = None;
     state.state_changed_at = unix_now();
 }
 
@@ -645,7 +706,7 @@ fn accept_ready_or_child_exit(
 
 /// Exact HTTP PUT /configs against the adapter-owned fake-core port.
 /// Does not use production Clash API clients.
-async fn put_configs_direct(http_port: u16, config_path: &str) -> anyhow::Result<()> {
+async fn apply_runtime_config_direct(http_port: u16, config_path: &str) -> anyhow::Result<()> {
     let body = serde_json::json!({ "path": config_path }).to_string();
     let request = format!(
         "PUT /configs HTTP/1.1\r\n\
@@ -767,6 +828,24 @@ mod tests {
             .unwrap();
     }
 
+    async fn promoted_snapshot(
+        adapter: &ProcessCoreLifecycleAdapter,
+    ) -> Arc<crate::core::actor::runtime::RuntimeSnapshot> {
+        let product_bytes = tokio::fs::read(adapter.runtime_paths().product())
+            .await
+            .unwrap();
+        Arc::new(crate::core::actor::runtime::RuntimeSnapshot::from_data(
+            crate::core::actor::runtime::RuntimeRevision(1),
+            ClashCore::default(),
+            Arc::from(product_bytes),
+            crate::core::actor::runtime::RuntimeSnapshotData {
+                config: Default::default(),
+                exists_keys: Vec::new(),
+                postprocessing_output: Default::default(),
+            },
+        ))
+    }
+
     fn process_exists(pid: u32) -> bool {
         #[cfg(target_os = "linux")]
         {
@@ -811,7 +890,7 @@ mod tests {
                 .start_promoted_runtime()
                 .await
                 .expect("seed apply/start");
-            let before = client.runtime_lifecycle_state().await;
+            let before = client.inner.core_client.lifecycle();
             assert!(before.promoted.is_some());
             assert!(before.applied.is_some());
             assert!(
@@ -845,7 +924,7 @@ mod tests {
                 "product must stay unchanged on check fail"
             );
 
-            let after = client.runtime_lifecycle_state().await;
+            let after = client.inner.core_client.lifecycle();
             assert!(
                 after
                     .promoted
@@ -862,6 +941,77 @@ mod tests {
                     .identity_eq(before.applied.as_ref().unwrap()),
                 "Applied must stay unchanged on check fail"
             );
+
+            let mut lease = env.adapter.begin().await.unwrap();
+            lease.stop().await.unwrap();
+            client.shutdown().await;
+        });
+    }
+
+    #[test]
+    fn s09_process_change_core_running_switches_end_to_end() {
+        let env = ProcessTestEnv::new().expect("process env");
+        tauri::async_runtime::block_on(seed_product(
+            &env.adapter,
+            b"# process-switch-old\nmode: rule\n",
+        ));
+        env.adapter.set_policy(ProcessCorePolicy {
+            http_port: Some(0),
+            apply_status: Some(204),
+            ..Default::default()
+        });
+        let client = env.client().expect("client");
+
+        tauri::async_runtime::block_on(async {
+            let old = client
+                .promote_existing_runtime_product()
+                .await
+                .expect("promote initial product");
+            client
+                .start_promoted_runtime()
+                .await
+                .expect("start initial process core");
+            let process_before = env.adapter.process_snapshot().await;
+            assert!(
+                process_before.pid.is_some(),
+                "initial process must be running"
+            );
+            assert_eq!(old.target_core, ClashCore::Mihomo);
+
+            let outcome = client
+                .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+                .await
+                .expect("real-process core switch must succeed");
+
+            assert!(matches!(
+                outcome,
+                crate::client::runtime::MutationOutcome::Applied { .. }
+            ));
+            assert_eq!(
+                outcome.value().outcome,
+                crate::client::runtime::RuntimeApplyOutcome::Switched
+            );
+            assert_eq!(
+                client.get_app_config().await.unwrap().core,
+                nyanpasu_config::application::ClashCore::ClashRs
+            );
+            let lifecycle = client.inner.core_client.lifecycle();
+            let promoted = lifecycle.promoted.expect("switch must publish Promoted");
+            let applied = lifecycle.applied.expect("switch must publish Applied");
+            assert_eq!(promoted.target_core, ClashCore::ClashRs);
+            assert!(applied.identity_eq(&promoted));
+            assert_eq!(outcome.value().desired_revision, promoted.revision.get());
+            assert_eq!(
+                outcome.value().applied_revision,
+                Some(promoted.revision.get())
+            );
+
+            let process_after = env.adapter.process_snapshot().await;
+            assert_eq!(
+                process_after.pid, process_before.pid,
+                "running switch must apply through the existing process"
+            );
+            assert_eq!(process_after.http_port, process_before.http_port);
 
             let mut lease = env.adapter.begin().await.unwrap();
             lease.stop().await.unwrap();
@@ -922,7 +1072,7 @@ mod tests {
                 .start_promoted_runtime()
                 .await
                 .expect("start old applied");
-            let before = client.runtime_lifecycle_state().await;
+            let before = client.inner.core_client.lifecycle();
             assert!(
                 before
                     .applied
@@ -955,7 +1105,7 @@ mod tests {
                 "unexpected error: {rendered}"
             );
 
-            let after = client.runtime_lifecycle_state().await;
+            let after = client.inner.core_client.lifecycle();
             let promoted = after
                 .promoted
                 .expect("Promoted must advance after successful check/promote");
@@ -1183,8 +1333,9 @@ mod tests {
 
             {
                 let mut lease = env_b.adapter.begin().await.unwrap();
+                let promoted = promoted_snapshot(&env_b.adapter).await;
                 lease
-                    .apply_promoted(env_b.adapter.runtime_paths().product())
+                    .apply_promoted(promoted)
                     .await
                     .expect("B apply still works after A stop");
                 lease.stop().await.unwrap();
@@ -1192,134 +1343,6 @@ mod tests {
 
             client_a.shutdown().await;
             client_b.shutdown().await;
-        });
-    }
-
-    /// Process-level `change_core` failure + successful old-core rollback.
-    ///
-    /// Uses a start-exit queue so new-core restart fails and rollback old-core
-    /// restart long-runs. Touches legacy Config globals via `change_core`
-    /// (PR-5 residual); run under `--test-threads=1` with the rest of the
-    /// process matrix. Does not re-enumerate every mock branch.
-    #[test]
-    fn s09_process_change_core_new_start_exit_rollback_old_restart_succeeds() {
-        let env = ProcessTestEnv::new().expect("process env");
-        // Seed a real product so restart never invents a placeholder.
-        tauri::async_runtime::block_on(seed_product(
-            &env.adapter,
-            b"# s09-change-core-seed\nmode: rule\n",
-        ));
-
-        let mut start_exit_queue = VecDeque::new();
-        // New-core restart fails immediately; rollback old-core restart runs.
-        start_exit_queue.push_back(Some(3));
-        start_exit_queue.push_back(None);
-        env.adapter.set_policy(ProcessCorePolicy {
-            start_exit_queue,
-            hold_port: Some(0),
-            http_port: Some(0),
-            apply_status: Some(204),
-            ..Default::default()
-        });
-        let client = env.client().expect("client");
-
-        tauri::async_runtime::block_on(async {
-            // Explicit promote so product/promoted are established before switch.
-            let seeded = client
-                .promote_existing_runtime_product()
-                .await
-                .expect("seed promote");
-            assert!(
-                env.adapter
-                    .runtime_paths()
-                    .product()
-                    .as_std_path()
-                    .is_file(),
-                "product must exist after promote"
-            );
-
-            let selected_before = crate::config::Config::verge()
-                .latest()
-                .clash_core
-                .unwrap_or_default();
-            assert_ne!(
-                selected_before,
-                crate::config::nyanpasu::ClashCore::ClashRs,
-                "baseline selected core must not already be the target"
-            );
-
-            let err = client
-                .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
-                .await
-                .expect_err("new-core start-exit must surface");
-            let rendered = format!("{err:?}");
-            assert!(
-                rendered.contains("start failed")
-                    || rendered.contains("immediate exit")
-                    || rendered.contains("exit"),
-                "unexpected change_core error: {rendered}"
-            );
-
-            let after = client.runtime_lifecycle_state().await;
-            let promoted = after
-                .promoted
-                .expect("rollback must leave Promoted published");
-            let applied = after
-                .applied
-                .expect("successful old restart must publish Applied");
-            assert!(
-                promoted.identity_eq(&applied),
-                "Applied must match Promoted after successful rollback restart"
-            );
-            assert_ne!(
-                promoted.target_core,
-                ClashCore::ClashRs,
-                "rollback rebuild must target the restored old selected core"
-            );
-            // Seeded promote may be superseded by the rollback rebuild product;
-            // product bytes must still exist and selected core restored.
-            assert!(
-                env.adapter
-                    .runtime_paths()
-                    .product()
-                    .as_std_path()
-                    .is_file(),
-                "product must remain after rollback"
-            );
-            let selected_after = crate::config::Config::verge()
-                .latest()
-                .clash_core
-                .unwrap_or_default();
-            assert_eq!(
-                selected_after, selected_before,
-                "selected core must restore via draft discard"
-            );
-            let _ = seeded;
-
-            let snap = env.adapter.process_snapshot().await;
-            assert!(
-                snap.pid.is_some(),
-                "old-core child must be running after rollback restart"
-            );
-            assert!(
-                snap.hold_port.is_some(),
-                "hold port announced after rollback"
-            );
-            assert!(
-                snap.http_port.is_some(),
-                "http port announced after rollback"
-            );
-
-            {
-                let mut lease = env.adapter.begin().await.unwrap();
-                lease.stop().await.expect("cleanup stop");
-            }
-            let cleaned = env.adapter.process_snapshot().await;
-            assert!(cleaned.pid.is_none(), "child cleaned after stop");
-            assert!(cleaned.hold_port.is_none());
-            assert!(cleaned.http_port.is_none());
-
-            client.shutdown().await;
         });
     }
 
@@ -1392,10 +1415,11 @@ mod tests {
 
         {
             let mut lease = env.adapter.begin().await.unwrap();
+            let promoted = promoted_snapshot(&env.adapter).await;
             // Apply itself must reap under the lease and return the stable error
             // (no sleep-based wait for process death — I/O failure + try_wait).
             let err = lease
-                .apply_promoted(env.adapter.runtime_paths().product())
+                .apply_promoted(promoted)
                 .await
                 .expect_err("apply must refuse after child exit");
             let msg = format!("{err:#}");

--- a/backend/tauri/src/client/rebuild.rs
+++ b/backend/tauri/src/client/rebuild.rs
@@ -13,12 +13,56 @@ use std::{
 };
 
 use nyanpasu_config::{application::NyanpasuAppConfig, clash::config::ClashConfig};
+use struct_patch::Patch as _;
 use tokio::sync::{mpsc, oneshot};
 
 use super::{ClientError, NyanpasuClient, Result};
-use crate::state::profiles::ports::RebuildNotifier;
+use crate::{core::actor::types::CoreActorError, state::profiles::ports::RebuildNotifier};
 
 const COALESCE_WINDOW: std::time::Duration = std::time::Duration::from_millis(500);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackgroundFailureDisposition {
+    QuietShutdown,
+    InvariantViolation,
+    Degraded,
+}
+
+pub(super) fn actor_error_is_post_commit_exempt(error: &CoreActorError) -> bool {
+    matches!(error, CoreActorError::ShuttingDown)
+        || matches!(
+            error,
+            CoreActorError::StaleOperation | CoreActorError::LifecycleInvariant(_)
+        )
+}
+
+fn actor_error_from_client(error: &ClientError) -> Option<&CoreActorError> {
+    match error {
+        ClientError::Anyhow(source) => source.downcast_ref::<CoreActorError>(),
+        _ => None,
+    }
+}
+
+pub(super) fn client_error_is_post_commit_exempt(error: &ClientError) -> bool {
+    matches!(
+        error,
+        ClientError::Anyhow(source)
+            if source.downcast_ref::<super::runtime::RuntimeRevisionExhausted>().is_some()
+    ) || actor_error_from_client(error).is_some_and(actor_error_is_post_commit_exempt)
+}
+
+fn background_failure_disposition(error: &ClientError) -> BackgroundFailureDisposition {
+    if matches!(
+        actor_error_from_client(error),
+        Some(CoreActorError::ShuttingDown)
+    ) {
+        return BackgroundFailureDisposition::QuietShutdown;
+    }
+    if client_error_is_post_commit_exempt(error) {
+        return BackgroundFailureDisposition::InvariantViolation;
+    }
+    BackgroundFailureDisposition::Degraded
+}
 
 /// Capacity-1 dirty notifier. `try_send` full means a rebuild is already pending.
 #[derive(Clone)]
@@ -86,7 +130,7 @@ impl RebuildCoordinator {
     pub fn start_worker<F, Fut>(&self, rebuild: F)
     where
         F: Fn() -> Fut + Send + 'static,
-        Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+        Fut: Future<Output = Result<()>> + Send + 'static,
     {
         let mut control = self.control.lock().expect("rebuild coordinator");
         let Some(rx) = control.dirty_rx.take() else {
@@ -143,7 +187,7 @@ fn spawn_worker<F, Fut>(
     rebuild: F,
 ) where
     F: Fn() -> Fut + Send + 'static,
-    Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+    Fut: Future<Output = Result<()>> + Send + 'static,
 {
     let fut = async move {
         loop {
@@ -170,7 +214,21 @@ fn spawn_worker<F, Fut>(
                     // Once rebuild starts it intentionally runs to completion even if
                     // shutdown races in — cancellation mid-apply is not demonstrably safe.
                     if let Err(error) = rebuild().await {
-                        tracing::warn!(%error, "background-driven rebuild failed (degraded)");
+                        match background_failure_disposition(&error) {
+                            BackgroundFailureDisposition::QuietShutdown => {}
+                            BackgroundFailureDisposition::InvariantViolation => {
+                                tracing::error!(
+                                    %error,
+                                    "background-driven rebuild hit an invariant violation"
+                                );
+                            }
+                            BackgroundFailureDisposition::Degraded => {
+                                tracing::warn!(
+                                    %error,
+                                    "background-driven rebuild failed (degraded)"
+                                );
+                            }
+                        }
                     }
                 }
             }
@@ -193,8 +251,8 @@ impl NyanpasuClient {
     /// Legacy-draft snapshot -> typed build inputs for the regeneration bridge.
     // FIXME(actor-migration): legacy-draft-aware input assembly for BC callers.
     // Legacy Config::generate() read Config::{verge,clash}().latest() — including
-    // uncommitted drafts. Legacy side-effect writers (feat::patch_clash /
-    // patch_verge tun+service paths, CoreManager::change_core) draft first and
+    // uncommitted drafts. Legacy side-effect writers (feat::patch_clash and
+    // patch_verge tun+service paths) draft first and
     // only reseed typed actors after the mutation commits, so regenerating from
     // typed snapshots would run one step behind (stale ports/secret/core).
     // Convert legacy latest() via the reseed converters instead — without
@@ -221,15 +279,14 @@ impl NyanpasuClient {
         Ok((app, clash))
     }
 
-    /// Regeneration entry for legacy bridge callers (`CoreManager::update_config`,
-    /// `feat::patch_clash`/`patch_verge` side-effect paths, `change_core`).
+    /// Regeneration entry for legacy bridge callers (`CoreManager::update_config`
+    /// and `feat::patch_clash`/`patch_verge` side-effect paths).
     /// Profiles come from the typed actor only; their legacy IPC writers moved
     /// onto the facade in T08 and the legacy profile code was removed in T10.
     #[allow(dead_code)]
     pub(crate) async fn regenerate_runtime_for_legacy(&self) -> Result<()> {
-        // Inputs are read under the rebuild gate so a legacy regeneration
+        // Inputs are read under the core operation guard so a legacy regeneration
         // serializes with facade rebuilds and always sees the newest drafts.
-        let _rebuild = self.inner.rebuild_gate.lock().await;
         let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
         self.regenerate_for_legacy_inner(&mut *lease)
             .await
@@ -239,176 +296,207 @@ impl NyanpasuClient {
     pub(super) async fn regenerate_for_legacy_inner(
         &self,
         lease: &mut dyn crate::client::CoreLifecycleLease,
-    ) -> Result<std::sync::Arc<crate::client::runtime::RuntimeSnapshot>> {
+    ) -> Result<std::sync::Arc<crate::core::actor::runtime::RuntimeSnapshot>> {
         let revision = self
             .inner
             .runtime_revisions
             .allocate()
-            .map_err(ClientError::Anyhow)?;
+            .map_err(|error| ClientError::Anyhow(error.into()))?;
         let (app, clash) = Self::legacy_regen_inputs()?;
         let profiles = self.inner.profiles.get().await?;
         self.regenerate_runtime_with(lease, revision, profiles, clash, app)
             .await
+            .map_err(Into::into)
     }
 
     pub(crate) async fn regenerate_and_apply_for_legacy(&self) -> Result<()> {
-        // P0-2: one gate hold covers regenerate AND apply — a concurrent rebuild
+        // P0-2: one operation guard covers regenerate AND apply — a concurrent rebuild
         // cannot replace the product between the two steps.
-        let _rebuild = self.inner.rebuild_gate.lock().await;
         let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
         let promoted = self.regenerate_for_legacy_inner(&mut *lease).await?;
-        lease
-            .apply_promoted(self.inner.runtime_paths.product())
+        let data = lease
+            .apply_promoted(promoted)
             .await
-            .map_err(ClientError::Anyhow)?;
-        self.publish_applied(promoted).await
+            .map_err(|error| ClientError::Anyhow(error.into()))?;
+        if data.outcome == nyanpasu_ipc::api::core::apply::ApplyOutcomeKind::RolledBack {
+            return Err(ClientError::Custom(
+                "runtime apply rolled back to the previous configuration".into(),
+            ));
+        }
+        Ok(())
     }
 
     pub(crate) async fn regenerate_and_restart_for_legacy(&self) -> Result<()> {
-        let _rebuild = self.inner.rebuild_gate.lock().await;
         let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
         let promoted = self.regenerate_for_legacy_inner(&mut *lease).await?;
-        lease.restart().await.map_err(ClientError::Anyhow)?;
-        self.publish_applied(promoted).await
+        lease
+            .restart()
+            .await
+            .map_err(|error| ClientError::Anyhow(error.into()))?;
+        lease
+            .publish_applied(promoted)
+            .await
+            .map_err(|error| ClientError::Anyhow(error.into()))
     }
 
-    /// Core-switch transaction (spec §5.4 / S03). The WHOLE
-    /// draft→rebuild→restart→commit/rollback sequence holds the rebuild gate,
-    /// so no concurrent rebuild can replace the checked product between check
-    /// and start (P0-2). On rollback, product / Promoted / Applied come from the
-    /// captured transaction snapshot; selected core is restored by verge
-    /// `discard()` before the rollback rebuild.
-    pub async fn change_core(&self, new_core: crate::config::nyanpasu::ClashCore) -> Result<()> {
-        let _rebuild = self.inner.rebuild_gate.lock().await;
+    pub async fn change_core(
+        &self,
+        new_core: crate::config::nyanpasu::ClashCore,
+    ) -> Result<crate::client::runtime::MutationOutcome<crate::client::runtime::RuntimeApplyReport>>
+    {
         let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
-
-        // Capture rollback material BEFORE any mutation (spec §6.5 D5).
-        let product_path = self.inner.runtime_paths.product().to_owned();
-        let product = match tokio::fs::read(&product_path).await {
-            Ok(bytes) => Some(bytes),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-            Err(error) => return Err(ClientError::Anyhow(error.into())),
+        let typed_core = match new_core {
+            crate::config::nyanpasu::ClashCore::ClashPremium => {
+                nyanpasu_config::application::ClashCore::ClashPremium
+            }
+            crate::config::nyanpasu::ClashCore::ClashRs => {
+                nyanpasu_config::application::ClashCore::ClashRs
+            }
+            crate::config::nyanpasu::ClashCore::Mihomo => {
+                nyanpasu_config::application::ClashCore::Mihomo
+            }
+            crate::config::nyanpasu::ClashCore::MihomoAlpha => {
+                nyanpasu_config::application::ClashCore::MihomoAlpha
+            }
+            crate::config::nyanpasu::ClashCore::ClashRsAlpha => {
+                nyanpasu_config::application::ClashCore::ClashRsAlpha
+            }
+            crate::config::nyanpasu::ClashCore::Meow => {
+                nyanpasu_config::application::ClashCore::Meow
+            }
         };
-        let transaction = crate::client::runtime::RuntimeTransactionSnapshot {
-            product,
-            lifecycle: self.runtime_lifecycle_state().await,
-        };
+        let mut patch = NyanpasuAppConfig::new_empty_patch();
+        patch.core = Some(typed_core);
+        self.inner.application.patch(patch).await?;
 
-        // TODO(actor-migration): core selection still drafts the legacy verge.
-        // Reason: verge feature flows migrate in PR-5/6.
-        // Remove when: core selection patches the typed app config.
-        crate::config::Config::verge().draft().clash_core = Some(new_core);
-
-        let new_snapshot = match self.regenerate_for_legacy_inner(&mut *lease).await {
-            Ok(snapshot) => snapshot,
+        // Revision exhaustion is an invariant violation, not a recoverable
+        // runtime degradation: the operation guard serializes one allocation per
+        // transaction and u64 space cannot be exhausted by a valid execution.
+        let revision = self
+            .inner
+            .runtime_revisions
+            .allocate()
+            .map_err(|error| ClientError::Anyhow(error.into()))?;
+        let promoted = match self
+            .regenerate_runtime_at_revision(&mut *lease, revision)
+            .await
+        {
+            Ok(promoted) => promoted,
             Err(error) => {
-                // New-core build/check failed: product/promoted/applied untouched.
-                crate::config::Config::verge().discard();
-                return Err(error);
+                return match Self::rebuild_failure_degradation(error) {
+                    Ok(degradation) => Ok(crate::client::runtime::MutationOutcome::from_parts(
+                        Self::not_applied_report(revision),
+                        vec![degradation],
+                    )),
+                    Err(error) => Err(error),
+                };
             }
         };
 
-        // TODO(actor-migration): legacy log sink clear on core switch (C7).
-        // Remove when: PR-5 injects the LogSink into CoreActor.
-        crate::core::logger::Logger::global().clear_log();
-
-        match lease.restart().await {
-            Ok(()) => {
-                crate::config::Config::verge().apply();
-                if let Err(error) = crate::config::Config::verge().latest().save_file() {
-                    tracing::error!(%error, "failed to persist verge after core switch");
+        let (running, lifecycle) = match lease.running_identity().await {
+            Ok(identity) => identity,
+            Err(error) => {
+                if actor_error_is_post_commit_exempt(&error) {
+                    return Err(Self::post_commit_actor_error(error));
                 }
-                // Successful apply/restart advances Applied (promoted already set).
-                self.publish_applied(new_snapshot).await
+                let (code, message) = match error {
+                    crate::core::actor::types::CoreActorError::NoBackend { last_error } => {
+                        ("core_backend_unavailable", last_error.to_string())
+                    }
+                    error => ("runtime_apply_failed", error.to_string()),
+                };
+                return Ok(crate::client::runtime::MutationOutcome::from_parts(
+                    Self::not_applied_report(revision),
+                    vec![Self::runtime_degradation(
+                        crate::client::runtime::DegradationPhase::RuntimeApply,
+                        code,
+                        message,
+                    )],
+                ));
             }
-            Err(new_core_error) => {
-                tracing::error!("failed to change core: {new_core_error:?}");
-                // 1. Restore old selected-core desired value before rebuild.
-                crate::config::Config::verge().discard();
+        };
+        let should_apply = running.is_some()
+            || matches!(
+                lifecycle,
+                crate::core::actor::types::FaithfulLifecycle::Running
+                    | crate::core::actor::types::FaithfulLifecycle::Starting
+                    | crate::core::actor::types::FaithfulLifecycle::Restarting
+                    | crate::core::actor::types::FaithfulLifecycle::Switching
+            );
 
-                // 2. Rebuild old-core runtime from committed desired state.
-                match self.regenerate_for_legacy_inner(&mut *lease).await {
-                    Ok(rollback_snapshot) => {
-                        // 5. Start old core off the rebuilt product.
-                        if let Err(restart_error) = lease.restart().await {
-                            // Promoted is the rollback rebuild; Applied stays the
-                            // pre-transaction snapshot (never advanced on failure).
-                            return Err(ClientError::Anyhow(new_core_error.context(format!(
-                                "old core restart failed after rollback: {restart_error}"
-                            ))));
-                        }
-                        // 6. Old core started → Applied tracks the rollback snapshot.
-                        self.publish_applied(rollback_snapshot).await?;
-                        Err(ClientError::Anyhow(new_core_error))
-                    }
-                    Err(rebuild_error) => {
-                        // 3. Rebuild failed → atomically restore previous product.
-                        let restored: anyhow::Result<()> = match &transaction.product {
-                            Some(bytes) => {
-                                crate::client::core_bridge::restore_product(
-                                    product_path.as_std_path(),
-                                    bytes,
-                                )
-                                .await
-                            }
-                            None => match tokio::fs::remove_file(&product_path).await {
-                                Ok(()) => Ok(()),
-                                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                                    Ok(())
-                                }
-                                Err(error) => Err(error.into()),
-                            },
-                        };
-                        if let Err(restore_error) = restored {
-                            return Err(ClientError::Anyhow(
-                                new_core_error
-                                    .context(format!("rollback rebuild failed: {rebuild_error}"))
-                                    .context(format!(
-                                        "product restore failed: {restore_error}; core left stopped"
-                                    )),
-                            ));
-                        }
-                        // 4. Product is authoritative → restore Promoted with it.
-                        // New-core restart never advanced Applied, but pre-transaction
-                        // Promoted may still be ahead of Applied (promote-ok / apply-fail).
-                        self.restore_promoted(transaction.lifecycle.promoted.clone())
-                            .await?;
-                        // 5. Start old core on the restored product.
-                        if let Err(restart_error) = lease.restart().await {
-                            // 7. Applied keeps the pre-transaction snapshot; core is
-                            // stopped/degraded. Structured error chain is preserved.
-                            return Err(ClientError::Anyhow(
-                                new_core_error
-                                    .context(format!("rollback rebuild failed: {rebuild_error}"))
-                                    .context(format!("old core restart failed: {restart_error}")),
-                            ));
-                        }
-                        // 6. Successful old restart runs the restored product, so
-                        // Applied must track the restored Promoted (including the
-                        // Promoted > Applied case). Skip when Promoted was unknown.
-                        if let Some(restored) = transaction.lifecycle.promoted.clone() {
-                            self.publish_applied(restored).await?;
-                        }
-                        // selected_core was restored via discard() before rebuild.
-                        Err(ClientError::Anyhow(new_core_error.context(format!(
-                            "rollback rebuild failed: {rebuild_error}; restored previous product"
-                        ))))
-                    }
+        if should_apply {
+            return match lease.apply_promoted(promoted).await {
+                Ok(data) => {
+                    let (report, degradations) =
+                        crate::client::runtime::runtime_outcome_from_apply_data(
+                            &data,
+                            revision.get(),
+                        );
+                    Ok(crate::client::runtime::MutationOutcome::from_parts(
+                        report,
+                        degradations,
+                    ))
                 }
-            }
+                Err(error) => match Self::apply_failure_degradation(error) {
+                    Ok(degradation) => Ok(crate::client::runtime::MutationOutcome::from_parts(
+                        Self::not_applied_report(revision),
+                        vec![degradation],
+                    )),
+                    Err(error) => Err(error),
+                },
+            };
         }
+
+        if let Err(error) = lease.restart().await {
+            let message = match error {
+                super::core_bridge::RestartFailure::Actor(error)
+                    if actor_error_is_post_commit_exempt(&error) =>
+                {
+                    return Err(Self::post_commit_actor_error(error));
+                }
+                super::core_bridge::RestartFailure::Actor(error) => error.to_string(),
+                super::core_bridge::RestartFailure::Operation(error) => error.to_string(),
+            };
+            return Ok(crate::client::runtime::MutationOutcome::from_parts(
+                Self::not_applied_report(revision),
+                vec![Self::runtime_degradation(
+                    crate::client::runtime::DegradationPhase::CoreLifecycle,
+                    "core_start_failed",
+                    message,
+                )],
+            ));
+        }
+        if let Err(error) = lease.publish_applied(promoted).await {
+            return match Self::rebuild_failure_degradation(super::RuntimeRebuildError::Publish(
+                error,
+            )) {
+                Ok(degradation) => Ok(crate::client::runtime::MutationOutcome::from_parts(
+                    Self::not_applied_report(revision),
+                    vec![degradation],
+                )),
+                Err(error) => Err(error),
+            };
+        }
+        Ok(crate::client::runtime::MutationOutcome::from_parts(
+            crate::client::runtime::RuntimeApplyReport {
+                outcome: crate::client::runtime::RuntimeApplyOutcome::Started,
+                desired_revision: revision.get(),
+                applied_revision: Some(revision.get()),
+            },
+            Vec::new(),
+        ))
     }
 
     /// Boot fallback (spec §5.6, D8): the default config is ALSO routed through
     /// candidate -> check -> promote — D5 has no exceptions. A failed check
     /// leaves no product; boot continues and the core start fails visibly.
     pub(crate) async fn promote_default_runtime_config(&self) -> Result<()> {
-        let _rebuild = self.inner.rebuild_gate.lock().await;
+        let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
         let revision = self
             .inner
             .runtime_revisions
             .allocate()
-            .map_err(ClientError::Anyhow)?;
+            .map_err(|error| ClientError::Anyhow(error.into()))?;
         // TODO(actor-migration): boot fallback reads the legacy clash mapping
         // directly (same source the old resolve.rs fallback used).
         // Remove when: PR-6 migrates boot/resolve onto typed clients.
@@ -420,11 +508,11 @@ impl NyanpasuClient {
                 .map_err(|error| ClientError::Custom(format!("serialize default: {error}")))?
         );
         let product_bytes: Arc<[u8]> = Arc::from(yaml.into_bytes());
-        let snapshot = Arc::new(crate::client::runtime::RuntimeSnapshot::from_data(
+        let snapshot = Arc::new(crate::core::actor::runtime::RuntimeSnapshot::from_data(
             revision,
             app.core,
             product_bytes.clone(),
-            crate::client::runtime::RuntimeSnapshotData {
+            crate::core::actor::runtime::RuntimeSnapshotData {
                 exists_keys: mapping
                     .keys()
                     .filter_map(serde_yaml::Value::as_str)
@@ -440,28 +528,58 @@ impl NyanpasuClient {
             .create_candidate(&product_bytes)
             .await
             .map_err(ClientError::Anyhow)?;
-        let mut lease = self.inner.core.begin().await.map_err(ClientError::Anyhow)?;
         let checked = lease
             .check_and_promote(&candidate, app.core, self.inner.runtime_paths.product())
             .await;
         if let Err(error) = candidate.cleanup().await {
             tracing::warn!(%error, "failed to remove candidate config");
         }
-        checked.map_err(ClientError::Anyhow)?;
-        self.publish_promoted(snapshot).await
+        checked.map_err(|error| ClientError::Anyhow(error.into()))?;
+        lease
+            .publish_promoted(snapshot)
+            .await
+            .map_err(|error| ClientError::Anyhow(error.into()))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
-    use nyanpasu_config::application::ClashCore;
     use std::sync::{
-        Arc, Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+        atomic::{AtomicUsize, Ordering},
     };
     use tokio::sync::oneshot as tokio_oneshot;
+
+    #[test]
+    fn background_failure_classification_separates_teardown_invariants_and_degradation() {
+        let actor_error = |error| ClientError::Anyhow(anyhow::Error::new(error));
+
+        assert_eq!(
+            background_failure_disposition(&actor_error(CoreActorError::ShuttingDown)),
+            BackgroundFailureDisposition::QuietShutdown
+        );
+        assert_eq!(
+            background_failure_disposition(&actor_error(CoreActorError::StaleOperation)),
+            BackgroundFailureDisposition::InvariantViolation
+        );
+        assert_eq!(
+            background_failure_disposition(&actor_error(CoreActorError::LifecycleInvariant(
+                crate::core::actor::types::LifecycleInvariantKind::PromotedRegression,
+            ))),
+            BackgroundFailureDisposition::InvariantViolation
+        );
+        assert_eq!(
+            background_failure_disposition(&ClientError::Anyhow(anyhow::Error::new(
+                super::super::runtime::RuntimeRevisionExhausted,
+            ))),
+            BackgroundFailureDisposition::InvariantViolation
+        );
+        assert_eq!(
+            background_failure_disposition(&ClientError::Custom("ordinary failure".into())),
+            BackgroundFailureDisposition::Degraded
+        );
+    }
 
     /// Capacity-1 dirty burst folds into one rebuild after the coalesce window.
     /// Uses paused Tokio time — no real sleep ordering.
@@ -678,9 +796,9 @@ mod tests {
     }
 
     /// T07 review fix regression pin: the regeneration bridge assembles its
-    /// inputs from legacy verge/clash values as the writers drafted them
-    /// (feat::patch_clash / change_core draft first, reseed typed actors only
-    /// after commit). Tests the pure conversion half — the production wrapper
+    /// inputs from legacy verge/clash values as the writers expose them
+    /// (`feat::patch_clash` drafts first; `change_core` commits typed application
+    /// state directly). Tests the pure conversion half — the production wrapper
     /// reads Config::{verge,clash}().latest() and must stay draft-inclusive
     /// (mutating the process-global singletons here is inherently racy, so the
     /// wrapper's latest() choice is locked by comment + review, not by test).
@@ -706,585 +824,87 @@ mod tests {
         );
     }
 
-    #[test]
-    fn change_core_rolls_back_via_second_regenerate_and_restart() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut core = crate::client::tests::MockRunningCoreBridge::new();
-        let mut seq = mockall::Sequence::new();
-        // 新核:check+晋升成功 → 启动失败
-        core.expect_check_and_promote()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|_, _| Ok(()));
-        core.expect_restart_core()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|| Err(anyhow::anyhow!("new core boom")));
-        // 回滚:旧核 check+晋升成功 → 旧核启动成功
-        core.expect_check_and_promote()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|_, _| Ok(()));
-        core.expect_restart_core()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|| Ok(()));
-        core.expect_on_profile_change().returning(|| ());
-        let client = crate::client::NyanpasuClient::try_new_with_args(
-            crate::client::tests::test_profiles_client_args(&dir, std::sync::Arc::new(core)),
-        )
-        .unwrap();
-        let result = tauri::async_runtime::block_on(
-            client.change_core(crate::config::nyanpasu::ClashCore::ClashRs),
-        );
-        assert!(
-            result.is_err(),
-            "change_core must surface the new-core error"
-        );
-    }
-
-    /// P0-4 deepest branch (brief Step 7 ¶2 fallback coverage): when the ROLLBACK
-    /// rebuild ALSO fails its check, the failure is never swallowed. change_core
-    /// restores the previous checked product bytes, makes one old-core restart
-    /// attempt, and surfaces a compound error whose chain records the
-    /// rollback-rebuild failure. The mock sequence pins that a second check Err
-    /// never reaches the restart-success path (which would apply the verge draft).
-    ///
-    /// RuntimePaths keeps the product under this test's TempDir, so the fallback
-    /// restore is exercised without touching the user's product config.
-    #[test]
-    fn change_core_rollback_rebuild_failure_restores_product_and_errors() {
-        let dir = tempfile::tempdir().unwrap();
-        // Seed the injected product so change_core captures old_product before
-        // entering the rollback-rebuild failure path.
-        let product = crate::client::RuntimePaths::from_resolver(
-            &crate::utils::path::PathResolver::with_base_dirs(
-                dir.path().into(),
-                dir.path().join("data"),
-            ),
-        )
-        .unwrap()
-        .product()
-        .to_owned();
-        if let Some(parent) = product.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        std::fs::write(&product, b"# nyanpasu-test previous product\n").unwrap();
-
-        let mut core = crate::client::tests::MockRunningCoreBridge::new();
-        let mut seq = mockall::Sequence::new();
-        // 新核:check+晋升成功 → 启动失败
-        core.expect_check_and_promote()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|_, _| Ok(()));
-        core.expect_restart_core()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|| Err(anyhow::anyhow!("new core boom")));
-        // 回滚重建:check 失败(P0-4 深分支)→ 恢复旧产物 → 旧核重启一次
-        core.expect_check_and_promote()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|_, _| Err(anyhow::anyhow!("rollback check boom")));
-        core.expect_restart_core()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|| Ok(()));
-        core.expect_on_profile_change().returning(|| ());
-
-        let client = crate::client::NyanpasuClient::try_new_with_args(
-            crate::client::tests::test_profiles_client_args(&dir, std::sync::Arc::new(core)),
-        )
-        .unwrap();
-        let result = tauri::async_runtime::block_on(
-            client.change_core(crate::config::nyanpasu::ClashCore::ClashRs),
-        );
-
-        let err = result.expect_err("rollback-rebuild failure must surface an error");
-        let rendered = format!("{err:?}");
-        assert!(
-            rendered.contains("rollback rebuild failed"),
-            "compound error must record the rollback-rebuild failure; got: {rendered}"
-        );
-    }
-
     // ── S03/S04 regression contracts and the remaining S09 failure pin ─────
 
-    struct BarrierCore {
-        lifecycle: Arc<tokio::sync::Mutex<()>>,
-        state: Arc<BarrierState>,
-    }
-
-    struct BarrierState {
-        begin_calls: AtomicUsize,
-        restart_calls: AtomicUsize,
-        concurrent_begin_attempted_tx: Mutex<Option<tokio_oneshot::Sender<()>>>,
-        entered_before_rollback: AtomicBool,
-        first_entered_tx: Mutex<Option<tokio_oneshot::Sender<()>>>,
-        release_first_rx: Mutex<Option<tokio_oneshot::Receiver<()>>>,
-        rollback_finished: AtomicBool,
-        rollback_finished_tx: Mutex<Option<tokio_oneshot::Sender<()>>>,
-        concurrent_entered_tx: Mutex<Option<tokio_oneshot::Sender<()>>>,
-    }
-
-    struct BarrierLease {
-        state: Arc<BarrierState>,
-        _guard: tokio::sync::OwnedMutexGuard<()>,
-    }
-
-    #[async_trait]
-    impl crate::client::CoreLifecyclePort for BarrierCore {
-        async fn begin(&self) -> anyhow::Result<Box<dyn crate::client::CoreLifecycleLease>> {
-            let begin_call = self.state.begin_calls.fetch_add(1, Ordering::SeqCst);
-            if begin_call > 0 {
-                if let Some(tx) = self
-                    .state
-                    .concurrent_begin_attempted_tx
-                    .lock()
-                    .unwrap()
-                    .take()
-                {
-                    let _ = tx.send(());
-                }
-            }
-            let guard = self.lifecycle.clone().lock_owned().await;
-            if begin_call > 0 && !self.state.rollback_finished.load(Ordering::SeqCst) {
-                self.state
-                    .entered_before_rollback
-                    .store(true, Ordering::SeqCst);
-            }
-            Ok(Box::new(BarrierLease {
-                state: self.state.clone(),
-                _guard: guard,
-            }))
-        }
-
-        async fn status(&self) -> anyhow::Result<crate::client::core_bridge::CoreStatusSnapshot> {
-            anyhow::bail!("status is not used by this barrier test")
-        }
-
-        async fn on_profile_change(&self) {}
-    }
-
-    #[async_trait]
-    impl crate::client::CoreLifecycleLease for BarrierLease {
-        async fn check_and_promote(
-            &mut self,
-            candidate: &crate::client::runtime::CandidateFile,
-            _target_core: ClashCore,
-            _product: &camino::Utf8Path,
-        ) -> anyhow::Result<[u8; 32]> {
-            Ok(candidate.bytes_sha256())
-        }
-
-        async fn apply_candidate(
-            &mut self,
-            _candidate: &crate::client::runtime::CandidateFile,
-            _target_core: ClashCore,
-        ) -> anyhow::Result<()> {
-            Ok(())
-        }
-
-        async fn apply_promoted(&mut self, _product: &camino::Utf8Path) -> anyhow::Result<()> {
-            Ok(())
-        }
-
-        async fn restart(&mut self) -> anyhow::Result<()> {
-            match self.state.restart_calls.fetch_add(1, Ordering::SeqCst) {
-                0 => {
-                    if let Some(tx) = self.state.first_entered_tx.lock().unwrap().take() {
-                        let _ = tx.send(());
-                    }
-                    let release = self.state.release_first_rx.lock().unwrap().take();
-                    if let Some(release) = release {
-                        let _ = release.await;
-                    }
-                    Err(anyhow::anyhow!("new core boom (barrier)"))
-                }
-                1 => {
-                    self.state.rollback_finished.store(true, Ordering::SeqCst);
-                    if let Some(tx) = self.state.rollback_finished_tx.lock().unwrap().take() {
-                        let _ = tx.send(());
-                    }
-                    Ok(())
-                }
-                _ => {
-                    assert!(
-                        self.state.rollback_finished.load(Ordering::SeqCst),
-                        "concurrent lifecycle restart entered before rollback completed"
-                    );
-                    if let Some(tx) = self.state.concurrent_entered_tx.lock().unwrap().take() {
-                        let _ = tx.send(());
-                    }
-                    Ok(())
-                }
-            }
-        }
-
-        async fn stop(&mut self) -> anyhow::Result<()> {
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn s04_concurrent_restart_waits_until_change_core_rollback_completes() {
-        let dir = tempfile::tempdir().unwrap();
-        let (first_entered_tx, first_entered_rx) = tokio_oneshot::channel();
-        let (concurrent_begin_attempted_tx, concurrent_begin_attempted_rx) =
-            tokio_oneshot::channel();
-        let (release_first_tx, release_first_rx) = tokio_oneshot::channel();
-        let (rollback_finished_tx, rollback_finished_rx) = tokio_oneshot::channel();
-        let (concurrent_entered_tx, concurrent_entered_rx) = tokio_oneshot::channel();
-        let state = Arc::new(BarrierState {
-            begin_calls: AtomicUsize::new(0),
-            restart_calls: AtomicUsize::new(0),
-            concurrent_begin_attempted_tx: Mutex::new(Some(concurrent_begin_attempted_tx)),
-            entered_before_rollback: AtomicBool::new(false),
-            first_entered_tx: Mutex::new(Some(first_entered_tx)),
-            release_first_rx: Mutex::new(Some(release_first_rx)),
-            rollback_finished: AtomicBool::new(false),
-            rollback_finished_tx: Mutex::new(Some(rollback_finished_tx)),
-            concurrent_entered_tx: Mutex::new(Some(concurrent_entered_tx)),
-        });
-        let core = Arc::new(BarrierCore {
-            lifecycle: Arc::new(tokio::sync::Mutex::new(())),
-            state: state.clone(),
-        });
-        let client =
-            crate::client::NyanpasuClient::try_new_with_args(crate::client::ClientSetupArgs {
-                core: Some(core.clone()),
-                ..crate::client::tests::test_profiles_client_args(
-                    &dir,
-                    Arc::new(crate::client::tests::MockRunningCoreBridge::new()),
-                )
-            })
-            .unwrap();
-
-        tauri::async_runtime::block_on(async move {
-            let change = tauri::async_runtime::spawn({
-                let client = client.clone();
-                async move {
-                    client
-                        .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
-                        .await
-                }
-            });
-            first_entered_rx.await.expect("new-core restart must enter");
-
-            let concurrent = tauri::async_runtime::spawn(async move {
-                let mut lease = crate::client::CoreLifecyclePort::begin(&*core).await?;
-                lease.restart().await
-            });
-            concurrent_begin_attempted_rx
-                .await
-                .expect("concurrent restart must attempt lifecycle begin while rollback is active");
-            assert!(
-                !state.entered_before_rollback.load(Ordering::SeqCst),
-                "concurrent lifecycle begin must wait for rollback"
-            );
-            let _ = release_first_tx.send(());
-
-            rollback_finished_rx
-                .await
-                .expect("old-core rollback restart must complete");
-            concurrent_entered_rx
-                .await
-                .expect("concurrent restart must enter after rollback");
-            concurrent
-                .await
-                .expect("concurrent restart task must join")
-                .expect("concurrent restart must succeed");
-            assert!(
-                !state.entered_before_rollback.load(Ordering::SeqCst),
-                "concurrent lifecycle begin entered before rollback completed"
-            );
-            assert!(
-                change.await.expect("change_core task must join").is_err(),
-                "change_core must surface the new-core failure"
-            );
-        });
-    }
-
-    /// S01→S03 contract (task §S01.2 / design failure matrix change_core row):
-    /// when rollback rebuild fails and product bytes are restored, the runtime
-    /// read model (Promoted) must also be restored to the pre-transaction
-    /// snapshot. Product restore + Promoted restore are atomic (S03).
-    #[test]
-    fn s01_contract_product_restore_leaves_runtime_read_model_on_new_core() {
-        let dir = tempfile::tempdir().unwrap();
-        let product = crate::client::RuntimePaths::from_resolver(
-            &crate::utils::path::PathResolver::with_base_dirs(
-                dir.path().into(),
-                dir.path().join("data"),
-            ),
-        )
-        .unwrap()
-        .product()
-        .to_owned();
-        if let Some(parent) = product.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        // Distinct old product bytes so we can detect the restore.
-        const OLD_PRODUCT: &[u8] = b"# s01-old-product\nmode: rule\n";
-        std::fs::write(&product, OLD_PRODUCT).unwrap();
-
-        let mut core = crate::client::tests::MockRunningCoreBridge::new();
-        let mut seq = mockall::Sequence::new();
-        // New core: promote ok → restart fails.
-        core.expect_check_and_promote()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|_, _| Ok(()));
-        core.expect_restart_core()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|| Err(anyhow::anyhow!("new core boom")));
-        // Rollback rebuild: check fails → product restore path → old restart.
-        core.expect_check_and_promote()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|_, _| Err(anyhow::anyhow!("rollback check boom")));
-        core.expect_restart_core()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|| Ok(()));
-        core.expect_on_profile_change().returning(|| ());
-
-        let client = crate::client::NyanpasuClient::try_new_with_args(
-            crate::client::tests::test_profiles_client_args(&dir, std::sync::Arc::new(core)),
-        )
-        .unwrap();
-
-        // No prior Promoted/Applied before change_core — product restore must
-        // clear the new-core publish left by regenerate_for_legacy_inner.
-        let pre = tauri::async_runtime::block_on(client.runtime_lifecycle_state());
-        assert!(pre.promoted.is_none());
-        assert!(pre.applied.is_none());
-
-        let result = tauri::async_runtime::block_on(
-            client.change_core(crate::config::nyanpasu::ClashCore::ClashRs),
-        );
-        assert!(result.is_err(), "change_core must surface compound error");
-
-        // Product bytes restored to OLD_PRODUCT by the last-resort path.
-        let restored_bytes = std::fs::read(&product).unwrap_or_default();
-        assert_eq!(
-            restored_bytes, OLD_PRODUCT,
-            "product restore must rewrite the injected product path"
-        );
-
-        // S03: after product restore, Promoted is the pre-transaction snapshot
-        // (None here) — never the new-core publish.
-        let lifecycle = tauri::async_runtime::block_on(client.runtime_lifecycle_state());
-        assert!(
-            lifecycle.promoted.is_none(),
-            "product restore after rollback-rebuild failure must restore Promoted; \
-             got Some(revision={:?}, core={:?})",
-            lifecycle.promoted.as_ref().map(|s| s.revision.get()),
-            lifecycle.promoted.as_ref().map(|s| s.target_core),
-        );
-        assert!(
-            lifecycle.applied.is_none(),
-            "Applied must stay pre-transaction (None) when new-core restart never applied"
-        );
-        assert!(
-            tauri::async_runtime::block_on(client.promoted_runtime()).is_none(),
-            "runtime read model (Promoted) must not remain on the new-core publish"
-        );
-    }
-
-    /// H-1: deep product-restore with pre-transaction Promoted > Applied.
-    /// Setup: product bytes = P2; Promoted = P2; Applied = P1 (stale after a
-    /// prior promote-ok/apply-fail). change_core fails new-core restart, then
-    /// rollback rebuild also fails check → product restore + Promoted restore
-    /// + successful old-core restart. Applied must advance to the restored P2.
-    #[test]
-    fn change_core_product_restore_advances_applied_when_promoted_ahead() {
-        use sha2::{Digest, Sha256};
-
-        let dir = tempfile::tempdir().unwrap();
-        let mut core = crate::client::tests::MockRunningCoreBridge::new();
-        let mut seq = mockall::Sequence::new();
-        // Seed Applied=P1: promote existing P1 product, then start core.
-        core.expect_check_and_promote()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|_, _| Ok(()));
-        core.expect_restart_core()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|| Ok(()));
-        // Seed Promoted=P2 without advancing Applied (promote-ok / apply-fail shape).
-        core.expect_check_and_promote()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|_, _| Ok(()));
-        // change_core: new-core promote ok → restart fails.
-        core.expect_check_and_promote()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|_, _| Ok(()));
-        core.expect_restart_core()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|| Err(anyhow::anyhow!("new core boom")));
-        // Rollback rebuild check fails → product restore path → old restart ok.
-        core.expect_check_and_promote()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|_, _| Err(anyhow::anyhow!("rollback check boom")));
-        core.expect_restart_core()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|| Ok(()));
-        core.expect_on_profile_change().returning(|| ());
-
-        let client = crate::client::NyanpasuClient::try_new_with_args(
-            crate::client::tests::test_profiles_client_args(&dir, std::sync::Arc::new(core)),
-        )
-        .unwrap();
-
-        let product = client.runtime_product_path().to_owned();
-        if let Some(parent) = product.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        const P1_BYTES: &[u8] = b"# h1-p1-product\nmode: direct\n";
-        const P2_BYTES: &[u8] = b"# h1-p2-product\nmode: rule\n";
-
-        tauri::async_runtime::block_on(async {
-            std::fs::write(&product, P1_BYTES).unwrap();
-            let p1 = client
-                .promote_existing_runtime_product()
-                .await
-                .expect("seed Promoted=P1");
-            client
-                .start_promoted_runtime()
-                .await
-                .expect("seed Applied=P1");
-
-            std::fs::write(&product, P2_BYTES).unwrap();
-            let p2 = client
-                .promote_existing_runtime_product()
-                .await
-                .expect("seed Promoted=P2 ahead of Applied");
-            assert_eq!(
-                p2.product_sha256,
-                <[u8; 32]>::from(Sha256::digest(P2_BYTES)),
-                "seed product must be P2"
-            );
-
-            let before = client.runtime_lifecycle_state().await;
-            let before_promoted = before.promoted.expect("Promoted=P2");
-            let before_applied = before.applied.expect("Applied=P1");
-            assert!(
-                before_promoted.identity_eq(p2.as_ref()),
-                "pre-transaction Promoted must be P2"
-            );
-            assert!(
-                before_applied.identity_eq(p1.as_ref()),
-                "pre-transaction Applied must be P1"
-            );
-            assert!(
-                before_promoted.revision > before_applied.revision,
-                "precondition: Promoted revision must be ahead of Applied"
-            );
-
-            let result = client
-                .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
-                .await;
-            assert!(result.is_err(), "change_core must surface compound error");
-
-            let restored_bytes = tokio::fs::read(&product).await.unwrap_or_default();
-            assert_eq!(
-                restored_bytes, P2_BYTES,
-                "deep product restore must rewrite injected product to P2"
-            );
-
-            let after = client.runtime_lifecycle_state().await;
-            let after_promoted = after.promoted.expect("restored Promoted=P2");
-            let after_applied = after
-                .applied
-                .expect("successful old restart must advance Applied to restored Promoted");
-            assert!(
-                after_promoted.identity_eq(p2.as_ref()),
-                "Promoted must restore to pre-transaction P2"
-            );
-            assert!(
-                after_applied.identity_eq(after_promoted.as_ref()),
-                "Applied must advance to restored Promoted after successful old-core restart"
-            );
-            assert!(
-                after_applied.identity_eq(p2.as_ref()),
-                "Applied must equal restored P2, not stale P1"
-            );
-        });
-    }
-
-    /// Successful rollback rebuild restores Applied to the rebuilt old-core
-    /// snapshot; product/promoted/applied stay coherent after the error.
-    #[test]
-    fn change_core_successful_rollback_publishes_applied_from_old_core() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut core = crate::client::tests::MockRunningCoreBridge::new();
-        let mut seq = mockall::Sequence::new();
-        core.expect_check_and_promote()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|_, _| Ok(()));
-        core.expect_restart_core()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|| Err(anyhow::anyhow!("new core boom")));
-        core.expect_check_and_promote()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|_, _| Ok(()));
-        core.expect_restart_core()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(|| Ok(()));
-        core.expect_on_profile_change().returning(|| ());
-
-        let client = crate::client::NyanpasuClient::try_new_with_args(
-            crate::client::tests::test_profiles_client_args(&dir, std::sync::Arc::new(core)),
-        )
-        .unwrap();
-        let result = tauri::async_runtime::block_on(
-            client.change_core(crate::config::nyanpasu::ClashCore::ClashRs),
-        );
-        assert!(result.is_err());
-
-        let lifecycle = tauri::async_runtime::block_on(client.runtime_lifecycle_state());
-        let promoted = lifecycle.promoted.expect("rollback must leave Promoted");
-        let applied = lifecycle
-            .applied
-            .expect("successful old restart publishes Applied");
-        assert!(
-            promoted.identity_eq(&applied),
-            "Applied must match Promoted after successful rollback restart"
-        );
-        // Discard restored selected core to default (not ClashRs).
-        assert_ne!(
-            promoted.target_core,
-            nyanpasu_config::application::ClashCore::ClashRs,
-            "rollback rebuild must target the restored old selected core"
-        );
-    }
-
-    #[test]
-    fn rollback_build_failure_restarts_the_committed_old_core() {
+    #[tokio::test]
+    async fn s04_concurrent_restart_waits_until_change_core_transaction_completes() {
         let dir = tempfile::tempdir().unwrap();
         let backend = crate::core::actor::backend::TestBackend::new(
             crate::core::actor::types::BackendObservation {
                 view: crate::core::actor::types::CoreStatusView {
-                    state: nyanpasu_ipc::api::status::CoreState::Running,
+                    state: nyanpasu_ipc::api::status::CoreState::Stopped(None),
                     state_changed_at: 1,
                     run_type: crate::core::RunType::Normal,
                     revision: None,
                     recovery_exhausted: false,
                 },
-                lifecycle: crate::core::actor::types::FaithfulLifecycle::Running,
+                lifecycle: crate::core::actor::types::FaithfulLifecycle::Stopped { reason: None },
+            },
+        );
+        let client = crate::client::tests::actor_backed_test_client(
+            &dir,
+            backend.clone(),
+            crate::client::tests::test_degradation_sink(),
+        )
+        .await;
+        let (change_run_started, release_change_run) = backend.block_next_run();
+
+        let change = tokio::spawn({
+            let client = client.clone();
+            async move {
+                client
+                    .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
+                    .await
+            }
+        });
+        change_run_started
+            .await
+            .expect("change-core restart must enter the backend");
+
+        let (concurrent_attempted_tx, concurrent_attempted_rx) = tokio_oneshot::channel();
+        let concurrent = tokio::spawn({
+            let client = client.clone();
+            async move {
+                let _ = concurrent_attempted_tx.send(());
+                client.restart_core().await
+            }
+        });
+        concurrent_attempted_rx
+            .await
+            .expect("concurrent restart task must begin");
+        tokio::task::yield_now().await;
+        assert_eq!(
+            backend.run_calls(),
+            1,
+            "concurrent restart must wait behind the change-core operation guard"
+        );
+
+        let _ = release_change_run.send(());
+        change
+            .await
+            .expect("change_core task must join")
+            .expect("change_core must succeed");
+        concurrent
+            .await
+            .expect("concurrent restart task must join")
+            .expect("concurrent restart must succeed");
+        assert_eq!(backend.run_calls(), 2);
+    }
+    /// Default fallback publishes Promoted only — Applied stays unset until a
+    /// successful apply/start/restart (boot path uses start_promoted_runtime).
+    #[test]
+    fn promote_default_runtime_config_publishes_promoted_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let backend = crate::core::actor::backend::TestBackend::new(
+            crate::core::actor::types::BackendObservation {
+                view: crate::core::actor::types::CoreStatusView {
+                    state: nyanpasu_ipc::api::status::CoreState::Stopped(None),
+                    state_changed_at: 1,
+                    run_type: crate::core::RunType::Normal,
+                    revision: None,
+                    recovery_exhausted: false,
+                },
+                lifecycle: crate::core::actor::types::FaithfulLifecycle::Stopped { reason: None },
             },
         );
         let client =
@@ -1294,66 +914,10 @@ mod tests {
                 crate::client::tests::test_degradation_sink(),
             ));
 
-        tauri::async_runtime::block_on(async {
-            let report = client
-                .inner
-                .profiles
-                .add(
-                    crate::client::tests::minimal_file_profile_request(),
-                    Some("proxies: []\nmode: rule\n".into()),
-                )
-                .await
-                .unwrap();
-            let uid = report.created.unwrap();
-            client
-                .inner
-                .profiles
-                .set_current(Some(uid.clone()))
-                .await
-                .unwrap();
-            let materialized = client.get_profile_materialized_path(uid).await.unwrap();
-            assert!(materialized.is_file());
-            backend.fail_next_run_with(move || std::fs::remove_file(materialized).unwrap());
-
-            let result = client
-                .change_core(crate::config::nyanpasu::ClashCore::ClashRs)
-                .await;
-            assert!(result.is_err());
-            assert_eq!(backend.check_calls(), 1);
-            let requests = backend.run_requests();
-            assert_eq!(requests.len(), 2);
-            assert_eq!(
-                requests[0].core_type,
-                nyanpasu_utils::core::CoreType::Clash(
-                    nyanpasu_utils::core::ClashCoreType::ClashRust
-                )
-            );
-            assert_eq!(
-                requests[1].core_type,
-                nyanpasu_utils::core::CoreType::Clash(nyanpasu_utils::core::ClashCoreType::Mihomo)
-            );
-        });
-    }
-
-    /// Default fallback publishes Promoted only — Applied stays unset until a
-    /// successful apply/start/restart (boot path uses start_promoted_runtime).
-    #[test]
-    fn promote_default_runtime_config_publishes_promoted_only() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut core = crate::client::tests::MockRunningCoreBridge::new();
-        core.expect_check_and_promote()
-            .times(1)
-            .returning(|_, _| Ok(()));
-        core.expect_on_profile_change().returning(|| ());
-        let client = crate::client::NyanpasuClient::try_new_with_args(
-            crate::client::tests::test_profiles_client_args(&dir, std::sync::Arc::new(core)),
-        )
-        .unwrap();
-
         tauri::async_runtime::block_on(client.promote_default_runtime_config())
             .expect("default fallback promote");
 
-        let lifecycle = tauri::async_runtime::block_on(client.runtime_lifecycle_state());
+        let lifecycle = client.inner.core_client.lifecycle();
         assert!(
             lifecycle.promoted.is_some(),
             "fallback must publish Promoted"
@@ -1362,6 +926,7 @@ mod tests {
             lifecycle.applied.is_none(),
             "fallback must not advance Applied before core start"
         );
+        assert_eq!(backend.check_calls(), 1);
     }
 
     /// S09: two client graphs are independent — each owns its coordinator/core path.

--- a/backend/tauri/src/client/runtime.rs
+++ b/backend/tauri/src/client/runtime.rs
@@ -5,188 +5,52 @@
 use std::{
     fs::OpenOptions,
     io::Write,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::atomic::{AtomicU64, Ordering},
     time::{Duration, SystemTime},
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
-use nyanpasu_config::application::ClashCore;
+use nyanpasu_ipc::api::core::apply::{ApplyOutcomeKind, CoreApplyData};
 use serde::{Deserialize, Serialize};
-use serde_yaml::Mapping;
 use sha2::{Digest, Sha256};
 
-use crate::{enhance::PostProcessingOutput, utils::path::PathResolver};
+use crate::{core::actor::runtime::RuntimeRevision, utils::path::PathResolver};
 
 pub const RUNTIME_CONFIG_DIR: &str = "runtime";
 pub const RUNTIME_CONFIG: &str = "clash-config.yaml";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct RuntimeRevision(u64);
-
-impl RuntimeRevision {
-    pub fn get(self) -> u64 {
-        self.0
-    }
-}
-
 pub(crate) struct RuntimeRevisionAllocator(AtomicU64);
+
+#[derive(Debug, thiserror::Error)]
+#[error("runtime revision space exhausted")]
+pub(crate) struct RuntimeRevisionExhausted;
 
 impl RuntimeRevisionAllocator {
     pub(crate) fn new() -> Self {
         Self(AtomicU64::new(0))
     }
 
-    pub(crate) fn allocate(&self) -> anyhow::Result<RuntimeRevision> {
+    pub(crate) fn allocate(
+        &self,
+    ) -> std::result::Result<RuntimeRevision, RuntimeRevisionExhausted> {
         let previous = self
             .0
             .try_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
                 value.checked_add(1)
             })
-            .map_err(|_| anyhow::anyhow!("runtime revision space exhausted"))?;
+            .map_err(|_| RuntimeRevisionExhausted)?;
         Ok(RuntimeRevision(previous + 1))
-    }
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct RuntimeSnapshotData {
-    pub config: Mapping,
-    pub exists_keys: Vec<String>,
-    pub postprocessing_output: PostProcessingOutput,
-}
-
-#[derive(Debug, Clone)]
-pub struct RuntimeSnapshot {
-    pub revision: RuntimeRevision,
-    pub target_core: ClashCore,
-    pub product_sha256: [u8; 32],
-    product_bytes: Arc<[u8]>,
-    pub config: Mapping,
-    pub exists_keys: Vec<String>,
-    pub postprocessing_output: PostProcessingOutput,
-}
-
-impl RuntimeSnapshot {
-    pub(crate) fn from_data(
-        revision: RuntimeRevision,
-        target_core: ClashCore,
-        product_bytes: Arc<[u8]>,
-        data: RuntimeSnapshotData,
-    ) -> Self {
-        let product_sha256 = Sha256::digest(&product_bytes).into();
-        Self {
-            revision,
-            target_core,
-            product_sha256,
-            product_bytes,
-            config: data.config,
-            exists_keys: data.exists_keys,
-            postprocessing_output: data.postprocessing_output,
-        }
-    }
-
-    pub(crate) fn product_bytes(&self) -> &[u8] {
-        &self.product_bytes
-    }
-
-    pub(crate) fn identity_eq(&self, other: &Self) -> bool {
-        self.revision == other.revision
-            && self.target_core == other.target_core
-            && self.product_sha256 == other.product_sha256
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct RuntimeLifecycleState {
-    pub promoted: Option<Arc<RuntimeSnapshot>>,
-    pub applied: Option<Arc<RuntimeSnapshot>>,
-}
-
-#[derive(Debug, Clone)]
-pub struct RuntimeTransactionSnapshot {
-    pub product: Option<Vec<u8>>,
-    pub lifecycle: RuntimeLifecycleState,
-}
-
-/// Facade-held runtime lifecycle store. It is instance-owned and non-persistent:
-/// writers are serialized by `rebuild_gate`, while runtime IPC reads clone the
-/// Promoted snapshot. With no subscribers, a plain RwLock keeps lifecycle writes
-/// infallible after product promotion or a successful core apply/restart.
-pub type RuntimeLifecycleStore = tokio::sync::RwLock<RuntimeLifecycleState>;
-
-pub async fn new_runtime_lifecycle_store() -> anyhow::Result<RuntimeLifecycleStore> {
-    Ok(tokio::sync::RwLock::new(RuntimeLifecycleState::default()))
-}
-
-/// Compensation for an API-first patch is planned from the last successfully
-/// applied runtime snapshot. The plan is intentionally independent of the
-/// core's patch transport semantics.
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct PatchCompensationPlan {
-    expected_applied_revision: RuntimeRevision,
-    ops: Vec<PatchCompensationOp>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum PatchCompensationOp {
-    Set {
-        key: String,
-        value: serde_yaml::Value,
-    },
-    Remove {
-        key: String,
-    },
-}
-
-impl PatchCompensationPlan {
-    pub(crate) fn expected_applied_revision(&self) -> RuntimeRevision {
-        self.expected_applied_revision
     }
 
     #[cfg(test)]
-    pub(crate) fn ops(&self) -> &[PatchCompensationOp] {
-        &self.ops
+    pub(crate) fn last_allocated(&self) -> RuntimeRevision {
+        RuntimeRevision(self.0.load(Ordering::Relaxed))
     }
 
-    pub(crate) fn fence_matches(&self, applied: Option<&RuntimeSnapshot>) -> bool {
-        applied.is_some_and(|snapshot| snapshot.revision == self.expected_applied_revision)
+    #[cfg(test)]
+    pub(crate) fn exhaust(&self) {
+        self.0.store(u64::MAX, Ordering::Relaxed);
     }
-}
-
-pub(crate) fn compensation_for(
-    patch: &Mapping,
-    applied: Option<&RuntimeSnapshot>,
-) -> Option<PatchCompensationPlan> {
-    let applied = applied?;
-    if patch.is_empty() {
-        return None;
-    }
-
-    let ops = patch
-        .keys()
-        .map(|key| match applied.config.get(key) {
-            Some(value) => PatchCompensationOp::Set {
-                key: key
-                    .as_str()
-                    .expect("clash patch keys must be YAML strings")
-                    .to_owned(),
-                value: value.clone(),
-            },
-            None => PatchCompensationOp::Remove {
-                key: key
-                    .as_str()
-                    .expect("clash patch keys must be YAML strings")
-                    .to_owned(),
-            },
-        })
-        .collect();
-
-    Some(PatchCompensationPlan {
-        expected_applied_revision: applied.revision,
-        ops,
-    })
 }
 
 #[derive(Debug, Clone)]
@@ -374,6 +238,70 @@ fn utf8_path(path: std::path::PathBuf) -> anyhow::Result<Utf8PathBuf> {
         .map_err(|path| anyhow::anyhow!("runtime path is not UTF-8: {}", path.display()))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeApplyOutcome {
+    Noop,
+    Patched,
+    Reloaded,
+    Restarted,
+    Switched,
+    RolledBack,
+    Started,
+    NotApplied,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct RuntimeApplyReport {
+    pub outcome: RuntimeApplyOutcome,
+    pub desired_revision: u64,
+    pub applied_revision: Option<u64>,
+}
+
+pub(crate) fn runtime_outcome_from_apply_data(
+    data: &CoreApplyData,
+    promoted_revision: u64,
+) -> (RuntimeApplyReport, Vec<Degradation>) {
+    let outcome = match data.outcome {
+        ApplyOutcomeKind::Noop => RuntimeApplyOutcome::Noop,
+        ApplyOutcomeKind::Patched => RuntimeApplyOutcome::Patched,
+        ApplyOutcomeKind::Reloaded => RuntimeApplyOutcome::Reloaded,
+        ApplyOutcomeKind::Restarted => RuntimeApplyOutcome::Restarted,
+        ApplyOutcomeKind::Switched => RuntimeApplyOutcome::Switched,
+        ApplyOutcomeKind::RolledBack => RuntimeApplyOutcome::RolledBack,
+    };
+    let mut degradations = Vec::new();
+    let applied_revision = if data.outcome == ApplyOutcomeKind::RolledBack {
+        degradations.push(Degradation {
+            phase: DegradationPhase::CoreRollback,
+            code: "core_rollback".into(),
+            message: data.failed_apply.clone().unwrap_or_else(|| {
+                "the new runtime was rejected and the previous revision restored".into()
+            }),
+            retryable: true,
+        });
+        Some(data.revision.generation)
+    } else {
+        Some(promoted_revision)
+    };
+    if let Some(warning) = data.warning.as_ref() {
+        degradations.push(Degradation {
+            phase: DegradationPhase::RuntimeApply,
+            code: "core_apply_durability_uncertain".into(),
+            message: warning.clone(),
+            retryable: false,
+        });
+    }
+    (
+        RuntimeApplyReport {
+            outcome,
+            desired_revision: promoted_revision,
+            applied_revision,
+        },
+        degradations,
+    )
+}
+
 /// Public mutation wire (PR-4S S08 / plan §12): state is committed first; post-
 /// commit side-effect failures degrade instead of erroring.
 ///
@@ -473,6 +401,7 @@ pub enum DegradationPhase {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nyanpasu_ipc::api::status::ConfigRevisionInfo;
 
     #[test]
     fn runtime_revision_allocator_is_monotonic() {
@@ -483,6 +412,15 @@ mod tests {
         assert_eq!(first.get(), 1);
         assert_eq!(second.get(), 2);
         assert!(second > first);
+    }
+
+    #[test]
+    fn runtime_revision_exhaustion_is_typed_as_an_invariant_failure() {
+        let allocator = RuntimeRevisionAllocator(AtomicU64::new(u64::MAX));
+        assert!(matches!(
+            allocator.allocate(),
+            Err(RuntimeRevisionExhausted)
+        ));
     }
 
     #[test]
@@ -524,6 +462,87 @@ mod tests {
     }
 
     #[test]
+    fn apply_outcome_wire_matrix_covers_six_outcomes_with_and_without_warning() {
+        let outcomes = [
+            (ApplyOutcomeKind::Noop, RuntimeApplyOutcome::Noop, true),
+            (
+                ApplyOutcomeKind::Patched,
+                RuntimeApplyOutcome::Patched,
+                true,
+            ),
+            (
+                ApplyOutcomeKind::Reloaded,
+                RuntimeApplyOutcome::Reloaded,
+                true,
+            ),
+            (
+                ApplyOutcomeKind::Restarted,
+                RuntimeApplyOutcome::Restarted,
+                true,
+            ),
+            (
+                ApplyOutcomeKind::Switched,
+                RuntimeApplyOutcome::Switched,
+                true,
+            ),
+            (
+                ApplyOutcomeKind::RolledBack,
+                RuntimeApplyOutcome::RolledBack,
+                false,
+            ),
+        ];
+
+        for (apply_outcome, runtime_outcome, advances) in outcomes {
+            for warning in [None, Some("directory sync uncertain".to_owned())] {
+                let data = CoreApplyData {
+                    outcome: apply_outcome,
+                    revision: ConfigRevisionInfo {
+                        epoch: 7,
+                        generation: 41,
+                        source_hash: "source".into(),
+                        effective_hash: "effective".into(),
+                    },
+                    warning: warning.clone(),
+                    failed_apply: (apply_outcome == ApplyOutcomeKind::RolledBack)
+                        .then(|| "new config rejected".into()),
+                };
+                let (report, degradations) = runtime_outcome_from_apply_data(&data, 42);
+                let outcome = MutationOutcome::from_parts(report, degradations);
+
+                assert_eq!(
+                    crate::core::actor::runtime::advances_applied(apply_outcome),
+                    advances
+                );
+                assert_eq!(outcome.value().outcome, runtime_outcome);
+                assert_eq!(outcome.value().desired_revision, 42);
+                assert_eq!(
+                    outcome.value().applied_revision,
+                    if advances { Some(42) } else { Some(41) }
+                );
+                let expected_degradations = usize::from(!advances) + usize::from(warning.is_some());
+                assert_eq!(outcome.degradations().len(), expected_degradations);
+                assert_eq!(
+                    matches!(outcome, MutationOutcome::Applied { .. }),
+                    expected_degradations == 0
+                );
+                if !advances {
+                    assert_eq!(
+                        outcome.degradations()[0].phase,
+                        DegradationPhase::CoreRollback
+                    );
+                    assert_eq!(outcome.degradations()[0].code, "core_rollback");
+                }
+                if warning.is_some() {
+                    let durability = outcome.degradations().last().unwrap();
+                    assert_eq!(durability.phase, DegradationPhase::RuntimeApply);
+                    assert_eq!(durability.code, "core_apply_durability_uncertain");
+                    assert!(!durability.retryable);
+                }
+            }
+        }
+    }
+
+    #[test]
     fn degradation_phase_serde_is_snake_case() {
         let json = serde_json::to_string(&DegradationPhase::ProfileMaterialization).unwrap();
         assert_eq!(json, "\"profile_materialization\"");
@@ -556,83 +575,6 @@ mod tests {
         );
         assert_eq!(degraded_json["degradations"][0]["phase"], "runtime_build");
         assert_eq!(degraded_json["degradations"][0]["retryable"], true);
-    }
-
-    fn applied_snapshot(revision: u64, config: Mapping) -> RuntimeSnapshot {
-        RuntimeSnapshot::from_data(
-            RuntimeRevision(revision),
-            ClashCore::default(),
-            Arc::from([]),
-            RuntimeSnapshotData {
-                config,
-                exists_keys: Vec::new(),
-                postprocessing_output: PostProcessingOutput::default(),
-            },
-        )
-    }
-
-    #[test]
-    fn compensation_plan_emits_set_and_remove_for_each_patch_key() {
-        let mut applied_config = Mapping::new();
-        applied_config.insert("mode".into(), "rule".into());
-        applied_config.insert("allow-lan".into(), false.into());
-        let applied = applied_snapshot(7, applied_config);
-
-        let mut patch = Mapping::new();
-        patch.insert("mode".into(), "direct".into());
-        patch.insert("ipv6".into(), true.into());
-
-        let plan = compensation_for(&patch, Some(&applied)).expect("plan");
-        assert_eq!(plan.expected_applied_revision(), RuntimeRevision(7));
-        assert_eq!(
-            plan.ops.as_slice(),
-            &[
-                PatchCompensationOp::Set {
-                    key: "mode".into(),
-                    value: "rule".into(),
-                },
-                PatchCompensationOp::Remove { key: "ipv6".into() },
-            ]
-        );
-    }
-
-    #[test]
-    fn compensation_plan_is_absent_without_applied_or_patch() {
-        let applied = applied_snapshot(7, Mapping::new());
-        assert!(compensation_for(&Mapping::new(), Some(&applied)).is_none());
-        let mut patch = Mapping::new();
-        patch.insert("mode".into(), "direct".into());
-        assert!(compensation_for(&patch, None).is_none());
-    }
-
-    #[test]
-    fn compensation_plan_fence_accepts_matching_revision_and_rejects_conflict() {
-        let applied = applied_snapshot(7, Mapping::new());
-        let mut patch = Mapping::new();
-        patch.insert("mode".into(), "direct".into());
-        let plan = compensation_for(&patch, Some(&applied)).expect("plan");
-
-        assert!(plan.fence_matches(Some(&applied)));
-        assert!(!plan.fence_matches(Some(&applied_snapshot(8, Mapping::new()))));
-        assert!(!plan.fence_matches(None));
-    }
-
-    #[test]
-    fn compensation_plan_preserves_old_applied_values() {
-        let mut config = Mapping::new();
-        config.insert("mode".into(), "rule".into());
-        let applied = applied_snapshot(3, config);
-        let mut patch = Mapping::new();
-        patch.insert("mode".into(), "direct".into());
-
-        let plan = compensation_for(&patch, Some(&applied)).expect("plan");
-        assert_eq!(
-            plan.ops.as_slice(),
-            &[PatchCompensationOp::Set {
-                key: "mode".into(),
-                value: "rule".into(),
-            }]
-        );
     }
 
     fn temp_runtime_paths(dir: &tempfile::TempDir) -> RuntimePaths {

--- a/backend/tauri/src/core/actor/backend.rs
+++ b/backend/tauri/src/core/actor/backend.rs
@@ -49,12 +49,14 @@ struct TestBackendState {
     observation: std::sync::Mutex<BackendObservation>,
     observe_calls: std::sync::atomic::AtomicUsize,
     check_calls: std::sync::atomic::AtomicUsize,
+    apply_calls: std::sync::atomic::AtomicUsize,
+    apply_results:
+        std::sync::Mutex<std::collections::VecDeque<Result<CoreApplyData, CoreBackendError>>>,
     run_calls: std::sync::atomic::AtomicUsize,
     run_requests: std::sync::Mutex<Vec<CoreRequest>>,
     shutdown_calls: std::sync::atomic::AtomicUsize,
     fail_observe: std::sync::atomic::AtomicBool,
     fail_run: std::sync::atomic::AtomicBool,
-    fail_run_action: std::sync::Mutex<Option<Box<dyn FnOnce() + Send>>>,
     fail_replace: std::sync::atomic::AtomicBool,
     run_barrier: std::sync::Mutex<Option<TestRunBarrier>>,
 }
@@ -109,12 +111,13 @@ impl TestBackend {
                 observation: std::sync::Mutex::new(observation),
                 observe_calls: std::sync::atomic::AtomicUsize::new(0),
                 check_calls: std::sync::atomic::AtomicUsize::new(0),
+                apply_calls: std::sync::atomic::AtomicUsize::new(0),
+                apply_results: std::sync::Mutex::new(std::collections::VecDeque::new()),
                 run_calls: std::sync::atomic::AtomicUsize::new(0),
                 run_requests: std::sync::Mutex::new(Vec::new()),
                 shutdown_calls: std::sync::atomic::AtomicUsize::new(0),
                 fail_observe: std::sync::atomic::AtomicBool::new(false),
                 fail_run: std::sync::atomic::AtomicBool::new(false),
-                fail_run_action: std::sync::Mutex::new(None),
                 fail_replace: std::sync::atomic::AtomicBool::new(false),
                 run_barrier: std::sync::Mutex::new(None),
             }),
@@ -123,6 +126,16 @@ impl TestBackend {
 
     pub(crate) fn set_observation(&self, observation: BackendObservation) {
         *self.state.observation.lock().unwrap() = observation;
+    }
+
+    pub(crate) fn push_apply_result(&self, result: Result<CoreApplyData, CoreBackendError>) {
+        self.state.apply_results.lock().unwrap().push_back(result);
+    }
+
+    pub(crate) fn apply_calls(&self) -> usize {
+        self.state
+            .apply_calls
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     pub(crate) fn fail_next_observe(&self) {
@@ -135,11 +148,6 @@ impl TestBackend {
         self.state
             .fail_run
             .store(true, std::sync::atomic::Ordering::Release);
-    }
-
-    pub(crate) fn fail_next_run_with(&self, action: impl FnOnce() + Send + 'static) {
-        *self.state.fail_run_action.lock().unwrap() = Some(Box::new(action));
-        self.fail_next_run();
     }
 
     pub(crate) fn fail_next_replace(&self) {
@@ -296,9 +304,6 @@ impl CoreBackend {
                     .fail_run
                     .swap(false, std::sync::atomic::Ordering::AcqRel)
                 {
-                    if let Some(action) = test.state.fail_run_action.lock().unwrap().take() {
-                        action();
-                    }
                     return Err(CoreBackendError::Construct(anyhow::anyhow!(
                         "scripted run failure"
                     )));
@@ -366,7 +371,35 @@ impl CoreBackend {
                 })
                 .await?),
             #[cfg(test)]
-            Self::Test(_) => unreachable!("test backend does not implement apply"),
+            Self::Test(test) => {
+                test.state
+                    .apply_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+                if let Some(result) = test.state.apply_results.lock().unwrap().pop_front() {
+                    result
+                } else {
+                    let revision = test
+                        .state
+                        .observation
+                        .lock()
+                        .unwrap()
+                        .view
+                        .revision
+                        .clone()
+                        .unwrap_or(ConfigRevisionInfo {
+                            epoch: 0,
+                            generation: 0,
+                            source_hash: String::new(),
+                            effective_hash: String::new(),
+                        });
+                    Ok(CoreApplyData {
+                        outcome: ApplyOutcomeKind::Noop,
+                        revision,
+                        warning: None,
+                        failed_apply: None,
+                    })
+                }
+            }
         }
     }
 
@@ -602,6 +635,43 @@ pub(crate) enum CoreBackendError {
     Construct(#[source] anyhow::Error),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BackendFailureClass {
+    RevisionConflict,
+    NotRunning,
+    TransportLost,
+    Other,
+}
+
+pub(crate) fn classify_apply_backend_failure(error: &CoreBackendError) -> BackendFailureClass {
+    match error {
+        CoreBackendError::Local(nyanpasu_core_manager::Error::RevisionConflict { .. }) => {
+            BackendFailureClass::RevisionConflict
+        }
+        CoreBackendError::Local(nyanpasu_core_manager::Error::NotStarted) => {
+            BackendFailureClass::NotRunning
+        }
+        CoreBackendError::Local(_) => BackendFailureClass::Other,
+        CoreBackendError::Service(ClientError::Server {
+            error_kind: Some(kind),
+            ..
+        }) if kind == error_kind::REVISION_CONFLICT => BackendFailureClass::RevisionConflict,
+        CoreBackendError::Service(ClientError::Server {
+            error_kind: Some(kind),
+            ..
+        }) if kind == error_kind::NOT_STARTED => BackendFailureClass::NotRunning,
+        CoreBackendError::Service(
+            ClientError::BuildClient(_)
+            | ClientError::Request { .. }
+            | ClientError::WebSocket { .. }
+            | ClientError::HttpStatus { .. },
+        ) => BackendFailureClass::TransportLost,
+        CoreBackendError::Service(_)
+        | CoreBackendError::Binary(_)
+        | CoreBackendError::Construct(_) => BackendFailureClass::Other,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -630,6 +700,7 @@ mod tests {
     use nyanpasu_ipc::api::{
         RBuilder,
         core::{
+            apply::{CORE_APPLY_ENDPOINT, CoreApplyReq, CoreApplyRes},
             check::{CORE_CHECK_ENDPOINT, CoreCheckReq, CoreCheckRes},
             recover::{CORE_RECOVER_ENDPOINT, CoreRecoverRes},
             start::{CORE_START_ENDPOINT, CoreStartReq, CoreStartRes},
@@ -727,6 +798,7 @@ mod tests {
         calls: VecDeque<&'static str>,
         stop_error_kind: Option<&'static str>,
         generation: u64,
+        apply_data: CoreApplyData,
     }
 
     impl Harness {
@@ -736,6 +808,9 @@ mod tests {
                 calls: VecDeque::new(),
                 stop_error_kind: None,
                 generation: 0,
+                apply_data: map_apply_outcome(&ApplyOutcome::Noop {
+                    revision: revision(0),
+                }),
             })))
         }
 
@@ -758,6 +833,10 @@ mod tests {
                 source_hash: format!("source-{generation}"),
                 effective_hash: format!("effective-{generation}"),
             });
+        }
+
+        fn set_apply_data(&self, data: CoreApplyData) {
+            self.0.lock().unwrap().apply_data = data;
         }
 
         fn take_calls(&self) -> Vec<&'static str> {
@@ -831,6 +910,15 @@ mod tests {
     async fn recover_handler(State(harness): State<Harness>) -> Json<CoreRecoverRes<'static>> {
         harness.0.lock().unwrap().calls.push_back("recover");
         Json(RBuilder::success(()))
+    }
+
+    async fn apply_handler(
+        State(harness): State<Harness>,
+        Json(_request): Json<CoreApplyReq<'static>>,
+    ) -> Json<CoreApplyRes<'static>> {
+        let mut state = harness.0.lock().unwrap();
+        state.calls.push_back("apply");
+        Json(RBuilder::success(state.apply_data.clone()))
     }
 
     struct IpcListener(Listener, String);
@@ -909,6 +997,7 @@ mod tests {
             .route(CORE_START_ENDPOINT, post(start_handler))
             .route(CORE_STOP_ENDPOINT, post(stop_handler))
             .route(CORE_RECOVER_ENDPOINT, post(recover_handler))
+            .route(CORE_APPLY_ENDPOINT, post(apply_handler))
             .with_state(harness);
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         tokio::spawn(async move {
@@ -986,6 +1075,132 @@ mod tests {
         let mapped = map_apply_outcome(&nested);
         assert_eq!(mapped.outcome, ApplyOutcomeKind::Noop);
         assert_eq!(mapped.warning.as_deref(), Some("outer; inner"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn local_and_service_apply_conversion_preserve_identical_data() {
+        if !transport_available() {
+            return;
+        }
+        let local_data = map_apply_outcome(&ApplyOutcome::DurabilityUncertain {
+            outcome: Box::new(ApplyOutcome::RolledBack {
+                revision: revision(13),
+                failed_apply: "scripted apply failure".to_owned(),
+            }),
+            warning: "directory sync uncertain".to_owned(),
+        });
+        let harness = Harness::new();
+        harness.set_apply_data(local_data.clone());
+        let (placeholder, shutdown) = spawn_harness(harness.clone());
+        let service = CoreBackend::Service(ServiceBackend::with_placeholder(&placeholder).unwrap());
+        let dir = tempfile::tempdir().unwrap();
+        let factory = test_factory(&dir, Utf8PathBuf::from("unused"));
+        let request = factory.for_product(ClashCore::Mihomo).unwrap();
+
+        let service_data = service.apply(&request, None).await.unwrap();
+
+        assert_eq!(service_data, local_data);
+        assert_eq!(harness.take_calls(), ["apply"]);
+        let _ = shutdown.send(());
+    }
+
+    fn request_client_error() -> ClientError {
+        let client = nyanpasu_ipc::client::Client::new("classifier-test").unwrap();
+        let source = client.http_client().get("::::").build().unwrap_err();
+        ClientError::Request {
+            operation: "apply",
+            source,
+        }
+    }
+
+    fn build_client_error() -> ClientError {
+        let client = nyanpasu_ipc::client::Client::new("classifier-test").unwrap();
+        let source = client.http_client().get("::::").build().unwrap_err();
+        ClientError::BuildClient(source)
+    }
+
+    fn service_server_error(error_kind: Option<&str>) -> CoreBackendError {
+        CoreBackendError::Service(ClientError::Server {
+            operation: "apply",
+            code: nyanpasu_ipc::api::ResponseCode::OtherError,
+            msg: "scripted".into(),
+            error_kind: error_kind.map(str::to_owned),
+        })
+    }
+
+    #[test]
+    fn apply_backend_classifier_recognizes_revision_conflicts() {
+        let revision = RevisionId {
+            epoch: 1,
+            generation: 2,
+            effective_hash: "hash".into(),
+        };
+        let local = CoreBackendError::Local(ManagerError::RevisionConflict {
+            expected: revision,
+            actual: None,
+        });
+        let service = service_server_error(Some(error_kind::REVISION_CONFLICT));
+        assert_eq!(
+            classify_apply_backend_failure(&local),
+            BackendFailureClass::RevisionConflict
+        );
+        assert_eq!(
+            classify_apply_backend_failure(&service),
+            BackendFailureClass::RevisionConflict
+        );
+    }
+
+    #[test]
+    fn apply_backend_classifier_recognizes_not_running() {
+        let local = CoreBackendError::Local(ManagerError::NotStarted);
+        let service = service_server_error(Some(error_kind::NOT_STARTED));
+        assert_eq!(
+            classify_apply_backend_failure(&local),
+            BackendFailureClass::NotRunning
+        );
+        assert_eq!(
+            classify_apply_backend_failure(&service),
+            BackendFailureClass::NotRunning
+        );
+    }
+
+    #[test]
+    fn apply_backend_classifier_recognizes_transport_failures() {
+        let cases = [
+            CoreBackendError::Service(request_client_error()),
+            CoreBackendError::Service(ClientError::HttpStatus {
+                operation: "apply",
+                status: reqwest::StatusCode::BAD_GATEWAY,
+                body: None,
+            }),
+            CoreBackendError::Service(build_client_error()),
+        ];
+        for error in cases {
+            assert_eq!(
+                classify_apply_backend_failure(&error),
+                BackendFailureClass::TransportLost
+            );
+        }
+    }
+
+    #[test]
+    fn apply_backend_classifier_keeps_decoded_and_unclassified_failures_other() {
+        let cases = [
+            service_server_error(None),
+            CoreBackendError::Service(ClientError::Decode {
+                operation: "apply",
+                source: serde_json::from_str::<()>("!").unwrap_err(),
+            }),
+            CoreBackendError::Service(ClientError::EmptyData { operation: "apply" }),
+            CoreBackendError::Binary(anyhow::anyhow!("binary")),
+            CoreBackendError::Construct(anyhow::anyhow!("construct")),
+        ];
+        for error in cases {
+            assert_eq!(
+                classify_apply_backend_failure(&error),
+                BackendFailureClass::Other
+            );
+        }
     }
 
     #[test]

--- a/backend/tauri/src/core/actor/mod.rs
+++ b/backend/tauri/src/core/actor/mod.rs
@@ -10,12 +10,15 @@ use std::{
 use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
 use tokio::sync::watch;
 
+use nyanpasu_ipc::api::{core::apply::CoreApplyData, status::RevisionIdInfo};
+
 use self::{
     backend::{BackendSlot, CoreBackend, CoreBackendError, CoreDegradationSink},
     request::CoreRequestFactory,
+    runtime::{RuntimeLifecycleState, RuntimeSnapshot, advances_applied},
     types::{
         BackendObservation, CoreActorError, CoreRequest, CoreStatusView, FaithfulLifecycle,
-        is_recovery_exhausted,
+        LifecycleInvariantKind, is_recovery_exhausted,
     },
 };
 pub(crate) use gate::OperationError;
@@ -25,6 +28,7 @@ pub(crate) mod backend;
 mod error_kind;
 mod gate;
 pub(crate) mod request;
+pub(crate) mod runtime;
 pub(crate) mod types;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -35,6 +39,7 @@ pub(crate) struct CoreActorArgs {
     pub(crate) requests: CoreRequestFactory,
     pub(crate) degradation: Arc<dyn CoreDegradationSink>,
     pub(crate) status_tx: watch::Sender<CoreStatusView>,
+    pub(crate) lifecycle_tx: watch::Sender<RuntimeLifecycleState>,
     pub(crate) hint_pending: Arc<AtomicBool>,
     #[cfg(test)]
     pub(crate) backend: Option<BackendSlot>,
@@ -51,6 +56,8 @@ pub(crate) struct CoreActorState {
     pub(crate) observed: BackendObservation,
     pub(crate) running: Option<CoreRequest>,
     pub(crate) status_tx: watch::Sender<CoreStatusView>,
+    pub(crate) lifecycle: RuntimeLifecycleState,
+    pub(crate) lifecycle_tx: watch::Sender<RuntimeLifecycleState>,
     pub(crate) hint_pending: Arc<AtomicBool>,
     pub(crate) recovery_exhausted_published: bool,
     pub(crate) degradation: Arc<dyn CoreDegradationSink>,
@@ -80,6 +87,23 @@ pub(crate) enum CoreActorMessage {
         request: CoreRequest,
         reply: RpcReplyPort<Result<(), CoreActorError>>,
     },
+    PublishPromoted {
+        operation: OperationId,
+        snapshot: Arc<RuntimeSnapshot>,
+        reply: RpcReplyPort<Result<(), CoreActorError>>,
+    },
+    ApplyPromoted {
+        operation: OperationId,
+        request: CoreRequest,
+        expected: Option<RevisionIdInfo>,
+        snapshot: Arc<RuntimeSnapshot>,
+        reply: RpcReplyPort<Result<CoreApplyData, CoreActorError>>,
+    },
+    PublishApplied {
+        operation: OperationId,
+        snapshot: Arc<RuntimeSnapshot>,
+        reply: RpcReplyPort<Result<(), CoreActorError>>,
+    },
     Run {
         operation: OperationId,
         request: CoreRequest,
@@ -105,7 +129,7 @@ pub(crate) enum CoreActorMessage {
     RefreshHint,
     RunningIdentity {
         operation: OperationId,
-        reply: RpcReplyPort<Result<Option<CoreRequest>, CoreActorError>>,
+        reply: RpcReplyPort<Result<(Option<CoreRequest>, FaithfulLifecycle), CoreActorError>>,
     },
     Shutdown(RpcReplyPort<()>),
 }
@@ -163,6 +187,38 @@ impl CoreActorState {
             .is_active(operation)
             .then_some(())
             .ok_or(CoreActorError::StaleOperation)
+    }
+
+    fn publish_promoted(&mut self, snapshot: Arc<RuntimeSnapshot>) -> Result<(), CoreActorError> {
+        if self
+            .lifecycle
+            .promoted
+            .as_ref()
+            .is_some_and(|current| snapshot.revision <= current.revision)
+        {
+            return Err(CoreActorError::LifecycleInvariant(
+                LifecycleInvariantKind::PromotedRegression,
+            ));
+        }
+        self.lifecycle.promoted = Some(snapshot);
+        self.lifecycle_tx.send_replace(self.lifecycle.clone());
+        Ok(())
+    }
+
+    fn publish_applied(&mut self, snapshot: Arc<RuntimeSnapshot>) -> Result<(), CoreActorError> {
+        let Some(promoted) = self.lifecycle.promoted.as_ref() else {
+            return Err(CoreActorError::LifecycleInvariant(
+                LifecycleInvariantKind::AppliedWithoutPromoted,
+            ));
+        };
+        if !promoted.identity_eq(&snapshot) {
+            return Err(CoreActorError::LifecycleInvariant(
+                LifecycleInvariantKind::AppliedWithoutPromoted,
+            ));
+        }
+        self.lifecycle.applied = Some(snapshot);
+        self.lifecycle_tx.send_replace(self.lifecycle.clone());
+        Ok(())
     }
 
     fn commit(&mut self, observation: BackendObservation) {
@@ -354,6 +410,8 @@ impl Actor for CoreActor {
             observed,
             running: None,
             status_tx: args.status_tx,
+            lifecycle: RuntimeLifecycleState::default(),
+            lifecycle_tx: args.lifecycle_tx,
             hint_pending: args.hint_pending,
             recovery_exhausted_published: false,
             degradation: args.degradation,
@@ -388,6 +446,55 @@ impl Actor for CoreActor {
                     },
                     Err(error) => Err(error),
                 };
+                let _ = reply.send(result);
+            }
+            CoreActorMessage::PublishPromoted {
+                operation,
+                snapshot,
+                reply,
+            } => {
+                let result = state
+                    .validate_operation(operation)
+                    .and_then(|()| state.publish_promoted(snapshot));
+                let _ = reply.send(result);
+            }
+            CoreActorMessage::ApplyPromoted {
+                operation,
+                request,
+                expected,
+                snapshot,
+                reply,
+            } => {
+                let result = match state.validate_operation(operation) {
+                    Ok(()) => match state.backend() {
+                        Ok(backend) => backend
+                            .apply(&request, expected)
+                            .await
+                            .map_err(backend_error),
+                        Err(error) => Err(error),
+                    },
+                    Err(error) => Err(error),
+                };
+                let result = match result {
+                    Ok(data) => {
+                        if advances_applied(data.outcome) {
+                            state.publish_applied(snapshot).map(|()| data)
+                        } else {
+                            Ok(data)
+                        }
+                    }
+                    Err(error) => Err(error),
+                };
+                let _ = reply.send(result);
+            }
+            CoreActorMessage::PublishApplied {
+                operation,
+                snapshot,
+                reply,
+            } => {
+                let result = state
+                    .validate_operation(operation)
+                    .and_then(|()| state.publish_applied(snapshot));
                 let _ = reply.send(result);
             }
             CoreActorMessage::Run {
@@ -486,7 +593,9 @@ impl Actor for CoreActor {
             }
             CoreActorMessage::RunningIdentity { operation, reply } => {
                 let result = match state.validate_operation(operation) {
-                    Ok(()) => state.backend().map(|_| state.running.clone()),
+                    Ok(()) => state
+                        .backend()
+                        .map(|_| (state.running.clone(), state.observed.lifecycle.clone())),
                     Err(error) => Err(error),
                 };
                 let _ = reply.send(result);

--- a/backend/tauri/src/core/actor/runtime.rs
+++ b/backend/tauri/src/core/actor/runtime.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use nyanpasu_config::application::ClashCore;
+use nyanpasu_ipc::api::core::apply::ApplyOutcomeKind;
+use serde_yaml::Mapping;
+use sha2::{Digest, Sha256};
+
+use crate::enhance::PostProcessingOutput;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RuntimeRevision(pub(crate) u64);
+
+impl RuntimeRevision {
+    pub(crate) fn get(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeSnapshotData {
+    pub(crate) config: Mapping,
+    pub(crate) exists_keys: Vec<String>,
+    pub(crate) postprocessing_output: PostProcessingOutput,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeSnapshot {
+    pub(crate) revision: RuntimeRevision,
+    pub(crate) target_core: ClashCore,
+    pub(crate) product_sha256: [u8; 32],
+    product_bytes: Arc<[u8]>,
+    pub(crate) config: Mapping,
+    pub(crate) exists_keys: Vec<String>,
+    pub(crate) postprocessing_output: PostProcessingOutput,
+}
+
+impl RuntimeSnapshot {
+    pub(crate) fn from_data(
+        revision: RuntimeRevision,
+        target_core: ClashCore,
+        product_bytes: Arc<[u8]>,
+        data: RuntimeSnapshotData,
+    ) -> Self {
+        let product_sha256 = Sha256::digest(&product_bytes).into();
+        Self {
+            revision,
+            target_core,
+            product_sha256,
+            product_bytes,
+            config: data.config,
+            exists_keys: data.exists_keys,
+            postprocessing_output: data.postprocessing_output,
+        }
+    }
+
+    pub(crate) fn product_bytes(&self) -> &[u8] {
+        &self.product_bytes
+    }
+
+    pub(crate) fn identity_eq(&self, other: &Self) -> bool {
+        self.revision == other.revision
+            && self.target_core == other.target_core
+            && self.product_sha256 == other.product_sha256
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RuntimeLifecycleState {
+    pub(crate) promoted: Option<Arc<RuntimeSnapshot>>,
+    pub(crate) applied: Option<Arc<RuntimeSnapshot>>,
+}
+
+pub(crate) fn advances_applied(outcome: ApplyOutcomeKind) -> bool {
+    !matches!(outcome, ApplyOutcomeKind::RolledBack)
+}

--- a/backend/tauri/src/core/actor/types.rs
+++ b/backend/tauri/src/core/actor/types.rs
@@ -56,6 +56,14 @@ pub(super) fn is_recovery_exhausted(reason: &str) -> bool {
     reason.starts_with(RECOVERY_EXHAUSTED_PREFIX)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LifecycleInvariantKind {
+    /// PublishPromoted's revision did not advance strictly.
+    PromotedRegression,
+    /// PublishApplied had no matching Promoted snapshot.
+    AppliedWithoutPromoted,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum CoreActorError {
     #[error("operation id does not match the active operation")]
@@ -66,4 +74,6 @@ pub(crate) enum CoreActorError {
     Backend(Arc<CoreBackendError>),
     #[error("core actor is shutting down")]
     ShuttingDown,
+    #[error("core lifecycle invariant violated: {0:?}")]
+    LifecycleInvariant(LifecycleInvariantKind),
 }

--- a/backend/tauri/src/core/clash/api.rs
+++ b/backend/tauri/src/core/clash/api.rs
@@ -131,20 +131,6 @@ pub async fn get_group_delay(group: String, url: Option<String>) -> Result<HashM
     Ok(resp)
 }
 
-/// PUT /configs
-/// path 是绝对路径
-#[instrument]
-pub async fn put_configs(config_path: &str) -> Result<()> {
-    let path = "/configs";
-
-    let mut data = HashMap::new();
-    data.insert("path", config_path);
-
-    let _ = perform_request((Method::PUT, path, Data(data))).await?;
-
-    Ok(())
-}
-
 /// PATCH /configs
 #[instrument]
 pub async fn patch_configs(config: &Mapping) -> Result<()> {

--- a/backend/tauri/src/core/updater/instance.rs
+++ b/backend/tauri/src/core/updater/instance.rs
@@ -328,6 +328,7 @@ async fn replacement_target(
     let operation = core.begin_operation().await?;
     let running = core.running(&operation).await?;
     let restart_target = running
+        .0
         .filter(|request| request.core_type == nyanpasu_utils::core::CoreType::from(&target));
     Ok((operation, restart_target))
 }

--- a/backend/tauri/src/enhance/artifact_bridge.rs
+++ b/backend/tauri/src/enhance/artifact_bridge.rs
@@ -94,7 +94,7 @@ pub fn runtime_snapshot_data_from_artifact(
     profiles: &Profiles,
     core: ClashCore,
     builtin_enabled: bool,
-) -> anyhow::Result<crate::client::runtime::RuntimeSnapshotData> {
+) -> anyhow::Result<crate::core::actor::runtime::RuntimeSnapshotData> {
     let value = serde_yaml::to_value(&*artifact.final_config)
         .context("failed to serialize final config")?;
     let config: Mapping = value
@@ -110,7 +110,7 @@ pub fn runtime_snapshot_data_from_artifact(
     } else {
         Vec::new()
     };
-    Ok(crate::client::runtime::RuntimeSnapshotData {
+    Ok(crate::core::actor::runtime::RuntimeSnapshotData {
         config,
         exists_keys,
         postprocessing_output: map_postprocessing(&artifact.step_logs, profiles, &builtin_names),

--- a/backend/tauri/src/feat.rs
+++ b/backend/tauri/src/feat.rs
@@ -251,6 +251,24 @@ pub async fn patch_clash(client: crate::client::NyanpasuClient, patch: Mapping) 
     .await
 }
 
+fn finish_successful_clash_rebuild<T>(
+    rebuilt: T,
+    apply_mirror: impl FnOnce(),
+    persist_mirror: impl FnOnce() -> Result<()>,
+) -> T {
+    apply_mirror();
+    // TODO(actor-migration): legacy clash persistence is best-effort now that the typed
+    // store is the source of truth after the rebuild succeeds.
+    // Remove when: all remaining Config::clash() readers migrate to the typed store.
+    if let Err(error) = persist_mirror() {
+        log::error!(
+            target: "app",
+            "failed to persist best-effort legacy clash mirror: {error:#}"
+        );
+    }
+    rebuilt
+}
+
 pub async fn patch_clash_with_rebuild<F, Fut, T>(
     client: crate::client::NyanpasuClient,
     patch: Mapping,
@@ -323,11 +341,13 @@ where
         Ok(rebuilt)
     };
     match run().await {
-        Ok(rebuilt) => {
-            Config::clash().apply();
-            Config::clash().data().save_config()?;
-            Ok(rebuilt)
-        }
+        Ok(rebuilt) => Ok(finish_successful_clash_rebuild(
+            rebuilt,
+            || {
+                Config::clash().apply();
+            },
+            || Config::clash().data().save_config(),
+        )),
         Err(err) => {
             Config::clash().discard();
             Err(err)
@@ -552,6 +572,7 @@ pub fn update_proxies_buff(rx: Option<tokio::sync::oneshot::Receiver<()>>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
 
     #[test]
     fn core_restart_only_for_port_controller_secret() {
@@ -567,5 +588,36 @@ mod tests {
         let mut patch = serde_yaml::Mapping::new();
         patch.insert("external-controller".into(), "127.0.0.1:9090".into());
         assert!(requires_core_restart(&patch));
+    }
+
+    #[test]
+    fn legacy_persistence_is_attempted_and_failure_is_swallowed() {
+        let mirror_applied = Cell::new(false);
+        let persist_invoked = Cell::new(false);
+        let injected_failure_produced = Cell::new(false);
+        let rebuilt = finish_successful_clash_rebuild(
+            "typed commit and rebuild succeeded",
+            || mirror_applied.set(true),
+            || {
+                persist_invoked.set(true);
+                let failure: Result<()> = Err(anyhow::anyhow!("injected legacy save failure"));
+                injected_failure_produced.set(failure.is_err());
+                failure
+            },
+        );
+
+        assert!(
+            mirror_applied.get(),
+            "the in-memory mirror must still apply"
+        );
+        assert!(
+            persist_invoked.get(),
+            "legacy persistence must be attempted"
+        );
+        assert!(
+            injected_failure_produced.get(),
+            "the injected persistence failure must be produced and consumed"
+        );
+        assert_eq!(rebuilt, "typed commit and rebuild succeeded");
     }
 }

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -438,7 +438,7 @@ pub struct PatchRuntimeConfig {
 pub async fn patch_clash_config(
     client: State<'_, NyanpasuClient>,
     payload: PatchRuntimeConfig,
-) -> Result {
+) -> Result<crate::client::runtime::MutationOutcome<crate::client::runtime::RuntimeApplyReport>> {
     // Explicit-field whitelist so future DTO fields never auto-leak into logs.
     tracing::debug!(
         allow_lan = ?payload.allow_lan,
@@ -453,8 +453,7 @@ pub async fn patch_clash_config(
         _ => return Err(IpcError::Custom("Expected a mapping".to_string())),
     };
 
-    client.patch_running_config(mapping).await?;
-    Ok(())
+    Ok(client.patch_running_config(mapping).await?)
 }
 
 #[tauri::command]
@@ -480,19 +479,11 @@ pub async fn patch_verge_config(legacy: State<'_, LegacyVergeBridge>, payload: I
 #[specta::specta]
 pub async fn change_clash_core(
     client: State<'_, NyanpasuClient>,
-    legacy: State<'_, LegacyVergeBridge>,
     clash_core: Option<nyanpasu::ClashCore>,
-) -> Result {
+) -> Result<crate::client::runtime::MutationOutcome<crate::client::runtime::RuntimeApplyReport>> {
     let clash_core =
         clash_core.ok_or_else(|| IpcError::Custom("clash core is null".to_string()))?;
-    // reseed wrapper 语义不变:核心切换动了 legacy verge,须回灌 typed actors。
-    let client = client.inner().clone();
-    legacy
-        .run_legacy_verge_mutation(move || async move {
-            client.change_core(clash_core).await.map_err(Into::into)
-        })
-        .await?;
-    Ok(())
+    Ok(client.change_core(clash_core).await?)
 }
 
 /// restart the sidecar

--- a/backend/tauri/src/setup.rs
+++ b/backend/tauri/src/setup.rs
@@ -8,8 +8,8 @@ use crate::{
         window::LegacyWindowBridge,
     },
     client::{
-        ClientSetupArgs, LegacyBridgeSet, LegacyRunningConfigPatchBridge, NyanpasuClient,
-        OsSystemDnsCache, RuntimePaths, TauriCoreDegradationSink, TauriUiEventSink, UiEventSink,
+        ClientSetupArgs, LegacyBridgeSet, NyanpasuClient, OsSystemDnsCache, RuntimePaths,
+        TauriCoreDegradationSink, TauriUiEventSink, UiEventSink,
     },
     utils::path::PathResolver,
 };
@@ -54,7 +54,6 @@ pub fn setup<R: tauri::Runtime, M: tauri::Manager<R>>(app: &M) -> Result<(), any
         binary_resolver,
         degradation: Arc::new(TauriCoreDegradationSink::new(ui_sink)),
         service_control: Arc::new(crate::core::service::control::OsServiceControlOps),
-        clash_patch: Some(Arc::new(LegacyRunningConfigPatchBridge)),
         system_dns: Arc::new(OsSystemDnsCache),
     })
     .context("Failed to setup nyanpasu client")?;

--- a/docs/superpowers/plans/2026-08-02-pr5b-runtime-apply.md
+++ b/docs/superpowers/plans/2026-08-02-pr5b-runtime-apply.md
@@ -1,0 +1,1177 @@
+# PR-5b 实施计划 — 单一 runtime apply 管线
+
+**日期：** 2026-08-02
+**版本：** v9（七轮复审后定稿；**D1–D5 全裁 A** 不重开）
+**分支基线：** `refactor/core-manager-actor` @ `9727ef1d4`（PR-5a 阶段门已关闭：`ae4e0f288` + `6a3878bba` + `5277482a5` + `9727ef1d4`）
+**权威 spec：** `docs/superpowers/specs/2026-08-01-pr5-core-actor/task.md` 卡 B1–B4；`design.md` §6–§8
+**路线图定位：** `docs/design/actor-migration-roadmap.md` §6.2；必答项 §6.4 **RQ-01 / RQ-03**
+**平台：** Windows 11 / PowerShell
+
+> **本计划对着已实施的 5a 代码写，不是对着 5a 计划的纸面附录写。** 全部事实来自 `9727ef1d4` 的工作树。
+
+**v2 修订索引（leader 审查）：**
+
+| 项  | 内容                                                 | 落点                        |
+| --- | ---------------------------------------------------- | --------------------------- |
+| L1  | `CandidateFile` 一并迁入 `core/actor/runtime.rs`     | S1、A.1、A.2、§4 D1         |
+| L2  | `RuntimeRevisionAllocator` **留在 client 侧**        | S1、S2、A.1、A.3、§4 D1 后  |
+| L3  | `restart()` 残余审计 → T-B4-03 改钉真实语义、F8 重述 | F26/F27、S6、§4 D5、T-B4-03 |
+| L4  | 后台 rebuild 的 degradation 去向（I-B 缺口）         | F28/F29、§2.4、S2、T-PC-09  |
+| L5  | 删除 `LifecycleSnapshot` 消息                        | F30、A.2、S2                |
+| L6  | S4 重试判据预先定死；specta 已启用（新事实 F25）     | F25、S4、§8 风险表          |
+| L7  | T-PC-06 用 `TestBackend` 脚本化传输错误              | §6.2 T-PC-06                |
+
+**v2.1 盖章（leader 裁定 D5=A + 两条 rider）：**
+
+| 项  | 内容                                                                        | 落点                           |
+| --- | --------------------------------------------------------------------------- | ------------------------------ |
+| D5  | 停止态 `change_core` 走 `RunningIdentity` 分支 + 仓内 `RuntimeApplyOutcome` | §4 D5、S6、A.4                 |
+| R1  | §3 表补 `Started` 行（Applied **推进**）；restart 失败走 post-commit 路径   | §3.1、S6 流程、T-B4-03/05、A.6 |
+| R2  | 仓内枚举是**语义**选择而非编译必要；F25 保留原样                            | §4 D5 的 R2 注                 |
+
+**v3 修订索引（codex 对抗审 REJECT → 逐条处理）：**
+
+| 项  | 结论                                                                                    | 落点                                |
+| --- | --------------------------------------------------------------------------------------- | ----------------------------------- |
+| C1  | `RuntimeApplyOutcome` 加第八变体 `NotApplied`；T-PC 系列补 report 值断言                | F31、§2.2、§3.1、A.4、§6.2          |
+| C2  | `CheckAndPromote` 改为 **`PublishPromoted { operation, snapshot }`**；文件工作留 client | F32、A.2、A.3、S2、§4 D1 的 L1 后记 |
+| C3  | 推进决策与 wire 表示拆分：`advances_applied` 纯谓词 + `PublishApplied` 守卫消息         | F33b、A.2、A.5、S2、S4、S7          |
+| H4  | F12 是错的——gate→begin 例外**三处**不是一处                                             | F12 改写、S3、T-B2-02               |
+| H5  | `RunningIdentity` 的 `Ok(None)` ≠ 核已停止（attach 场景）                               | F33、S6 分支规则、T-B4-06           |
+| H6  | rebuild 管线有**四类**调用上下文，不是两类                                              | F34、§2.1、§2.4、T-PC-10/11         |
+| H7  | `change_clash_core` **去掉** `run_legacy_verge_mutation` 包裹                           | F35、S6、§10                        |
+| H8  | `expected` 改为「观察到 revision 则 `Some`，缺失则 `None`」                             | F36、S4                             |
+| M9  | `RuntimeLifecycleStore` 的删除从 S1 挪到 S2                                             | S1、S2                              |
+| M10 | T-AP-13 空转——`TestBackend::apply` 是 `unreachable!`                                    | F37、§6.1 T-AP-13                   |
+| M11 | 必删测试清单补 5 条                                                                     | §6.4                                |
+| M12 | S3 顺序自相矛盾——统一为**先分配 revision**                                              | S3                                  |
+| L13 | F10 措辞收窄                                                                            | F10                                 |
+
+**v4 修订索引（复审 REJECT：3 High + 2 残留 + 6 处陈旧文本）：**
+
+| 项       | 结论                                                                                            | 落点                              |
+| -------- | ----------------------------------------------------------------------------------------------- | --------------------------------- |
+| NH1      | `RunningIdentity` reply 扩为 **(身份, `FaithfulLifecycle`) 原子守卫联合读**；真值表改读忠实六态 | F40、S6 真值表、A.2、A.3、T-B4-06 |
+| NH2      | lease seam 声明**类型化** `CheckAndPromoteError { phase, source }`；相位由构造位置打标签        | F41、A.1b、S2 分工表              |
+| NH3      | I-A 加两条豁免；§2.2 第 4 行拆 4a/4b；分裂窗口诚实记录 + 自愈论证，**不加二层恢复**             | F42、§2.2、§2.3、A.6 注           |
+| C1 残留  | T-B4-05 补 `value` 三字段断言                                                                   | §6.3 T-B4-05                      |
+| M10 残留 | parity 改测**真实转换层**；`TestBackend` 不得冒充 parity                                        | §3.2                              |
+| 陈旧 ×6  | D1 两处 / D5 一处 / S4 实参 / S6 箭头 / S7「两条」/「其余 8 处」                                | 各处就地                          |
+
+**v5 修订索引（三轮复审 REJECT：NH4–NH9 + 四项机械修）：**
+
+| 项      | 结论                                                                                               | 落点                    |
+| ------- | -------------------------------------------------------------------------------------------------- | ----------------------- |
+| NH4     | `CoreActorError` 加 `LifecycleInvariant(_)`（双 kind）；豁免 (b) 写成可 `matches!` 的规则          | F43、§2.3、A.1          |
+| NH5     | §2.2 拆出 E-a / E-b 发布中止行块；四处 categorical 表述改**引用** §2.3                             | §2.2、§2.1、I-B、S6     |
+| NH6     | T-PC-04 拆 04a / 04b；新增 T-PC-12 豁免边界分类测试                                                | §6.2                    |
+| NH7     | 行 7 拆 7a / 7b / 7c；report 段落排除 7a（`RolledBack` **有** `CoreApplyData`）                    | §2.2                    |
+| NH8     | `NoBackend` 独立成行 6b（`core_backend_unavailable`）                                              | §2.2、S6、§2.3          |
+| NH9     | 新函数改名 `runtime_outcome_from_apply_data`；既有同名函数**不动**、引用处写全限定名               | F44、A.5、§3.2、T-AP-13 |
+| 机械 ×4 | A.6 表格归位（两 code 复位）／陈旧 `Ok(None)` 形消除／T-AP-13 删 TestBackend 前置／D1 删已裁条件句 | 各处就地                |
+| 作废    | 「六提交→七」经核实**全文无一处声称提交数**（§9 本就列七条），该机械项**作废**，非漏项             | ——                      |
+
+**v6 修订索引（四轮复审 REJECT：H1–H3 + 三项 Medium）：**
+
+| 项   | 结论                                                                                               | 落点                                     |
+| ---- | -------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| H1   | 同款 categorical 措辞另三处改引用；**用 grep 收口该措辞类**（第四次同形残留）                      | §2.1 边界定义、入口表、S6 流程、I-A 首句 |
+| H2   | `CheckAndPromoteError` **只覆盖 check + 文件工作**；发布类错误以**裸 `CoreActorError`** 逃回编排层 | F45、D3 措辞、A.1b doc                   |
+| H3   | 新增 **A.7 有序分类器**——`Backend(_)` 必须过它才能定行；每条判据锚到真实类型化谓词                 | F46/F47/F48、A.7、§2.3                   |
+| M ×3 | T-PC-12 进出口与提交切分／T-AP-11/12 补 report 值断言／S4 的「第 7 行」改 7b                       | §7、§9、§6.1、S4                         |
+| 索引 | 补齐 v5 与 v6 两张索引表（v5 那张原押后，现并入本版）                                              | 本表与上表                               |
+| 补   | `707dd2dbc` —— A.7 作用域声明 + F49/F50（第五轮前追加的第五个提交）                                | A.7、§2.3、§2.2 第八项                   |
+
+**v7 修订索引（五轮复审 REJECT：一条 High + 三处过度断言修正 + 两 Low）：**
+
+| 项         | 结论                                                                                                             | 落点              |
+| ---------- | ---------------------------------------------------------------------------------------------------------------- | ----------------- |
+| H2 残留    | seam 改**外层和** `CheckAndPromoteFailure`（`Actor` / `Operation`）——check 本身是 actor 调用，actor 错误必然到场 | F51、A.1b、D3、S2 |
+| H3 残留    | `Decode` / `EmptyData` 改归 `Other`；判别原则写成一句话；**`HttpStatus` 归 `TransportLost`**                     | F52、A.7          |
+| 作用域绑定 | 改名 `classify_apply_backend_failure` + 单一调用点；**不做 newtype**（理由在原地）                               | A.7               |
+| F50 收窄   | 删「确定性/必然」——只在**以服务端信封返回时**恒为 `None`；一条可达路径已足以立论                                 | F50、A.7 作用域段 |
+| T-CL       | 新增 A.7 分类器单测四例（独立成组，测「错误变体 → 行」）                                                         | §6.2b             |
+| Low ×2     | 索引补 `707dd2dbc` 并注明「六提交」项作废；附录顺序调为 A.5 → A.6 → A.7                                          | 索引表、附录      |
+
+**v8 修订索引（六轮复审 REJECT：一条 High + 一处表述降级 + 一处机械）：**
+
+| 项       | 结论                                                                                                                | 落点            |
+| -------- | ------------------------------------------------------------------------------------------------------------------- | --------------- |
+| H1       | A.1b 写死**五臂穷尽派发表**；`Actor(Backend(_))` → 行 3（seam 内唯一 actor 调用是 Check）；**A.7 永不从 seam 可达** | A.1b、A.7、S2   |
+| F52 降级 | Service 分档改述为**诊断政策**而非推导，写进两处已知不严格边界；映射不变                                            | F52、A.7        |
+| T-CL     | 补进 RQ 出口门与第 4 提交；并把「新增测试组须更新三处」定成规矩                                                     | §6 抬头、§7、§9 |
+
+**v9 修订索引（七轮复审：两条 BLOCKING + 一条 QUALITY，全为机械项）：**
+
+| 项  | 结论                                                                                                                                 | 落点      |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------ | --------- |
+| B1  | 删掉 `Actor` 变体 doc 里残留的 A.7 路由指令——**规范性附录内的一句话会被当规范读**                                                    | A.1b      |
+| B2  | 两个 kind 枚举补 `#[derive(Debug, Clone, Copy, PartialEq, Eq)]`；**外层和补 `Debug + thiserror`**（它不能 Clone/Copy，理由写在原地） | A.1、A.1b |
+| Q1  | A.7 表格去掉两个绝对谓词，改列变体归属；推理留给下方的政策注                                                                         | A.7       |
+
+---
+
+## 0. 本阶段的边界
+
+**做（= task.md B1–B4）：**
+
+1. **B1**：Promoted / Applied 所有权迁入 `CoreActor`；删除 client 侧 `RuntimeLifecycleStore` 与 `publish_promoted` / `publish_applied` / `restore_promoted`；lifecycle 经第二条 watch 暴露；
+2. **B2**：`CoreOperationGuard` 取代 `rebuild_gate`；全部事务**先取 guard 再读 snapshot**；保留 rebuild worker 的 capacity-1 coalesce；
+3. **B3**：删除 API-first patch 与补偿层；`apply_promoted` 改走 `CoreBackend::apply`，按 `CoreApplyData` 映射结果；
+4. **B4**：`change_core` 降级为普通 commit-first mutation，返回通用 `MutationOutcome<RuntimeApplyReport>`。
+
+**不做（越界即返工）：**
+
+- 不动 `CoreBackend` 封闭 enum 的形状，不加 trait / factory（已裁定）；
+- 不加 actor 层二次恢复（design §5）；
+- 不做 watch snapshot 的**状态投影**扩展、log ring、`set_mode` / `reconcile_mode`、macOS DNS（全部 C1–C3）；
+- 不删 5 s 健康轮询线程与 `IPC_STATE` static（C2）；
+- 不迁移 `feat::patch_clash_with_rebuild` 里的 sysproxy / systray / locale 副作用编排（PR-6e）；
+- 不动 `on_profile_change` 的连接中断服务（PR-6）；
+- 不碰 Updater 的 `UpdaterManager::global()`（PR-6d）。
+
+---
+
+## 1. 已核验事实（2026-08-02，全部读自 `9727ef1d4` 工作树）
+
+### 1.1 5a 交付的 actor 面（B1/B3 的落点）
+
+| ID  | 事实                                                                                                                                                                                                                   | 锚点                                 |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| F1  | `CoreActorState` 已有 `observed: BackendObservation`、`running: Option<CoreRequest>`、`status_tx: watch::Sender<CoreStatusView>`、`backend: Option<BackendSlot>`；**没有** promoted/applied 字段                       | `core/actor/mod.rs:47-62`            |
+| F2  | `commit()` 与 `commit_backend()` **分流**：前者只更新缓存 + 发布 watch + 跑 latch + 终止态清 `running`；后者额外把 `view.run_type` 归一化为 `state.mode`。**合成观察走 `commit()`，真实后端观察走 `commit_backend()`** | `mod.rs:168-180`（`9727ef1d4` 引入） |
+| F3  | `CoreBackend::apply(&request, expected: Option<RevisionIdInfo>) -> Result<CoreApplyData, CoreBackendError>` **已实现**（D4=A：5a 实现但生产未接线）                                                                    | `core/actor/backend.rs:344-348`      |
+| F4  | actor 消息集已含 `Check` / `Run` / `Stop` / `Recover` / `SetBackend` / `RefreshStatus` / `RefreshHint` / `RunningIdentity` / `Shutdown`；**没有** apply 类消息                                                         | `mod.rs:70-111`                      |
+| F5  | `CoreActorError` 四变体：`StaleOperation` / `NoBackend{last_error}` / `Backend(Arc<..>)` / `ShuttingDown`                                                                                                              | `core/actor/types.rs:59-69`          |
+| F6  | `CoreOperationGuard::acquire` 超时常量 `CORE_ACQUIRE_TIMEOUT = 120s`                                                                                                                                                   | `client/core.rs:30`、`:278-293`      |
+
+### 1.2 lease seam 现状（B2/B3 的落点）
+
+| ID  | 事实                                                                                                                                                                                                                                                                           | 锚点                     |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
+| F7  | `CoreLeaseAdapter` 字段：`guard` / `core` / `application` / `requests` / `runtime_paths` / `target_core: Option<ClashCore>`                                                                                                                                                    | `client/core.rs:331-338` |
+| F8  | **`restart()` 用 `self.target_core.take()`**（一次性消费）——`9727ef1d4` 的语义之一：回滚深路径因此会回退到 typed 快照里**已提交的旧核**，这是有意的                                                                                                                            | `client/core.rs:463-471` |
+| F9  | 五个 lease 方法的当前实现：`check_and_promote` 经 actor `check` + 客户端文件工作；`apply_candidate` **混合**（actor `check` + 裸 `put_configs`）；`apply_promoted` **纯裸 HTTP**；`restart` 经 actor `run`；`stop` 经 actor `stop`                                             | `client/core.rs:390-477` |
+| F10 | **PR-5b 迁移范围内唯一的全量 runtime apply 通道**是 `apply_config_from()`：5 次重试包 `crate::core::clash::api::put_configs`，每次间隔 250 ms。`feat.rs:79` 的 `change_clash_mode` 是另一条裸 `put_configs`，但它只切单个 mode 字段、属 PR-6，不在本阶段管线内（L13 收窄措辞） | `client/core.rs:479-489` |
+
+### 1.3 client 侧待删除面（B1/B2/B3 的落点）
+
+| ID  | 事实                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 锚点                                                                |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| F11 | `NyanpasuClientInner` 含 `clash_patch` / `clash_patch_gate` / `rebuild_gate` / `rebuild` / `runtime_revisions` / `runtime`                                                                                                                                                                                                                                                                                                                                             | `client/mod.rs:232-261`                                             |
+| F12 | `rebuild_gate` **共 10 处获取**；**「gate → `core.begin()` 紧邻」的只有 7 处，例外有 3 处**（v2 写「唯独 promote_default 一处」是错的，H4 纠正）：`promote_default_runtime_config`（gate `rebuild.rs:406` → begin `:443`，其间建 snapshot + candidate）、`promote_existing_runtime_product`（gate `mod.rs:1391` → begin `:1423`，其间分配 revision、读产物、建 snapshot + candidate）、`start_promoted_runtime`（gate `mod.rs:1436` → begin `:1440`，其间读 Promoted） | `mod.rs:1391,1436,1512,1574,1590`；`rebuild.rs:232,257,268,282,406` |
+| F13 | `clash_patch_gate` **只有 1 处获取**（`patch_running_config`）                                                                                                                                                                                                                                                                                                                                                                                                         | `mod.rs:1511`                                                       |
+| F14 | `publish_applied` **8 个调用点**、`publish_promoted` 3 个、`restore_promoted` **仅 1 个**（change_core 深回滚）；另有一处**绕过 publisher 的裸写** `runtime.write().applied = ...`                                                                                                                                                                                                                                                                                     | `mod.rs:1343/1360/1380`；裸写 `mod.rs:1501`                         |
+| F15 | `regenerate_runtime_inner` **先分配 revision、再读 typed snapshots**，doc 明写「必须在 `rebuild_gate` 下运行」                                                                                                                                                                                                                                                                                                                                                         | `mod.rs:1595-1611`                                                  |
+| F16 | `regenerate_runtime_with` 是 typed 与 legacy 两条路径**共用的** candidate→check→promote 核心                                                                                                                                                                                                                                                                                                                                                                           | `mod.rs:1613-1687`                                                  |
+| F17 | `patch_running_config` 的 API-first 顺序：捕获 lifecycle → `compensation_for` → **先打 `clash_patch.patch()` 到运行核** → 再 `patch_clash_with_rebuild` → 失败走 `restore_applied_after_patch_failure`                                                                                                                                                                                                                                                                 | `mod.rs:1507-1571`                                                  |
+| F18 | `restore_applied_after_patch_failure` 的 `Ok` 分支**不可达**——它总是以 `bail!` 收尾                                                                                                                                                                                                                                                                                                                                                                                    | `mod.rs:1445-1505`（`:1502-1504`）                                  |
+| F19 | `change_core` 有**三条回滚分支**：A 构建失败（discard，产物未动）／B 回滚重建成功后重启旧核／C 回滚重建也失败 → `restore_product` + `restore_promoted` + 重启旧核                                                                                                                                                                                                                                                                                                      | `rebuild.rs:275-400`                                                |
+| F20 | **`ControllerBinding` 与 `config_patch_from_mapping` 在代码库中不存在**——仅出现在 spec/roadmap 文本里。B3 卡上这两项对当前代码是 **no-op**                                                                                                                                                                                                                                                                                                                             | 全仓 grep 仅命中 docs                                               |
+| F21 | **`RuntimeApplyReport` 与 `ChangeCoreReport` 都不存在**；`change_clash_core` 与 `patch_clash_config` 两个命令目前都返回 unit `Result`                                                                                                                                                                                                                                                                                                                                  | `ipc.rs:479-496`、`:435-458`                                        |
+| F22 | `MutationOutcome::from_parts` 是 **`CommittedDegraded` 的唯一产出点**（degradations 为空即 `Applied`）；`DegradationPhase` 已含 `CoreRollback` 与 `RuntimeApply`                                                                                                                                                                                                                                                                                                       | `client/runtime.rs:395-404`、`:456-471`                             |
+| F23 | `RebuildCoordinator` 的 capacity-1 coalesce：`mpsc::channel(1)` + `try_send` 丢弃 + 500 ms 接收端去抖 + `try_recv` 排空；worker 经 `Weak<NyanpasuClientInner>` 调 `rebuild_running_config()`                                                                                                                                                                                                                                                                           | `rebuild.rs:21,24-44,58-187`；`mod.rs:435-449`                      |
+| F24 | service harness 测试须套 `transport_available()` 守卫（`9727ef1d4` 的语义之三）；Unix 下它探测 `/var/run` 可写性                                                                                                                                                                                                                                                                                                                                                       | `core/actor/backend.rs:864-880`                                     |
+
+### 1.4 v2 新增事实（L3/L4/L5/L6 的依据）
+
+| ID  | 事实                                                                                                                                                                                                                                                                                  | 锚点                                                                       |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| F25 | **workspace 已启用 `specta`**：`nyanpasu-utils` 与 `nyanpasu-ipc` 的 features 含 `"specta"`，`apply.rs` 的 `ApplyOutcomeKind` / `CoreApplyData` 都带 `#[cfg_attr(feature = "specta", derive(specta::Type))]`。**A.4 可直接内嵌 upstream 类型，无需镜像 DTO**                          | `backend/Cargo.toml:36-41`；`nyanpasu_ipc/src/api/core/apply.rs:34-38,66`  |
+| F26 | `lease.restart()` 今日**生产**调用点共 4 类 6 处：`start_promoted_runtime`（启动）、`patch_running_config`（B3 删）、`regenerate_and_restart_for_legacy`（legacy replay）、`change_core` 三处（B4 删）。**B3+B4 之后仍剩两类**——启动路径与 legacy replay，二者都不在 5b 范围内        | `mod.rs:1441,1540`；`rebuild.rs:271,315,333,377`                           |
+| F27 | **`CoreBackend::apply` 要求核已在运行**——upstream doc 原文「apply never starts one」。今日 `change_core` 用 `restart()`，**核处于停止态时会把新核启起来**；而 `rebuild_running_config` / `patch_running_config` 的 apply 走裸 HTTP，核停止时本来就失败。故只有 `change_core` 有语义差 | `apply.rs:10-18`；`rebuild.rs:315`                                         |
+| F28 | 后台 rebuild worker 对 `rebuild_running_config()` 的 `Err` **只写 `tracing::warn!`**，无人接收；唯一会把它转成 degradation 的是**同步** caller `collect_post_commit_degradations`，经 `map_runtime_rebuild_degradation` 塌成单一 `runtime_rebuild_failed` / `RuntimeBuild`            | `rebuild.rs:172-174`；`mod.rs:1013-1016`、`:979-988`                       |
+| F29 | `CoreDegradationSink` 已存在并已注入 actor（5a 的 D5 latch 用它发 `core_recovery_exhausted`）；生产实现 `TauriCoreDegradationSink` 落到 `UiEventSink::notice_message`。`ClientSetupArgs` 有 `degradation` 字段，但 **`NyanpasuClientInner` 没有保存它**                               | `backend.rs:581-583`；`mod.rs:36,193`；`event_sink.rs:85-105`；`mod.rs:86` |
+| F30 | `commit()` 在**消息处理函数内**就 `status_tx.send_replace`，早于 reply 发出。因此「await 守卫消息的 reply」happens-before「读到新的 watch 值」——测试不需要额外的快照消息                                                                                                              | `mod.rs:168-175`                                                           |
+
+### 1.5 v3 新增事实（codex 对抗审的依据，全部已复核）
+
+| ID   | 事实                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 锚点                                                                                                                                                             |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F31  | `MutationOutcome` 的**两个变体都要求 `value: T`**——`Applied { value }` 与 `CommittedDegraded { value, degradations }`。因此 post-commit 失败也必须给出一个诚实的 report 取值（C1 的根因）                                                                                                                                                                                                                                                                                                                                                                     | `client/runtime.rs:382-392`                                                                                                                                      |
+| F32  | `RuntimeSnapshot` **完全在 client 侧构建**：revision、`RuntimeSnapshotData`、解析后的 config、target core、产物字节全部在 `lease.check_and_promote()` **调用之前**备齐；candidate 哈希比对也在 client 侧（`:1668-1673`）。actor 拿不到构建这份快照所需的任何输入（C2 的根因）                                                                                                                                                                                                                                                                                 | `mod.rs:1656-1686`                                                                                                                                               |
+| F33  | `pre_start` **会观察后端**：注入或新建 backend 后调 `observe_status()` 并把结果写进 `observed`——因此进程启动时 attach 到一个**已在运行**的 Service 核是可能的；但 `state.running` 恒初始化为 `None`，只有 GUI 发过 `Run` 才填充。**`RunningIdentity` 的 `Ok(None)` 因此不等于「核已停止」**（H5 的根因）                                                                                                                                                                                                                                                      | `core/actor/mod.rs:320-347`、`:355`                                                                                                                              |
+| F33b | `Run` 处理器只做「调 backend.run → `commit_backend`」，**不碰 lifecycle**——5a 的任何消息都没有推进 Applied 的途径（C3 的根因之一）                                                                                                                                                                                                                                                                                                                                                                                                                            | `core/actor/mod.rs:393-401`                                                                                                                                      |
+| F34  | rebuild 管线的调用上下文**有四类**，不是两类：①同步 post-commit（`collect_post_commit_degradations`，`mod.rs:1012`）；②后台 worker（`mod.rs:444`）；③**`enhance_profiles` 命令**——doc 明写「there is no prior state commit, so a failure is a plain error」（`ipc.rs:135-140`）；④legacy no-commit 入口 `regenerate_and_apply_for_legacy` / `regenerate_and_restart_for_legacy`（`rebuild.rs:254,267`）（H6 的根因）                                                                                                                                          | `mod.rs:1012,444`；`ipc.rs:135-140`；`rebuild.rs:254,267`                                                                                                        |
+| F35  | `run_legacy_verge_mutation<F, Fut>` 的签名是 `Fut: Future<Output = anyhow::Result<()>>` → `ClientResult<()>`，**装不下 `MutationOutcome<RuntimeApplyReport>`**；且它在 `mutate()` 成功后还要做 legacy restore / 投影刷新 / typed patch plan / finalize，**这些失败都在 typed commit 之后却返回普通 `Err`**。它在 `change_clash_core` 的存在理由由代码注释写死：「核心切换动了 legacy verge,须回灌 typed actors」——**而 B4 恰恰删掉那次 legacy verge 写入**（H7 的根因）                                                                                       | `bridge/verge.rs:257-300`；`ipc.rs:479-496`（注释 `:489`）                                                                                                       |
+| F36  | upstream `apply_config` **先取 `ctrl.current` 并在其为 `None` 时直接返回 `Error::NotStarted`，早于 `expected_revision` 的 CAS 比较**。停止核天然没有 revision，因此「缺失 expected 即不变量破坏」的规则与「停止核给 degraded」的要求互斥（H8 的根因）                                                                                                                                                                                                                                                                                                         | `nyanpasu-core-manager/src/manager/apply.rs:19-37`（`:26` 取 current，`:29-37` 才比 CAS）                                                                        |
+| F37  | `CoreBackend::apply` 的 `Test` 分支是 **`unreachable!("test backend does not implement apply")`**——`TestBackend` 今天根本无法脚本化 apply（M10 的根因）                                                                                                                                                                                                                                                                                                                                                                                                       | `core/actor/backend.rs:369`                                                                                                                                      |
+| F38  | **typed → legacy 的镜像由 state actor 的提交路径自动维护，与任何包裹器无关**：`ApplicationActor::commit` 每次 typed 提交都走 `prepare_replace`（内含 `bridge.prepare(&next)`）→ `manager.upsert` 持久化 → **`mirror.apply()`**；条件替换路径的 `Replaced` 分支同样调 `mirror.apply()`。投影函数 `apply_app_config_to_legacy_verge` **含 `clash_core`**（`draft.clash_core = Some(yaml_convert(snap.core)?)`）。`Patch` 消息也汇入同一个 `commit`。**`fn apply(self: Box<Self>)` 返回 unit——镜像不可失败**，因此不引入新的 degradation 路径                    | `state/application.rs:75-87`（commit）、`:101-103`（条件替换）、`:140-150`（Patch→commit）；`bridge/verge.rs:678`（clash_core 投影）、`:149-152`（`apply` 签名） |
+| F39  | change_core 之后仍在读 legacy `clash_core` 的残余读者共 4 处：托盘两处、`feat.rs` 的核心选择、clash core 模块一处。它们读的是 F38 那条镜像，**B4 之后由 typed 提交自动刷新**                                                                                                                                                                                                                                                                                                                                                                                  | `core/tray/mod.rs:167,336`；`feat.rs:379`；`core/clash/core.rs:98`                                                                                               |
+| F40  | **`CoreStatusView.state` 是二值投影，不能用来判「核在不在跑」**：`map_local_status` 的 `lifecycle` 忠实保留六态，但 `state` 把 `Running`/`Switching`/**`Stopping`** 压成 `CoreState::Running`，把 `Stopped` 之外的其余（**`Starting`**/**`Restarting`**）落进兜底 `_ => Stopped(None)`。即 **Starting→Stopped、Restarting→Stopped、Stopping→Running 三个分支会被反转**（NH1 的根因）                                                                                                                                                                          | `core/actor/backend.rs:438-457`（`:445-447` 兜底、`:450-452` 三态归 Running）；`types.rs:20`                                                                     |
+| F41  | lease seam 的 `check_and_promote` 返回 **`anyhow::Result<[u8; 32]>`**——一个**未分化**的错误类型，**不携带任何相位信息**。v3 说「anyhow 天然区分 check 与 promote」是**错的**：知道相位的是 adapter 里的**构造位置**，不是错误值本身；照 v3 写下去，`runtime_check_failed` / `runtime_promote_failed` 的区分只能靠嗅探错误字符串（NH2 的根因）                                                                                                                                                                                                                 | `client/core_bridge.rs:48-58`                                                                                                                                    |
+| F42  | promote 是**先写后验**：`restore_product` 写入产物后才读回比对哈希（`core.rs:421` 写、`:422-427` 验）。因此「产物已是新值、Promoted 仍是旧值」的分裂窗口**今天的代码里就存在**，不是 5b 引入的（NH3 的根因之一）                                                                                                                                                                                                                                                                                                                                              | `client/core.rs:405-428`                                                                                                                                         |
+| F43  | **`CoreActorError` 今天只有四个变体** `StaleOperation` / `NoBackend` / `Backend` / `ShuttingDown`——**没有任何不变量类变体**。因此 v4 的「豁免 (b) 靠类型区分」在代码里**没有落点**：实施者要么挪用 `StaleOperation`（语义是守卫身份不符，不是单调性），要么裹进 `Backend`（把 bug 伪装成后端故障）——两条路都退回 NH2 刚消灭的字符串嗅探（NH4 的根因）                                                                                                                                                                                                         | `core/actor/types.rs:59-70`                                                                                                                                      |
+| F44  | **`map_apply_outcome` 这个名字已被占用**：`backend.rs:536` 的既有函数做的是 **manager `ApplyOutcome` → `CoreApplyData`**（Local 侧 wire DTO 转换），有 3 处引用（`:358` 生产、`:975`/`:986` 测试）。C3 要新增的函数方向**相反**（`CoreApplyData` → `RuntimeApplyOutcome`）却同名、且在相邻模块（NH9 的根因）                                                                                                                                                                                                                                                  | `core/actor/backend.rs:536`、`:358`、`:975`、`:986`                                                                                                              |
+| F45  | 今天的实现里 **check/晋升 与 发布本来就是分离的两段**：`check_and_promote` 在 `mod.rs:1678-1680` 完成并 `?` 出错误，`publish_promoted` 在 `:1685` **独立调用**。v5 的 D3 那句「`check_and_promote` **内部**发 `PublishPromoted`」是全文唯一与此矛盾的措辞（H2 的根因）                                                                                                                                                                                                                                                                                        | `client/mod.rs:1678-1685`                                                                                                                                        |
+| F46  | **`Backend(_)` 是一个未分化的口袋**：`CoreBackendError` 有四支 `Local` / `Service` / `Binary` / `Construct`，而 `backend_error()` 把**全部**裹进 `CoreActorError::Backend`。revision 冲突、not-started、传输丢失**全藏在这一支里面**——没有有序判据，§2.2 的第 5 行与 7b 会掉进 7c 兜底，6a 与 7c 互相歧义（H3 的根因）                                                                                                                                                                                                                                        | `core/actor/backend.rs:593-603`；`core/actor/mod.rs:297-299`                                                                                                     |
+| F47  | **Local 侧有类型化谓词**：`nyanpasu_core_manager::Error::RevisionConflict { .. }`（`error.rs:44`）与 `Error::NotStarted`（`error.rs:11`）。注意 `NotStarted` 是 **`Err` 而非 outcome**——`manager/apply.rs:26` 的 `.ok_or(Error::NotStarted)?` 与 `:28` 的 `return Err(Error::NotStarted)` 都走错误通道                                                                                                                                                                                                                                                        | `crates/nyanpasu-core-manager/src/error.rs:11,44`；`manager/apply.rs:26,28`                                                                                      |
+| F48  | **Service 侧的分类键是 `error_kind: Option<String>`，不是 `code`**：`ClientError::Server` 同时带 `code: ResponseCode` 与 `error_kind: Option<String>`，而**后者才是 R0 收敛出来的那个字段**（对照 `api::error_kind::{NOT_STARTED, REVISION_CONFLICT, …}` 字符串常量）。另：`ClientError` **共七支**（`BuildClient` / `Request` / `HttpStatus` / `Decode` / `Server` / `EmptyData` / `WebSocket`）**且标了 `#[non_exhaustive]`**——分类器必须有兜底                                                                                                             | `nyanpasu_ipc/src/client/mod.rs:23-62`；`api/mod.rs:40,45`                                                                                                       |
+| F49  | **停止态 `restart()` 的失败也是 `Backend(_)`**：`Run` 处理器是 `backend.run(&request).await.map_err(backend_error)`，而 `backend_error()` 把它包成 `CoreActorError::Backend`——与 apply 路径的失败**在类型上无法区分**（A.7 作用域漏洞的根因）                                                                                                                                                                                                                                                                                                                 | `core/actor/mod.rs:400`、`:297-299`                                                                                                                              |
+| F50  | **`start` / `stop` / `restart` 不带 `error_kind`**：submodule 明写它们「predate `error_kind` 并继续返回 `anyhow::Error`」，只有 S8 新增的那批操作才填充该字段；而 `error_kind` 缺失的语义是「**not classified**，never no error」。因此**当启核失败以服务端信封的形式返回时**，`error_kind` 恒为 `None`，A.7 第 4 行会把它判成 `Other` → 行 7c。（**不是「确定性地」**——生命周期调用也可能在拿到信封之前就以 `Request` / `HttpStatus` 失败而落进 `TransportLost`；但只要有这一条可达路径，就足以与 R1 裁定的 `core_start_failed` 冲突，作用域声明依然必要。） | `nyanpasu-runtime/.../manager_bridge.rs:47-52`；`nyanpasu_ipc/src/api/mod.rs:35-37`                                                                              |
+| F51  | **check 阶段本身就是一次 actor 调用**：`CoreClient::check` 返回 `Result<(), CoreActorError>`，而 `check_and_promote` 内部正是 `self.core.check(&self.guard, &request).await?`。所以 seam 的错误面**必然**会遇到 `CoreActorError`——v6 那句「`CheckAndPromoteError` 永不承载 `CoreActorError`」在 check 阶段不可能成立（H2 残留的根因）                                                                                                                                                                                                                         | `client/core.rs:172-176`、`:408`                                                                                                                                 |
+| F52  | `HttpStatus` **通常**意味着「回包不是格式良好的服务信封」：客户端拿到非 2xx 后先试解信封，解得出**且 `code != Ok`** 才走 `Server`，否则落 `HttpStatus`。**但这不是一条严格等价**——两处边界：①非 2xx 而 body 解得出信封**却 `code == Ok`** 时也落 `HttpStatus`；②2xx 成功路径上 `OpResponse<Op>` 反序列化失败会产生 `Decode`（`:176`），此时**并没有有效信封到达**                                                                                                                                                                                             | `nyanpasu_ipc/src/client/mod.rs:135-151`、`:176`                                                                                                                 |
+
+---
+
+## 2. RQ-01 — post-commit 失败矩阵（必答）
+
+### 2.1 分界线的定义
+
+**分界线是「typed desired state 是否已经提交」**，不是「操作是否已经开始」。
+
+- `ApplicationClient::patch` / `ClashConfigClient::patch` 返回 `Ok` 的那一刻起，用户意图已经持久化 → 此后的失败**除 §2.3 的 E-a / E-b 两条豁免外**都不得表现为普通 `Err`（否则 UI 会显示「失败」而磁盘上已经变了）；
+- 在此之前的任何失败，desired 未动，返回 `Err` 是诚实的。
+
+因此 5b 的三类入口有不同的分界位置：
+
+| 入口                                                                                                                         | 有无 desired commit           | 分界                                                                                                                                                                                        |
+| ---------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `patch_running_config`（B3）、`change_core`（B4）                                                                            | **有**，且在最前              | commit 之后**除 §2.3 两条豁免外**全部 degraded                                                                                                                                              |
+| profile mutation 的 `after_commit`                                                                                           | **有**                        | guard acquisition 本身已是 post-commit；失败映射 `core_operation_unavailable` 并并入 `MutationOutcome`，见 §2.4                                                                             |
+| `rebuild_running_config`（**后台脏重建**，`RebuildCoordinator` worker）                                                      | 无（响应更早的 commit）       | 普通失败经 sink 发布；E-a `ShuttingDown` 安静退出，E-b（`StaleOperation` / `LifecycleInvariant(_)` / `RuntimeRevisionExhausted`）以 error 级别报告不变量违反且**不产 degradation**，见 §2.4 |
+| `rebuild_running_config`（**`enhance_profiles` 命令**，F34 ③）                                                               | 无（doc 明写无前置 commit）   | **全部 `Err`**——命令 doc 原文「there is no prior state commit, so a failure is a plain error」                                                                                              |
+| `regenerate_and_apply_for_legacy` / `regenerate_and_restart_for_legacy`（**legacy 重播**，F34 ④）                            | 无（legacy draft 尚未 apply） | **全部 `Err`**——调用方 `feat::*` 靠 `Err` 触发 `Config::verge().discard()`；`RolledBack` 也必须映射成 `Err`，否则 legacy draft 会被误当成功而 `apply()`                                     |
+| `promote_existing_runtime_product` / `start_promoted_runtime` / `promote_default_runtime_config`（启动路径）、`restart_core` | 无                            | 全部 `Err`（没有已提交的用户意图需要保护）                                                                                                                                                  |
+
+### 2.2 七项逐条作答
+
+`P` 列 = 该失败发生在分界线之前（`pre`）还是之后（`post`）。**除 §2.3 的两条豁免（E-a / E-b）外**，`post` 一律映射为 `Degradation { phase, code, retryable }` 并经 `MutationOutcome::from_parts` 变成 `CommittedDegraded`。
+
+| #   | 失败                                               | 触发点                                                                              | P       | commit-first 入口的结果                                                                                                                                                               | 无-commit 入口的结果 |
+| --- | -------------------------------------------------- | ----------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| 1a  | **operation acquire 超时（命令入口）**             | `patch_running_config` / `change_core` 在 desired commit 前等待 `begin_operation()` | **pre** | `Err(OperationError::AcquireTimeout)`——这些命令按 S3 先取 guard 再提交 desired                                                                                                        | `Err`                |
+| 1b  | **operation acquire 超时（既有 commit 的副作用）** | profile mutation 的 `after_commit`，或后台 dirty rebuild                            | post    | `phase = CoreLifecycle`、`code = "core_operation_unavailable"`、`retryable = true`；同步 profile caller 得到 `CommittedDegraded`，后台经 sink 发布                                    | 不适用               |
+| 2   | **build 失败**                                     | `regenerate_runtime_with` 的 `spawn_blocking` 构建段                                | post    | `phase = RuntimeBuild`、`code = "runtime_build_failed"`、`retryable = true`                                                                                                           | `Err`                |
+| 3   | **check 失败**                                     | `CoreBackend::check`（dry-run）                                                     | post    | `phase = RuntimeCheck`、`code = "runtime_check_failed"`、`retryable = true`                                                                                                           | `Err`                |
+| 4a  | **promote 前置失败**                               | candidate 哈希不符 / `check` 后文件被改 / `restore_product` 写入本身失败            | post    | `phase = RuntimePromote`、`code = "runtime_promote_failed"`、`retryable = true`；**产物保持旧值**——原保证仍然成立                                                                     | `Err`                |
+| 4b  | **写后校验失败**                                   | `restore_product` 已写入**之后**：读回哈希不符                                      | post    | `phase = RuntimePromote`、`code = "runtime_promote_failed"`、`retryable = true`、report = `NotApplied`（**message 与 4a 区分**）；**产物已是新值、Promoted 仍是旧值**——见下方分裂窗口 | `Err`                |
+| 5   | **revision 冲突**                                  | `CoreBackend::apply` 的 CAS（`Error::RevisionConflict`）                            | post    | `phase = RuntimeApply`、`code = "revision_conflict"`、`retryable = true`；**Applied 不变**，下一次 rebuild 会带新 revision 重试                                                       | `Err`                |
+| 6a  | **IPC 连接丢失**                                   | Service backend 的传输错误（`ClientError`）                                         | post    | `phase = RuntimeApply`、`code = "core_transport_lost"`、`retryable = true`、report = `NotApplied`；**Applied 不变**                                                                   | `Err`                |
+| 6b  | **后端不可用**                                     | `CoreActorError::NoBackend`（后端构造失败，槽位为 `Failed`）                        | post    | `phase = RuntimeApply`、`code = "core_backend_unavailable"`、`retryable = true`、report = `NotApplied`（NH8：它与 6a **不是同一回事**，A.6 早有独立 code）                            | `Err`                |
+| 7a  | **apply 回滚**                                     | `CoreApplyData.outcome == RolledBack`（**有** `CoreApplyData`）                     | post    | `phase = CoreRollback`、`code = "core_rollback"`、`retryable = true`；**report = `RolledBack`，不是 `NotApplied`**——旧配置确实在跑，这是一个真实终态动作                              | `Err`                |
+| 7b  | **核未运行**                                       | backend 返回 `NotStarted`（F27 / F36）                                              | post    | `phase = RuntimeApply`、`code = "core_not_running"`、`retryable = true`、report = `NotApplied`                                                                                        | `Err`                |
+| 7c  | **其它 apply 失败**                                | backend 返回其它 `Err`                                                              | post    | `phase = RuntimeApply`、`code = "runtime_apply_failed"`、`retryable = true`、report = `NotApplied`                                                                                    | `Err`                |
+
+**发布中止（两条豁免类；穷尽性要求它们必须上桌，NH5 ①）**
+
+下面两类**不产 degradation、返回 `Err`**——把它们从矩阵里省略，正是 v4 让 4b 变得自相矛盾的原因。判别依据是 §2.3 的 `matches!` 规则，**不是**看失败发生在哪一步：
+
+| #   | 情形                                                          | 元组                                                  | 为什么不降级                                              |
+| --- | ------------------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------- |
+| E-a | 发布时进程正在关停（`ShuttingDown`）                          | `Err`、**无 degradation**、无 report                  | teardown 期没有任何读者会去渲染 degraded 结果（豁免 (a)） |
+| E-b | 发布被不变量拒绝（`LifecycleInvariant(_)`、`StaleOperation`） | `Err` + **错误级日志**、**无 degradation**、无 report | 这只可能是 bug，必须响亮失败（豁免 (b)）                  |
+
+> **E-a / E-b 与第 4b 行的区别**：三者都可能发生在「产物已写入」之后，终态也都是产物新 / Promoted 旧。区别**只在错误类型**——4b 是真实的运行时失败（读回哈希不符），E-a / E-b 匹配豁免规则。实施者按 `matches!` 分流，不靠推断失败位置。
+
+> **revision allocator 耗尽属于 E-b，不是 degradation**：`RuntimeRevisionAllocator` 在 operation guard 串行域内每事务只分配一次；合法执行不可能耗尽 `u64`。它由 A.1 的 `RuntimeRevisionExhausted` 明确类型化并返回普通 `Err`，避免未来把实现不变量伪装成运行时降级。
+
+> **第八项（D5=A 引入，不在 RQ-01 原列表内）**：停止态 `change_core` 的 `restart()` 失败。`restart()` 以 A.1b 的 `RestartFailure` 保留来源；必须先按 §2.3 分流：`Actor(StaleOperation | LifecycleInvariant(_) | ShuttingDown)` 返回普通 `Err`，不产 degradation；其余 `Actor(_)` 与 `Operation(_)` 才落本行。desired 早已提交，故非豁免失败同样是 `post`——`phase = CoreLifecycle`、`code = "core_start_failed"`、`retryable = true`，Applied 不推进（§3.1 的 `Started` 行、T-B4-05）。**它不过 A.7 的分类器**——A.7 只管 apply 路径，见其作用域声明。用 `CoreLifecycle` 而非 `RuntimeApply`：失败发生在核**生命周期**上，不是在配置应用上，与 5a 的 `core_recovery_exhausted` 同相。
+
+> **上表各行的 `report` 取值（C1，按 NH7 修正）**：`MutationOutcome` 的两个变体都要求 `value: T`（F31），所以 post-commit 失败也得给出一个诚实的 report。**第 2、3、4a、4b、5、6a、6b、7b、7c 行**都**没有发生任何终态动作**——既没有 `CoreApplyData`，也没有启核——因此一律取 **`RuntimeApplyOutcome::NotApplied`**、`applied_revision = None`，「为什么」由 degradations 承载。**唯一的例外是第 7a 行**：`RolledBack` **是有 `CoreApplyData` 的**，旧配置确实在跑、这是 apply 主动做出的真实终态动作，所以它的 report 就是 `RolledBack`（与 §3.1 的映射一致）——v4 把它一并归进 `NotApplied` 是错的。**E-a / E-b 两类没有 report**（返回 `Err`，不构造 `MutationOutcome`）。`desired_revision` 始终填本次分配的 revision。
+
+> **4b 的分裂窗口：诚实记录，不加第二套回滚（NH3 ②）**
+>
+> 产物先落盘、`PublishPromoted` 后到，中间任何失败都会留下「产物 = 新、Promoted = 旧」的分裂。**这个窗口今天的代码里就有**——`restore_product` 写完才读回比对（F42：`core.rs:421` 写、`:422-427` 验），**不是 5b 引入的**。
+>
+> **它是自愈的**：Promoted 只是读模型，产物才是核实际加载的文件；下一次 rebuild（coalesce worker 的脏重建，或任何后续事务）会重新走 build→check→promote 并重新发布，两者随即收敛。窗口期内的可观测后果是「runtime 读 IPC 返回的快照比磁盘产物旧一拍」，不会让核加载到错误配置。
+>
+> **明确不做**：不加产物回滚、不加二段提交、不加补偿事务——B 范围明令禁止二层恢复（§0），而为一个自愈窗口引入一套恢复机制，恰恰是 5a 已经裁掉的那类复杂度。4a 与 4b 共用 `runtime_promote_failed`，靠 `message` 区分是哪一侧。
+
+### 2.3 三条不变量
+
+- **I-A（不撒谎）**：desired 已提交时，**除下列两条豁免外绝不**返回 `Err`——只返回 `CommittedDegraded`。**两条显式豁免（NH3 ① / NH4）**：
+  - **(a) 进程正在关停**（`CoreActorError::ShuttingDown`）：teardown 期没有任何读者会去渲染一个 degraded 结果，返回 `Err` 是诚实的；把它包成 `CommittedDegraded` 只是制造一个没人看的假成功；
+  - **(b) 不变量破坏**：**这些只可能是 bug**——守卫串行化 + 单事务单次分配之下，陈旧 operation 与非递增 revision 都不该发生。**bug 必须响亮失败**（`Err` + 错误级日志）；包装成 degradation 等于把实现缺陷伪装成一次「运行时小故障」，让它长期潜伏。
+
+  **豁免的判据是一条可 `matches!` 的类型规则，全文在此声明一次（NH4）：**
+
+  ```rust
+  // 豁免当且仅当匹配这两支；其余一律 degraded。
+  matches!(err, CoreActorError::ShuttingDown)                  // 豁免 (a)
+      || matches!(err, CoreActorError::StaleOperation
+                     | CoreActorError::LifecycleInvariant(_))  // 豁免 (b)
+  ```
+
+  **`Backend`、`NoBackend`、以及任何 `CheckAndPromoteError` 永不符合豁免**——它们是真实的运行时失败，一律 degraded。这条规则由 **T-PC-12** 钉住（§6.2），其中「`Backend` / `NoBackend` → `CommittedDegraded`」那两例是证明**豁免吞不掉真实失败**的关键断言。
+
+  > v4 说「豁免 (b) 靠类型区分、边界够硬」——**那是错的**：`CoreActorError` 当时只有四个变体，没有任何不变量变体（F43），所谓硬边界并不存在。NH4 补上 `LifecycleInvariant`，规则才真正可判别。
+
+- **I-B（不静默）**：**除本节两条豁免外**，任何 `post` 失败**必须**产出至少一条 `Degradation`，不允许只写日志（豁免类改为 `Err` + 错误级日志，同样不静默）；
+- **I-C（状态单调）**：`post` 失败不得回退已经推进的 Promoted；Applied 只在 backend 确认采纳新 revision 时才推进（§3）。
+
+> 与 `CoreActorError` 的关系：`StaleOperation` / `LifecycleInvariant(_)` / `ShuttingDown` 走上面的 `matches!` 豁免规则，**不映射 degradation**；`NoBackend` 按 §2.2 第 **6b** 行处理（`core_backend_unavailable`）；**apply 路径上的 `Backend(_)` 不是单一去向**——它是个未分化口袋（F46），必须过 **A.7 的有序分类器**才能定到第 5 / 6a / 7b / 7c 行；**生命周期路径（停止态 `restart()`）的 `Backend(_)` 不过 A.7**，直接落 restart-failure 行（见 §2.2 第八项）。**后两者永不豁免。**
+
+### 2.4 degradation 投递到哪里（I-B 对**无 caller 的入口**如何满足）
+
+I-B 说「不允许只写日志」，但 rebuild 管线有**四类**调用上下文（F34），其中只有三类有 degradation 的容身处。四条路径必须分清——v2 只写了三条，漏掉 `enhance_profiles` 与 legacy 重播两类，而那两类**根本不该 degrade**：
+
+| 调用上下文                                                                                                                        | 有无前置 commit | 投递路径                                                                                                                                                                                                                    | 现状                      |
+| --------------------------------------------------------------------------------------------------------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| **① 同步 post-commit**：`collect_post_commit_degradations`（profile mutation 的 `after_commit` 等 5 处）                          | 有              | 返回值——运行时 degradation 追加进调用方的 `MutationOutcome<..>`；guard 获取失败映射为 `core_operation_unavailable`                                                                                                          | 已覆盖                    |
+| **② 后台 worker**：`RebuildCoordinator` 的 dirty 重建                                                                             | 有（更早）      | **`CoreDegradationSink::publish`**（F29 已有的注入面，与 5a 的 `core_recovery_exhausted` 同一 sink）；既有 degradation 与普通 bare `Err` 必须发布。§2.3 豁免除外：E-a 安静退出，E-b 只写 error 级不变量日志、零 degradation | 已覆盖                    |
+| **③ 命令入口**：`patch_running_config` / `change_core`                                                                            | 有              | 返回值——`MutationOutcome<RuntimeApplyReport>`                                                                                                                                                                               | S5 / S6 新建              |
+| **④ 无 commit 入口**：`enhance_profiles`（`ipc.rs:135-140`）、`regenerate_and_{apply,restart}_for_legacy`（`rebuild.rs:254,267`） | **无**          | **普通 `Err`，不产 degradation**                                                                                                                                                                                            | 已是现状，5b **不得**改动 |
+
+> ④ 为什么不 degrade：`enhance_profiles` 的命令 doc 原文就是「there is no prior state commit, so a failure is a plain error」；legacy 重播的调用方（`feat::patch_verge` / `patch_clash` 等）**靠 `Err` 触发 `Config::verge().discard()`**——把失败包装成 `CommittedDegraded` 会让 legacy draft 被误当成功而 `apply()`，在磁盘上留下一份从未生效的配置。**`RolledBack` 在 ④ 里也必须映射成 `Err`**（它意味着新配置没生效），这是 ④ 与 ①②③ 的关键差异。
+
+> ④ 只约束 **rebuild 本身的失败**。`patch_clash_with_rebuild` 的 rebuild 已成功返回后，typed store 与运行时结果已经成为事实；随后 `Config::clash().apply()` 的 legacy mirror 持久化若失败，只能写 error log 并保留成功返回。让 `save_config` 的 `Err` 翻转整个调用会同时撒两个谎：typed commit / rebuild 结果已经成立，却向 caller 报整个操作失败；而且 draft 已经 apply，`?` 也不会走失败分支的 `discard()`。该持久化在 typed store 成为 source of truth 后明确为 best-effort，待剩余 legacy reader 迁走时删除。成功不可翻转由 `finish_successful_clash_rebuild -> T` 的签名结构性保证；T-PC-14 只负责钉住 persistence callback 确实执行、确实产生注入错误且错误被吞掉。
+
+**因此管线要拆成「内部」与「公共包装」两层：**
+
+```text
+内部：rebuild_pipeline(..) -> (Result<RuntimeApplyReport>, Vec<Degradation>)   ← 只报事实，不决定表现形式
+  ├─ ① 同步 post-commit → 调用方并入自己的 MutationOutcome
+  ├─ ② 后台 worker      → 逐条 degradation.publish()；普通 bare Err 映射为
+  │                       core_operation_unavailable 后 publish；E-a 安静退出，
+  │                       E-b 写 error 级不变量日志且不 publish
+  ├─ ③ 命令入口         → MutationOutcome::from_parts(report, degradations)
+  └─ ④ 无 commit 入口   → 有 degradation 或 RolledBack 即折叠成 Err
+                          （公共 rebuild_running_config / 两个 legacy 重播方法
+                            的签名与 Err 语义一字不改）
+```
+
+> §2.3 的 E-a/E-b 在有 caller 的 mutation 上仍返回普通 `Err`。后台 worker 没有 caller，因此 terminal handler 必须复用同一豁免判据分类：`ShuttingDown` 是预期 teardown race，安静退出；`StaleOperation` / `LifecycleInvariant(_)` / `RuntimeRevisionExhausted` 是 E-b，以 `tracing::error!` 明确命名 invariant violation，零 degradation；其余 bare `Err` 才经 sink 发布 `core_operation_unavailable` 或保留既有 degraded warning。
+
+**5b 的三项对应动作：**
+
+1. **同步路径精度提升**：`map_runtime_rebuild_degradation` 的 doc 现在写着「不要臆造 `RuntimeCheck` / `Promote` / `Apply` 精度，错误面撑不住」（`mod.rs:979-980`）——5b 恰恰把错误面做出来了。把它改为直接透传管线产出的 `Vec<Degradation>`（§2.2 的 phase/code 分级），删掉那条 doc 与单一 `runtime_rebuild_failed` 常量。
+2. **后台路径补 sink**：`NyanpasuClientInner` 增 `degradation: Arc<dyn CoreDegradationSink>` 字段（`ClientSetupArgs` 早有此值，F29，只是没留存）；worker 闭包把 degradations 逐条 `publish`。`tracing::warn!` 保留（可观测性），但**不再是唯一出口**。
+3. **④ 保持原样**：公共 `rebuild_running_config()` 与两个 legacy 重播方法的**签名和 `Err` 语义一字不改**，内部改调新管线并在出口折叠。T-PC-10 / T-PC-11 钉住这条。
+
+> 为什么用 `CoreDegradationSink` 而不是 lifecycle watch 携带 `last_error`：watch 是**状态**投影（当前值、可被下一次覆盖），degradation 是**事件**（每条都要送达一次）。用状态通道送事件会在两次重建之间静默丢失中间那条。5a 已经为「事件」选定了 sink，5b 沿用，不新造第二套。
+
+---
+
+## 3. RQ-03 — apply parity 矩阵（必答）
+
+### 3.1 六个 apply outcome + 一个非 apply 终态 + 一个正交标志
+
+`CoreApplyData { outcome: ApplyOutcomeKind, revision: ConfigRevisionInfo, warning: Option<String>, failed_apply: Option<String> }`。
+
+**`Warning` 不是第七个分支**——它是与 outcome 正交的标志位，可以与**任何**一个 outcome 组合出现（来源是 runtime 的 `ApplyOutcome::DurabilityUncertain` 包装，可嵌套两层并以 `"; "` 拼接）。
+
+| outcome                               | Applied 是否推进 | 返回                                         | 说明                                                                                                                                                                                                                        |
+| ------------------------------------- | ---------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Noop`                                | **推进**         | `Applied`                                    | 配置已在生效——运行的就是该 revision，Applied 必须等于 Promoted，否则读模型会永远滞后                                                                                                                                        |
+| `Patched`                             | **推进**         | `Applied`                                    | 就地 `PATCH /configs`                                                                                                                                                                                                       |
+| `Reloaded`                            | **推进**         | `Applied`                                    | 就地 `PUT /configs`                                                                                                                                                                                                         |
+| `Restarted`                           | **推进**         | `Applied`                                    | 同 epoch 内换进程                                                                                                                                                                                                           |
+| `Switched`                            | **推进**         | `Applied`                                    | 换核（B4 的正常成功路径）                                                                                                                                                                                                   |
+| `RolledBack`                          | **不推进**       | `CommittedDegraded { phase: CoreRollback }`  | **旧配置在跑**；desired 与 Promoted 保留新值，Applied 保留旧值                                                                                                                                                              |
+| **`Started`**（非 apply 产出，D5=A）  | **推进**         | `Applied`                                    | 核原本停止，本路径把它启起来了：restart 成功后**运行的就是 promoted revision**，因此与 `Noop` 同理必须推进，否则读模型永远滞后。`report.outcome = Started`                                                                  |
+| **`NotApplied`**（非 apply 产出，C1） | **不推进**       | `CommittedDegraded`（degradations 说明原因） | **什么终态动作都没发生**：build / check / promote / 传输 / `NoBackend` 失败时用它。`applied_revision = None`。它存在的唯一理由是 `MutationOutcome` 两变体都要求 `value`（F31），而拿 `RolledBack` 或 `Started` 顶替就是撒谎 |
+
+前六格逐一映射到 `RuntimeApplyOutcome` 的同名变体（A.4）。第七行 `Started` **不由 `apply` 产出**——它是 D5=A 的停止态启核路径直接构造的，**不进 `runtime_outcome_from_apply_data`**，因此不进 §3.2 的 12 格 parity 矩阵；但它是一个真实终态，Applied 推进规则必须在这张表上说清。
+
+**`Started` 路径的失败侧（R1）**：停止态分支的 `restart()` 失败时，先保留 `RestartFailure` 的来源并应用 §2.3；三类 actor 豁免返回普通 `Err`。其余失败因 desired 已提交（§2.1）而**走 §2.2 的 post-commit 路径**——返回 `CommittedDegraded`，`phase = CoreLifecycle`、`code = "core_start_failed"`、`retryable = true`，Applied **不推进**。成功侧由 **T-B4-03** 钉住，失败两臂由 **T-B4-05** 钉住（§6.3）。
+
+**Warning 的处理（与上表正交）：**
+
+- `warning.is_some()` 时**追加**一条 `Degradation { phase: RuntimeApply, code: "core_apply_durability_uncertain", retryable: false }`；
+- **不改变**上表的 Applied 推进决策；
+- 因此 `Applied + warning` 会变成 `CommittedDegraded`（`from_parts` 见 F22），而 `RolledBack + warning` 会有**两条** degradation。
+
+### 3.2 parity 测试要求
+
+矩阵是 **6 × 2 = 12 个组合**（六个 outcome × warning 有/无），每个组合都要断言三件事：Applied 是否推进、返回的 `MutationOutcome` 变体、degradation 列表内容。测试编号 T-AP-01…12（§6）。
+
+**双后端 parity（M10 残留已修）**：Local 与 Service 对同一 outcome 必须产出同一结果，而 parity 的价值全在**后端各自的转换层**，不在共用的 mapper。因此：**Local 侧直接单测真实的 manager-outcome → `CoreApplyData` 转换函数**（喂 manager 的 `ApplyOutcome` fixtures），**Service 侧走 IPC harness 解码**（套 `transport_available()` 守卫，F24），两侧得到的 `CoreApplyData` 逐字段相等后再各自过 `runtime_outcome_from_apply_data`。**`TestBackend` 的脚本化 apply 只服务 actor 层测试，不得冒充 parity**——用它喂 `CoreApplyData` 等于把两个后端的转换层双双旁路掉（F37 说明它今天还是 `unreachable!`，须先补）。
+
+---
+
+## 4. 决策点（D1–D5 leader 已全部裁定，2026-08-02；**无待决项**）
+
+### D1 — `RuntimeSnapshot` 等类型放哪 —— **裁定 A**
+
+B1 要把 Promoted/Applied 搬进 actor，但 `RuntimeSnapshot` / `RuntimeRevision` / `RuntimeLifecycleState` 现在住在 `client/runtime.rs`（F11 邻域）。
+
+- **裁定 A**：把 `RuntimeRevision` / `RuntimeSnapshot` / `RuntimeSnapshotData` / `RuntimeLifecycleState` 移到 **`core/actor/runtime.rs`**（新文件）。理由：所有权跟着数据走；actor 反向依赖 `client::` 是层次倒置。（**`CandidateFile` 原也在此列，v3 起不再迁移**——见下方 v3 后记。）
+- **选项 B（未采纳）**：类型不动，actor 直接 `use crate::client::runtime::*`。改动小，但让 `core::actor` 依赖 `client`，与 5a 建立的方向相反。
+
+> **L1 修正（已被 v3 后记取代，保留以存档决策脉络）**：v1 曾把 `CandidateFile` 留在 `client/runtime.rs`，同时让 A.2 的 `CheckAndPromote` 消息携带它——那确实是 D1=A 要消灭的反向依赖。**但 C2 换掉了那条消息，前提随之消失**，最终结论见下方 v3 后记：不迁。
+>
+> **L2 修正**：`RuntimeRevisionAllocator` **不迁**，留在 `client/runtime.rs`。它是 **ID 源泉**（一个 `AtomicU64`），不是 lifecycle 状态；迁入 actor 会逼出一条 `AllocateRevision` 守卫消息和一次多余的 round-trip，而单调性本来就由 actor 在 promote 时校验（T-LC-01 已钉）。它 `use` 迁走的 `RuntimeRevision`，方向仍是 client → core。**A.1 / A.2 / A.3 / S1 / S2 / S3 五处已按此对齐。**
+>
+> **v3 后记（C2 使 L1 的前提消失）**：L1 的理由是「`CheckAndPromote` 消息按值携带 `CandidateFile`」。C2 把该消息换成了 `PublishPromoted { operation, snapshot }`——**actor 不再碰任何文件类型**，`CandidateFile` 也就不必迁移。因此实施时 **`CandidateFile` 留在 `client/runtime.rs`**：L1 要保护的不变量（`core::actor` 不反向依赖 `client::`）由 C2 更彻底地实现了，而搬一个 actor 用不到的类型属于无谓改动。**这是对 L1 落地方式的修正，不是对 L1 裁定的推翻**；leader 已于 2026-08-02 确认。
+
+### D2 — lifecycle 用第二条 watch 还是塞进 `CoreStatusView` —— **裁定 A**
+
+B1 要求「CoreClient 通过 watch 暴露 lifecycle」。
+
+- **裁定 A：第二条 watch 通道** `watch::Sender<RuntimeLifecycleState>`，与 `status_tx` 并列。理由：`CoreStatusView` 是 UI 投影（5 个小字段，每次 `commit()` 都克隆），而 `RuntimeSnapshot` 持有产物字节与整个 config Mapping——塞进同一条通道会让每次状态变化都克隆一份重量级快照。
+- **选项 B（未采纳）**：扩 `CoreStatusView`。省一条通道，但把重负载塞进高频路径，且会改 5a 已稳定的 `commit()` 语义（F2）。
+
+### D3 — `apply_candidate` 的去留 —— **裁定 A**
+
+`apply_candidate`（F9）今天只被 `restore_applied_after_patch_failure` 使用，而后者随 B3 删除。
+
+- **裁定 A：一并删除** `apply_candidate`，`CoreLifecycleLease` 收敛到 4 个方法（`check_and_promote` / `apply_promoted` / `restart` / `stop`）。C2 之后 lease 的 `check_and_promote` **名字与文件工作都留在 client 侧**，且它**不发 `PublishPromoted`**，且其错误面是 A.1b 的**外层和** `CheckAndPromoteFailure`（actor 错误原样透出，H2 残留）——发布是编排层紧随其后的**独立一段**（H2；今天的实现本就如此，F45）。`restart` 因 F26 的两类残余调用者而**保留**（见 D5）。理由：删掉唯一调用者后 `apply_candidate` 就是死代码。
+- **选项 B（未采纳）**：保留备用。违反「不留无调用者的抽象」。
+
+### D4 — `change_core` 的 wire 变化幅度 —— **裁定 A**
+
+B4 让 `change_clash_core` 返回 `MutationOutcome<RuntimeApplyReport>`（F21：今天返回 unit）。
+
+- **裁定 A**：新增 `RuntimeApplyReport { outcome, desired_revision: u64, applied_revision: Option<u64> }`（design §8 的形状），命令返回 `MutationOutcome<RuntimeApplyReport>`。bindings 因此新增两个 TS 类型 + 命令返回类型变化——**这是本阶段唯一的 wire 变化**，S9 按「恰好这些」核对。`specta` 已在 workspace 启用（F25），upstream 类型可直接内嵌，**不做镜像 DTO**。
+- **选项 B（未采纳）**：仍返回 unit，degraded 只进日志。B4 卡明写「前端复用通用 `RuntimeApplyReport`/MutationOutcome 展示 degraded」。
+
+### D5 — 核处于停止态时 `change_core` 怎么办（L3 审计的产物）—— **裁定 A**
+
+L3 让我审计 `restart()` 残余，审出一条 v1 漏掉的语义差（F26/F27）：
+
+- `CoreBackend::apply` **不启核**（upstream doc「apply never starts one」）；
+- 今天的 `change_core` 用 `lease.restart()`，因此**核停止时切核会把新核启起来**；
+- 另两条 apply 入口（`rebuild_running_config` / `patch_running_config`）今天走裸 HTTP，核停止时本来就失败——所以**只有 `change_core` 有行为差**。
+
+若 B4 无条件改走 `ApplyPromoted`，「停止态下切核」会从「切完并启动」变成「切完但失败」，这是 B4 卡没有授权的行为回归。
+
+- **裁定 A：按 `RunningIdentity` 分支**。**判据是「身份 + 忠实六态」的原子守卫联合读**（NH1；`Ok(None)` 单独看**不等于**核已停止，二值 `CoreStatusView.state` 更会把三个分支判反——真值表见 S6）。在跑 → `ApplyPromoted` 承载切换（`Switched`）；已停 → `restart()` 启新核，**与今天逐字同行为**；后端不可用 → 按 §2.2 第 6b 行 degraded。`RuntimeApplyReport.outcome` 用**本仓自有**枚举 `RuntimeApplyOutcome`（镜像 upstream 六变体 + `Started` + `NotApplied`，共八个）。
+- **选项 B（未采纳）**：无条件 apply，停止态切核返回 degraded。更简单，但改用户可见行为，且 `Started` 这个真实状态在 wire 上无处表达。
+
+**leader 裁定 A（2026-08-02），四条理由：** ①前提经独立核实——`apply.rs` doc 原文「The core must already be running: apply never starts one」；②选项 B 未经 B4 卡授权就改用户可见行为，违反迁移政策；③`Ok(None)` → `restart()` 与今天逐字同行为，且与 5a updater 的 `Ok(None)` 先例不冲突——两者各自保留各自的 legacy 行为（updater 停止态换二进制**不**启动，change_core 停止态切核**启动**）；④`Started` 第七变体是诚实建模，把 `Ok(None)` 分支映射成 `Switched` 是撒谎（apply 根本没承载它）。
+
+> **R2 —— 为什么用仓内枚举而不是直接复用 `ApplyOutcomeKind`：这是语义选择，不是编译必要。** F25（specta 已在 workspace 启用）说明的是「直接内嵌 upstream 类型**能编译**、无需镜像 DTO」；本条决定的是「**不该**直接内嵌」，理由有两条且都与编译无关：`Started` 在 upstream 枚举里没有对应变体（承载不了 D5=A 的真实终态），以及把我们的 TS wire 与 submodule 的 API 版本解耦。**两条事实并立不矛盾**——F25 保留原样不动。
+
+---
+
+## 5. 实施步骤
+
+> 每步给出编辑内容 → 验证 → 通过判据。**不要**跑 `cargo clippy -- -D warnings`（仓库本就红）。已知坑：共享 target 的 kache 污染会造成本地 clippy 假红，用独立 `--target-dir` 复验再判定。
+
+### S1 — 迁移 runtime lifecycle 类型（按 D1=A）
+
+新建 `backend/tauri/src/core/actor/runtime.rs`，从 `client/runtime.rs` 整体搬入（**逻辑一字不改**，只改可见性与 `use` 路径）：
+
+| 搬入 `core/actor/runtime.rs`                                                                                                          | 留在 `client/runtime.rs`                                                                                                                                                                                                                                                                             |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RuntimeRevision`（`:27-33`）、`RuntimeSnapshotData`（`:52-57`）、`RuntimeSnapshot`（`:59-96`）、`RuntimeLifecycleState`（`:98-102`） | **`RuntimeRevisionAllocator`（`:35-50`）**、**`CandidateFile`（`:297-334`）**、`MutationOutcome` / `Degradation` / `DegradationPhase`、candidate 构建函数与 `prepare_private_dir` 等文件工作、`compensation_*`（S5 删）、`RuntimeTransactionSnapshot`（S6 删）、`RuntimeLifecycleStore`（**S2 删**） |
+
+- **`CandidateFile` 不迁（C2 使 L1 的前提消失）**：改用 `PublishPromoted { operation, snapshot }` 后 actor 不再碰任何文件类型，搬迁没有收益。L1 要保护的不变量由 C2 更彻底地满足——详见 §4 D1 的 v3 后记。
+- **`RuntimeRevisionAllocator` 不迁（L2）**：留在 client 侧，`use crate::core::actor::runtime::RuntimeRevision`。F15 的「先分配 revision、再读 typed snapshot」顺序因此**原样保留**，也不需要新增 `AllocateRevision` 消息。
+- **`RuntimeLifecycleStore` / `new_runtime_lifecycle_store` 的删除挪到 S2（M9）**：S1 若把它删了，替代品（actor 的 `lifecycle` 字段）还不存在，「纯搬迁、零行为」的第一个 commit 就不成立、也无法独立回滚。S1 只搬类型。
+
+**验证：** `cargo check`；`rg 'client::runtime::(RuntimeSnapshot|RuntimeLifecycleState)' backend/tauri/src` 为 0。**此步 `RuntimeLifecycleStore` 仍应存在**（M9），其归零判据在 S2。
+
+### S2 — B1：Promoted / Applied 入 actor
+
+**附录 A.1 声明全部新增字段与消息，此处只述行为。**
+
+- `CoreActorState` 增 `lifecycle: RuntimeLifecycleState`、`lifecycle_tx: watch::Sender<RuntimeLifecycleState>`。**不增 `revisions`**（L2：allocator 留 client 侧）；
+- 新增**三条守卫消息** `PublishPromoted` / `ApplyPromoted` / `PublishApplied`（见 A.2，全部校验 active `OperationId`）。**actor 只做 lifecycle 簿记，不碰文件**——这是 C2 的裁定：
+
+  | 谁做什么                                          | 在哪                                                                                                        | 理由                                                                                                                                                                                                            |
+  | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | 建 candidate、比对哈希、`check`、原子晋升产物文件 | **client 侧 lease adapter**（沿用今天 `regenerate_runtime_with` 的顺序，`check` 走 5a 已有的 `Check` 消息） | 快照的全部输入都在 client 侧（F32）。**相位区分靠新增的类型化错误 `CheckAndPromoteError`（NH2）**，不是靠 `anyhow`——v3 说「anyhow 天然区分」是错的，今天 seam 只有一个未分化的 `anyhow::Result<[u8;32]>`（F41） |
+  | 单调性校验 + 状态提交 + watch 发布                | **actor**（`PublishPromoted`）                                                                              | actor 是 lifecycle 的**单一写者与读模型**，这正是 B1 的实质                                                                                                                                                     |
+
+  > v2 的 `CheckAndPromote { operation, request, candidate, reply -> Arc<RuntimeSnapshot> }` **在类型上就不可实现**：actor 拿不到 revision、`RuntimeSnapshotData`、解析后的 config、target core、产物字节中的任何一个（F32），却承诺返回由它们构成的快照。
+
+  **lease seam 的类型化错误（NH2 + H2 残留）**：`check_and_promote` 的返回类型由 `anyhow::Result<[u8; 32]>` 改为 `Result<[u8; 32], CheckAndPromoteFailure>`（A.1b）。**外层和把两类不同源的失败分开**——`Actor(_)` 原样透出（check 本身就是一次 actor 调用，F51），`Operation(_)` 才是本 seam 自己的两相位失败。相位标签由 **adapter 内的构造位置**打，编排层按臂分流、按 `phase` 查表，**不做字符串嗅探、不 downcast**。两相位分类学不扩大。 编排层按 **A.1b 的穷尽派发表**分流（五臂：三类豁免 / `NoBackend` → 行 6b / `Backend(_)` → 行 3 / `Operation(Check)` → 行 3 / `Operation(Promote)` → 行 4a·4b），**不经 A.7**。
+
+- **推进决策与 wire 表示拆分（C3）**：
+  - **推进决策**：`core/actor` 内一个**纯谓词** `advances_applied(outcome: ApplyOutcomeKind) -> bool`；`ApplyPromoted` 处理器在提交前调它——这是 **apply 路径唯一的推进点**；
+  - **wire 表示**：`runtime_outcome_from_apply_data` 只产 `RuntimeApplyReport` + `Vec<Degradation>`，**不再决定推进**（A.5 的契约相应改述）。两者读同一个 `outcome`，但一个决定 actor 状态、一个决定给前端看什么，不构成双决策；
+  - **restart 类路径**：5a 的 `Run` 只更新 backend 观察、不碰 lifecycle（F33b），所以 `start_promoted_runtime` / legacy 重播 / D5 的 `Started` 分支都需要一条显式的 `PublishApplied { operation, snapshot }`（与 `PublishPromoted` 同族），由 client 在 `run` 成功后发送。
+- promote 成功推进 `lifecycle.promoted` 并发布 `lifecycle_tx`；apply 成功按 §3 决定是否推进 `lifecycle.applied`；
+- **`publish_promoted` 的「拒绝非递增 revision」与 `publish_applied` 的「必须存在 Promoted 且 `identity_eq`」两条校验原样迁入 actor**（F14 的语义不能丢）。**单调性由 actor 兜底**，因此 allocator 留在 client 侧不削弱任何不变量（T-LC-01 直接打 actor）；
+- `CoreClient` 增 `lifecycle()`（同步 watch 克隆）。**不加 `LifecycleSnapshot` 消息、也不加 `subscribe_lifecycle()`**（L5）：`lifecycle_tx` 的发布发生在消息处理函数内、早于 reply（F30 已在 `commit()` 上验证同一时序），所以「await 守卫调用的 reply → 读 `lifecycle()`」已经是确定性的读后写；再加一条诊断消息只会多一个需要 `cfg(test)` 门控的面。
+
+client 侧删除：`runtime` 字段、`RuntimeLifecycleStore` / `new_runtime_lifecycle_store` 类型本身（M9：替代品在本步才存在）、`publish_promoted` / `publish_applied` / `restore_promoted` / `runtime_lifecycle_state`，以及 6 处测试构造点（`mod.rs:2256/2327/2612/2928/3983` 等）。**`runtime_revisions` 字段保留**（L2）。`promoted_runtime()` **保留同名同签名**，内部改读 `core_client.lifecycle().promoted`。
+
+**同时接上 §2.4 的 sink（L4）**：`NyanpasuClientInner` 增 `degradation: Arc<dyn CoreDegradationSink>`（值早已在 `ClientSetupArgs` 里，F29），供后台 rebuild worker 投递 degradation 使用。
+
+> **`restore_promoted` 直接删除、不迁入**：它唯一的调用者是 `change_core` 的深回滚（F14），而 B4 删掉整条深回滚路径。
+
+**四条 runtime 读 IPC**（`ipc.rs:346/362/377/390`）改读 `client.promoted_runtime()` 的新实现——facade 方法保留同名同签名，内部改为 `core_client.lifecycle().promoted`，**wire 不变**。
+
+**验证：** `rg 'RuntimeLifecycleStore|publish_promoted|publish_applied|restore_promoted|LifecycleSnapshot' backend/tauri/src` 为 0；四条读 IPC 的 bindings 不变。
+
+### S3 — B2：`CoreOperationGuard` 取代 `rebuild_gate`
+
+删除 `rebuild_gate` 字段与全部 10 处获取（F12）。**顺序约束（关键，M12 已统一为「先分配 revision」——基线 `mod.rs:1601` 就是先分配）**：
+
+```text
+begin_operation()  →  分配 revision  →  读 typed snapshots  →  build → check → promote → apply
+```
+
+- **7 处「gate → begin」紧邻的站点**：删掉 gate 那一行即可，`begin()` 已经在最前；
+- **三处例外必须调整**（H4 纠正了 v2「唯独一处」的错误陈述）：
+
+  | 站点                               | 今天的 gate→begin 间隙                                                                          | 改法                         |
+  | ---------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------- |
+  | `promote_default_runtime_config`   | gate `rebuild.rs:406` → begin `:443`；其间建 snapshot 与 candidate                              | `begin()` 提到原 gate 的位置 |
+  | `promote_existing_runtime_product` | gate `mod.rs:1391` → begin `:1423`；其间**分配 revision、读产物文件、建 snapshot 与 candidate** | 同上                         |
+  | `start_promoted_runtime`           | gate `mod.rs:1436` → begin `:1440`；其间读 Promoted                                             | 同上                         |
+
+  > `start_promoted_runtime` 的间隙**最危险**：它可以读到旧 Promoted、在 `begin()` 上排队等另一个 rebuild 跑完、然后启动**新**产物却把 Applied 关联到**旧**快照——read-then-act 竞态，产物与读模型直接对不上。三处都必须在 guard 内读快照。
+
+- `restart_core` facade（`mod.rs:491-493`）本就自取 guard，删 gate 后自然一致。
+
+**保留 coalesce（F23）**：`RebuildCoordinator` 的通道、去抖与串行语义不改；只把 worker 的错误类型保留为 `ClientError`，供 terminal handler 按 §2.3 分类。它的串行化来自 worker 单线程 + capacity-1 通道，与 gate 无关。「构建期间到达的新 commit 触发下一次 rebuild」由 `try_send` + `try_recv` 排空保证。
+
+**验证：** `rg 'rebuild_gate' backend/tauri/src` 为 0；`rebuild.rs` 的 5 个 coordinator 语义测试继续通过，并增加 terminal failure 分类测试，分别钉住安静 teardown、E-b error 路径与普通 degraded warning 路径。
+
+### S4 — 统一 apply：`apply_promoted` 改走 backend
+
+`ApplyPromoted`（A.2）内部调 `CoreBackend::apply`（F3）；**推进决策在 actor 内**由纯谓词 `advances_applied(outcome)` 做出（C3），成功推进后发布 `lifecycle_tx`。
+
+`CoreLeaseAdapter::apply_promoted` 改为调 `core.apply_promoted(&guard, &request, expected, snapshot)`（四个实参，与 A.3 的声明一致）；**删除 `apply_config_from`**（F10）。
+
+**`expected` 的取值规则（H8 改写了 v2 的规则）：**
+
+| actor 观察到的 revision | `expected`                 | 理由                                                                                                                                                                                                                                         |
+| ----------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 存在                    | `Some(..)`                 | 正常 CAS，防刷新竞态——这是 5a RQ-02 讨论的情形                                                                                                                                                                                               |
+| **缺失**                | **`None`**（无条件 apply） | **核处于停止态时天然没有 revision**。upstream 在 CAS 比较**之前**就因 `ctrl.current == None` 返回 `Error::NotStarted`（F36），所以传什么 `expected` 都不影响结果；此时返回 `Err` 反而与 §2.2「停止核给 `core_not_running` degraded」直接矛盾 |
+
+> v2 写「`expected` 为 `None` 即不变量破坏，返回 `Err`」是错的。5a 的 RQ-02 注解讨论的是**刷新竞态**下要不要带 CAS，不是停止核；本条是对它的**细化**，不是推翻——有 revision 时依旧一律 `Some`。backend 返回的 `NotStarted` 按 §2.2 第 **7b** 行映射（A.7 的分类器第 2 顺位）为 `core_not_running` degradation。
+
+按 D3=A **删除 `apply_candidate`**。
+
+#### S4 的重试判据（L6：预先定死，不留「实测再说」）
+
+旧路径 `apply_config_from` 是 5 次 × 250 ms 重试（F10）；新路径由 runtime 的 `apply_config` 承担 reconcile。**决策规则如下，实施时按规则走，不再开放讨论：**
+
+| 新路径把该类失败暴露为                                             | 动作                                                                               |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| **传输类**硬失败（连接被拒 / 连接重置 / socket 未就绪 / 读写超时） | 在 **`CoreLeaseAdapter` 层**对**仅传输类错误**补有界重试，沿用 **5 × 250 ms** 形状 |
+| `check` 失败、语义失败（revision 冲突、配置被拒）、`RolledBack`    | **一律不重试**——重试对它们没有意义，只会把一次失败放大成 5 次副作用                |
+| runtime 内部已自带重试 / reconcile 且传输类失败不外泄              | **不补**，保持单次调用                                                             |
+
+判定方法：实施时读 `CoreBackendError` 的传输类变体（Service 侧 `ClientError`、Local 侧 manager 的 IO 错误）在新路径下是否会原样冒出到 `apply_promoted` 的返回值。**实测数据（哪类错误、是否外泄、重试是否生效）写进实施报告**，但**加不加重试由上表决定，不由实测口味决定**。
+
+**验证：** `rg 'put_configs' backend/tauri/src` 只剩 `feat.rs:79`（`change_clash_mode`，PR-6 范围）；`rg 'apply_config_from|apply_candidate' backend/tauri/src` 为 0。
+
+### S5 — B3：删除 API-first patch 与补偿层
+
+`patch_running_config`（F17）重写为：
+
+```text
+guard → typed desired commit（ClashConfigClient::patch）→ 统一 rebuild → apply → 按 §3 映射
+```
+
+删除：`clash_patch` 字段与 `ClientSetupArgs.clash_patch`、`RunningConfigPatchPort`、`LegacyRunningConfigPatchBridge`、`clash_patch_gate`、`restore_applied_after_patch_failure`（F18）、`client/runtime.rs:123-190` 的 `PatchCompensationPlan` / `PatchCompensationOp` / `compensation_for`、以及 `mod.rs:1501` 的裸写。
+
+**保留** `feat::patch_clash_with_rebuild`（`feat.rs:254-336`）：它的 mixed-port / external-controller 检查与 sysproxy / systray 后效属于 PR-6e，本阶段只把它的 rebuild 闭包接到新管线上。
+
+> **B3 卡的两项对当前代码是 no-op**：`ControllerBinding` 与 `ConfigPatch mapper`（`config_patch_from_mapping`）**在代码库中不存在**（F20）。计划照实记录，**不要**为了「删掉它们」而先造出来。
+
+`patch_clash_config` 命令返回类型改为 `MutationOutcome<RuntimeApplyReport>`（与 B4 统一）。
+
+**验证：** `rg 'RunningConfigPatchPort|LegacyRunningConfigPatchBridge|clash_patch_gate|compensation_for|PatchCompensationPlan' backend/tauri/src` 为 0。
+
+### S6 — B4：`change_core` 降级为普通 commit-first mutation
+
+新形态（对比 F19 的三分支回滚）：
+
+```text
+guard → ApplicationClient::patch(core = new)   ← desired 提交；此后除 §2.3 的 E-a/E-b 外一律 degraded
+      → 统一 rebuild（新核）→ check → 晋升产物 → PublishPromoted   （C2：文件工作在 client）
+      → RunningIdentity → (身份, FaithfulLifecycle) 原子守卫联合读        （NH1）
+          在跑        → ApplyPromoted          ← apply 内部承载切核（Switched）
+                         actor 内 advances_applied() 决定推进（C3）
+          已停        → restart()              ← 核本来就停着：启新核，与今天同行为
+                         Ok  → PublishApplied，outcome=Started      （C3）
+                         Err → CommittedDegraded(CoreLifecycle /
+                                 core_start_failed)，Applied 不推进  （R1）
+          无后端      → §2.2 第 6b 行 degraded（core_backend_unavailable，NH8）
+        注：只有「在跑」这条走 runtime_outcome_from_apply_data()（C3：wire 表示的唯一决策点）；
+            「已停」两侧与各类失败由 S7 直接构造 report（Started / NotApplied）。
+```
+
+**删除**：legacy `Config::verge().draft()/apply()/discard()`、回滚重建、`restore_product` 调用、回滚分支里的两次 old-core restart、`RuntimeTransactionSnapshot`（连类型一起删——change_core 是它唯一的使用者）。
+
+**`RolledBack` 时的终态**（B4 卡与 Exit 判据）：desired = 新核，Promoted = 新配置，Applied = 旧值。**不做**第二套应用层回滚。
+
+#### 「核在跑吗」怎么判（H5：`Ok(None)` ≠ 已停止）
+
+`state.running` 是**身份缓存**，恒初始化为 `None`，只有 GUI 发过 `Run` 才填充；而 `pre_start` 会 `observe_status()`，所以进程启动后 attach 到一个**已在运行**的 Service 核完全可能（F33）。此时联合读的身份分量是 `None` 但生命周期分量是 `Running`——**核正在跑**——照 v2 的写法会对一个运行中的核走 `restart()`，把用户的连接全部打断。
+
+**判据必须读忠实六态，不能读 `CoreStatusView.state`（NH1）**：后者是二值投影，`Starting`/`Restarting` 被压成 `Stopped`、`Stopping` 被压成 `Running`（F40）——直接用它会把下表**三个分支判反**。这与 5a 规划期裁过的 wire 塌缩是同一类问题，只是换了场景。
+
+**裁定：`RunningIdentity` 的 reply 扩为一次原子守卫读**，返回 `(Option<CoreRequest>, FaithfulLifecycle)`——身份与忠实生命周期在**同一个 mailbox 轮次内**取齐，杜绝两次查询之间的撕裂读（A.2 已改声明）。真值表从这个联合值取：
+
+| 身份      | `FaithfulLifecycle`                                 | 分支        | 理由                                                                                   |
+| --------- | --------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------- |
+| `Some(_)` | 任意                                                | **apply**   | 本进程启的核，身份已知                                                                 |
+| `None`    | `Running` / `Starting` / `Restarting` / `Switching` | **apply**   | 核在跑或正在起来——apply 能承载切换，不该重启                                           |
+| `None`    | `Stopped { .. }`                                    | **restart** | 真的停着，D5=A 的启核分支                                                              |
+| `None`    | `Stopping`                                          | **restart** | 正在停——等它停稳后启新核；**注意二值投影会把它读成 `Running`**，这正是必须读六态的原因 |
+| —         | 后端不可用（`Err(NoBackend)`）                      | degraded    | §2.2 第 **6b** 行（`core_backend_unavailable`，NH8）                                   |
+
+> **先取 guard 再读**，所以联合读到的值不会被并发操作改写。attach 场景与三个过渡态由 **T-B4-06** 钉住（`Starting` / `Restarting` / `Stopping` 各至少一例断言分支方向——这三例正是二值投影会判反的那三个）。
+
+#### `restart()` 残余审计（L3）与 F8 的重新表述
+
+v1 说「事务内 `restart()` 恰好一次」，**那是错的**：新流程的切核由 `CoreBackend::apply` 内部承载（F27 的 upstream doc 明写「`core_type` 与运行核不同即为切换」，产出 `Switched`），`restart()` 在核**在跑**的那条主路径上根本不出现。审计结果（F26）：
+
+| `restart()` 调用点                                          | B3/B4 之后         | 归属                                                 |
+| ----------------------------------------------------------- | ------------------ | ---------------------------------------------------- |
+| `change_core` 主路径 + 两处回滚（`rebuild.rs:315/333/377`） | **删除**           | B4                                                   |
+| `patch_running_config` 的 restart 分支（`mod.rs:1540`）     | **删除**           | B3——restart-vs-apply 改由 `apply` 自己分类           |
+| `start_promoted_runtime`（`mod.rs:1441`）                   | **保留**           | 启动路径；apply 不启核（F27）                        |
+| `regenerate_and_restart_for_legacy`（`rebuild.rs:271`）     | **保留**           | legacy replay（`feat.rs:244/369/392`），PR-6/7a 范围 |
+| `change_core` 的**停止态**分支（D5=A 新增）                 | **保留，条件触发** | B4                                                   |
+
+**结论：`restart()` 归零不了**，方法与 `target_core` 机制都必须留着（D3 只删 `apply_candidate`）。
+
+**F8 的重新表述**：`restart()` 的 `target_core.take()` 是一次性消费，其目的是「回滚深路径不得重启失败的新核」。B4 删掉整条深回滚路径后，**这个防护对象消失了**——`take()` 从「防回滚误重启」退化为「防同一 lease 内第二次 restart 误用陈旧目标」。因此 T-B4-03 改钉真实语义（见 §6.3）：**同一 lease 内 `check_and_promote` 设置的 `target_core` 只能被消费一次；若停止态分支触发，`restart()` 使用的正是本次 promote 的新核**。
+
+**验证（一）：** `rg 'lease\.restart\(\)|\.restart\(\)\.await' backend/tauri/src/client/rebuild.rs` 只剩 `regenerate_and_restart_for_legacy` 与 change_core 的停止态分支两处。
+
+#### `change_clash_core` 去掉 `run_legacy_verge_mutation` 包裹（H7）
+
+v2 写「外层 `run_legacy_verge_mutation` 的 typed 重播保留（PR-7a 才删）」，**那是在追溯它的存在理由之前写的，现予纠正**。
+
+包裹器在这个调用点的理由由代码注释写死：「核心切换动了 legacy verge,须回灌 typed actors」（`ipc.rs:489`）。**B4 恰恰删掉那次 legacy verge 写入**（`Config::verge().draft().clash_core = ...`），前提随之消失：
+
+- 前提没了：`legacy_patch_between(previous, desired)` 得到空 patch，整趟重播是 no-op；
+- 类型装不下：包裹器签名是 `Fut: Future<Output = anyhow::Result<()>>` → `ClientResult<()>`（F35），承不住 `MutationOutcome<RuntimeApplyReport>`；
+- **还会违 I-A**：它在 `mutate()` 成功后仍要做 legacy restore / 投影刷新 / typed patch plan / finalize，这些**发生在 typed commit 之后**却一律返回普通 `Err`——用户会看到「切核失败」而磁盘上核已经换了。
+
+**做法**：`change_clash_core` 命令直接调 `client.change_core(core)`，返回 `MutationOutcome<RuntimeApplyReport>`；`LegacyVergeBridge` 参数从该命令签名移除。**其余 7 处 `run_legacy_verge_mutation` 调用点一律不动**（今天共 8 处，含 `change_clash_core` 自身）（它们确实还在写 legacy verge），包裹器本身也不改签名——不为一个即将退场的调用点去泛化一个即将删除的 compat 包裹器。
+
+**「摘掉之后，残余的 legacy 读者谁来喂？」——F38 / F39 预先钉死这条**（leader 独立核验，v3.1 记入）：
+
+- **喂食者是 state actor 的提交路径，不是包裹器**：`ApplicationActor::commit` 在每次 typed 提交内部 `prepare` → 持久化 → `mirror.apply()`（`state/application.rs:75-87`；条件替换 `:101-103` 同样），而 `Patch` 消息正汇入这个 `commit`（`:140-150`）。B4 的 `ApplicationClient::patch(core = new)` 因此**自动刷新镜像**；
+- **投影确实含 `clash_core`**：`apply_app_config_to_legacy_verge` 的 `draft.clash_core = Some(yaml_convert(snap.core)?)`（`bridge/verge.rs:678`）；
+- **四个残余读者读到的都是新鲜值**（F39）：`core/tray/mod.rs:167,336`、`feat.rs:379`、`core/clash/core.rs:98`；
+- **镜像不可失败**：`fn apply(self: Box<Self>)` 返回 unit（`bridge/verge.rs:149-152`），所以摘掉包裹器**不新增任何 degradation 路径**；
+- **`verge_update_lock` 的互斥域退出是正确的**：B4 后 change_core 不再触碰 legacy draft，留在锁内反而是无谓的跨域串行。
+
+> 换句话说：包裹器负责的是 **legacy → typed 的回灌**，而残余读者依赖的是 **typed → legacy 的镜像**——**两个方向**。B4 删掉的是前者的输入源，后者一直由 state actor 独立维护，不受影响。
+
+> 这是 CLAUDE.md §11「优先可迁移的破坏性变更，而不是加兼容层」的直接应用：前提消失的兼容层就该在该阶段摘掉，而不是留到 PR-7a 陪葬。**leader 已于 2026-08-02 裁定摘除**（独立核验过上述镜像链后确认），不改为泛化包裹器——本条不再是待决问题。
+
+命令 `patch_clash_config` **本来就没有**走包裹器（`ipc.rs:435-458`），不受影响。
+
+**验证（二）：** `rg 'restore_promoted|RuntimeTransactionSnapshot' backend/tauri/src` 为 0。
+
+### S7 — degradation 映射与 `RuntimeApplyReport`
+
+新增 `RuntimeApplyReport`（D4=A 的三字段，`serde` + `specta`；F25 确认 workspace 已启用 specta，upstream 类型可直接内嵌）与 `RuntimeApplyOutcome`（D5=A），放在 `client/runtime.rs` 与 `MutationOutcome` 同层。
+
+新增纯函数 `runtime_outcome_from_apply_data(data: &CoreApplyData, promoted_revision: u64) -> (RuntimeApplyReport, Vec<Degradation>)`。**它的契约按 C3 改述：它是「wire 表示」的唯一决策点，不再是「Applied 是否推进」的决策点**——后者由 actor 内的纯谓词 `advances_applied(outcome)` 独占（S2 / S4）。两者读同一个 `outcome`：一个决定 actor 状态、一个决定给前端看什么，职责不重叠。§3 的 12 格 parity 矩阵仍全部由 `runtime_outcome_from_apply_data` 决定，测试直接打它。
+
+**三条不经过它的路径**（都没有 `CoreApplyData`，由 S5/S6 直接构造报告）：
+
+| 路径                                                    | report                                                   | degradations                          |
+| ------------------------------------------------------- | -------------------------------------------------------- | ------------------------------------- |
+| 停止态启核成功（D5=A / R1）                             | `outcome = Started`、`applied_revision = Some(promoted)` | 空                                    |
+| 停止态启核失败（R1）                                    | `outcome = NotApplied`、`applied_revision = None`        | `CoreLifecycle` / `core_start_failed` |
+| build / check / promote / 传输 / `NoBackend` 失败（C1） | `outcome = NotApplied`、`applied_revision = None`        | §2.2 对应行                           |
+
+> 三行的 `desired_revision` 都填本次分配的 revision——它确实分配了，这不是猜测。
+
+**同时收敛 §2.4 的两条投递路径：**
+
+- 删掉 `map_runtime_rebuild_degradation`（`mod.rs:981`）与它那条「错误面撑不住精度」的 doc——5b 之后 rebuild 失败带着 §2.2 的 phase/code 出来，`collect_post_commit_degradations` 直接并入即可；
+- 后台 worker 闭包（`mod.rs:435-449` 处注册的那条）改为：拿到 degradations 后逐条 `inner.degradation.publish(..)`，`tracing::warn!` 保留。
+
+**验证：** T-AP-01…12 全绿；T-PC-09 证明后台失败到达 sink；T-PC-10/11 证明无-commit 入口仍是普通 `Err`。
+
+### S8 — 测试适配
+
+按 §6 的清单逐个改。原则：**只改构造与断言目标，不改测试语义**；coordinator 的 5 个测试与 5a 的 16 个 `client/core.rs` 测试**期望零改动**（若被迫改动，说明 B2/B3 溢出了范围，停下核查）。
+
+### S9 — 门禁
+
+```powershell
+pnpm fmt:backend
+pnpm lint:rustfmt
+pnpm lint:clippy
+cargo build --manifest-path .\backend\Cargo.toml -p fake-core --bin manager-probe-core
+pnpm test:backend
+git diff frontend/interface/src/ipc/bindings.ts
+pnpm lint:ts
+pnpm architecture-ledger
+pnpm lint:architecture-ledger
+```
+
+**bindings 预期差异（恰好这些）**：新增 `RuntimeApplyReport` 与 `RuntimeApplyOutcome` 两个 TS 类型（D5=A：第二个是**本仓自有**枚举，不是 upstream 的 `ApplyOutcomeKind`）；`changeClashCore` 与 `patchClashConfig` 的返回类型由 `null` 变为 `MutationOutcome<RuntimeApplyReport>`。**其余零变化**——四条 runtime 读 IPC、`getCoreStatus` 均不得变。 `changeClashCore` 命令**去掉了 `LegacyVergeBridge` 参数**（H7），但 tauri `State<'_, _>` 参数本就不进 bindings，**因此该改动的 bindings 差异为零**——若 diff 里出现它，说明改错了地方。
+
+**ledger 预期**：`config_calls` 应**下降**（B4 删掉 `change_core` 的 legacy draft/apply/discard 三处 `Config::verge()`）；`migration_markers` 应下降（`rebuild.rs` 的 core-selection 与 log-sink 两条 TODO 随 B4 删除）；`test_real_dirs` **必须仍为 0**。逐项核对后再 `--write-snapshot`。
+
+---
+
+## 6. 测试矩阵
+
+> **新增测试组的三处自查（定为规矩）**：每加一组测试，必须同时更新 **①本节的定义、②§7 的 RQ 出口门清单、③§9 的提交分配**。T-PC-12 与 T-CL 两次都只落了①而漏了②③——同一形状出现两次，靠逐条对照裁定列表抓不住，只能在加测试组时按这三处过一遍。
+
+### 6.1 apply parity（RQ-03；§3 的 12 格）
+
+| ID         | 组合                                        | 断言                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ---------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T-AP-01    | `Noop` 无 warning                           | Applied **推进**至 Promoted；`Applied`；degradations 空                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| T-AP-02    | `Noop` + warning                            | Applied 推进；`CommittedDegraded`；恰 1 条 `RuntimeApply` durability                                                                                                                                                                                                                                                                                                                                                                                                      |
+| T-AP-03/04 | `Patched` 无/有 warning                     | 同上形态                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| T-AP-05/06 | `Reloaded` 无/有 warning                    | 同上形态                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| T-AP-07/08 | `Restarted` 无/有 warning                   | 同上形态                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| T-AP-09/10 | `Switched` 无/有 warning                    | 同上形态                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| T-AP-11    | `RolledBack` 无 warning                     | Applied **不推进**；`CommittedDegraded`；恰 1 条 `CoreRollback`；**并断言 report 值**：`value.outcome == RolledBack`（**不是 `NotApplied`**——§2.2 行 7a 的例外）、`value.desired_revision` = 本次分配的 revision、`value.applied_revision` = 旧值                                                                                                                                                                                                                         |
+| T-AP-12    | `RolledBack` + warning                      | Applied 不推进；**2 条** degradation（`CoreRollback` + durability）；report 值断言同 T-AP-11                                                                                                                                                                                                                                                                                                                                                                              |
+| T-AP-13    | Local / Service 双后端对同一 outcome 同映射 | **不比共用的 mapper**（M10）——parity 的价值全在各后端的转换层。Local 侧**直接在模块内单测既有的 `core::actor::backend::map_apply_outcome`**（喂 manager `ApplyOutcome` fixtures → `CoreApplyData`；`:975`/`:986` 已有两个测试可扩），Service 侧走 IPC harness 解码（套 `transport_available()`，F24）；两侧 `CoreApplyData` 逐字段相等。**不需要 `TestBackend` 前置**——M10 由此彻底关闭。注意它与新增的 `runtime_outcome_from_apply_data` 是**两个不同函数**（NH9 / F44） |
+
+### 6.2 post-commit 失败矩阵（RQ-01；§2.2 的七项）
+
+> **每一行都必须同时断言 report 值（C1）**：v2 的 T-PC-02…07 与 T-B4-05 只断言外层变体与 degradation、从不看 `value`——正是这个空转掩盖了「report 没有诚实取值」的洞。第 2–7 行一律断言 `outcome == NotApplied` 且 `applied_revision == None`，`desired_revision` 等于本次分配的 revision。
+
+| ID       | 失败注入                                           | 入口                                           | 断言                                                                                                                                                                                                                                                                                                                                                                         |
+| -------- | -------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T-PC-01  | acquire 超时                                       | `change_core`                                  | `Err`；**desired 未提交**（typed 快照未变）                                                                                                                                                                                                                                                                                                                                  |
+| T-PC-01b | acquire 超时                                       | profile mutation 的 post-commit rebuild        | `CommittedDegraded`；已提交 profile 保留；`CoreLifecycle` / `core_operation_unavailable` / `retryable=true`                                                                                                                                                                                                                                                                  |
+| T-PC-02  | build 失败                                         | `change_core`                                  | `CommittedDegraded`；`RuntimeBuild`；desired = 新核                                                                                                                                                                                                                                                                                                                          |
+| T-PC-03  | check 失败                                         | `change_core`                                  | `CommittedDegraded`；`RuntimeCheck`；Promoted 未推进                                                                                                                                                                                                                                                                                                                         |
+| T-PC-04a | promote **前置**失败（candidate 哈希不符）         | `patch_running_config`                         | `CommittedDegraded`；`RuntimePromote` / `runtime_promote_failed`；**产物保持旧值**；report = `NotApplied`                                                                                                                                                                                                                                                                    |
+| T-PC-04b | promote **写后校验**失败（产物已写、读回哈希不符） | `patch_running_config`                         | `CommittedDegraded`；同上 phase/code（message 区分）；**产物 = 新、Promoted = 旧**（分裂窗口）；report = `NotApplied`；**并断言下一次 rebuild 使两者重新收敛**——这是「自愈」论证的实证，没有它 §2.2 的 4b 就只是一句主张                                                                                                                                                     |
+| T-PC-05  | revision 冲突                                      | `patch_running_config`                         | `CommittedDegraded`；`RuntimeApply` / `revision_conflict`；Applied 不变                                                                                                                                                                                                                                                                                                      |
+| T-PC-06  | IPC 传输丢失                                       | `change_core`                                  | `CommittedDegraded`；`core_transport_lost`；Applied 不变。**实现方式（L7）：优先用 `TestBackend` 脚本化传输错误**——不需要真 harness、也就不需要 `transport_available()` 守卫；只有在必须验证真实 `ClientError` 映射时才起真 IPC harness，那时套守卫（F24）                                                                                                                   |
+| T-PC-07  | apply error（非 RolledBack）                       | `patch_running_config`                         | `CommittedDegraded`；`runtime_apply_failed`；Applied 不变                                                                                                                                                                                                                                                                                                                    |
+| T-PC-08  | 启动路径同类失败                                   | `promote_default_runtime_config`               | **`Err`**（无 desired commit）且 degradation sink 为空——证明分界线按入口区分                                                                                                                                                                                                                                                                                                 |
+| T-PC-09  | 后台 rebuild 失败                                  | `RebuildCoordinator` worker                    | 普通 degradation 到达 `CoreDegradationSink`，而不是只进日志；guard acquisition bare `Err` 映射 `CoreLifecycle` / `core_operation_unavailable`。terminal 分类另断言：`ShuttingDown` 安静退出；`StaleOperation` / `LifecycleInvariant(_)` / revision exhaustion 走 E-b invariant violation；普通错误保留 degraded warning。同步 caller 的普通失败仍出现在 `MutationOutcome` 里 |
+| T-PC-13  | revision allocator 耗尽                            | allocator 单测 + 后台 orchestration            | allocator 返回类型化 `RuntimeRevisionExhausted`；真实 `rebuild_running_config_in_background` 路径返回普通 `Err`，degradation sink 严格为空，不得映射 `CommittedDegraded` 或 `core_operation_unavailable`                                                                                                                                                                     |
+| T-PC-14  | legacy clash mirror 持久化失败                     | `finish_successful_clash_rebuild` seam         | helper 返回原始 `T`，因此 persistence 失败不可能翻转为 `Err`（类型系统承担该保证）。测试断言 in-memory mirror 已 apply、persistence callback 已调用、callback 确实产生注入 `Err` 且该错误被吞掉，最后直接断言返回的 `T` 未变                                                                                                                                                 |
+| T-PC-10  | build / check / apply 失败                         | **`enhance_profiles`**（F34 ③）                | **普通 `Err`**，**零 degradation**、**不进 sink**——命令 doc 明写无前置 commit（§2.4 ④）                                                                                                                                                                                                                                                                                      |
+| T-PC-11  | apply 返回 `RolledBack`                            | **`regenerate_and_apply_for_legacy`**（F34 ④） | **普通 `Err`**——否则 legacy draft 会被误当成功而 `apply()`，在磁盘留下一份从未生效的配置（§2.4 ④ 的关键差异）                                                                                                                                                                                                                                                                |
+| T-PC-12  | **豁免边界分类**（NH4 / NH6）                      | 任意 commit-first 入口                         | 四例分类断言：①`ShuttingDown` → `Err`、**零 degradation**；②`LifecycleInvariant(PromotedRegression)` → `Err` + 错误级日志、**零 degradation**；③**`Backend(_)` → `CommittedDegraded`**；④**`NoBackend` → `CommittedDegraded`（`core_backend_unavailable`）**。**③④ 是关键**——它们证明豁免**吞不掉真实运行时失败**；没有 T-PC-12，§2.3 的 `matches!` 规则就只是纸面上的       |
+
+### 6.2b A.7 分类器单测（T-CL；测分类器本身，不经管线）
+
+直接喂 `CoreBackendError` 构造值，断言 `classify_apply_backend_failure` 的返回类。**与管线解耦**——管线测试证明「行 → 元组」，这组证明「错误变体 → 行」。
+
+| ID      | 输入                                                                                                                             | 期望类 → 行                                                         |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| T-CL-01 | `Local(Error::RevisionConflict { .. })`；`Service(Server { error_kind: Some("revision_conflict"), .. })`                         | `RevisionConflict` → 行 5（两侧同类，这就是 parity）                |
+| T-CL-02 | `Local(Error::NotStarted)`；`Service(Server { error_kind: Some("not_started"), .. })`                                            | `NotRunning` → 行 7b                                                |
+| T-CL-03 | `Service(Request { .. })`、`Service(HttpStatus { .. })`、`Service(BuildClient(..))`                                              | `TransportLost` → 行 6a（**`HttpStatus` 在此**，见 A.7 判别原则）   |
+| T-CL-04 | `Service(Server { error_kind: None, .. })`、`Service(Decode { .. })`、`Service(EmptyData { .. })`、`Binary(..)`、`Construct(..)` | `Other` → 行 7c（**`Decode` / `EmptyData` 在此**，v6 曾误归传输类） |
+
+> T-CL-03 / T-CL-04 是这组的重点：它们钉住的正是本轮修正的两处归类。`Server { error_kind: None }` 单列一例，因为它同时是 F50 那条冲突的输入形状。
+
+### 6.3 B1/B2/B4 结构测试
+
+| ID      | 断言                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T-LC-01 | Promoted 推进拒绝非递增 revision（迁自 F14 的 `publish_promoted` 校验）                                                                                                                                                                                                                                                                                                                                    |
+| T-LC-02 | Applied 推进要求存在 Promoted 且 `identity_eq`（迁自 `publish_applied` 校验）                                                                                                                                                                                                                                                                                                                              |
+| T-LC-03 | `lifecycle()` 是同步 watch 克隆，慢 `Run` 阻塞期间**立即返回**（沿用 5a 的活性性质）                                                                                                                                                                                                                                                                                                                       |
+| T-B2-01 | **两个并发 rebuild 不重叠**，后一个在 `OperationGate` FIFO 之后**读取最新 snapshot**（Exit 判据原文）                                                                                                                                                                                                                                                                                                      |
+| T-B2-02 | **三处** gate→begin 例外都在 guard 内构建快照 / candidate（H4 纠正了 F12）：`promote_default_runtime_config`、`promote_existing_runtime_product`、`start_promoted_runtime`。三例**分别断言不合并**——`start_promoted_runtime` 那例必须构造「读到旧 Promoted → 在 begin 上排队 → 启动新产物」的竞态窗口并证明它已关闭                                                                                        |
+| T-B4-01 | change-core `RolledBack`：desired = **新核**、Promoted = **新配置**、Applied = **旧值**（Exit 判据原文）                                                                                                                                                                                                                                                                                                   |
+| T-B4-02 | change-core 成功（**核在跑**）：三者一致推进；`RuntimeApplyReport.outcome == Switched`；**全程零次 `restart()`**——切核由 `apply` 承载（L3 的真实语义）。除 in-memory backend pin 外，必须有 `process_core_bridge.rs` 的真实进程桥端到端测试，断言同一 PID 完成 switch；它接管 §6.4 删除的进程级 rollback 测试所留下的真实进程覆盖。                                                                        |
+| T-B4-03 | change-core（**核已停**，D5=A 分支）：`RunningIdentity` 返回 `Ok((None, FaithfulLifecycle::Stopped { .. }))` → 恰好一次 `restart()`，且该次 Run 请求用的是**本次 promote 的新核**（`target_core.take()` 消费的正是它，F8 重述）；`outcome == Started`                                                                                                                                                      |
+| T-B4-04 | `restart()` 的 `target_core` 一次性消费：同一 lease 内第二次 `restart()` 落回 typed 快照而非重用陈旧目标（把 F8 的机制本身钉住，与 change_core 流程解耦）                                                                                                                                                                                                                                                  |
+| T-B4-05 | change-core 停止态分支的**失败侧**（R1）分两臂：① `Actor(StaleOperation \| LifecycleInvariant(\_) \| ShuttingDown)` 按 §2.3 返回普通 `Err`、零 degradation；②真实 backend/operation 失败 → `CommittedDegraded`，`phase = CoreLifecycle`/`code = "core_start_failed"`；desired = 新核（已提交）、Promoted = 新配置、**Applied 不推进**。②并断言 report 三字段，含 `desired_revision ==` 本次分配的 revision |
+| T-B4-06 | **attach 场景 + 三个过渡态**（H5 / NH1）：(a) `pre_start` 观察到 `Running` 但 `state.running == None` → change_core **必须走 apply**（`outcome == Switched`）、**零次 `restart()`**；(b) `Starting`、(c) `Restarting`、(d) `Stopping` 各一例，断言分支方向。**(b)(c)(d) 正是二值 `CoreStatusView.state` 会判反的三个**（F40），所以它们同时也是「判据确实读了忠实六态」的证明                              |
+
+### 6.4 回归（期望零改动通过）
+
+- `rebuild.rs` coordinator 五连：`:469 / 505 / 537 / 573 / 623`（B2 的 coalesce 不变式）；
+- `client/core.rs` 的 16 个 5a 测试（`:671`…`:1182`）——**若被迫修改，说明范围溢出**；唯一预期的例外见下一条；
+- **`rollback_build_failure_restarts_the_committed_old_core`（`rebuild.rs:1276`，`9727ef1d4` 为 PR-5a Finding 1 新增）**：它脚本化的正是 change_core 的**回滚重建失败**分支，而 B4 把整条深回滚路径删掉。该测试**必须删除**，其保护的不变量由 **T-B4-04** 接手（直接钉 `target_core` 的一次性消费机制，不再依赖已消失的回滚流程）。实施时在 commit body 里写明这次接管，否则会被读成「删了个回归测试」；
+- **B4 删除深回滚后必然失效的另外 6 条**（M11 补齐，逐条写明理由）：
+
+  | 测试                                                                   | 位置                          | 为什么失效 / 谁接管                                                                                      |
+  | ---------------------------------------------------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------- |
+  | `change_core_rolls_back_via_second_regenerate_and_restart`             | `rebuild.rs:710`              | 断言的「二次重建 + 重启」在 B4 后不存在。**删除**                                                        |
+  | `change_core_rollback_rebuild_failure_restores_product_and_errors`     | `rebuild.rs:756`              | 断言 `restore_product` + 返回 `Err`；B4 改为 `CommittedDegraded` 且不再回滚产物。语义由 **T-B4-01** 接管 |
+  | `s01_contract_product_restore_leaves_runtime_read_model_on_new_core`   | `rebuild.rs:1014`             | 产物恢复路径整体删除。读模型终态由 **T-B4-01** 接管                                                      |
+  | `change_core_product_restore_advances_applied_when_promoted_ahead`     | `rebuild.rs:1103`             | 同上；「Promoted 领先于 Applied」的不变量由 **T-LC-02** 接管                                             |
+  | `change_core_successful_rollback_publishes_applied_from_old_core`      | `rebuild.rs:1227`             | 回滚后 publish_applied 的路径不存在。**删除**                                                            |
+  | `s09_process_change_core_new_start_exit_rollback_old_restart_succeeds` | `process_core_bridge.rs:1205` | 进程级回滚重启场景消失。**删除**；进程级切核成功路径由 **T-B4-02** 覆盖                                  |
+
+  > 连同上一条的 `rollback_build_failure_restarts_the_committed_old_core`，B4 共删 **7** 条回滚测试。**每一条都要在 commit body 里写明「删除原因 + 接管者」**——一次性删掉 7 条测试而不交代，任何审查者都会（合理地）怀疑是在掩盖回归。
+
+- `s04_concurrent_restart_waits_until_change_core_rollback_completes`（`rebuild.rs:931`）：B4 删掉回滚分支后该测试**必须重写**为「并发 restart 在 change_core 事务后串行执行」，语义（互斥）保持。
+
+---
+
+## 7. Exit 判据映射
+
+| task.md B-Exit                                                                                     | 交付步骤 | 验证                              |
+| -------------------------------------------------------------------------------------------------- | -------- | --------------------------------- |
+| `rg 'rebuild_gate\|clash_patch_gate\|RunningConfigPatchPort\|LegacyRunningConfigPatchBridge'` 为 0 | S3、S5   | 该 `rg` 命令输出为空              |
+| apply parity：Noop/Patched/Reloaded/Restarted/Switched/RolledBack；Warning 正交                    | S4、S7   | T-AP-01…13 全绿（12 格 + 双后端） |
+| change-core rollback 断言 desired=new、Promoted=new、Applied=old                                   | S6       | T-B4-01                           |
+| 两个并发 rebuild 不重叠，后一个读最新 snapshot                                                     | S3       | T-B2-01                           |
+| RQ-01 已作答（含 §2.4 的**四类**投递上下文与 §2.3 的两条豁免）                                     | §2       | T-PC-01…12 + **T-CL-01…04**       |
+| RQ-03 已作答（含 R1 的 `Started` 与 C1 的 `NotApplied` 两个非 apply 终态）                         | §3       | T-AP-01…13 + T-B4-03 / T-B4-05    |
+
+---
+
+## 8. 风险与回滚
+
+| 风险                                                      | 概率 | 影响                    | 缓解                                                                                                                                                                                          |
+| --------------------------------------------------------- | ---- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Promoted/Applied 迁入 actor 后四条读 IPC 行为漂移         | 中   | 前端读到空/陈旧 runtime | facade 方法保持同名同签名，内部改实现；四条 IPC 的 bindings 必须零变化（S9 判据）                                                                                                             |
+| 删 `rebuild_gate` 后 coalesce 语义被牵连                  | 中   | 重复/丢失 rebuild       | `RebuildCoordinator` 一行不改；五个 coordinator 测试零改动通过（T-6.4）                                                                                                                       |
+| `apply_promoted` 改道后重试语义丢失                       | 中   | 瞬时失败变成硬失败      | 旧路径是 5 次 250 ms 重试（F10）。**判据已在 S4 预先定死**：仅传输类错误在 `CoreLeaseAdapter` 层补 5 × 250 ms，check / 语义失败 / `RolledBack` 一律不重试；实测数据入实施报告，但**不改判据** |
+| `change_core` 在停止态下的行为回归                        | 中   | 切核后核不再自动启动    | D5=A 的 `RunningIdentity` 分支保留今天的启核行为；成功侧 T-B4-03、失败侧 T-B4-05 钉住                                                                                                         |
+| `RolledBack` 被误判为成功                                 | 中   | Applied 错误推进        | §3 的映射集中在 `runtime_outcome_from_apply_data` 一个纯函数里；T-AP-11/12 直接打它                                                                                                           |
+| `target_core.take()` 在多次 restart 下失效                | 低   | 启核用错目标            | T-B4-04 直接钉机制本身（不再依赖 B4 已删除的回滚流程）；T-B4-03 钉停止态分支只消费一次                                                                                                        |
+| B3 删除面过大牵连 profile mutation 的 `CommittedDegraded` | 中   | 既有 degraded 路径回归  | `MutationOutcome::from_parts` 是唯一产出点（F22），不动它；profile 侧测试零改动                                                                                                               |
+| Service parity 测试在 CI 某平台不可用                     | 中   | parity 静默消失         | 沿用 5a 规则：`transport_available()` 守卫 + 支持平台上必须常规运行（F24）                                                                                                                    |
+
+**回滚：** 改动集中在 `core/actor/{mod,backend,runtime,types}.rs`、`client/{mod,core,rebuild,runtime}.rs`、`ipc.rs`、`setup.rs`、`bridge/verge.rs`。S1–S2 可独立成一个 commit（类型迁移 + actor 增字段，生产路径未变），单独回滚不影响行为。
+
+---
+
+## 9. 提交切分建议
+
+1. `refactor(core): move runtime lifecycle types into the actor module` —— S1（纯搬迁，零行为）；
+2. `feat(core): own promoted and applied state in CoreActor` —— S2 + T-LC；
+3. `refactor(client): replace rebuild_gate with the core operation guard` —— S3 + T-B2；
+4. `feat(core): route promoted apply through the core backend` —— S4 + S7 + T-AP + **T-CL-01…04**（分类器与 wire 映射同批落地，回归可归因）；
+5. `refactor(client): delete the api-first patch and compensation layer` —— S5 + T-PC-01…08、T-PC-10/11、**T-PC-12**（豁免边界分类测试随 §2.3 的规则一起落地）；
+6. `feat(client): publish background rebuild degradations to the core sink` —— §2.4 的两项动作 + T-PC-09；
+7. `refactor(client): make change_core a commit-first mutation` —— S6 + T-B4 + S8 + S9。
+
+第 2 步与第 3 步**必须分开**：前者改所有权，后者改并发原语；混在一起的 diff 无法判断回归来自哪一侧。第 6 步单独成 commit：它是 §2.4 认定的既有 I-B 缺口修复，与 B1–B4 的删除面无关，混进去会让「本来就漏、还是这次改漏」分不清。
+
+---
+
+## 10. 明确 out-of-scope（登记去向）
+
+| 项                                                                                                                        | 去向                                                 |
+| ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| watch snapshot 的状态投影扩展、100 条 `LogFrame` ring                                                                     | **PR-5c / C1**                                       |
+| `set_mode` / `reconcile_mode`、删 5 s 轮询与 statics                                                                      | **PR-5c / C2**                                       |
+| macOS DNS 归入 actor                                                                                                      | **PR-5c / C3**                                       |
+| `feat::patch_clash_with_rebuild` 的 sysproxy/systray/locale 后效                                                          | **PR-6e**                                            |
+| `on_profile_change` 的连接中断服务                                                                                        | **PR-6**                                             |
+| `UpdaterManager::global()`                                                                                                | **PR-6d**                                            |
+| `run_legacy_verge_mutation` 的 typed 重播（**其余 7 处调用点**；今天共 8 处，`change_clash_core` 那处 H7 已在本阶段摘除） | **PR-7a**                                            |
+| `feat.rs:79` 的 `change_clash_mode` 裸 `put_configs`                                                                      | **PR-6**（不在本阶段的 apply 管线内）                |
+| `ControllerBinding` / `config_patch_from_mapping`                                                                         | **不存在**（F20）；B3 卡该两项记为 no-op，不新造再删 |
+
+---
+
+## 11. 附录 A — 接线单点声明（normative；其它小节只引用，不复述）
+
+> 沿用 5a 的反漂移机制：本附录是 5b 全部新增/变更类型与消息的**唯一声明处**。
+
+### A.1 actor 侧新增
+
+```rust
+// core/actor/runtime.rs（S1 从 client/runtime.rs 迁入，逻辑不改）
+pub(crate) struct RuntimeRevision(u64);
+pub(crate) struct RuntimeSnapshotData { /* 字段与迁移前逐字相同 */ }
+pub(crate) struct RuntimeSnapshot { /* 字段与迁移前逐字相同 */ }
+pub(crate) struct RuntimeLifecycleState {
+    pub(crate) promoted: Option<Arc<RuntimeSnapshot>>,
+    pub(crate) applied: Option<Arc<RuntimeSnapshot>>,
+}
+// CandidateFile **不迁**（C2 使 L1 前提消失）：actor 不再碰文件类型，它留在 client/runtime.rs。
+
+// 注意（L2）：RuntimeRevisionAllocator **留在 client/runtime.rs**，
+// 它 `use crate::core::actor::runtime::RuntimeRevision`。actor 不持有 allocator。
+#[derive(Debug, thiserror::Error)]
+#[error("runtime revision space exhausted")]
+pub(crate) struct RuntimeRevisionExhausted;
+// RuntimeRevisionAllocator::allocate
+//   -> Result<RuntimeRevision, RuntimeRevisionExhausted>
+// 此错误是 §2.3 E-b，不得映射 degradation。
+
+// core/actor/types.rs —— 扩 5a 的 CoreActorError（NH4；加法式，5a 四变体不动）
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]   // 无字段枚举，四者皆成立；{0:?} 需要 Debug
+pub(crate) enum LifecycleInvariantKind {
+    /// PublishPromoted 的 revision 未严格递增
+    PromotedRegression,
+    /// PublishApplied 找不到匹配的 Promoted，或身份不符
+    AppliedWithoutPromoted,
+}
+// CoreActorError 新增第五变体：
+//   #[error("core lifecycle invariant violated: {0:?}")]
+//   LifecycleInvariant(LifecycleInvariantKind),
+// I-A 豁免 (b) 的判据即 matches!(err, StaleOperation | LifecycleInvariant(_))——§2.3 单点声明。
+
+// core/actor/mod.rs —— CoreActorState 新增字段（其余字段见 5a 现状）
+pub(crate) lifecycle: RuntimeLifecycleState,
+pub(crate) lifecycle_tx: watch::Sender<RuntimeLifecycleState>,
+
+// CoreActorArgs 新增
+pub(crate) lifecycle_tx: watch::Sender<RuntimeLifecycleState>,
+```
+
+### A.1b lease seam 的类型化错误（NH2 + H2 残留）
+
+```rust
+// client/core_bridge.rs —— 取代今天未分化的 anyhow::Result<[u8; 32]>（F41）
+
+/// 外层和：把**两类不同源**的失败分开（H2 残留）。
+/// check 阶段本身是一次 actor 调用（F51），所以 actor 错误必然会出现在这个 seam 上；
+/// 把它压进下面的两相位类型，会让 ShuttingDown / StaleOperation 失去豁免资格、
+/// 让 NoBackend 被导向行 3 而不是行 6b。
+/// 注：本类型**不能** Clone/Copy——两臂都装着不可克隆的错误值；只给 Debug + Error。
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CheckAndPromoteFailure {
+    /// 原样透出，不被改写。派发见下方的穷尽派发表（**不经 A.7**——它签名是
+    /// &CoreBackendError，装不下 CoreActorError，且作用域是 apply 路径）。
+    #[error(transparent)]
+    Actor(CoreActorError),
+    /// 本 seam 自己的失败，仍然**恰好两相位**（NH2 的分类学不扩大）。
+    #[error(transparent)]
+    Operation(CheckAndPromoteError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]   // 无字段枚举；CheckAndPromoteError 的 {phase:?} 需要 Debug
+pub(crate) enum CheckAndPromotePhase {
+    Check,      // → §2.2 行 3
+    Promote,    // → §2.2 行 4a / 4b（写前 / 写后，按构造位置区分）
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{phase:?} failed: {source:#}")]
+pub(crate) struct CheckAndPromoteError {
+    pub(crate) phase: CheckAndPromotePhase,
+    pub(crate) source: anyhow::Error,
+}
+
+/// restart seam 保留 actor 错误身份，避免 §2.3 豁免被 anyhow 擦除。
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum RestartFailure {
+    #[error(transparent)]
+    Actor(CoreActorError),
+    #[error(transparent)]
+    Operation(anyhow::Error),
+}
+
+// trait 签名：
+//   async fn check_and_promote(..) -> Result<[u8; 32], CheckAndPromoteFailure>;
+//   async fn restart(&mut self) -> Result<(), RestartFailure>;
+//
+// 编排层分流（**穷尽派发表；照此实现，不要自由发挥**）：
+//
+//   Actor(StaleOperation | LifecycleInvariant(_) | ShuttingDown)
+//       → §2.3 豁免（E-a / E-b）：Err，无 degradation
+//   Actor(NoBackend)
+//       → 行 6b（core_backend_unavailable）
+//   Actor(Backend(_))
+//       → 行 3（runtime_check_failed）
+//         ——因为本 seam 里唯一的 actor 调用就是 Check（core.rs:408），
+//           这条 Actor 臂只可能源自它。
+//   Operation(Check)
+//       → 行 3
+//   Operation(Promote)
+//       → 行 4a / 4b（写前 / 写后，按构造位置）
+//
+// **A.7 永远不从本 seam 可达**：它的签名是 &CoreBackendError，装不下 CoreActorError；
+// 且它的作用域是 apply 路径。seam 的 Actor(Backend(_)) 走行 3，不走 A.7。
+//
+// 同一个 Backend(_)：**在 seam 里意味着「检查失败」，在 apply 臂里才意味着「应用失败」**。
+// 区分二者的是**臂的来源**，不是错误内容——与 A.7 作用域是同一条道理。
+//
+// 相位仍由 adapter 内的构造位置打标签——它确切知道自己停在哪一步；
+// 编排层不做字符串嗅探，也不 downcast anyhow。
+//
+// **边界（H2）**：`CheckAndPromoteError`（内层）只承载本 seam 自己的失败——
+// candidate 文件工作与 check 的**非 actor** 部分。actor 侧的错误走 `Actor(_)` 臂，
+// 不被改写、不被降级、不丢豁免资格。`PublishPromoted` 同样在 seam 之外独立一段（F45）。
+```
+
+### A.2 新增消息（三条，全部守卫消息）
+
+```rust
+/// C2：actor 只做 lifecycle 簿记。candidate 建立、哈希比对、check、产物原子晋升
+/// 全部留在 client 侧 lease adapter —— 快照的输入本来就只在那里（F32），
+/// 相位区分靠 A.1b 的类型化 CheckAndPromoteError（NH2），不是靠 anyhow。
+PublishPromoted {
+    operation: OperationId,
+    snapshot: Arc<RuntimeSnapshot>,          // client 已建好并已晋升产物
+    reply: RpcReplyPort<Result<(), CoreActorError>>,   // 拒绝非递增 revision
+},
+ApplyPromoted {
+    operation: OperationId,
+    request: CoreRequest,
+    expected: Option<RevisionIdInfo>,        // H8：观察到 revision 则 Some，缺失则 None
+    snapshot: Arc<RuntimeSnapshot>,          // 供 advances_applied 为真时提交
+    reply: RpcReplyPort<Result<CoreApplyData, CoreActorError>>,
+},
+/// C3：Run 不碰 lifecycle（F33b），restart 类路径靠这条推进 Applied——
+/// start_promoted_runtime、legacy 重播、D5 的 Started 分支。
+PublishApplied {
+    operation: OperationId,
+    snapshot: Arc<RuntimeSnapshot>,
+    reply: RpcReplyPort<Result<(), CoreActorError>>,   // 要求存在 Promoted 且 identity_eq
+},
+/// NH1：5a 的 RunningIdentity 的 reply 由 Option<CoreRequest> 扩为联合值——
+/// 身份与忠实六态必须在同一个 mailbox 轮次内取齐，否则两次查询之间会撕裂读；
+/// 且 CoreStatusView.state 是二值投影，单独用它会把 Starting/Restarting/Stopping 判反（F40）。
+RunningIdentity {
+    operation: OperationId,
+    reply: RpcReplyPort<Result<(Option<CoreRequest>, FaithfulLifecycle), CoreActorError>>,
+},
+// L5：不加 LifecycleSnapshot 诊断消息。lifecycle_tx 在处理函数内、reply 之前发布
+// （F30 的时序），所以 await reply 后读 lifecycle() 已经确定性可见。
+```
+
+**actor 内的纯谓词（C3，非消息）：**
+
+```rust
+// core/actor/runtime.rs —— Applied 是否推进的唯一决策点
+pub(crate) fn advances_applied(outcome: ApplyOutcomeKind) -> bool;
+```
+
+### A.3 client 侧新增与删除
+
+```rust
+// CoreClient 新增
+pub(crate) fn lifecycle(&self) -> RuntimeLifecycleState;          // 同步 watch 克隆
+// NH1：5a 的 running(&guard) 返回类型随 A.2 一起加宽
+pub(crate) async fn running(&self, op: &CoreOperationGuard)
+    -> Result<(Option<CoreRequest>, FaithfulLifecycle), CoreActorError>;
+pub(crate) async fn publish_promoted(&self, op: &CoreOperationGuard, snapshot: Arc<RuntimeSnapshot>)
+    -> Result<(), CoreActorError>;
+pub(crate) async fn publish_applied(&self, op: &CoreOperationGuard, snapshot: Arc<RuntimeSnapshot>)
+    -> Result<(), CoreActorError>;
+pub(crate) async fn apply_promoted(&self, op: &CoreOperationGuard, req: &CoreRequest,
+    expected: Option<RevisionIdInfo>, snapshot: Arc<RuntimeSnapshot>) -> Result<CoreApplyData, CoreActorError>;
+
+// NyanpasuClientInner 删除字段
+- clash_patch, clash_patch_gate, rebuild_gate, runtime
+// NyanpasuClientInner 保留字段（L2）
+  runtime_revisions: runtime::RuntimeRevisionAllocator
+// NyanpasuClientInner 新增字段（L4）
++ degradation: Arc<dyn crate::core::actor::backend::CoreDegradationSink>
+
+// ClientSetupArgs 删除字段
+- clash_patch
+```
+
+### A.4 wire 类型（D4=A + D5=A）
+
+```rust
+// client/runtime.rs，与 MutationOutcome 同层。
+// F25：workspace 已启用 specta，upstream apply 类型自带 specta::Type，无需镜像 DTO。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeApplyOutcome {
+    Noop,
+    Patched,
+    Reloaded,
+    Restarted,
+    Switched,
+    RolledBack,
+    /// 核原本停止，本次操作把它启起来了（D5=A）。upstream 的 apply 不启核，
+    /// 因此这个状态在 `ApplyOutcomeKind` 里没有对应变体。
+    Started,
+    /// 什么终态动作都没发生（C1）：build / check / promote / 传输 / NoBackend 失败。
+    /// MutationOutcome 的两变体都要求 value（F31），而 RolledBack / Started 在这些情形下都是假话。
+    NotApplied,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct RuntimeApplyReport {
+    pub outcome: RuntimeApplyOutcome,
+    pub desired_revision: u64,
+    pub applied_revision: Option<u64>,
+}
+```
+
+命令返回：`change_clash_core` 与 `patch_clash_config` 均改为 `Result<MutationOutcome<RuntimeApplyReport>>`。
+
+### A.5 wire 表示的唯一决策点（C3 改述）
+
+```rust
+/// §3 的 12 格矩阵**全部**由它决定：outcome→report 取值、warning→追加 degradation。
+/// C3：它**不**决定 Applied 是否推进——那由 actor 内的 advances_applied() 独占。
+/// 其它地方不得再判 outcome 来产 wire 值。
+/// NH9：**不要叫 map_apply_outcome**——那个名字已属于
+/// core::actor::backend::map_apply_outcome（manager ApplyOutcome → CoreApplyData，
+/// 方向相反、模块相邻，F44）。既有函数不改名，新函数两端都写进名字。
+/// 都在这里，其它地方不得再判 outcome。
+pub(crate) fn runtime_outcome_from_apply_data(
+    data: &CoreApplyData,
+    promoted_revision: u64,
+) -> (RuntimeApplyReport, Vec<Degradation>);
+```
+
+### A.6 degradation code 常量表（§2.2 / §3 引用）
+
+| code                              | phase            | retryable |
+| --------------------------------- | ---------------- | --------- |
+| `runtime_build_failed`            | `RuntimeBuild`   | true      |
+| `runtime_check_failed`            | `RuntimeCheck`   | true      |
+| `runtime_promote_failed`          | `RuntimePromote` | true      |
+| `revision_conflict`               | `RuntimeApply`   | true      |
+| `core_transport_lost`             | `RuntimeApply`   | true      |
+| `core_backend_unavailable`        | `RuntimeApply`   | true      |
+| `runtime_apply_failed`            | `RuntimeApply`   | true      |
+| `core_not_running`                | `RuntimeApply`   | true      |
+| `core_start_failed`               | `CoreLifecycle`  | true      |
+| `core_operation_unavailable`      | `CoreLifecycle`  | true      |
+| `core_rollback`                   | `CoreRollback`   | true      |
+| `core_apply_durability_uncertain` | `RuntimeApply`   | false     |
+
+> **actor 发布失败的归类（NH3 ③）——本表不新增 code**：
+>
+> - `PublishPromoted` 因**单调性**被拒（`LifecycleInvariant(PromotedRegression)`）→ 不是 degradation，按 I-A 豁免 (b) 处理为 `Err` + 错误级日志。守卫串行 + 单事务单次分配之下，非递增 revision 只可能是 bug；
+> - `PublishApplied` 找不到匹配 Promoted 或身份不符（`LifecycleInvariant(AppliedWithoutPromoted)`）→ 同上；
+> - `PublishPromoted` / `PublishApplied` 遇 `ShuttingDown` → 按 I-A 豁免 (a) 处理为 `Err`；
+> - 写后校验失败（§2.2 第 4b 行）→ 复用 `runtime_promote_failed`，`message` 注明是「产物已写、发布未成」侧。**它不是豁免类**——见 §2.3 的 `matches!` 规则。
+
+### A.7 `Backend(_)` 的有序分类器（H3；**唯一实现处**）
+
+**作用域（先读这条）：A.7 只分类 apply 路径上的 `Backend(_)`。** 生命周期路径（D5 停止态分支的 `restart()`）的失败**不过 A.7**，直接落 §2.2 的 restart-failure 行（`CoreLifecycle` / `core_start_failed`，R1 裁定、T-B4-05 钉住）。
+
+**绑定手段：名字 + 单一调用点。** 函数叫 `classify_apply_backend_failure`（作用域写进标识符），**只在 `ApplyPromoted` 的错误臂调用一次**，不得下沉到两条路径共用的 helper。**不做 newtype 包装**：包装类型的构造点同样在 apply 臂，能调错分类器的人也能构造错 newtype，保护是薄的；而为一个只有单一调用点的函数引入包装类型属于推测性抽象（CLAUDE.md §2）。这是诚实的 80%——**若将来真出现第二个调用点，届时再上 newtype**。 **A.7 永不从 lease seam 可达**——seam 的 `Actor(Backend(_))` 按 A.1b 的派发表走行 3（检查失败），不进本分类器。
+
+> **为什么必须显式圈作用域**：两条路径的失败**在类型上完全同形**——`Run` 与 apply 一样经 `backend_error()` 包成 `Backend(_)`（F49）。而启核失败**以服务端信封返回时** `error_kind` 恒为 `None`（`start`/`stop`/`restart` 早于 `error_kind` 引入，F50），A.7 第 4 行会把它判成 `Other` → 行 7c → `runtime_apply_failed`，**与 R1 裁定的 `core_start_failed` 冲突**。该冲突**不必是每次都发生**（信封之前失败的会落 `TransportLost`）——**存在一条可达路径就够了**。靠判据本身分不开，只能靠调用点的路径归属。
+
+`CoreActorError::Backend(_)`（apply 路径）是个口袋：revision 冲突、not-started、传输丢失全在里面（F46）。
+
+```rust
+// core/actor/backend.rs —— 与 CoreBackendError 同模块（它最清楚自己的内部结构）
+pub(crate) enum BackendFailureClass {
+    RevisionConflict,   // → §2.2 行 5
+    NotRunning,         // → §2.2 行 7b
+    TransportLost,      // → §2.2 行 6a
+    Other,              // → §2.2 行 7c
+}
+
+/// **唯一调用点：`ApplyPromoted` 的错误臂**（A.2）。作用域写进了名字——
+/// 生命周期路径（停止态 restart）的 `Backend(_)` 不调它。
+/// 不得放进两条路径共用的 helper 里，否则名字就白改了。
+pub(crate) fn classify_apply_backend_failure(error: &CoreBackendError) -> BackendFailureClass;
+```
+
+| 顺序 | 类                        | Local 判据（`CoreBackendError::Local`）                                             | Service 判据（`CoreBackendError::Service`）                                                           |
+| ---- | ------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 1    | `RevisionConflict` → 行 5 | `matches!(e, Error::RevisionConflict { .. })`（`error.rs:44`）                      | `Server { error_kind: Some(k), .. }` 且 `k == api::error_kind::REVISION_CONFLICT`（`api/mod.rs:45`）  |
+| 2    | `NotRunning` → 行 7b      | `matches!(e, Error::NotStarted)`（`error.rs:11`；**它是 `Err` 不是 outcome**，F47） | 同上，`k == api::error_kind::NOT_STARTED`（`api/mod.rs:40`）                                          |
+| 3    | `TransportLost` → 行 6a   | **本地管理器无此类——照实说明，见下**                                                | `BuildClient` / `Request` / `WebSocket` / `HttpStatus`                                                |
+| 4    | `Other` → 行 7c           | 其余 `Error` 变体                                                                   | `Decode` / `EmptyData`；`Server` 带其它或缺失 `error_kind`；**以及 `#[non_exhaustive]` 的未来新变体** |
+
+`CoreBackendError::Binary` / `Construct` 一律归 `Other`（行 7c）。
+
+> **Service 侧的分档是一条「政策」，不是一条推导。**
+>
+> 选择它的目的是**诊断方向**：看到 `core_transport_lost` 该去查链路（反代、端口、监听），看到 `runtime_apply_failed` 该去查配置与核状态。分档大体沿着「**服务信封是否到达**」这条线：
+>
+> - **没拿到信封** → `TransportLost`：`BuildClient`（连没建起来）、`Request`（发不出/收不回）、`WebSocket`、**`HttpStatus`**；
+> - **拿到了信封但本次操作的载荷不可用** → `Other`：`Decode`、`EmptyData`；
+> - **拿到了且服务端分过类** → 按 `error_kind` 走第 1 / 2 顺位，否则 `Other`。
+>
+> **已知两处边界不严格（F52，别把这条当定理用）：**
+>
+> 1. 非 2xx 而 body **解得出信封却 `code == Ok`** 时也会落 `HttpStatus`——此时信封其实到了，仍归 `TransportLost`；
+> 2. 2xx 成功路径上 `OpResponse<Op>` 反序列化失败产生 `Decode`（`client/mod.rs:176`）——此时**并没有有效信封到达**，仍归 `Other`。
+>
+> 两处都不改映射：**这两行行为完全相同**（`retryable = true`、report = `NotApplied`），赌注只有 degradation 的 code 字符串、即诊断精度。为了让论证看起来干净而在文档里留一句可被证伪的话，不划算。
+>
+> **`EmptyData` 归第二档是严格成立的**：它的产生条件就是解码成功但缺必需数据。
+>
+> **`Decode` / `EmptyData` 归 `Other` 是对 v6 的修正**：连接成功、服务也应答了，只是回包内容用不了——把它叫「传输丢失」是错的。
+> **`HttpStatus` 归 `TransportLost`**：它多数情况下指向「请求没到达一个能按协议作答的服务」，而这正是 `core_transport_lost` 要把人引去看的地方。
+
+> **第 4 行的 `error_kind: None` 读作「未分类」而不是「无错误」**（`api/mod.rs:35-37` 原文「Absent means "not classified", never "no error"」）。所以在 **apply 路径内**把未分类归 7c 是对的；但正因为「未分类」这个集合同时装着生命周期那批失败（F50），**作用域声明是必需的**——否则 7c 会把启核失败一并吞掉。
+
+> **两处对裁定输入的修正（我逐一核过源码）：**
+>
+> 1. **Service 侧的分类键是 `error_kind: Option<String>`，不是 `code`。** `ClientError::Server` 两个字段都有：`code: ResponseCode` 是协议层响应码，`error_kind` 才是 **R0 收敛出来的**那个（doc 原文「The envelope's `error_kind`, when the service classified the failure」）。按 `code` 分类会分错。
+> 2. **`ClientError` 是七支且 `#[non_exhaustive]`**，不是四支。除 `Server` 外还有 `EmptyData` 与 `WebSocket`；`#[non_exhaustive]` 意味着 submodule 升级可能加新支，**分类器必须有兜底**（第 4 行已覆盖）。
+
+> **Local 侧的传输类没有类型化谓词——照实记录，不造。** `nyanpasu_core_manager` 是**进程内**管理器，没有 IPC 传输层，所以「传输丢失」在 Local 侧**根本不存在**；第 3 行的 Local 格因此为空，不是漏写。Local 的其余失败一律落 `Other`（行 7c）。
+
+> **这条分类链是 R0 的实证价值落点**：Service 侧之所以能把 revision 冲突与 not-started 从传输错误里**分**出来，靠的正是 R0 把服务端错误收敛成 `error_kind` 字符串常量。没有 R0，Service 侧只能看 HTTP 状态码与错误文本——那就退回 NH2 刚消灭的字符串嗅探。**R0 先行的必要性在这里得到实证。**

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -32,7 +32,9 @@ export const commands = {
     typedError<string[], string>(__TAURI_INVOKE('get_clash_logs')),
   /**  patch clash runtime config */
   patchClashConfig: (payload: PatchRuntimeConfig_Deserialize) =>
-    typedError<null, string>(__TAURI_INVOKE('patch_clash_config', { payload })),
+    typedError<MutationOutcome<RuntimeApplyReport>, string>(
+      __TAURI_INVOKE('patch_clash_config', { payload }),
+    ),
   changeClashCore: (
     clashCore:
       | 'clash'
@@ -45,7 +47,7 @@ export const commands = {
       | 'meow'
       | null,
   ) =>
-    typedError<null, string>(
+    typedError<MutationOutcome<RuntimeApplyReport>, string>(
       __TAURI_INVOKE('change_clash_core', { clashCore }),
     ),
   /**  get the runtime config */
@@ -2033,6 +2035,22 @@ export type RunType =
   | 'service'
   /**  Run as elevated process, if profile advice to run as elevated */
   | 'elevated'
+
+export type RuntimeApplyOutcome =
+  | 'noop'
+  | 'patched'
+  | 'reloaded'
+  | 'restarted'
+  | 'switched'
+  | 'rolled_back'
+  | 'started'
+  | 'not_applied'
+
+export type RuntimeApplyReport = {
+  outcome: RuntimeApplyOutcome
+  desired_revision: number
+  applied_revision: number | null
+}
 
 export type RuntimeInfos = {
   service_data_dir: string

--- a/scripts/architecture-ledger.snapshot.json
+++ b/scripts/architecture-ledger.snapshot.json
@@ -4,14 +4,14 @@
   ],
   "metrics": {
     "config_calls": {
-      "total": 109,
+      "total": 102,
       "byKey": {
-        "Config::verge()": 83,
+        "Config::verge()": 76,
         "Config::clash()": 26
       }
     },
     "service_globals": {
-      "total": 59,
+      "total": 58,
       "byKey": {
         "ProxiesGuard::global()": 14,
         "Handle::global()": 11,
@@ -20,23 +20,23 @@
         "WindowManager::global()": 8,
         "Hotkey::global()": 3,
         "UpdaterManager::global()": 3,
-        "Logger::global()": 2,
-        "CoreManager::global()": 1
+        "CoreManager::global()": 1,
+        "Logger::global()": 1
       }
     },
     "migration_markers": {
-      "total": 17,
+      "total": 15,
       "byKey": {
-        "TODO(actor-migration)": 15,
+        "TODO(actor-migration)": 13,
         "FIXME(actor-migration)": 2
       }
     },
     "legacy_dto_refs": {
-      "total": 300,
+      "total": 299,
       "byKey": {
         "IVerge": 175,
         "IClashTemp": 30,
-        "LegacyVergeBridge": 29,
+        "LegacyVergeBridge": 28,
         "ClashLegacyBridge": 18,
         "VergeLegacyBridge": 18,
         "LegacyVergePatchRoute": 9,


### PR DESCRIPTION
Third of five stacked PRs. **Base is `pr5/2-core-lifecycle` (#5071).**

## What this does

Collapses the api-first patch path and its compensation layer into one pipeline owned by `CoreActor`.

## The central change: commit-first, and no fake rollback

State is committed before side effects are triggered, and a post-commit failure is reported as a **degradation** rather than being dressed up as a rollback.

The compensation layer this removes tried to undo persisted state on failure. That could not be made correct: by the time compensation runs, the write has already been observed by readers. Reporting "we failed and undid it" was therefore a claim the code could not honour. The replacement reports what actually happened — the commit stands, the side effect did not complete.

## Error classification

Apply-path backend failures go through a single ordered classifier keyed on the daemon's typed error kind.

**Lifecycle-path failures deliberately bypass it.** `start`/`stop`/`restart` predate that error-kind field, so their Service-side kind is always absent and the classifier would deterministically bucket them as "other" — colliding with the lifecycle failure disposition. The scope restriction is intentional and is stated at the classifier.

`LifecycleInvariant` carries exactly two kinds so that an invariant breach is `matches!`-able and can never be swallowed as a degradable failure.

## Verification

467 passed / 0 failed / 1 ignored. Bindings diff is exactly the four items predicted by the plan.

Stage review closed after three rounds; the final round's only finding was a vacuous test, which was retargeted rather than papered over.