### PR TITLE
feat(core): add CoreActor v2, the ServiceActor, and the DNS wiring (PR-C/D-new, unwired)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1817,6 +1817,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clash-api"
+version = "1.0.0-rc.1"
+dependencies = [
+ "backon",
+ "chrono",
+ "futures-core",
+ "futures-util",
+ "indexmap 2.14.0",
+ "ipnet",
+ "reqwest 0.13.4",
+ "reqwest-websocket",
+ "serde",
+ "serde_json",
+ "specta",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "clash-nyanpasu"
 version = "0.1.0"
 dependencies = [
@@ -1876,6 +1898,7 @@ dependencies = [
  "notify-debouncer-full",
  "nyanpasu-config",
  "nyanpasu-core",
+ "nyanpasu-core-manager",
  "nyanpasu-egui",
  "nyanpasu-ipc",
  "nyanpasu-macro",
@@ -1913,7 +1936,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "serde_yaml_ng",
+ "serde_yaml_ng 0.10.0 (git+https://github.com/libnyanpasu/serde-yaml-ng.git?rev=363da138dc97f90ef0a356f971c2dc1d8fe04c9e)",
  "sha2 0.10.9",
  "single-instance",
  "smol-cancellation-token",
@@ -5012,6 +5035,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iptools"
@@ -6214,7 +6240,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml_ng",
+ "serde_yaml_ng 0.10.0 (git+https://github.com/libnyanpasu/serde-yaml-ng.git?rev=363da138dc97f90ef0a356f971c2dc1d8fe04c9e)",
  "slab",
  "specta",
  "struct-patch",
@@ -6244,10 +6270,32 @@ dependencies = [
  "indexmap 2.14.0",
  "nyanpasu-utils",
  "serde",
- "serde_yaml_ng",
+ "serde_yaml_ng 0.10.0 (git+https://github.com/libnyanpasu/serde-yaml-ng.git?rev=363da138dc97f90ef0a356f971c2dc1d8fe04c9e)",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "nyanpasu-core-manager"
+version = "1.0.0-rc.1"
+dependencies = [
+ "camino",
+ "chrono",
+ "clash-api",
+ "enumset",
+ "nyanpasu-core-metadata",
+ "nyanpasu-utils",
+ "parking_lot",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "specta",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -6337,11 +6385,13 @@ dependencies = [
  "dirs 6.0.0",
  "encoding_rs",
  "kill_tree",
+ "libc",
  "log",
  "memchr",
  "nix 0.31.3",
  "os_pipe",
  "parking_lot",
+ "processkit",
  "serde",
  "shared_child",
  "specta",
@@ -6349,6 +6399,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-attributes",
  "windows 0.62.2",
@@ -7821,6 +7872,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "processkit"
+version = "2.2.5"
+source = "git+https://github.com/ZelAnton/ProcessKit-rs?rev=2adad322f1e3d7c471f3b9c8c625e44f356e416b#2adad322f1e3d7c471f3b9c8c625e44f356e416b"
+dependencies = [
+ "async-trait",
+ "encoding_rs",
+ "libc",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8405,6 +8472,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -9201,6 +9269,19 @@ dependencies = [
 [[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "git+https://github.com/libnyanpasu/serde-yaml-ng.git?rev=363da138dc97f90ef0a356f971c2dc1d8fe04c9e#363da138dc97f90ef0a356f971c2dc1d8fe04c9e"
 dependencies = [
  "indexmap 2.14.0",
@@ -9664,6 +9745,7 @@ version = "2.0.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f9a30cbcbb7011f1da7d73483983bf838af123883e45f2b36ed76328df9c50"
 dependencies = [
+ "chrono",
  "indexmap 2.14.0",
  "paste",
  "rustc_version 0.4.1",
@@ -10902,6 +10984,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1815,6 +1815,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clash-api"
+version = "1.0.0-rc.1"
+dependencies = [
+ "backon",
+ "chrono",
+ "futures-core",
+ "futures-util",
+ "indexmap 2.14.1",
+ "ipnet",
+ "reqwest 0.13.4",
+ "reqwest-websocket",
+ "serde",
+ "serde_json",
+ "specta",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "clash-nyanpasu"
 version = "0.1.0"
 dependencies = [
@@ -1874,6 +1896,7 @@ dependencies = [
  "notify-debouncer-full",
  "nyanpasu-config",
  "nyanpasu-core",
+ "nyanpasu-core-manager",
  "nyanpasu-egui",
  "nyanpasu-ipc",
  "nyanpasu-macro",
@@ -1911,7 +1934,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "serde_yaml_ng",
+ "serde_yaml_ng 0.10.0 (git+https://github.com/libnyanpasu/serde-yaml-ng.git?rev=363da138dc97f90ef0a356f971c2dc1d8fe04c9e)",
  "sha2 0.10.9",
  "single-instance",
  "smol-cancellation-token",
@@ -5075,6 +5098,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iptools"
@@ -6340,7 +6366,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml_ng",
+ "serde_yaml_ng 0.10.0 (git+https://github.com/libnyanpasu/serde-yaml-ng.git?rev=363da138dc97f90ef0a356f971c2dc1d8fe04c9e)",
  "slab",
  "specta",
  "struct-patch",
@@ -6370,11 +6396,34 @@ dependencies = [
  "indexmap 2.14.1",
  "nyanpasu-utils",
  "serde",
- "serde_yaml_ng",
+ "serde_yaml_ng 0.10.0 (git+https://github.com/libnyanpasu/serde-yaml-ng.git?rev=363da138dc97f90ef0a356f971c2dc1d8fe04c9e)",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "nyanpasu-core-manager"
+version = "1.0.0-rc.1"
+dependencies = [
+ "camino",
+ "chrono",
+ "clash-api",
+ "enumset",
+ "nyanpasu-core-metadata",
+ "nyanpasu-utils",
+ "parking_lot",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "specta",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6463,11 +6512,13 @@ dependencies = [
  "dirs 6.0.0",
  "encoding_rs",
  "kill_tree",
+ "libc",
  "log",
  "memchr",
  "nix 0.31.3",
  "os_pipe",
  "parking_lot",
+ "processkit",
  "serde",
  "shared_child",
  "specta",
@@ -6475,6 +6526,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-attributes",
  "windows 0.62.2",
@@ -7957,6 +8009,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "processkit"
+version = "2.2.5"
+source = "git+https://github.com/ZelAnton/ProcessKit-rs?rev=2adad322f1e3d7c471f3b9c8c625e44f356e416b#2adad322f1e3d7c471f3b9c8c625e44f356e416b"
+dependencies = [
+ "async-trait",
+ "encoding_rs",
+ "libc",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8541,6 +8609,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -9338,6 +9407,19 @@ dependencies = [
 [[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap 2.14.1",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "git+https://github.com/libnyanpasu/serde-yaml-ng.git?rev=363da138dc97f90ef0a356f971c2dc1d8fe04c9e#363da138dc97f90ef0a356f971c2dc1d8fe04c9e"
 dependencies = [
  "indexmap 2.14.1",
@@ -9801,6 +9883,7 @@ version = "2.0.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f9a30cbcbb7011f1da7d73483983bf838af123883e45f2b36ed76328df9c50"
 dependencies = [
+ "chrono",
  "indexmap 2.14.1",
  "paste",
  "rustc_version 0.4.1",
@@ -11039,6 +11122,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -41,6 +41,7 @@ nyanpasu-ipc = { path = "nyanpasu-runtime/nyanpasu_ipc", features = [
   "client",
   "specta",
 ] } # IPC bridge between the UI process and service process
+nyanpasu-core-manager = { path = "nyanpasu-runtime/crates/nyanpasu-core-manager" } # Local-host CoreControl (v2 control plane)
 
 # --- forks ---
 # `rev` values are the commits Cargo.lock already resolved.

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -39,6 +39,7 @@ nyanpasu-ipc = { path = "nyanpasu-runtime/nyanpasu_ipc", features = [
   "client",
   "specta",
 ] } # IPC bridge between the UI process and service process
+nyanpasu-core-manager = { path = "nyanpasu-runtime/crates/nyanpasu-core-manager" } # Local-host CoreControl (v2 control plane)
 
 # --- forks ---
 # `rev` values are the commits Cargo.lock already resolved.

--- a/backend/tauri/Cargo.toml
+++ b/backend/tauri/Cargo.toml
@@ -25,6 +25,7 @@ semver = "1.0"
 [dependencies]
 # Local Dependencies
 nyanpasu-ipc = { workspace = true }
+nyanpasu-core-manager = { workspace = true }
 nyanpasu-macro = { path = "../nyanpasu-macro" }
 nyanpasu-core = { path = "../nyanpasu-core" }
 nyanpasu-config = { path = "../nyanpasu-config" }

--- a/backend/tauri/src/core/actor_v2/endpoint.rs
+++ b/backend/tauri/src/core/actor_v2/endpoint.rs
@@ -1,0 +1,401 @@
+//! The endpoint port of CoreActor v2: one narrow trait over "a host's
+//! `CoreControl`", implemented by the in-process Local adapter and the IPC v2
+//! Service adapter.
+//!
+//! Design note (deviation from the integration design's concrete
+//! `EndpointHandle` enum, recorded): the router consumes a trait object plus
+//! an [`ExecutionHost`] tag instead of a two-variant enum. Same shape, one
+//! test seam — the fake endpoint in the actor tests is the third
+//! implementation the enum could not have carried.
+//!
+//! Everything here is *reading or forwarding*; the router never synthesizes
+//! lifecycle state (invariant I-R3). The normalized snapshot below is a
+//! field-by-field projection of what the host published, nothing more.
+
+use std::{borrow::Cow, future::Future, pin::Pin, sync::Arc, time::Duration};
+
+use nyanpasu_core_manager::{
+    ApplyOutcome, CoreCommandEnvelope, CoreControl, CoreError, CoreErrorKind, OperationId,
+    OperationOutput, OperationState,
+};
+use nyanpasu_ipc::api::{
+    core::v2::{
+        CoreCommandInfo, CoreOperationReq, CoreSubmitReq, OperationInfo, OperationOutputInfo,
+        OperationPhase, ReconcileOutcomeInfo, ReconcileOutcomeKind,
+    },
+    status::{CoreInfos, CoreStateDetail},
+};
+
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Which controller owns the runtime. The app perceives the difference in
+/// exactly two places: this tag on the endpoint slot, and the handoff
+/// protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionHost {
+    Local,
+    Service,
+}
+
+/// The host's canonical core status, projected field by field for the app.
+/// No field here is ever derived by the router itself.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CoreStatusSnapshot {
+    pub state: CoreStateDetail,
+    pub state_changed_at: i64,
+    /// The applied revision's CAS identity, when one is running.
+    pub revision: Option<nyanpasu_ipc::api::status::RevisionIdInfo>,
+    /// Healthy / unhealthy, when the host reports it.
+    pub healthy: Option<bool>,
+}
+
+/// One host's control plane, as the router consumes it. Submit is the only
+/// mutating call and is always envelope-shaped; waiting on an operation is a
+/// read and deliberately not routed through the actor mailbox.
+pub trait ControlEndpoint: Send + Sync {
+    fn host(&self) -> ExecutionHost;
+
+    /// Admission into the host's executor. Returns the operation's
+    /// admission-time snapshot; the transaction survives this future's drop.
+    fn submit<'a>(
+        &'a self,
+        envelope: CoreCommandEnvelope,
+    ) -> BoxFuture<'a, Result<OperationInfo, CoreError>>;
+
+    /// Long-poll the host's registry. `None` = unknown/evicted id (recover by
+    /// re-reading status; the revision CAS blocks double application).
+    fn wait_operation<'a>(
+        &'a self,
+        id: OperationId,
+        timeout: Duration,
+    ) -> BoxFuture<'a, Option<OperationInfo>>;
+
+    fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>>;
+}
+
+// ---------------------------------------------------------------------------
+// Local host: the in-process CoreControl.
+// ---------------------------------------------------------------------------
+
+pub struct LocalEndpoint {
+    control: CoreControl,
+}
+
+impl LocalEndpoint {
+    pub fn new(control: CoreControl) -> Self {
+        Self { control }
+    }
+}
+
+impl ControlEndpoint for LocalEndpoint {
+    fn host(&self) -> ExecutionHost {
+        ExecutionHost::Local
+    }
+
+    fn submit<'a>(
+        &'a self,
+        envelope: CoreCommandEnvelope,
+    ) -> BoxFuture<'a, Result<OperationInfo, CoreError>> {
+        Box::pin(async move {
+            let handle = self.control.submit(envelope)?;
+            Ok(map_local_operation(handle.id(), handle.state()))
+        })
+    }
+
+    fn wait_operation<'a>(
+        &'a self,
+        id: OperationId,
+        timeout: Duration,
+    ) -> BoxFuture<'a, Option<OperationInfo>> {
+        Box::pin(async move {
+            self.control
+                .wait_operation(id, timeout)
+                .await
+                .map(|state| map_local_operation(id, state))
+        })
+    }
+
+    fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
+        Box::pin(async move { Ok(map_local_status(&self.control.status())) })
+    }
+}
+
+/// The local sibling of the daemon bridge's wire mapping. Duplicated on
+/// purpose: the app must not depend on the daemon host crate, and the wire
+/// DTO is the shared vocabulary both sides project into.
+fn map_local_operation(id: OperationId, state: OperationState) -> OperationInfo {
+    let (phase, output, error) = match state {
+        OperationState::Queued => (OperationPhase::Queued, None, None),
+        OperationState::Running => (OperationPhase::Running, None, None),
+        OperationState::Succeeded(output) => (
+            OperationPhase::Succeeded,
+            Some(match output {
+                OperationOutput::Reconciled(outcome) => {
+                    OperationOutputInfo::Reconciled(map_local_outcome(&outcome))
+                }
+                OperationOutput::Stopped => OperationOutputInfo::Stopped,
+                OperationOutput::Recovered => OperationOutputInfo::Recovered,
+                OperationOutput::ShutDown => OperationOutputInfo::ShutDown,
+            }),
+            None,
+        ),
+        OperationState::Failed(failure) => (
+            OperationPhase::Failed,
+            None,
+            Some(nyanpasu_ipc::api::core::v2::OperationErrorInfo {
+                kind: failure.kind.map(|kind| Cow::Borrowed(kind.as_str())),
+                message: failure.message,
+                retryable: failure.retryable,
+            }),
+        ),
+    };
+    OperationInfo {
+        id: id.to_string(),
+        phase,
+        output,
+        error,
+    }
+}
+
+fn map_local_outcome(outcome: &ApplyOutcome) -> ReconcileOutcomeInfo {
+    let mut warnings = Vec::new();
+    let mut current = outcome;
+    while let ApplyOutcome::DurabilityUncertain { outcome, warning } = current {
+        warnings.push(warning.clone());
+        current = &**outcome;
+    }
+    let (kind, revision, failed_apply) = match current {
+        ApplyOutcome::Started { revision } => (ReconcileOutcomeKind::Started, revision, None),
+        ApplyOutcome::Noop { revision } => (ReconcileOutcomeKind::Noop, revision, None),
+        ApplyOutcome::Patched { revision } => (ReconcileOutcomeKind::Patched, revision, None),
+        ApplyOutcome::Reloaded { revision } => (ReconcileOutcomeKind::Reloaded, revision, None),
+        ApplyOutcome::Restarted { revision } => (ReconcileOutcomeKind::Restarted, revision, None),
+        ApplyOutcome::Switched { revision } => (ReconcileOutcomeKind::Switched, revision, None),
+        ApplyOutcome::RolledBack {
+            revision,
+            failed_apply,
+        } => (
+            ReconcileOutcomeKind::RolledBack,
+            revision,
+            Some(failed_apply.clone()),
+        ),
+        ApplyOutcome::DurabilityUncertain { .. } => unreachable!("unwrapped by the loop above"),
+    };
+    ReconcileOutcomeInfo {
+        outcome: kind,
+        revision: nyanpasu_ipc::api::status::ConfigRevisionInfo {
+            epoch: revision.epoch,
+            generation: revision.generation,
+            source_hash: revision.source_hash.clone(),
+            effective_hash: revision.effective_hash.clone(),
+        },
+        warning: (!warnings.is_empty()).then(|| warnings.join("; ")),
+        failed_apply,
+    }
+}
+
+fn map_local_status(status: &nyanpasu_core_manager::CoreStatus) -> CoreStatusSnapshot {
+    use nyanpasu_core_manager::CoreState as ManagerCoreState;
+    let state = match &status.state {
+        ManagerCoreState::Stopped { reason } => CoreStateDetail::Stopped {
+            reason: reason.as_ref().map(|reason| reason.to_string()),
+        },
+        ManagerCoreState::Starting { epoch } => CoreStateDetail::Starting { epoch: *epoch },
+        ManagerCoreState::Running { epoch, pid } => CoreStateDetail::Running {
+            epoch: *epoch,
+            pid: *pid,
+        },
+        ManagerCoreState::Restarting { epoch, attempt } => CoreStateDetail::Restarting {
+            epoch: *epoch,
+            attempt: *attempt,
+        },
+        ManagerCoreState::Switching { from, to } => CoreStateDetail::Switching {
+            from: *from,
+            to: *to,
+        },
+        ManagerCoreState::Stopping { epoch } => CoreStateDetail::Stopping { epoch: *epoch },
+        // `CoreState` is `#[non_exhaustive]`; an unknown future state must not
+        // be guessed into an existing one.
+        other => CoreStateDetail::Stopped {
+            reason: Some(format!("unknown manager state: {other:?}")),
+        },
+    };
+    CoreStatusSnapshot {
+        state,
+        state_changed_at: status.changed_at,
+        revision: status.revision.as_ref().map(|revision| {
+            nyanpasu_ipc::api::status::RevisionIdInfo {
+                epoch: revision.epoch,
+                generation: revision.generation,
+                effective_hash: revision.effective_hash.clone(),
+            }
+        }),
+        healthy: status
+            .health
+            .as_ref()
+            .map(|health| matches!(health.state, nyanpasu_core_manager::HealthState::Healthy)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Service host: the daemon's CoreControl behind the IPC v2 wire.
+// ---------------------------------------------------------------------------
+
+pub struct ServiceEndpoint {
+    client: &'static nyanpasu_ipc::client::Client,
+}
+
+impl ServiceEndpoint {
+    pub fn new(client: &'static nyanpasu_ipc::client::Client) -> Self {
+        Self { client }
+    }
+
+    fn transport_error(error: impl std::fmt::Display) -> CoreError {
+        CoreError::new(
+            CoreErrorKind::BackendUnavailable,
+            format!("service endpoint unreachable: {error}"),
+            true,
+        )
+    }
+}
+
+impl ControlEndpoint for ServiceEndpoint {
+    fn host(&self) -> ExecutionHost {
+        ExecutionHost::Service
+    }
+
+    fn submit<'a>(
+        &'a self,
+        envelope: CoreCommandEnvelope,
+    ) -> BoxFuture<'a, Result<OperationInfo, CoreError>> {
+        Box::pin(async move {
+            let request = wire_submit_request(&envelope)?;
+            self.client
+                .submit_core(&request)
+                .await
+                .map_err(Self::transport_error)
+        })
+    }
+
+    fn wait_operation<'a>(
+        &'a self,
+        id: OperationId,
+        timeout: Duration,
+    ) -> BoxFuture<'a, Option<OperationInfo>> {
+        Box::pin(async move {
+            let id = id.to_string();
+            let request = CoreOperationReq {
+                operation_id: Cow::Borrowed(id.as_str()),
+                wait_ms: Some(timeout.as_millis().min(u128::from(u64::MAX)) as u64),
+            };
+            // Transport failure and "unknown id" both surface as None here;
+            // the caller's recovery path (re-read status + CAS) covers both.
+            self.client.core_operation(&request).await.ok()
+        })
+    }
+
+    fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
+        Box::pin(async move {
+            let infos = self
+                .client
+                .core_status_v2()
+                .await
+                .map_err(Self::transport_error)?;
+            Ok(map_service_status(&infos))
+        })
+    }
+}
+
+/// The wire form of a local envelope. Only `Reconcile`, `Stop` and `Recover`
+/// travel; a local-only command (`Shutdown`) aimed at the daemon is a caller
+/// bug reported as such rather than silently dropped.
+fn wire_submit_request(
+    envelope: &CoreCommandEnvelope,
+) -> Result<CoreSubmitReq<'static>, CoreError> {
+    use nyanpasu_core_manager::{ConfigInput, CoreCommand};
+    let command = match &envelope.command {
+        CoreCommand::Reconcile(request) => {
+            let ConfigInput::Inline {
+                bytes,
+                expected_digest,
+            } = &request.config;
+            let config = String::from_utf8(bytes.clone()).map_err(|_| {
+                CoreError::new(
+                    CoreErrorKind::InvalidConfig,
+                    "config bytes are not UTF-8 text",
+                    false,
+                )
+            })?;
+            CoreCommandInfo::Reconcile {
+                core_type: Cow::Owned(app_core_kind_to_type(request.core.kind)?),
+                config: Cow::Owned(config),
+                expected_digest: expected_digest.clone().map(Cow::Owned),
+                expected_applied: request.expected_applied.as_ref().map(|revision| {
+                    nyanpasu_ipc::api::status::RevisionIdInfo {
+                        epoch: revision.epoch,
+                        generation: revision.generation,
+                        effective_hash: revision.effective_hash.clone(),
+                    }
+                }),
+            }
+        }
+        CoreCommand::Stop => CoreCommandInfo::Stop,
+        CoreCommand::Recover => CoreCommandInfo::Recover,
+        CoreCommand::Shutdown => {
+            return Err(CoreError::new(
+                CoreErrorKind::OperationConflict,
+                "the daemon's lifecycle is not controlled over the core wire",
+                false,
+            ));
+        }
+    };
+    Ok(CoreSubmitReq {
+        operation_id: Cow::Owned(envelope.operation_id.to_string()),
+        command,
+    })
+}
+
+/// Lossy by construction: `CoreKind` collapses the alpha channel (the daemon
+/// resolves the binary from the full `CoreType`). Known limitation, on the
+/// audit ledger: the bridge-stage facade must carry the intent's own
+/// `CoreType` to the service endpoint instead of round-tripping through the
+/// kind. `Meow` has no wire `CoreType` today and cannot be requested.
+fn app_core_kind_to_type(
+    kind: nyanpasu_core_manager::CoreKind,
+) -> Result<nyanpasu_utils::core::CoreType, CoreError> {
+    use nyanpasu_utils::core::{ClashCoreType, CoreType};
+    match kind {
+        nyanpasu_core_manager::CoreKind::Mihomo => Ok(CoreType::Clash(ClashCoreType::Mihomo)),
+        nyanpasu_core_manager::CoreKind::ClashRust => Ok(CoreType::Clash(ClashCoreType::ClashRust)),
+        nyanpasu_core_manager::CoreKind::ClashPremium => {
+            Ok(CoreType::Clash(ClashCoreType::ClashPremium))
+        }
+        other => Err(CoreError::new(
+            CoreErrorKind::Internal,
+            format!("core kind {other:?} has no wire core type"),
+            false,
+        )),
+    }
+}
+
+fn map_service_status(infos: &CoreInfos) -> CoreStatusSnapshot {
+    let state = infos
+        .detail
+        .clone()
+        .unwrap_or(CoreStateDetail::Stopped { reason: None });
+    CoreStatusSnapshot {
+        state,
+        state_changed_at: infos.state_changed_at,
+        revision: infos.revision.as_ref().map(|revision| revision.id()),
+        healthy: infos.health.as_ref().map(|health| {
+            matches!(
+                health.state,
+                nyanpasu_ipc::api::status::CoreHealthState::Healthy
+            )
+        }),
+    }
+}
+
+/// Shared handle shape the router stores and hands out.
+pub type EndpointHandle = Arc<dyn ControlEndpoint>;

--- a/backend/tauri/src/core/actor_v2/endpoint.rs
+++ b/backend/tauri/src/core/actor_v2/endpoint.rs
@@ -1,0 +1,509 @@
+//! The endpoint port of CoreActor v2: one narrow trait over "a host's
+//! `CoreControl`", implemented by the in-process Local adapter and the IPC v2
+//! Service adapter.
+//!
+//! Design note (deviation from the integration design's concrete
+//! `EndpointHandle` enum, recorded): the router consumes a trait object plus
+//! an [`ExecutionHost`] tag instead of a two-variant enum. Same shape, one
+//! test seam — the fake endpoint in the actor tests is the third
+//! implementation the enum could not have carried.
+//!
+//! Everything here is *reading or forwarding*; the router never synthesizes
+//! lifecycle state (invariant I-R3). The normalized snapshot below is a
+//! field-by-field projection of what the host published, nothing more.
+
+use std::{borrow::Cow, future::Future, pin::Pin, sync::Arc, time::Duration};
+
+use nyanpasu_core_manager::{
+    ApplyOutcome, CoreCommandEnvelope, CoreControl, CoreError, CoreErrorKind, OperationId,
+    OperationOutput, OperationState,
+};
+use nyanpasu_ipc::api::{
+    core::v2::{
+        CoreCommandInfo, CoreOperationReq, CoreSubmitReq, OperationInfo, OperationOutputInfo,
+        OperationPhase, ReconcileOutcomeInfo, ReconcileOutcomeKind,
+    },
+    status::{CoreInfos, CoreStateDetail},
+};
+
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Which controller owns the runtime. The app perceives the difference in
+/// exactly two places: this tag on the endpoint slot, and the handoff
+/// protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionHost {
+    Local,
+    Service,
+}
+
+/// The host's canonical core status, projected field by field for the app.
+/// No field here is ever derived by the router itself.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CoreStatusSnapshot {
+    /// `None` means the host published no state this router can trust — an
+    /// unmapped future variant, or a daemon that answered without a detail.
+    /// No consumer may read it as `Stopped`: "we do not know" is the one
+    /// answer a stop proof must never accept.
+    pub state: Option<CoreStateDetail>,
+    pub state_changed_at: i64,
+    /// The applied revision's CAS identity, when one is running.
+    pub revision: Option<nyanpasu_ipc::api::status::RevisionIdInfo>,
+    /// Healthy / unhealthy, when the host reports it.
+    pub healthy: Option<bool>,
+}
+
+/// One host's control plane, as the router consumes it. Submit is the only
+/// mutating call and is always envelope-shaped; waiting on an operation is a
+/// read and deliberately not routed through the actor mailbox.
+pub trait ControlEndpoint: Send + Sync {
+    fn host(&self) -> ExecutionHost;
+
+    /// Admission into the host's executor. Returns the operation's
+    /// admission-time snapshot; the transaction survives this future's drop.
+    fn submit<'a>(
+        &'a self,
+        envelope: CoreCommandEnvelope,
+    ) -> BoxFuture<'a, Result<OperationInfo, CoreError>>;
+
+    /// Long-poll the host's registry. `None` = unknown/evicted id (recover by
+    /// re-reading status; the revision CAS blocks double application).
+    fn wait_operation<'a>(
+        &'a self,
+        id: OperationId,
+        timeout: Duration,
+    ) -> BoxFuture<'a, Option<OperationInfo>>;
+
+    fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>>;
+}
+
+// ---------------------------------------------------------------------------
+// Local host: the in-process CoreControl.
+// ---------------------------------------------------------------------------
+
+pub struct LocalEndpoint {
+    control: CoreControl,
+}
+
+impl LocalEndpoint {
+    pub fn new(control: CoreControl) -> Self {
+        Self { control }
+    }
+}
+
+impl ControlEndpoint for LocalEndpoint {
+    fn host(&self) -> ExecutionHost {
+        ExecutionHost::Local
+    }
+
+    fn submit<'a>(
+        &'a self,
+        envelope: CoreCommandEnvelope,
+    ) -> BoxFuture<'a, Result<OperationInfo, CoreError>> {
+        Box::pin(async move {
+            let handle = self.control.submit(envelope)?;
+            Ok(map_local_operation(handle.id(), handle.state()))
+        })
+    }
+
+    fn wait_operation<'a>(
+        &'a self,
+        id: OperationId,
+        timeout: Duration,
+    ) -> BoxFuture<'a, Option<OperationInfo>> {
+        Box::pin(async move {
+            self.control
+                .wait_operation(id, timeout)
+                .await
+                .map(|state| map_local_operation(id, state))
+        })
+    }
+
+    fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
+        Box::pin(async move { Ok(map_local_status(&self.control.status())) })
+    }
+}
+
+/// The local sibling of the daemon bridge's wire mapping. Duplicated on
+/// purpose: the app must not depend on the daemon host crate, and the wire
+/// DTO is the shared vocabulary both sides project into.
+fn map_local_operation(id: OperationId, state: OperationState) -> OperationInfo {
+    let (phase, output, error) = match state {
+        OperationState::Queued => (OperationPhase::Queued, None, None),
+        OperationState::Running => (OperationPhase::Running, None, None),
+        OperationState::Succeeded(output) => (
+            OperationPhase::Succeeded,
+            Some(match output {
+                OperationOutput::Reconciled(outcome) => {
+                    OperationOutputInfo::Reconciled(map_local_outcome(&outcome))
+                }
+                OperationOutput::Stopped => OperationOutputInfo::Stopped,
+                OperationOutput::Recovered => OperationOutputInfo::Recovered,
+                OperationOutput::ShutDown => OperationOutputInfo::ShutDown,
+            }),
+            None,
+        ),
+        OperationState::Failed(failure) => (
+            OperationPhase::Failed,
+            None,
+            Some(nyanpasu_ipc::api::core::v2::OperationErrorInfo {
+                kind: failure.kind.map(|kind| Cow::Borrowed(kind.as_str())),
+                message: failure.message,
+                retryable: failure.retryable,
+            }),
+        ),
+    };
+    OperationInfo {
+        id: id.to_string(),
+        phase,
+        output,
+        error,
+    }
+}
+
+fn map_local_outcome(outcome: &ApplyOutcome) -> ReconcileOutcomeInfo {
+    let mut warnings = Vec::new();
+    let mut current = outcome;
+    while let ApplyOutcome::DurabilityUncertain { outcome, warning } = current {
+        warnings.push(warning.clone());
+        current = &**outcome;
+    }
+    let (kind, revision, failed_apply) = match current {
+        ApplyOutcome::Started { revision } => (ReconcileOutcomeKind::Started, revision, None),
+        ApplyOutcome::Noop { revision } => (ReconcileOutcomeKind::Noop, revision, None),
+        ApplyOutcome::Patched { revision } => (ReconcileOutcomeKind::Patched, revision, None),
+        ApplyOutcome::Reloaded { revision } => (ReconcileOutcomeKind::Reloaded, revision, None),
+        ApplyOutcome::Restarted { revision } => (ReconcileOutcomeKind::Restarted, revision, None),
+        ApplyOutcome::Switched { revision } => (ReconcileOutcomeKind::Switched, revision, None),
+        ApplyOutcome::RolledBack {
+            revision,
+            failed_apply,
+        } => (
+            ReconcileOutcomeKind::RolledBack,
+            revision,
+            Some(failed_apply.clone()),
+        ),
+        ApplyOutcome::DurabilityUncertain { .. } => unreachable!("unwrapped by the loop above"),
+    };
+    ReconcileOutcomeInfo {
+        outcome: kind,
+        revision: nyanpasu_ipc::api::status::ConfigRevisionInfo {
+            epoch: revision.epoch,
+            generation: revision.generation,
+            source_hash: revision.source_hash.clone(),
+            effective_hash: revision.effective_hash.clone(),
+        },
+        warning: (!warnings.is_empty()).then(|| warnings.join("; ")),
+        failed_apply,
+    }
+}
+
+fn map_local_status(status: &nyanpasu_core_manager::CoreStatus) -> CoreStatusSnapshot {
+    use nyanpasu_core_manager::CoreState as ManagerCoreState;
+    let state = match &status.state {
+        ManagerCoreState::Stopped { reason } => Some(CoreStateDetail::Stopped {
+            reason: reason.as_ref().map(|reason| reason.to_string()),
+        }),
+        ManagerCoreState::Starting { epoch } => Some(CoreStateDetail::Starting { epoch: *epoch }),
+        ManagerCoreState::Running { epoch, pid } => Some(CoreStateDetail::Running {
+            epoch: *epoch,
+            pid: *pid,
+        }),
+        ManagerCoreState::Restarting { epoch, attempt } => Some(CoreStateDetail::Restarting {
+            epoch: *epoch,
+            attempt: *attempt,
+        }),
+        ManagerCoreState::Switching { from, to } => Some(CoreStateDetail::Switching {
+            from: *from,
+            to: *to,
+        }),
+        ManagerCoreState::Stopping { epoch } => Some(CoreStateDetail::Stopping { epoch: *epoch }),
+        // `CoreState` is `#[non_exhaustive]`; an unknown future state stays
+        // unknown. Folding it into `Stopped` is how a router invents a stop
+        // proof it never received.
+        other => {
+            tracing::warn!("unmapped manager core state: {other:?}");
+            None
+        }
+    };
+    CoreStatusSnapshot {
+        state,
+        state_changed_at: status.changed_at,
+        revision: status.revision.as_ref().map(|revision| {
+            nyanpasu_ipc::api::status::RevisionIdInfo {
+                epoch: revision.epoch,
+                generation: revision.generation,
+                effective_hash: revision.effective_hash.clone(),
+            }
+        }),
+        healthy: status
+            .health
+            .as_ref()
+            .map(|health| matches!(health.state, nyanpasu_core_manager::HealthState::Healthy)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Service host: the daemon's CoreControl behind the IPC v2 wire.
+// ---------------------------------------------------------------------------
+
+pub struct ServiceEndpoint {
+    client: nyanpasu_ipc::client::Client,
+}
+
+impl ServiceEndpoint {
+    pub fn new(client: nyanpasu_ipc::client::Client) -> Self {
+        Self { client }
+    }
+}
+
+/// The daemon's own classification, kept whole.
+///
+/// A `Server` failure is the daemon answering: its `error_kind` and
+/// `retryable` are facts about that failure and are carried through unchanged,
+/// including a kind this build has no variant for — which stays `None` rather
+/// than becoming a guess. Everything else is the transport itself failing,
+/// which no daemon classified and which is retryable by definition.
+fn map_client_error(error: nyanpasu_ipc::client::ClientError) -> CoreError {
+    use nyanpasu_ipc::client::ClientError;
+    if !matches!(error, ClientError::Server { .. }) {
+        return CoreError::new(
+            CoreErrorKind::BackendUnavailable,
+            format!("service endpoint unreachable: {error}"),
+            true,
+        );
+    }
+    CoreError {
+        kind: error.core_error_kind(),
+        retryable: error.retryable(),
+        message: error.to_string(),
+        operation_id: None,
+    }
+}
+
+impl ControlEndpoint for ServiceEndpoint {
+    fn host(&self) -> ExecutionHost {
+        ExecutionHost::Service
+    }
+
+    fn submit<'a>(
+        &'a self,
+        envelope: CoreCommandEnvelope,
+    ) -> BoxFuture<'a, Result<OperationInfo, CoreError>> {
+        Box::pin(async move {
+            let request = wire_submit_request(&envelope)?;
+            self.client
+                .submit_core(&request)
+                .await
+                .map_err(map_client_error)
+        })
+    }
+
+    fn wait_operation<'a>(
+        &'a self,
+        id: OperationId,
+        timeout: Duration,
+    ) -> BoxFuture<'a, Option<OperationInfo>> {
+        Box::pin(async move {
+            let id = id.to_string();
+            let request = CoreOperationReq {
+                operation_id: Cow::Borrowed(id.as_str()),
+                wait_ms: Some(timeout.as_millis().min(u128::from(u64::MAX)) as u64),
+            };
+            // Transport failure and "unknown id" both surface as None here;
+            // the caller's recovery path (re-read status + CAS) covers both.
+            self.client
+                .core_operation(&request)
+                .await
+                .inspect_err(|error| {
+                    tracing::debug!("operation {id} could not be waited on: {error}");
+                })
+                .ok()
+        })
+    }
+
+    fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
+        Box::pin(async move {
+            let infos = self
+                .client
+                .core_status_v2()
+                .await
+                .map_err(map_client_error)?;
+            Ok(map_service_status(&infos))
+        })
+    }
+}
+
+/// The wire form of a local envelope. Only `Reconcile`, `Stop` and `Recover`
+/// travel; a local-only command (`Shutdown`) aimed at the daemon is a caller
+/// bug reported as such rather than silently dropped.
+fn wire_submit_request(
+    envelope: &CoreCommandEnvelope,
+) -> Result<CoreSubmitReq<'static>, CoreError> {
+    use nyanpasu_core_manager::{ConfigInput, CoreCommand};
+    let command = match &envelope.command {
+        CoreCommand::Reconcile(request) => {
+            let ConfigInput::Inline {
+                bytes,
+                expected_digest,
+            } = &request.config;
+            let config = String::from_utf8(bytes.clone()).map_err(|_| {
+                CoreError::new(
+                    CoreErrorKind::InvalidConfig,
+                    "config bytes are not UTF-8 text",
+                    false,
+                )
+            })?;
+            CoreCommandInfo::Reconcile {
+                core_type: Cow::Owned(app_core_kind_to_type(request.core.kind)?),
+                config: Cow::Owned(config),
+                expected_digest: expected_digest.clone().map(Cow::Owned),
+                expected_applied: request.expected_applied.as_ref().map(|revision| {
+                    nyanpasu_ipc::api::status::RevisionIdInfo {
+                        epoch: revision.epoch,
+                        generation: revision.generation,
+                        effective_hash: revision.effective_hash.clone(),
+                    }
+                }),
+            }
+        }
+        CoreCommand::Stop => CoreCommandInfo::Stop,
+        CoreCommand::Recover => CoreCommandInfo::Recover,
+        CoreCommand::Shutdown => {
+            return Err(CoreError::new(
+                CoreErrorKind::OperationConflict,
+                "the daemon's lifecycle is not controlled over the core wire",
+                false,
+            ));
+        }
+    };
+    Ok(CoreSubmitReq {
+        operation_id: Cow::Owned(envelope.operation_id.to_string()),
+        command,
+    })
+}
+
+/// Lossy by construction: `CoreKind` collapses the alpha channel (the daemon
+/// resolves the binary from the full `CoreType`). Known limitation, on the
+/// audit ledger: the bridge-stage facade must carry the intent's own
+/// `CoreType` to the service endpoint instead of round-tripping through the
+/// kind. `Meow` has no wire `CoreType` today and cannot be requested.
+fn app_core_kind_to_type(
+    kind: nyanpasu_core_manager::CoreKind,
+) -> Result<nyanpasu_utils::core::CoreType, CoreError> {
+    use nyanpasu_utils::core::{ClashCoreType, CoreType};
+    match kind {
+        nyanpasu_core_manager::CoreKind::Mihomo => Ok(CoreType::Clash(ClashCoreType::Mihomo)),
+        nyanpasu_core_manager::CoreKind::ClashRust => Ok(CoreType::Clash(ClashCoreType::ClashRust)),
+        nyanpasu_core_manager::CoreKind::ClashPremium => {
+            Ok(CoreType::Clash(ClashCoreType::ClashPremium))
+        }
+        other => Err(CoreError::new(
+            CoreErrorKind::Internal,
+            format!("core kind {other:?} has no wire core type"),
+            false,
+        )),
+    }
+}
+
+fn map_service_status(infos: &CoreInfos) -> CoreStatusSnapshot {
+    CoreStatusSnapshot {
+        // A daemon too old to publish `detail` leaves this unknown. The coarse
+        // `CoreInfos::state` cannot stand in: it collapses Starting and
+        // Restarting into a Stopped shape, which would read as a stop proof.
+        state: infos.detail.clone(),
+        state_changed_at: infos.state_changed_at,
+        revision: infos.revision.as_ref().map(|revision| revision.id()),
+        healthy: infos.health.as_ref().map(|health| {
+            matches!(
+                health.state,
+                nyanpasu_ipc::api::status::CoreHealthState::Healthy
+            )
+        }),
+    }
+}
+
+/// Shared handle shape the router stores and hands out.
+pub type EndpointHandle = Arc<dyn ControlEndpoint>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nyanpasu_ipc::{
+        api::{ResponseCode, status::CoreState},
+        client::ClientError,
+    };
+
+    fn infos(detail: Option<CoreStateDetail>) -> CoreInfos {
+        CoreInfos {
+            r#type: None,
+            // Deliberately the shape a stopped core would publish: the point
+            // is that the coarse state must not be consulted at all.
+            state: CoreState::Stopped(None),
+            state_changed_at: 7,
+            config_path: None,
+            controller: None,
+            health: None,
+            revision: None,
+            detail,
+        }
+    }
+
+    /// A daemon too old to publish `detail` leaves the state unknown. Reading
+    /// the coarse `CoreState` instead would manufacture a `Stopped` that the
+    /// handoff would then accept as proof.
+    #[test]
+    fn missing_service_detail_maps_to_unknown() {
+        assert_eq!(map_service_status(&infos(None)).state, None);
+        assert_eq!(
+            map_service_status(&infos(Some(CoreStateDetail::Starting { epoch: 3 }))).state,
+            Some(CoreStateDetail::Starting { epoch: 3 })
+        );
+    }
+
+    fn server_error(kind: &str, retryable: Option<bool>) -> ClientError {
+        ClientError::Server {
+            operation: "/core/v2/submit",
+            code: ResponseCode::OtherError,
+            msg: "boom".into(),
+            error_kind: Some(kind.to_owned()),
+            retryable,
+        }
+    }
+
+    #[test]
+    fn a_classified_server_failure_keeps_its_kind_and_retryability() {
+        for (kind, retryable, expected_kind, expected_retryable) in [
+            (
+                "operation_conflict",
+                None,
+                Some(CoreErrorKind::OperationConflict),
+                false,
+            ),
+            ("queue_full", None, Some(CoreErrorKind::QueueFull), true),
+            // The daemon's own answer outranks the kind's default.
+            (
+                "operation_conflict",
+                Some(true),
+                Some(CoreErrorKind::OperationConflict),
+                true,
+            ),
+            // A kind this build does not know stays unclassified.
+            ("made_up", None, None, false),
+        ] {
+            let error = map_client_error(server_error(kind, retryable));
+            assert_eq!(error.kind, expected_kind, "kind for {kind}");
+            assert_eq!(error.retryable, expected_retryable, "retryable for {kind}");
+        }
+    }
+
+    #[test]
+    fn a_transport_failure_is_backend_unavailable_and_retryable() {
+        let error = map_client_error(ClientError::EmptyData {
+            operation: "/core/v2/submit",
+        });
+        assert_eq!(error.kind, Some(CoreErrorKind::BackendUnavailable));
+        assert!(error.retryable);
+    }
+}

--- a/backend/tauri/src/core/actor_v2/intent.rs
+++ b/backend/tauri/src/core/actor_v2/intent.rs
@@ -1,0 +1,84 @@
+//! RuntimeIntentBuilder: a pure service deriving the portable reconcile
+//! intent from an already-built runtime document. No I/O, no globals, no
+//! implicit inputs — `RunType::default()`-style hidden state has no entry
+//! here.
+//!
+//! Scope note: the snapshots → document merge itself remains the existing
+//! enhance pipeline (already pure); the bridge stage composes the two. This
+//! type owns the portable half: text, digest, CAS token.
+
+use nyanpasu_core_manager::payload_digest;
+use nyanpasu_ipc::api::status::RevisionIdInfo;
+use nyanpasu_utils::core::CoreType;
+
+/// The portable convergence intent: everything a `Reconcile` envelope needs
+/// that is not host-resolved (binary paths stay host-side).
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeIntent {
+    pub core_type: CoreType,
+    /// The full runtime config document, serialized.
+    pub config_text: String,
+    /// [`payload_digest`] of `config_text` — the change identity the daemon
+    /// verifies on receipt.
+    pub digest: String,
+    /// The revision the caller believes is applied; `None` on first start.
+    pub expected_applied: Option<RevisionIdInfo>,
+}
+
+pub struct RuntimeIntentBuilder;
+
+impl RuntimeIntentBuilder {
+    /// Deterministic: the same document and inputs produce the same intent,
+    /// digest included.
+    pub fn build(
+        core_type: CoreType,
+        document: &serde_yaml::Mapping,
+        expected_applied: Option<RevisionIdInfo>,
+    ) -> Result<RuntimeIntent, serde_yaml::Error> {
+        let config_text = serde_yaml::to_string(document)?;
+        let digest = payload_digest(config_text.as_bytes());
+        Ok(RuntimeIntent {
+            core_type,
+            config_text,
+            digest,
+            expected_applied,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nyanpasu_utils::core::ClashCoreType;
+
+    fn document() -> serde_yaml::Mapping {
+        let mut document = serde_yaml::Mapping::new();
+        document.insert(
+            serde_yaml::Value::String("external-controller".into()),
+            serde_yaml::Value::String("127.0.0.1:9090".into()),
+        );
+        document
+    }
+
+    #[test]
+    fn the_same_inputs_produce_the_same_intent() {
+        let core_type = CoreType::Clash(ClashCoreType::Mihomo);
+        let first = RuntimeIntentBuilder::build(core_type.clone(), &document(), None).unwrap();
+        let second = RuntimeIntentBuilder::build(core_type, &document(), None).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.digest, payload_digest(first.config_text.as_bytes()));
+    }
+
+    #[test]
+    fn a_document_change_changes_the_digest() {
+        let core_type = CoreType::Clash(ClashCoreType::Mihomo);
+        let base = RuntimeIntentBuilder::build(core_type.clone(), &document(), None).unwrap();
+        let mut changed = document();
+        changed.insert(
+            serde_yaml::Value::String("mixed-port".into()),
+            serde_yaml::Value::Number(7890.into()),
+        );
+        let next = RuntimeIntentBuilder::build(core_type, &changed, None).unwrap();
+        assert_ne!(base.digest, next.digest);
+    }
+}

--- a/backend/tauri/src/core/actor_v2/mod.rs
+++ b/backend/tauri/src/core/actor_v2/mod.rs
@@ -1,0 +1,1027 @@
+//! CoreActor v2: endpoint router + status projection, nothing else.
+//!
+//! Normative design: `docs/design/2026-08-12-core-actor-v2-app-integration.md`
+//! (§3–§5). The actor owns exactly four things — the active endpoint slot, the
+//! `ControllerGeneration`, the subscription pump, and the projection channels.
+//! Lifecycle truth, transactions, compensation and quarantine live only inside
+//! each host's `CoreControl`.
+//!
+//! Invariants:
+//! - **I-R1**: at most one `Connected` endpoint. A handoff moves the slot to
+//!   `HandingOff` for the whole stop-and-prove leg, and every submit that
+//!   arrives meanwhile is refused with `operation_conflict` (retryable)
+//!   rather than queued behind a leg that can take a minute.
+//! - **I-R2**: `Degraded` is an honest terminal, never a silent fallback to
+//!   another host. Recovery is an explicit new `ChangeHost` with a fresh
+//!   endpoint.
+//! - **I-R3**: the router never synthesizes lifecycle state. Projections carry
+//!   host-published snapshots verbatim.
+//!
+//! Deviations from the integration design, recorded:
+//! - `ChangeHost` carries the target endpoint (built by the facade from the
+//!   ServiceActor's supply or the local composition root) instead of the actor
+//!   resolving it — "desired state is delivered by orchestration, not fetched".
+//! - The post-handoff target `Reconcile` is facade orchestration: the actor
+//!   reports `Completed` with the runtime stopped, and the facade's reconcile
+//!   failure — not the actor — produces the `CommittedDegraded` report.
+//! - A handoff's stop leg runs outside the mailbox and carries the caller's
+//!   reply port with it. If the actor dies before the leg reports, the port is
+//!   dropped and the caller sees `Internal: the core router is gone` — the
+//!   same answer any other lost reply gives.
+
+pub mod endpoint;
+pub mod intent;
+pub mod service_actor;
+
+use std::time::Duration;
+
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+use tokio::sync::{broadcast, watch};
+
+use nyanpasu_core_manager::{
+    CoreCommand, CoreCommandEnvelope, CoreError, CoreErrorKind, OperationId,
+};
+use nyanpasu_ipc::api::core::v2::{OperationInfo, OperationOutputInfo, OperationPhase};
+
+use endpoint::{ControlEndpoint, CoreStatusSnapshot, EndpointHandle, ExecutionHost};
+
+/// Monotonic owner fence. Incremented exactly once per completed handoff;
+/// stale pump frames and stale down reports are dropped by comparing it.
+pub type ControllerGeneration = u64;
+
+/// How often the pump re-reads the endpoint's status. Phase 1 polls both
+/// hosts; a push feed (local watch / daemon event stream) replaces this
+/// without changing the message protocol (OQ-6).
+const PUMP_INTERVAL: Duration = Duration::from_secs(2);
+/// Bound for the source-stop leg of a handoff and the shutdown stop.
+const STOP_WAIT: Duration = Duration::from_secs(60);
+/// Bound on one endpoint read, in the pump and in the handoff preflight. An
+/// endpoint that accepts the call and never answers has to degrade the
+/// projection, not stall the router behind it.
+const PUMP_STATUS_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Scheduling and mailbox-hop slack layered on top of the worst-case internal
+/// leg sum for every caller-facing budget below. It is not a place to hide
+/// another retry; it only has to cover the time between the internal path
+/// finishing honestly and the reply crossing back to the caller.
+const CALL_BUDGET_SLACK: Duration = Duration::from_secs(10);
+
+// Scope of every budget below: each one bounds only the named message's own
+// execution legs -- the endpoint calls it makes plus the slack above. None of
+// them account for how long the message might sit in the actor's mailbox
+// behind other messages already queued ahead of it; the mailbox is unbounded
+// by construction, and bounding its depth is bridge-stage work this module
+// does not attempt. A submit queued behind two endpoint timeouts can exhaust
+// its own budget before its endpoint call even starts. When that happens,
+// `CoreClient::call`'s caller-side timeout error is what carries the recovery
+// contract for the caller -- not a wider number here. Widening a budget to
+// "cover" queueing would be a number with no argument behind it; the honest
+// fix is making that timeout error tell the caller what it can safely do next
+// (see `submit`/`change_host`/`shutdown` below).
+
+/// Caller bound for [`CoreClient::change_host`]. A handoff's worst case, leg
+/// by leg: the preflight read (`status_timeout`, `change_host`) + the stop's
+/// admission (`status_timeout`, `stop_and_confirm`) + the stop's long poll
+/// (`stop_wait + status_timeout`, `stop_and_confirm`'s own bound on
+/// `wait_operation`) + the stop's lost-result status fallback
+/// (`status_timeout`, `stop_and_confirm`) — four `status_timeout` legs plus
+/// `stop_wait`. A caller bound smaller than this sum reports `Internal`
+/// while the internal path is still honestly working, and ownership then
+/// moves out from under a caller who was told the call failed (F3).
+fn handoff_budget(status_timeout: Duration, stop_wait: Duration) -> Duration {
+    status_timeout * 4 + stop_wait + CALL_BUDGET_SLACK
+}
+
+/// Caller bound for [`CoreClient::shutdown`]. Same stop legs as
+/// [`handoff_budget`] minus the preflight — shutdown never probes a target —
+/// so three `status_timeout` legs plus `stop_wait`.
+fn shutdown_budget(status_timeout: Duration, stop_wait: Duration) -> Duration {
+    status_timeout * 3 + stop_wait + CALL_BUDGET_SLACK
+}
+
+/// Caller bound for [`CoreClient::submit`]. The `Submit` handler bounds its
+/// one endpoint call by `status_timeout` (F4); the caller has to outlast that
+/// leg or it reports `Internal` for a submit the actor is about to answer
+/// honestly with `BackendUnavailable`.
+fn submit_budget(status_timeout: Duration) -> Duration {
+    status_timeout + CALL_BUDGET_SLACK
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CoreStatusProjection {
+    pub host: ExecutionHost,
+    pub generation: ControllerGeneration,
+    pub connectivity: EndpointConnectivity,
+    /// The host's latest published snapshot; `None` before the first read.
+    pub snapshot: Option<CoreStatusSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum EndpointConnectivity {
+    Connected,
+    HandingOff {
+        from: ExecutionHost,
+        to: ExecutionHost,
+    },
+    /// The endpoint is unreachable. `desired` names the committed host; the
+    /// router never falls back on its own.
+    Degraded {
+        desired: ExecutionHost,
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum HandoffReport {
+    /// The target already owned the runtime; nothing moved.
+    NoChange,
+    /// Ownership moved: the source's death is proven, the generation is
+    /// advanced, and the runtime is *stopped* awaiting the facade's reconcile.
+    Completed { generation: ControllerGeneration },
+}
+
+#[derive(Debug, Clone)]
+pub struct ShutdownReport {
+    /// What the stop actually did. `Ok(Some(info))` is a proven stop,
+    /// `Ok(None)` means nothing was running, and `Err` says the runtime was
+    /// *not* proven stopped — including the degraded case, where no stop could
+    /// be attempted at all. A caller that needs to know whether a core outlived
+    /// the app reads this, and collapsing it to `None` was exactly the audited
+    /// fake-Stopped.
+    pub stop: Result<Option<OperationInfo>, CoreError>,
+    /// What the host last published before the channels closed.
+    pub final_status: Option<CoreStatusSnapshot>,
+}
+
+/// A successful submit: the operation's admission snapshot plus the endpoint
+/// to wait on. Waiting is a read and deliberately does not occupy the mailbox.
+pub struct SubmitTicket {
+    pub id: OperationId,
+    pub admitted: OperationInfo,
+    pub endpoint: EndpointHandle,
+    pub generation: ControllerGeneration,
+}
+
+impl std::fmt::Debug for SubmitTicket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubmitTicket")
+            .field("id", &self.id)
+            .field("admitted", &self.admitted)
+            .field("host", &self.endpoint.host())
+            .field("generation", &self.generation)
+            .finish()
+    }
+}
+
+pub enum CoreActorMessage {
+    /// Routed through the mailbox so it serializes with `ChangeHost`: while a
+    /// handoff runs, no submit can land on the wrong host (I-R1).
+    Submit {
+        envelope: CoreCommandEnvelope,
+        reply: RpcReplyPort<Result<SubmitTicket, CoreError>>,
+    },
+    /// Explicit ownership transfer. The endpoint is built by the caller; the
+    /// actor proves the source dead before adopting it.
+    ChangeHost {
+        target: EndpointHandle,
+        reply: RpcReplyPort<Result<HandoffReport, CoreError>>,
+    },
+    /// Pump feedback: a status frame from the endpoint of `generation`.
+    EndpointEvent {
+        generation: ControllerGeneration,
+        snapshot: CoreStatusSnapshot,
+    },
+    /// Pump feedback: the endpoint of `generation` stopped answering.
+    EndpointDown {
+        generation: ControllerGeneration,
+        reason: String,
+    },
+    /// Continuation of a handoff whose stop leg ran outside the mailbox. It
+    /// carries the original caller's reply port: a handoff answers exactly
+    /// once, and this is where.
+    HandoffStopped {
+        generation: ControllerGeneration,
+        result: Result<Option<OperationInfo>, CoreError>,
+        reply: RpcReplyPort<Result<HandoffReport, CoreError>>,
+    },
+    Shutdown {
+        reply: RpcReplyPort<ShutdownReport>,
+    },
+}
+
+pub struct CoreActor;
+
+pub struct CoreActorArgs {
+    /// The initial endpoint, adopted as-is (status read, no lifecycle writes).
+    pub initial: EndpointHandle,
+    /// Created by the composition root so the client keeps the receivers; the
+    /// actor is the only writer.
+    pub status_tx: watch::Sender<CoreStatusProjection>,
+    pub events_tx: broadcast::Sender<CoreStatusProjection>,
+    /// Bound on one endpoint read. Injected so the timeout paths are reachable
+    /// in a test without a wall-clock wait; production passes
+    /// [`PUMP_STATUS_TIMEOUT`].
+    pub status_timeout: Duration,
+    /// Bound on a stop's long poll, for the same reason; production passes
+    /// [`STOP_WAIT`].
+    pub stop_wait: Duration,
+}
+
+enum EndpointSlot {
+    Connected(EndpointHandle),
+    /// The stop-and-prove leg is in flight. Exhaustive matching on this enum
+    /// is what makes "routed something during a handoff" a compile error
+    /// rather than a race.
+    HandingOff {
+        from: EndpointHandle,
+        target: EndpointHandle,
+        /// Set when the source's pump reported it down mid-handoff. It decides
+        /// where a *failed* handoff returns to: back to a working source, or
+        /// to `Degraded`.
+        source_down: Option<String>,
+    },
+    Degraded {
+        desired: ExecutionHost,
+        reason: String,
+    },
+}
+
+pub struct CoreActorState {
+    slot: EndpointSlot,
+    generation: ControllerGeneration,
+    /// The active host's latest snapshot. Owned here rather than read back out
+    /// of the watch channel, because adoption has to be able to *clear* it: the
+    /// first frame of a new generation must not carry the previous host's
+    /// runtime state.
+    snapshot: Option<CoreStatusSnapshot>,
+    /// Shutdowns that arrived mid-handoff. All of them are settled from the
+    /// handoff's own stop result, so the source is never stopped twice and no
+    /// caller is left holding a reply port that was quietly replaced.
+    pending_shutdown: Vec<RpcReplyPort<ShutdownReport>>,
+    status_tx: watch::Sender<CoreStatusProjection>,
+    events_tx: broadcast::Sender<CoreStatusProjection>,
+    pump: Option<tokio::task::JoinHandle<()>>,
+    stop_wait: Duration,
+    /// The stop leg of a handoff in flight. Owned here so the actor's own
+    /// termination takes it down with the pump: it holds the source endpoint,
+    /// an `ActorRef` and the caller's reply port, and a hung call would keep
+    /// all three alive past the mailbox.
+    handoff: Option<tokio::task::JoinHandle<()>>,
+    status_timeout: Duration,
+}
+
+impl CoreActorState {
+    fn publish(&self) {
+        let projection = self.projection();
+        self.status_tx.send_replace(projection.clone());
+        let _ = self.events_tx.send(projection);
+    }
+
+    fn projection(&self) -> CoreStatusProjection {
+        let snapshot = self.snapshot.clone();
+        match &self.slot {
+            EndpointSlot::Connected(endpoint) => CoreStatusProjection {
+                host: endpoint.host(),
+                generation: self.generation,
+                connectivity: EndpointConnectivity::Connected,
+                snapshot,
+            },
+            // Ownership has not moved yet: the source still owns the runtime
+            // until its death is proven.
+            EndpointSlot::HandingOff { from, target, .. } => CoreStatusProjection {
+                host: from.host(),
+                generation: self.generation,
+                connectivity: EndpointConnectivity::HandingOff {
+                    from: from.host(),
+                    to: target.host(),
+                },
+                snapshot,
+            },
+            EndpointSlot::Degraded { desired, reason } => CoreStatusProjection {
+                host: *desired,
+                generation: self.generation,
+                connectivity: EndpointConnectivity::Degraded {
+                    desired: *desired,
+                    reason: reason.clone(),
+                },
+                snapshot,
+            },
+        }
+    }
+
+    fn set_snapshot(&mut self, snapshot: CoreStatusSnapshot) {
+        self.snapshot = Some(snapshot);
+        self.publish();
+    }
+}
+
+fn spawn_pump(
+    myself: ActorRef<CoreActorMessage>,
+    endpoint: EndpointHandle,
+    generation: ControllerGeneration,
+    status_timeout: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            let read = tokio::time::timeout(status_timeout, endpoint.status()).await;
+            let reason = match read {
+                Ok(Ok(snapshot)) => {
+                    if myself
+                        .cast(CoreActorMessage::EndpointEvent {
+                            generation,
+                            snapshot,
+                        })
+                        .is_err()
+                    {
+                        break;
+                    }
+                    tokio::time::sleep(PUMP_INTERVAL).await;
+                    continue;
+                }
+                Ok(Err(error)) => error.to_string(),
+                // An endpoint that accepts the read and never answers is down
+                // as far as the router is concerned.
+                Err(_) => format!("the endpoint status read timed out after {status_timeout:?}"),
+            };
+            let _ = myself.cast(CoreActorMessage::EndpointDown { generation, reason });
+            break;
+        }
+    })
+}
+
+/// Stops the runtime on `endpoint` and proves it. `Ok(None)` means nothing
+/// was running; `Ok(Some(info))` is the stop's terminal snapshot.
+/// Every call is bounded by `call_timeout`, the long poll by `stop_wait` plus
+/// one call's slack. An endpoint that accepts a call and never answers would
+/// otherwise park the handoff in `HandingOff` permanently: the phase refuses
+/// every submit, the parked shutdown never settles, and nothing degrades.
+async fn stop_and_confirm(
+    endpoint: &dyn ControlEndpoint,
+    call_timeout: Duration,
+    stop_wait: Duration,
+) -> Result<Option<OperationInfo>, CoreError> {
+    let envelope = CoreCommandEnvelope {
+        operation_id: OperationId::generate(),
+        command: CoreCommand::Stop,
+    };
+    let requested = envelope.operation_id;
+    let admitted = tokio::time::timeout(call_timeout, endpoint.submit(envelope))
+        .await
+        .map_err(|_| {
+            CoreError::new(
+                CoreErrorKind::StopUnconfirmed,
+                "the stop admission did not answer within its bound; whether the host accepted it is unknown",
+                false,
+            )
+        })??;
+    let id: OperationId = admitted
+        .id
+        .parse()
+        .map_err(|_| CoreError::new(CoreErrorKind::Internal, "endpoint echoed a bad id", false))?;
+    // A syntactically valid id is not the id we asked about. Waiting on some
+    // other operation and accepting its `Stopped` is a proof about a runtime
+    // nobody asked to stop.
+    if id != requested {
+        return Err(CoreError::new(
+            CoreErrorKind::StopUnconfirmed,
+            "the endpoint admitted a different operation than the stop it was given",
+            false,
+        ));
+    }
+    let terminal = tokio::time::timeout(
+        stop_wait + call_timeout,
+        endpoint.wait_operation(id, stop_wait),
+    )
+    .await
+    // An overrun long poll is the same situation as a lost result: the status
+    // check below decides, and it cannot invent a proof either.
+    .unwrap_or(None);
+    match terminal {
+        Some(info) if info.id != admitted.id => Err(CoreError::new(
+            CoreErrorKind::StopUnconfirmed,
+            "the endpoint replayed another operation's terminal result",
+            false,
+        )),
+        Some(info) => match info.phase {
+            // Succeeding at *something else* is not a stop proof. Only the
+            // stop output proves the runtime this handoff is taking over from
+            // is gone.
+            OperationPhase::Succeeded => {
+                if matches!(info.output, Some(OperationOutputInfo::Stopped)) {
+                    Ok(Some(info))
+                } else {
+                    Err(CoreError::new(
+                        CoreErrorKind::StopUnconfirmed,
+                        "the endpoint answered a stop with a non-stop output",
+                        false,
+                    ))
+                }
+            }
+            OperationPhase::Failed => {
+                let wire_kind = info
+                    .error
+                    .as_ref()
+                    .and_then(|error| error.kind.as_deref())
+                    .map(str::to_owned);
+                match wire_kind.as_deref() {
+                    // Nothing was running: the stop goal already holds.
+                    Some("not_started") => Ok(None),
+                    // The host classified this failure; a kind this build does
+                    // not know stays unclassified rather than becoming
+                    // `Internal`, and the host's retryability is its own.
+                    _ => Err(CoreError {
+                        kind: wire_kind
+                            .as_deref()
+                            .and_then(nyanpasu_core_manager::CoreErrorKind::from_wire),
+                        retryable: info.error.as_ref().is_some_and(|error| error.retryable),
+                        message: info
+                            .error
+                            .map(|error| error.message)
+                            .unwrap_or_else(|| "stop failed".into()),
+                        operation_id: None,
+                    }),
+                }
+            }
+            // The wait bound elapsed without a terminal state: no proof, no
+            // handoff.
+            OperationPhase::Queued | OperationPhase::Running => Err(CoreError::new(
+                CoreErrorKind::StopUnconfirmed,
+                "the stop did not reach a terminal state within the wait bound",
+                false,
+            )),
+        },
+        // Registry lost or transport broke: verify by status before trusting.
+        None => match tokio::time::timeout(call_timeout, endpoint.status())
+            .await
+            .map_err(|_| {
+                CoreError::new(
+                    CoreErrorKind::StopUnconfirmed,
+                    "the stop's result was lost and the status check did not answer within its bound",
+                    false,
+                )
+            })??
+            .state
+        {
+            Some(nyanpasu_ipc::api::status::CoreStateDetail::Stopped { .. }) => Ok(None),
+            Some(_) => Err(CoreError::new(
+                CoreErrorKind::StopUnconfirmed,
+                "the stop's result was lost and the runtime still reports non-stopped",
+                false,
+            )),
+            None => Err(CoreError::new(
+                CoreErrorKind::StopUnconfirmed,
+                "the stop's result was lost and the host published no state to check it against",
+                false,
+            )),
+        },
+    }
+}
+
+impl Actor for CoreActor {
+    type Msg = CoreActorMessage;
+    type State = CoreActorState;
+    type Arguments = CoreActorArgs;
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let host = args.initial.host();
+        args.status_tx.send_replace(CoreStatusProjection {
+            host,
+            generation: 0,
+            connectivity: EndpointConnectivity::Connected,
+            snapshot: None,
+        });
+        let pump = spawn_pump(myself, args.initial.clone(), 0, args.status_timeout);
+        Ok(CoreActorState {
+            slot: EndpointSlot::Connected(args.initial),
+            generation: 0,
+            snapshot: None,
+            pending_shutdown: Vec::new(),
+            status_tx: args.status_tx,
+            events_tx: args.events_tx,
+            pump: Some(pump),
+            stop_wait: args.stop_wait,
+            handoff: None,
+            status_timeout: args.status_timeout,
+        })
+    }
+
+    async fn post_stop(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        // The pump outlives the mailbox otherwise: it holds an `ActorRef` and
+        // an endpoint, and a status read in flight keeps both alive.
+        if let Some(pump) = state.pump.take() {
+            pump.abort();
+            let _ = pump.await;
+        }
+        if let Some(handoff) = state.handoff.take() {
+            handoff.abort();
+            let _ = handoff.await;
+        }
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            CoreActorMessage::Submit { envelope, reply } => {
+                let result = match &state.slot {
+                    EndpointSlot::Connected(handle) => {
+                        let endpoint = handle.clone();
+                        let operation_id = envelope.operation_id;
+                        // F4: an endpoint that accepts the call and never
+                        // answers must not park the mailbox behind it — the
+                        // same bound the preflight and the stop admission
+                        // use, so it never outlasts the caller's own budget.
+                        match tokio::time::timeout(state.status_timeout, endpoint.submit(envelope))
+                            .await
+                        {
+                            Ok(Ok(admitted)) if admitted.id != operation_id.to_string() => {
+                                // F8: a syntactically fine id that is not the
+                                // one this submit asked about means the
+                                // ticket cannot be trusted to name the right
+                                // operation (mirrors the stop-path check).
+                                Err(CoreError::new(
+                                    CoreErrorKind::Internal,
+                                    "the endpoint admitted a different operation than the one submitted",
+                                    false,
+                                ))
+                            }
+                            Ok(Ok(admitted)) => Ok(SubmitTicket {
+                                id: operation_id,
+                                admitted,
+                                endpoint,
+                                generation: state.generation,
+                            }),
+                            Ok(Err(error)) => Err(error),
+                            Err(_) => Err(CoreError::new(
+                                CoreErrorKind::BackendUnavailable,
+                                "the endpoint did not answer the submission within its bound; retry with the same operation id attaches idempotently",
+                                true,
+                            )),
+                        }
+                    }
+                    // I-R1: refused, not queued. Queuing would park the
+                    // caller behind a leg bounded only by `STOP_WAIT`, and
+                    // that wait is what its own, much shorter submit budget
+                    // turns into an `Internal` the caller cannot act on.
+                    EndpointSlot::HandingOff { .. } => Err(CoreError::new(
+                        CoreErrorKind::OperationConflict,
+                        "a host handoff is in progress",
+                        true,
+                    )),
+                    EndpointSlot::Degraded { desired, reason } => Err(CoreError::new(
+                        CoreErrorKind::BackendUnavailable,
+                        format!("the {desired:?} endpoint is degraded: {reason}"),
+                        true,
+                    )),
+                };
+                let _ = reply.send(result);
+            }
+
+            CoreActorMessage::ChangeHost { target, reply } => {
+                self.change_host(&myself, state, target, reply).await;
+            }
+
+            CoreActorMessage::HandoffStopped {
+                generation,
+                result,
+                reply,
+            } => {
+                self.handoff_stopped(&myself, state, generation, result, reply);
+            }
+
+            CoreActorMessage::EndpointEvent {
+                generation,
+                snapshot,
+            } => {
+                // Stale frames from an abandoned endpoint are dropped, never
+                // merged (fencing use #1).
+                if generation == state.generation {
+                    state.set_snapshot(snapshot);
+                }
+            }
+
+            CoreActorMessage::EndpointDown { generation, reason } => {
+                if generation != state.generation {
+                    return Ok(());
+                }
+                let connected = match &state.slot {
+                    EndpointSlot::Connected(handle) => Some(handle.host()),
+                    _ => None,
+                };
+                match connected {
+                    // Honest terminal: desired host stays committed, nothing
+                    // falls back silently (I-R2).
+                    Some(desired) => {
+                        state.slot = EndpointSlot::Degraded { desired, reason };
+                        state.publish();
+                    }
+                    // Mid-handoff the source going down does not decide
+                    // anything yet; the stop leg's result does. Nothing is
+                    // published: `source_down` is not part of the projection,
+                    // so a frame here would be a byte-identical duplicate.
+                    None => {
+                        if let EndpointSlot::HandingOff { source_down, .. } = &mut state.slot {
+                            *source_down = Some(reason);
+                        }
+                    }
+                }
+            }
+
+            CoreActorMessage::Shutdown { reply } => {
+                if let Some(pump) = state.pump.take() {
+                    pump.abort();
+                }
+                if matches!(state.slot, EndpointSlot::HandingOff { .. }) {
+                    // A stop for this very runtime is already in flight.
+                    // Issuing a second one would submit two stops for one
+                    // core; the handoff continuation settles this report.
+                    state.pending_shutdown.push(reply);
+                    return Ok(());
+                }
+                let stop = match &state.slot {
+                    EndpointSlot::Connected(handle) => {
+                        stop_and_confirm(handle.as_ref(), state.status_timeout, state.stop_wait)
+                            .await
+                    }
+                    EndpointSlot::Degraded { desired, reason } => Err(CoreError::new(
+                        CoreErrorKind::BackendUnavailable,
+                        format!(
+                            "the {desired:?} endpoint is degraded ({reason}); no stop was attempted"
+                        ),
+                        true,
+                    )),
+                    EndpointSlot::HandingOff { .. } => unreachable!("deferred above"),
+                };
+                // Reported, never swallowed: the report is the structural fix
+                // for the audited fake-Stopped.
+                if let Err(error) = &stop {
+                    tracing::error!("shutdown stop failed: {error}");
+                }
+                let _ = reply.send(ShutdownReport {
+                    stop,
+                    final_status: state.snapshot.clone(),
+                });
+                myself.stop(Some("shutdown".into()));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl CoreActor {
+    /// The explicit handoff (design §5.2): preflight → stop-and-prove the
+    /// source → advance the generation → adopt the target. The runtime is
+    /// left stopped; the facade reconciles it on the target next.
+    ///
+    /// Only the preflight runs in this mailbox turn. The stop leg is spawned
+    /// with the caller's reply port and answers through
+    /// [`CoreActorMessage::HandoffStopped`], so the phase — not the turn — is
+    /// what keeps a submit off the wrong host.
+    async fn change_host(
+        &self,
+        myself: &ActorRef<CoreActorMessage>,
+        state: &mut CoreActorState,
+        target: EndpointHandle,
+        reply: RpcReplyPort<Result<HandoffReport, CoreError>>,
+    ) {
+        if matches!(state.slot, EndpointSlot::HandingOff { .. }) {
+            let _ = reply.send(Err(CoreError::new(
+                CoreErrorKind::OperationConflict,
+                "a host handoff is in progress",
+                true,
+            )));
+            return;
+        }
+
+        // Phase: Preflight — the target must answer before anything stops.
+        let preflight = match tokio::time::timeout(state.status_timeout, target.status()).await {
+            Ok(result) => result.err().map(|error| error.to_string()),
+            Err(_) => Some(format!(
+                "the target endpoint did not answer within {:?}",
+                state.status_timeout
+            )),
+        };
+        if let Some(error) = preflight {
+            let _ = reply.send(Err(CoreError::new(
+                CoreErrorKind::BackendUnavailable,
+                format!("handoff preflight failed: {error}"),
+                true,
+            )));
+            return;
+        }
+
+        let source = match &state.slot {
+            EndpointSlot::Connected(current) if current.host() == target.host() => {
+                let _ = reply.send(Ok(HandoffReport::NoChange));
+                return;
+            }
+            // Same host, fresh endpoint: ownership never moved, so there is no
+            // transfer to prove. This is the explicit recovery I-R2 demands.
+            EndpointSlot::Degraded { desired, .. } if *desired == target.host() => None,
+            // Moving to *another* host means claiming a runtime whose current
+            // owner cannot be reached — which is precisely the case where
+            // nothing can prove it stopped. Two hosts driving one core is
+            // worse than a refusal.
+            EndpointSlot::Degraded { desired, .. } => {
+                let _ = reply.send(Err(CoreError::new(
+                    CoreErrorKind::StopUnconfirmed,
+                    format!(
+                        "the {desired:?} endpoint is unreachable; its runtime is not proven stopped"
+                    ),
+                    true,
+                )));
+                return;
+            }
+            EndpointSlot::Connected(current) => Some(current.clone()),
+            EndpointSlot::HandingOff { .. } => unreachable!("refused above"),
+        };
+
+        let Some(source) = source else {
+            self.adopt(myself, state, target);
+            let _ = reply.send(Ok(HandoffReport::Completed {
+                generation: state.generation,
+            }));
+            return;
+        };
+
+        // Phase: StoppingSource — no StopProof, no next owner. The source's
+        // pump keeps running: its frames are still this generation's truth
+        // until ownership actually moves.
+        state.slot = EndpointSlot::HandingOff {
+            from: source.clone(),
+            target,
+            source_down: None,
+        };
+        state.publish();
+        let generation = state.generation;
+        let router = myself.clone();
+        let call_timeout = state.status_timeout;
+        let stop_wait = state.stop_wait;
+        state.handoff = Some(tokio::spawn(async move {
+            let result = stop_and_confirm(source.as_ref(), call_timeout, stop_wait).await;
+            let _ = router.cast(CoreActorMessage::HandoffStopped {
+                generation,
+                result,
+                reply,
+            });
+        }));
+    }
+
+    /// The handoff's second half, back inside the mailbox.
+    fn handoff_stopped(
+        &self,
+        myself: &ActorRef<CoreActorMessage>,
+        state: &mut CoreActorState,
+        generation: ControllerGeneration,
+        result: Result<Option<OperationInfo>, CoreError>,
+        reply: RpcReplyPort<Result<HandoffReport, CoreError>>,
+    ) {
+        // Fencing use #2: a completion belonging to an abandoned handoff
+        // changes nothing.
+        let EndpointSlot::HandingOff {
+            from,
+            target,
+            source_down,
+        } = &state.slot
+        else {
+            return;
+        };
+        if generation != state.generation {
+            return;
+        }
+        let (from, target, source_down) = (from.clone(), target.clone(), source_down.clone());
+        // Its own message; nothing is left to cancel.
+        state.handoff = None;
+
+        if !state.pending_shutdown.is_empty() {
+            let _ = reply.send(Err(CoreError::new(
+                CoreErrorKind::ShuttingDown,
+                "the core router is shutting down",
+                false,
+            )));
+            let report = ShutdownReport {
+                stop: result,
+                final_status: state.snapshot.clone(),
+            };
+            for shutdown_reply in state.pending_shutdown.drain(..) {
+                let _ = shutdown_reply.send(report.clone());
+            }
+            myself.stop(Some("shutdown".into()));
+            return;
+        }
+
+        match result {
+            Ok(_) => {
+                self.adopt(myself, state, target);
+                let _ = reply.send(Ok(HandoffReport::Completed {
+                    generation: state.generation,
+                }));
+            }
+            Err(error) => {
+                // Unproven: ownership stays where it was. If the source went
+                // down while we waited, "where it was" is degraded.
+                state.slot = match source_down {
+                    Some(reason) => EndpointSlot::Degraded {
+                        desired: from.host(),
+                        reason,
+                    },
+                    None => EndpointSlot::Connected(from),
+                };
+                state.publish();
+                let _ = reply.send(Err(error));
+            }
+        }
+    }
+
+    /// Phase: Adopt — the generation fences out every stale frame afterwards.
+    fn adopt(
+        &self,
+        myself: &ActorRef<CoreActorMessage>,
+        state: &mut CoreActorState,
+        target: EndpointHandle,
+    ) {
+        state.generation += 1;
+        if let Some(pump) = state.pump.take() {
+            pump.abort();
+        }
+        // The previous host's runtime is not this one's. Clearing before the
+        // publish is what keeps the new generation's first frame from carrying
+        // the old owner's state forward.
+        state.snapshot = None;
+        state.slot = EndpointSlot::Connected(target.clone());
+        state.publish();
+        state.pump = Some(spawn_pump(
+            myself.clone(),
+            target,
+            state.generation,
+            state.status_timeout,
+        ));
+    }
+}
+
+/// Typed wrapper: callers speak ordinary async Rust, never raw `ActorRef`.
+#[derive(Clone)]
+pub struct CoreClient {
+    actor: ActorRef<CoreActorMessage>,
+    status_rx: watch::Receiver<CoreStatusProjection>,
+    events_tx: broadcast::Sender<CoreStatusProjection>,
+    /// Caller bounds derived from the injected `status_timeout`/`stop_wait`
+    /// at spawn time (see [`submit_budget`], [`handoff_budget`],
+    /// [`shutdown_budget`]), so a caller's own timeout can never be tighter
+    /// than the internal path it is waiting on (F3).
+    submit_budget: Duration,
+    handoff_budget: Duration,
+    shutdown_budget: Duration,
+}
+
+impl CoreClient {
+    /// Spawns the router over its initial endpoint.
+    pub async fn spawn(initial: EndpointHandle) -> Result<Self, ractor::SpawnErr> {
+        Self::spawn_with_bounds(initial, PUMP_STATUS_TIMEOUT, STOP_WAIT).await
+    }
+
+    /// Same, with the two wait bounds injected. Only the tests need bounds
+    /// short enough to elapse inside one.
+    async fn spawn_with_bounds(
+        initial: EndpointHandle,
+        status_timeout: Duration,
+        stop_wait: Duration,
+    ) -> Result<Self, ractor::SpawnErr> {
+        let host = initial.host();
+        let (status_tx, status_rx) = watch::channel(CoreStatusProjection {
+            host,
+            generation: 0,
+            connectivity: EndpointConnectivity::Connected,
+            snapshot: None,
+        });
+        let (events_tx, _) = broadcast::channel(64);
+        let (actor, _handle) = Actor::spawn(
+            None,
+            CoreActor,
+            CoreActorArgs {
+                initial,
+                status_tx,
+                events_tx: events_tx.clone(),
+                status_timeout,
+                stop_wait,
+            },
+        )
+        .await?;
+        Ok(Self {
+            actor,
+            status_rx,
+            events_tx,
+            submit_budget: submit_budget(status_timeout),
+            handoff_budget: handoff_budget(status_timeout, stop_wait),
+            shutdown_budget: shutdown_budget(status_timeout, stop_wait),
+        })
+    }
+
+    /// Zero-mailbox synchronous read.
+    pub fn status(&self) -> CoreStatusProjection {
+        self.status_rx.borrow().clone()
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<CoreStatusProjection> {
+        self.status_rx.clone()
+    }
+
+    pub fn subscribe_events(&self) -> broadcast::Receiver<CoreStatusProjection> {
+        self.events_tx.subscribe()
+    }
+
+    pub async fn submit(&self, envelope: CoreCommandEnvelope) -> Result<SubmitTicket, CoreError> {
+        self.call(
+            |reply| CoreActorMessage::Submit { envelope, reply },
+            self.submit_budget,
+            // Mailbox residence, not a wedged endpoint, is the likely cause
+            // once the caller's own budget already outlasts the `Submit`
+            // handler's one bounded endpoint call (see the scope note above
+            // `handoff_budget`): a submit queued behind other work can clear
+            // this budget before its own endpoint call even starts, and then
+            // be admitted a moment later. That is exactly the situation the
+            // handler's own `BackendUnavailable` timeout describes, so the
+            // caller-side timeout has to carry the same contract rather than
+            // a non-retryable `Internal` that denies the retry it needs.
+            CoreError::new(
+                CoreErrorKind::BackendUnavailable,
+                "the caller-side submit budget elapsed before the router answered; the submission may already have been admitted, and retrying with the same operation id attaches to it idempotently rather than starting a second operation",
+                true,
+            ),
+        )
+        .await?
+    }
+
+    pub async fn change_host(&self, target: EndpointHandle) -> Result<HandoffReport, CoreError> {
+        self.call(
+            |reply| CoreActorMessage::ChangeHost { target, reply },
+            self.handoff_budget,
+            // Unlike `submit`, a handoff is not id-idempotent: retrying it
+            // blind could start a second transfer on top of one still
+            // running. The error stays non-retryable, but it must not imply
+            // nothing happened -- ownership can still be moving on the other
+            // side of this timeout.
+            CoreError::new(
+                CoreErrorKind::Internal,
+                "the caller-side handoff budget elapsed before the router answered; the handoff may still be in flight and ownership may already have moved",
+                false,
+            ),
+        )
+        .await?
+    }
+
+    pub async fn shutdown(&self) -> Result<ShutdownReport, CoreError> {
+        self.call(
+            |reply| CoreActorMessage::Shutdown { reply },
+            self.shutdown_budget,
+            // Same ambiguity as `change_host`: the stop this timeout raced
+            // may still complete on its own, so the message says so instead
+            // of implying the shutdown never started.
+            CoreError::new(
+                CoreErrorKind::Internal,
+                "the caller-side shutdown budget elapsed before the router answered; the stop may still be in flight",
+                false,
+            ),
+        )
+        .await
+    }
+
+    /// `on_timeout` is the error each public method above hands back when its
+    /// own caller-side budget elapses. It is not a generic message: for
+    /// `submit` it has to carry the same retryable, idempotent-retry contract
+    /// the `Submit` handler's own internal timeout already promises, because
+    /// mailbox residence ahead of the message (see the scope note above
+    /// `handoff_budget`) can make the caller's budget elapse before the
+    /// message's own execution even starts.
+    async fn call<T: Send + 'static>(
+        &self,
+        message: impl FnOnce(RpcReplyPort<T>) -> CoreActorMessage,
+        timeout: Duration,
+        on_timeout: CoreError,
+    ) -> Result<T, CoreError> {
+        match self.actor.call(message, Some(timeout)).await {
+            Ok(ractor::rpc::CallResult::Success(value)) => Ok(value),
+            Ok(ractor::rpc::CallResult::Timeout) => Err(on_timeout),
+            Ok(ractor::rpc::CallResult::SenderError) | Err(_) => Err(CoreError::new(
+                CoreErrorKind::Internal,
+                "the core router is gone",
+                false,
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/backend/tauri/src/core/actor_v2/mod.rs
+++ b/backend/tauri/src/core/actor_v2/mod.rs
@@ -1,0 +1,560 @@
+//! CoreActor v2: endpoint router + status projection, nothing else.
+//!
+//! Normative design: `docs/design/2026-08-12-core-actor-v2-app-integration.md`
+//! (§3–§5). The actor owns exactly four things — the active endpoint slot, the
+//! `ControllerGeneration`, the subscription pump, and the projection channels.
+//! Lifecycle truth, transactions, compensation and quarantine live only inside
+//! each host's `CoreControl`.
+//!
+//! Invariants:
+//! - **I-R1**: at most one `Connected` endpoint; submits during a handoff are
+//!   refused with `operation_conflict` (retryable) — by construction, because
+//!   the handoff runs inside the same mailbox turn.
+//! - **I-R2**: `Degraded` is an honest terminal, never a silent fallback to
+//!   another host. Recovery is an explicit new `ChangeHost` with a fresh
+//!   endpoint.
+//! - **I-R3**: the router never synthesizes lifecycle state. Projections carry
+//!   host-published snapshots verbatim.
+//!
+//! Deviations from the integration design, recorded:
+//! - `ChangeHost` carries the target endpoint (built by the facade from the
+//!   ServiceActor's supply or the local composition root) instead of the actor
+//!   resolving it — "desired state is delivered by orchestration, not fetched".
+//! - The post-handoff target `Reconcile` is facade orchestration: the actor
+//!   reports `Completed` with the runtime stopped, and the facade's reconcile
+//!   failure — not the actor — produces the `CommittedDegraded` report.
+
+pub mod endpoint;
+pub mod intent;
+pub mod service_actor;
+
+use std::time::Duration;
+
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+use tokio::sync::{broadcast, watch};
+
+use nyanpasu_core_manager::{
+    CoreCommand, CoreCommandEnvelope, CoreError, CoreErrorKind, OperationId,
+};
+use nyanpasu_ipc::api::core::v2::{OperationInfo, OperationPhase};
+
+use endpoint::{ControlEndpoint, CoreStatusSnapshot, EndpointHandle, ExecutionHost};
+
+/// Monotonic owner fence. Incremented exactly once per completed handoff;
+/// stale pump frames and stale down reports are dropped by comparing it.
+pub type ControllerGeneration = u64;
+
+/// How often the pump re-reads the endpoint's status. Phase 1 polls both
+/// hosts; a push feed (local watch / daemon event stream) replaces this
+/// without changing the message protocol (OQ-6).
+const PUMP_INTERVAL: Duration = Duration::from_secs(2);
+/// Bound for the source-stop leg of a handoff and the shutdown stop.
+const STOP_WAIT: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CoreStatusProjection {
+    pub host: ExecutionHost,
+    pub generation: ControllerGeneration,
+    pub connectivity: EndpointConnectivity,
+    /// The host's latest published snapshot; `None` before the first read.
+    pub snapshot: Option<CoreStatusSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum EndpointConnectivity {
+    Connected,
+    HandingOff {
+        from: ExecutionHost,
+        to: ExecutionHost,
+    },
+    /// The endpoint is unreachable. `desired` names the committed host; the
+    /// router never falls back on its own.
+    Degraded {
+        desired: ExecutionHost,
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum HandoffReport {
+    /// The target already owned the runtime; nothing moved.
+    NoChange,
+    /// Ownership moved: the source's death is proven, the generation is
+    /// advanced, and the runtime is *stopped* awaiting the facade's reconcile.
+    Completed { generation: ControllerGeneration },
+}
+
+#[derive(Debug)]
+pub struct ShutdownReport {
+    /// The stop operation's terminal snapshot, when one was submitted.
+    pub stop: Option<OperationInfo>,
+    /// What the host last published before the channels closed.
+    pub final_status: Option<CoreStatusSnapshot>,
+}
+
+/// A successful submit: the operation's admission snapshot plus the endpoint
+/// to wait on. Waiting is a read and deliberately does not occupy the mailbox.
+pub struct SubmitTicket {
+    pub id: OperationId,
+    pub admitted: OperationInfo,
+    pub endpoint: EndpointHandle,
+    pub generation: ControllerGeneration,
+}
+
+impl std::fmt::Debug for SubmitTicket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubmitTicket")
+            .field("id", &self.id)
+            .field("admitted", &self.admitted)
+            .field("host", &self.endpoint.host())
+            .field("generation", &self.generation)
+            .finish()
+    }
+}
+
+pub enum CoreActorMessage {
+    /// Routed through the mailbox so it serializes with `ChangeHost`: while a
+    /// handoff runs, no submit can land on the wrong host (I-R1).
+    Submit {
+        envelope: CoreCommandEnvelope,
+        reply: RpcReplyPort<Result<SubmitTicket, CoreError>>,
+    },
+    /// Explicit ownership transfer. The endpoint is built by the caller; the
+    /// actor proves the source dead before adopting it.
+    ChangeHost {
+        target: EndpointHandle,
+        reply: RpcReplyPort<Result<HandoffReport, CoreError>>,
+    },
+    /// Pump feedback: a status frame from the endpoint of `generation`.
+    EndpointEvent {
+        generation: ControllerGeneration,
+        snapshot: CoreStatusSnapshot,
+    },
+    /// Pump feedback: the endpoint of `generation` stopped answering.
+    EndpointDown {
+        generation: ControllerGeneration,
+        reason: String,
+    },
+    Shutdown {
+        reply: RpcReplyPort<ShutdownReport>,
+    },
+}
+
+pub struct CoreActor;
+
+pub struct CoreActorArgs {
+    /// The initial endpoint, adopted as-is (status read, no lifecycle writes).
+    pub initial: EndpointHandle,
+    /// Created by the composition root so the client keeps the receivers; the
+    /// actor is the only writer.
+    pub status_tx: watch::Sender<CoreStatusProjection>,
+    pub events_tx: broadcast::Sender<CoreStatusProjection>,
+}
+
+enum EndpointSlot {
+    Connected(EndpointHandle),
+    Degraded {
+        desired: ExecutionHost,
+        reason: String,
+    },
+}
+
+pub struct CoreActorState {
+    slot: EndpointSlot,
+    generation: ControllerGeneration,
+    status_tx: watch::Sender<CoreStatusProjection>,
+    events_tx: broadcast::Sender<CoreStatusProjection>,
+    pump: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl CoreActorState {
+    fn publish(&self) {
+        let projection = self.projection();
+        self.status_tx.send_replace(projection.clone());
+        let _ = self.events_tx.send(projection);
+    }
+
+    fn projection(&self) -> CoreStatusProjection {
+        let previous = self.status_tx.borrow().snapshot.clone();
+        match &self.slot {
+            EndpointSlot::Connected(endpoint) => CoreStatusProjection {
+                host: endpoint.host(),
+                generation: self.generation,
+                connectivity: EndpointConnectivity::Connected,
+                snapshot: previous,
+            },
+            EndpointSlot::Degraded { desired, reason } => CoreStatusProjection {
+                host: *desired,
+                generation: self.generation,
+                connectivity: EndpointConnectivity::Degraded {
+                    desired: *desired,
+                    reason: reason.clone(),
+                },
+                snapshot: previous,
+            },
+        }
+    }
+
+    fn set_snapshot(&mut self, snapshot: CoreStatusSnapshot) {
+        self.status_tx.send_modify(|projection| {
+            projection.snapshot = Some(snapshot.clone());
+        });
+        let _ = self.events_tx.send(self.status_tx.borrow().clone());
+    }
+}
+
+fn spawn_pump(
+    myself: ActorRef<CoreActorMessage>,
+    endpoint: EndpointHandle,
+    generation: ControllerGeneration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match endpoint.status().await {
+                Ok(snapshot) => {
+                    if myself
+                        .cast(CoreActorMessage::EndpointEvent {
+                            generation,
+                            snapshot,
+                        })
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    let _ = myself.cast(CoreActorMessage::EndpointDown {
+                        generation,
+                        reason: error.to_string(),
+                    });
+                    break;
+                }
+            }
+            tokio::time::sleep(PUMP_INTERVAL).await;
+        }
+    })
+}
+
+/// Stops the runtime on `endpoint` and proves it. `Ok(None)` means nothing
+/// was running; `Ok(Some(info))` is the stop's terminal snapshot.
+async fn stop_and_confirm(
+    endpoint: &dyn ControlEndpoint,
+) -> Result<Option<OperationInfo>, CoreError> {
+    let envelope = CoreCommandEnvelope {
+        operation_id: OperationId::generate(),
+        command: CoreCommand::Stop,
+    };
+    let admitted = endpoint.submit(envelope).await?;
+    let id: OperationId = admitted
+        .id
+        .parse()
+        .map_err(|_| CoreError::new(CoreErrorKind::Internal, "endpoint echoed a bad id", false))?;
+    let terminal = endpoint.wait_operation(id, STOP_WAIT).await;
+    match terminal {
+        Some(info) => match info.phase {
+            OperationPhase::Succeeded => Ok(Some(info)),
+            OperationPhase::Failed => {
+                let kind = info
+                    .error
+                    .as_ref()
+                    .and_then(|error| error.kind.as_deref())
+                    .map(str::to_owned);
+                match kind.as_deref() {
+                    // Nothing was running: the stop goal already holds.
+                    Some("not_started") => Ok(None),
+                    _ => Err(CoreError::new(
+                        kind.as_deref()
+                            .and_then(nyanpasu_core_manager::CoreErrorKind::from_wire)
+                            .unwrap_or(CoreErrorKind::Internal),
+                        info.error
+                            .map(|error| error.message)
+                            .unwrap_or_else(|| "stop failed".into()),
+                        false,
+                    )),
+                }
+            }
+            // The wait bound elapsed without a terminal state: no proof, no
+            // handoff.
+            OperationPhase::Queued | OperationPhase::Running => Err(CoreError::new(
+                CoreErrorKind::StopUnconfirmed,
+                "the stop did not reach a terminal state within the wait bound",
+                false,
+            )),
+        },
+        // Registry lost or transport broke: verify by status before trusting.
+        None => {
+            let status = endpoint.status().await?;
+            if matches!(
+                status.state,
+                nyanpasu_ipc::api::status::CoreStateDetail::Stopped { .. }
+            ) {
+                Ok(None)
+            } else {
+                Err(CoreError::new(
+                    CoreErrorKind::StopUnconfirmed,
+                    "the stop's result was lost and the runtime still reports non-stopped",
+                    false,
+                ))
+            }
+        }
+    }
+}
+
+impl Actor for CoreActor {
+    type Msg = CoreActorMessage;
+    type State = CoreActorState;
+    type Arguments = CoreActorArgs;
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let host = args.initial.host();
+        args.status_tx.send_replace(CoreStatusProjection {
+            host,
+            generation: 0,
+            connectivity: EndpointConnectivity::Connected,
+            snapshot: None,
+        });
+        let pump = spawn_pump(myself, args.initial.clone(), 0);
+        Ok(CoreActorState {
+            slot: EndpointSlot::Connected(args.initial),
+            generation: 0,
+            status_tx: args.status_tx,
+            events_tx: args.events_tx,
+            pump: Some(pump),
+        })
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            CoreActorMessage::Submit { envelope, reply } => {
+                let result = match &state.slot {
+                    EndpointSlot::Connected(handle) => {
+                        let endpoint = handle.clone();
+                        let operation_id = envelope.operation_id;
+                        endpoint
+                            .submit(envelope)
+                            .await
+                            .map(|admitted| SubmitTicket {
+                                id: operation_id,
+                                admitted,
+                                endpoint,
+                                generation: state.generation,
+                            })
+                    }
+                    EndpointSlot::Degraded { desired, reason } => Err(CoreError::new(
+                        CoreErrorKind::BackendUnavailable,
+                        format!("the {desired:?} endpoint is degraded: {reason}"),
+                        true,
+                    )),
+                };
+                let _ = reply.send(result);
+            }
+
+            CoreActorMessage::ChangeHost { target, reply } => {
+                let result = self.change_host(&myself, state, target).await;
+                let _ = reply.send(result);
+            }
+
+            CoreActorMessage::EndpointEvent {
+                generation,
+                snapshot,
+            } => {
+                // Stale frames from an abandoned endpoint are dropped, never
+                // merged (fencing use #1).
+                if generation == state.generation {
+                    state.set_snapshot(snapshot);
+                }
+            }
+
+            CoreActorMessage::EndpointDown { generation, reason } => {
+                if generation == state.generation
+                    && let EndpointSlot::Connected(handle) = &state.slot
+                {
+                    // Honest terminal: desired host stays committed, nothing
+                    // falls back silently (I-R2).
+                    state.slot = EndpointSlot::Degraded {
+                        desired: handle.host(),
+                        reason,
+                    };
+                    state.publish();
+                }
+            }
+
+            CoreActorMessage::Shutdown { reply } => {
+                if let Some(pump) = state.pump.take() {
+                    pump.abort();
+                }
+                let stop = match &state.slot {
+                    EndpointSlot::Connected(handle) => {
+                        match stop_and_confirm(handle.as_ref()).await {
+                            Ok(stop) => stop,
+                            Err(error) => {
+                                // Reported, never swallowed: the report is the
+                                // structural fix for the audited fake-Stopped.
+                                tracing::error!("shutdown stop failed: {error}");
+                                None
+                            }
+                        }
+                    }
+                    EndpointSlot::Degraded { .. } => None,
+                };
+                let final_status = state.status_tx.borrow().snapshot.clone();
+                let _ = reply.send(ShutdownReport { stop, final_status });
+                myself.stop(Some("shutdown".into()));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl CoreActor {
+    /// The explicit handoff (design §5.2): preflight → stop-and-prove the
+    /// source → advance the generation → adopt the target. The runtime is
+    /// left stopped; the facade reconciles it on the target next.
+    async fn change_host(
+        &self,
+        myself: &ActorRef<CoreActorMessage>,
+        state: &mut CoreActorState,
+        target: EndpointHandle,
+    ) -> Result<HandoffReport, CoreError> {
+        // Phase: Preflight — the target must answer before anything stops.
+        target.status().await.map_err(|error| {
+            CoreError::new(
+                CoreErrorKind::BackendUnavailable,
+                format!("handoff preflight failed: {error}"),
+                true,
+            )
+        })?;
+
+        match &state.slot {
+            EndpointSlot::Connected(current) if current.host() == target.host() => {
+                return Ok(HandoffReport::NoChange);
+            }
+            // Phase: StoppingSource — no StopProof, no next owner.
+            EndpointSlot::Connected(current) => {
+                stop_and_confirm(current.as_ref()).await?;
+            }
+            // A degraded source has no reachable runtime to stop; adopting a
+            // healthy target is exactly the recovery I-R2 demands be explicit.
+            EndpointSlot::Degraded { .. } => {}
+        }
+
+        // Phase: Adopt — generation fences out every stale frame afterwards.
+        state.generation += 1;
+        if let Some(pump) = state.pump.take() {
+            pump.abort();
+        }
+        state.slot = EndpointSlot::Connected(target.clone());
+        state.pump = Some(spawn_pump(myself.clone(), target, state.generation));
+        state.publish();
+        Ok(HandoffReport::Completed {
+            generation: state.generation,
+        })
+    }
+}
+
+/// Typed wrapper: callers speak ordinary async Rust, never raw `ActorRef`.
+#[derive(Clone)]
+pub struct CoreClient {
+    actor: ActorRef<CoreActorMessage>,
+    status_rx: watch::Receiver<CoreStatusProjection>,
+    events_tx: broadcast::Sender<CoreStatusProjection>,
+}
+
+impl CoreClient {
+    /// Spawns the router over its initial endpoint.
+    pub async fn spawn(initial: EndpointHandle) -> Result<Self, ractor::SpawnErr> {
+        let host = initial.host();
+        let (status_tx, status_rx) = watch::channel(CoreStatusProjection {
+            host,
+            generation: 0,
+            connectivity: EndpointConnectivity::Connected,
+            snapshot: None,
+        });
+        let (events_tx, _) = broadcast::channel(64);
+        let (actor, _handle) = Actor::spawn(
+            None,
+            CoreActor,
+            CoreActorArgs {
+                initial,
+                status_tx,
+                events_tx: events_tx.clone(),
+            },
+        )
+        .await?;
+        Ok(Self {
+            actor,
+            status_rx,
+            events_tx,
+        })
+    }
+
+    /// Zero-mailbox synchronous read.
+    pub fn status(&self) -> CoreStatusProjection {
+        self.status_rx.borrow().clone()
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<CoreStatusProjection> {
+        self.status_rx.clone()
+    }
+
+    pub fn subscribe_events(&self) -> broadcast::Receiver<CoreStatusProjection> {
+        self.events_tx.subscribe()
+    }
+
+    pub async fn submit(&self, envelope: CoreCommandEnvelope) -> Result<SubmitTicket, CoreError> {
+        self.call(
+            |reply| CoreActorMessage::Submit { envelope, reply },
+            Duration::from_secs(10),
+        )
+        .await?
+    }
+
+    pub async fn change_host(&self, target: EndpointHandle) -> Result<HandoffReport, CoreError> {
+        self.call(
+            |reply| CoreActorMessage::ChangeHost { target, reply },
+            // Covers the stop-and-prove leg plus slack.
+            STOP_WAIT + Duration::from_secs(30),
+        )
+        .await?
+    }
+
+    pub async fn shutdown(&self) -> Result<ShutdownReport, CoreError> {
+        self.call(
+            |reply| CoreActorMessage::Shutdown { reply },
+            STOP_WAIT + Duration::from_secs(30),
+        )
+        .await
+    }
+
+    async fn call<T: Send + 'static>(
+        &self,
+        message: impl FnOnce(RpcReplyPort<T>) -> CoreActorMessage,
+        timeout: Duration,
+    ) -> Result<T, CoreError> {
+        match self.actor.call(message, Some(timeout)).await {
+            Ok(ractor::rpc::CallResult::Success(value)) => Ok(value),
+            Ok(ractor::rpc::CallResult::Timeout) => Err(CoreError::new(
+                CoreErrorKind::Internal,
+                "the core router did not answer within its bound",
+                false,
+            )),
+            Ok(ractor::rpc::CallResult::SenderError) | Err(_) => Err(CoreError::new(
+                CoreErrorKind::Internal,
+                "the core router is gone",
+                false,
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/backend/tauri/src/core/actor_v2/service_actor.rs
+++ b/backend/tauri/src/core/actor_v2/service_actor.rs
@@ -1,0 +1,1333 @@
+//! ServiceActor: the daemon as a managed OS resource (integration design §6).
+//!
+//! Owns install/uninstall/start/stop/update of the privileged daemon —
+//! serialized by the mailbox because elevated commands must never interleave —
+//! plus health observation, the fail-closed version gate (its only
+//! implementation point), endpoint supply, and a bounded auto-restart with an
+//! exhaustion latch. It never touches core lifecycle: that belongs to the
+//! `CoreControl` running *inside* the daemon.
+//!
+//! Desired state arrives by facade orchestration, never by config-watch
+//! subscription — two owners racing one change was the audited 5d/5e failure
+//! shape.
+
+use std::sync::Arc;
+
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+use tokio::sync::watch;
+
+use nyanpasu_core_manager::{CoreError, CoreErrorKind};
+use nyanpasu_ipc::{
+    api::status::CoreStateDetail,
+    types::{ServiceStatus, StatusInfo},
+};
+
+use super::endpoint::{BoxFuture, EndpointHandle};
+use crate::core::service::compat::ServiceCompat;
+
+/// Elevated daemon mechanics behind one narrow boundary. `probe` reports
+/// what it actually knows: `Ok` is a real answer, `Err` is "unreachable or
+/// unparseable", never a synthesized `Stopped`. The actor is what bounds
+/// every call here (including `probe`) with its own timeout and turns an
+/// elapsed bound into the same `Err` shape, so a hung daemon surfaces as
+/// `ServicePhase::Unknown`, not as evidence of anything.
+pub trait ServiceHostAdapter: Send + Sync {
+    fn probe(&self) -> BoxFuture<'_, Result<StatusInfo<'static>, String>>;
+    fn install(&self) -> BoxFuture<'_, Result<(), String>>;
+    fn uninstall(&self) -> BoxFuture<'_, Result<(), String>>;
+    fn start_daemon(&self) -> BoxFuture<'_, Result<(), String>>;
+    fn stop_daemon(&self) -> BoxFuture<'_, Result<(), String>>;
+    fn update(&self) -> BoxFuture<'_, Result<(), String>>;
+    /// The v2 control endpoint for a daemon that passed the version gate.
+    fn endpoint(&self) -> EndpointHandle;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServicePhase {
+    Probing,
+    NotInstalled,
+    DaemonStopped,
+    Installing,
+    StartingDaemon,
+    Ready,
+    /// Version gate failed closed: upgrade required, never downgraded to.
+    Incompatible,
+    Restarting,
+    /// Auto-restart budget spent; waits for an explicit `EnsureReady`.
+    Exhausted,
+    Uninstalling,
+    /// The probe itself failed or timed out (F5): what the daemon actually
+    /// is cannot be determined. Never treated as `DaemonStopped` -- an
+    /// unreachable daemon might still be holding a core open, so callers
+    /// that gate on "no core held" (the uninstall guard, `EndpointDown`'s
+    /// restart) must refuse rather than proceed.
+    Unknown,
+}
+
+/// The watch projection (UI settings page + facade). Daemon state, never a
+/// second copy of core state.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ServiceHostStatus {
+    pub phase: ServicePhase,
+    pub compat: ServiceCompat,
+    pub restart_attempts: u8,
+}
+
+pub enum ServiceActorMessage {
+    /// Idempotent convergence to `Ready`: install → start → probe → gate, as
+    /// needed. The reply carries the endpoint the CoreActor will route to.
+    EnsureReady {
+        reply: RpcReplyPort<Result<EndpointHandle, CoreError>>,
+    },
+    Install {
+        reply: RpcReplyPort<Result<(), CoreError>>,
+    },
+    Update {
+        reply: RpcReplyPort<Result<(), CoreError>>,
+    },
+    /// Guarded twice: the facade only reaches this after a handoff away from
+    /// Service, and the actor itself refuses while the daemon owns a running
+    /// core.
+    Uninstall {
+        reply: RpcReplyPort<Result<(), CoreError>>,
+    },
+    StartDaemon {
+        reply: RpcReplyPort<Result<(), CoreError>>,
+    },
+    StopDaemon {
+        reply: RpcReplyPort<Result<(), CoreError>>,
+    },
+    /// Explicit probe. It reports and never escapes: `Exhausted` is cleared
+    /// only by an explicit `EnsureReady`, which is the same rule as the
+    /// variant's own doc.
+    Probe {
+        reply: RpcReplyPort<ServiceHostStatus>,
+    },
+    /// CoreActor feedback: the service endpoint stopped answering.
+    EndpointDown,
+}
+
+pub struct ServiceActor;
+
+/// Elevated commands are slow (UAC + SCM) but must still be bounded (F6): a
+/// wedged daemon must not hang the actor's single, serialized mailbox
+/// forever. Production policy; tests inject a short bound instead so a hang
+/// test does not wait on this wall clock (see `ServiceClient::spawn_with_bounds`).
+const DEFAULT_SERVICE_COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(100);
+
+pub struct ServiceActorArgs {
+    pub adapter: Arc<dyn ServiceHostAdapter>,
+    pub status_tx: watch::Sender<ServiceHostStatus>,
+    /// Auto-restart attempts before the exhaustion latch (design OQ-6; the
+    /// number is host policy, injected).
+    pub restart_budget: u8,
+    /// Bound applied to every adapter call the actor makes, `probe` included
+    /// (F6).
+    pub command_timeout: std::time::Duration,
+}
+
+pub struct ServiceActorState {
+    adapter: Arc<dyn ServiceHostAdapter>,
+    status_tx: watch::Sender<ServiceHostStatus>,
+    restart_budget: u8,
+    restart_attempts: u8,
+    /// The auto-restart budget is spent. A latch and not a comparison: the
+    /// counter alone is cleared by anything that resets it, and a probe that
+    /// happens to find the daemon up would then publish `Ready` for a host
+    /// nobody has re-armed.
+    exhausted: bool,
+    command_timeout: std::time::Duration,
+}
+
+impl ServiceActorState {
+    fn publish(&self, phase: ServicePhase, compat: ServiceCompat) {
+        self.status_tx.send_replace(ServiceHostStatus {
+            phase,
+            compat,
+            restart_attempts: self.restart_attempts,
+        });
+    }
+
+    fn command_error(what: &str, error: String) -> CoreError {
+        CoreError::new(
+            CoreErrorKind::BackendUnavailable,
+            format!("service {what} failed: {error}"),
+            true,
+        )
+    }
+
+    /// Bounds one adapter call (F6). An elapsed bound becomes the same
+    /// `Err(String)` shape an adapter-reported failure would, so every
+    /// existing call site's error handling covers both alike.
+    async fn bounded<T>(&self, call: BoxFuture<'_, Result<T, String>>) -> Result<T, String> {
+        tokio::time::timeout(self.command_timeout, call)
+            .await
+            .unwrap_or_else(|_| Err(format!("timed out after {:?}", self.command_timeout)))
+    }
+
+    /// Turns one probe answer into the compat fact and the phase it implies.
+    /// `Err` -- an adapter failure, or (via `bounded`) an elapsed timeout --
+    /// is `ServicePhase::Unknown`: it must never be read as `DaemonStopped`,
+    /// which is what let a hung probe wave the uninstall guard through (F5).
+    fn classify_probe(
+        result: &Result<StatusInfo<'static>, String>,
+    ) -> (ServiceCompat, ServicePhase) {
+        match result {
+            Ok(info) => {
+                let compat = ServiceCompat::classify(info);
+                let phase = match info.status {
+                    ServiceStatus::Running if compat.allows_service_backend() => {
+                        ServicePhase::Ready
+                    }
+                    ServiceStatus::Running => ServicePhase::Incompatible,
+                    ServiceStatus::Stopped => ServicePhase::DaemonStopped,
+                    ServiceStatus::NotInstalled => ServicePhase::NotInstalled,
+                };
+                (compat, phase)
+            }
+            Err(error) => {
+                tracing::warn!("service probe failed or timed out: {error}");
+                (ServiceCompat::Unknown, ServicePhase::Unknown)
+            }
+        }
+    }
+
+    /// One probe, classified. The classification is what the daemon actually
+    /// is; the latch decides what gets published.
+    async fn probe_and_publish(
+        &self,
+    ) -> (
+        Result<StatusInfo<'static>, String>,
+        ServiceCompat,
+        ServicePhase,
+    ) {
+        let result = self.bounded(self.adapter.probe()).await;
+        let (compat, phase) = Self::classify_probe(&result);
+        // A latched host stays latched no matter what a probe finds. `compat`
+        // still refreshes: the version fact is true either way.
+        let published = if self.exhausted {
+            ServicePhase::Exhausted
+        } else {
+            phase
+        };
+        self.publish(published, compat.clone());
+        (result, compat, phase)
+    }
+
+    /// The idempotent convergence: at most one install and one start per
+    /// call, then the gate decides. The only thing that clears the exhaustion
+    /// latch.
+    async fn ensure_ready(&mut self) -> Result<EndpointHandle, CoreError> {
+        self.exhausted = false;
+        self.restart_attempts = 0;
+        let result = self.converge().await;
+        if result.is_err() {
+            // The last thing published is a transitional phase --
+            // `Installing` or `StartingDaemon` -- which reads as "still
+            // working" forever. One more probe replaces it with what the
+            // daemon actually is; the command's own error is what returns.
+            let _ = self.probe_and_publish().await;
+        }
+        result
+    }
+
+    async fn converge(&self) -> Result<EndpointHandle, CoreError> {
+        let (_, _, phase) = self.probe_and_publish().await;
+        if phase == ServicePhase::NotInstalled {
+            self.publish(ServicePhase::Installing, ServiceCompat::Unknown);
+            self.bounded(self.adapter.install())
+                .await
+                .map_err(|error| Self::command_error("install", error))?;
+        }
+        let (_, _, phase) = self.probe_and_publish().await;
+        if phase == ServicePhase::DaemonStopped {
+            self.publish(ServicePhase::StartingDaemon, ServiceCompat::Unknown);
+            self.bounded(self.adapter.start_daemon())
+                .await
+                .map_err(|error| Self::command_error("start", error))?;
+        }
+        let (_, compat, phase) = self.probe_and_publish().await;
+        match phase {
+            ServicePhase::Ready => Ok(self.adapter.endpoint()),
+            ServicePhase::Incompatible => Err(CoreError::new(
+                CoreErrorKind::BackendUnavailable,
+                format!("daemon version gate failed closed: {compat:?}; upgrade required"),
+                false,
+            )),
+            // `Unknown` lands here too (F5): a probe we cannot trust is a
+            // retry candidate, exactly like any other not-yet-Ready phase.
+            other => Err(CoreError::new(
+                CoreErrorKind::BackendUnavailable,
+                format!("daemon did not reach Ready: {other:?}"),
+                true,
+            )),
+        }
+    }
+}
+
+impl Actor for ServiceActor {
+    type Msg = ServiceActorMessage;
+    type State = ServiceActorState;
+    type Arguments = ServiceActorArgs;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let state = ServiceActorState {
+            adapter: args.adapter,
+            status_tx: args.status_tx,
+            restart_budget: args.restart_budget,
+            restart_attempts: 0,
+            exhausted: false,
+            command_timeout: args.command_timeout,
+        };
+        // Startup version reconcile: an outdated-but-running daemon is
+        // upgraded once, preserving the product's auto `update_service`
+        // (UAC prompt) semantic. Fail-closed either way — a still-incompatible
+        // daemon never passes the gate.
+        let (_, compat, phase) = state.probe_and_publish().await;
+        if phase == ServicePhase::Incompatible {
+            tracing::info!("daemon incompatible at startup ({compat:?}); attempting one update");
+            if let Err(error) = state.bounded(state.adapter.update()).await {
+                tracing::warn!("startup daemon update failed: {error}");
+            }
+            let _ = state.probe_and_publish().await;
+        }
+        Ok(state)
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            ServiceActorMessage::EnsureReady { reply } => {
+                let _ = reply.send(state.ensure_ready().await);
+            }
+            ServiceActorMessage::Install { reply } => {
+                state.publish(ServicePhase::Installing, ServiceCompat::Unknown);
+                let result = state
+                    .bounded(state.adapter.install())
+                    .await
+                    .map_err(|error| ServiceActorState::command_error("install", error));
+                let _ = state.probe_and_publish().await;
+                let _ = reply.send(result);
+            }
+            ServiceActorMessage::Update { reply } => {
+                let result = state
+                    .bounded(state.adapter.update())
+                    .await
+                    .map_err(|error| ServiceActorState::command_error("update", error));
+                let _ = state.probe_and_publish().await;
+                let _ = reply.send(result);
+            }
+            ServiceActorMessage::Uninstall { reply } => {
+                let result = async {
+                    // Self-check half of the double guard: never uninstall
+                    // under a daemon that may still own a core. Fail-closed --
+                    // the refusal covers "we know it does" and "we cannot tell
+                    // that it does not" alike, because uninstalling out from
+                    // under a live core orphans it either way.
+                    //
+                    // The coarse `CoreState` takes no part in this: it
+                    // collapses Starting and Restarting into a Stopped shape,
+                    // and Switching and Stopping into a Running one. Neither
+                    // shape proves a terminal state.
+                    let probe_result = state.bounded(state.adapter.probe()).await;
+                    // F5: the probe call itself can fail outright -- not
+                    // merely quiet, unreachable. That is strictly less known
+                    // than the in-band "running but blind" case below, so it
+                    // is refused the same way, and must never be read as the
+                    // "not running" case that follows.
+                    let info = match &probe_result {
+                        Ok(info) => info,
+                        Err(_) => {
+                            return Err(CoreError {
+                                kind: None,
+                                message: "the daemon's status probe failed, so whether it owns a core cannot be determined; stop the daemon first".to_owned(),
+                                retryable: false,
+                                operation_id: None,
+                            });
+                        }
+                    };
+                    //
+                    // The kind says what is known, not merely that the answer
+                    // was no: `AlreadyRunning` asserts a running core exists,
+                    // which is a claim only the first case can make. The other
+                    // two know nothing, and callers branch on the kind rather
+                    // than on the message.
+                    let refusal = match (&info.status, info.server.as_ref()) {
+                        // A daemon that is not running cannot be holding a
+                        // core process open.
+                        (ServiceStatus::NotInstalled | ServiceStatus::Stopped, _) => None,
+                        (ServiceStatus::Running, None) => Some((
+                            None,
+                            "the daemon is running but did not answer its status probe, so whether it owns a core cannot be determined; stop the daemon first",
+                        )),
+                        (ServiceStatus::Running, Some(server)) => {
+                            match &server.core_infos.detail {
+                                Some(CoreStateDetail::Stopped { .. }) => None,
+                                Some(_) => Some((
+                                    Some(CoreErrorKind::AlreadyRunning),
+                                    "the daemon still owns a running core; hand off to Local first",
+                                )),
+                                None => Some((
+                                    None,
+                                    "the daemon published no core state detail, so whether it owns a core cannot be determined; stop the daemon first",
+                                )),
+                            }
+                        }
+                    };
+                    if let Some((kind, message)) = refusal {
+                        return Err(CoreError {
+                            kind,
+                            message: message.to_owned(),
+                            retryable: false,
+                            operation_id: None,
+                        });
+                    }
+                    state.publish(ServicePhase::Uninstalling, ServiceCompat::Unknown);
+                    if info.status == ServiceStatus::Running {
+                        state
+                            .bounded(state.adapter.stop_daemon())
+                            .await
+                            .map_err(|error| ServiceActorState::command_error("stop", error))?;
+                    }
+                    state
+                        .bounded(state.adapter.uninstall())
+                        .await
+                        .map_err(|error| ServiceActorState::command_error("uninstall", error))
+                }
+                .await;
+                let _ = state.probe_and_publish().await;
+                let _ = reply.send(result);
+            }
+            ServiceActorMessage::StartDaemon { reply } => {
+                let result = state
+                    .bounded(state.adapter.start_daemon())
+                    .await
+                    .map_err(|error| ServiceActorState::command_error("start", error));
+                let _ = state.probe_and_publish().await;
+                let _ = reply.send(result);
+            }
+            ServiceActorMessage::StopDaemon { reply } => {
+                let result = state
+                    .bounded(state.adapter.stop_daemon())
+                    .await
+                    .map_err(|error| ServiceActorState::command_error("stop", error));
+                let _ = state.probe_and_publish().await;
+                let _ = reply.send(result);
+            }
+            ServiceActorMessage::Probe { reply } => {
+                let _ = state.probe_and_publish().await;
+                let _ = reply.send(state.status_tx.borrow().clone());
+            }
+            ServiceActorMessage::EndpointDown => {
+                if state.exhausted {
+                    // Honest terminal: nothing pulls the daemon back up until
+                    // someone explicitly asks for convergence.
+                    return Ok(());
+                }
+                let (_, _, phase) = state.probe_and_publish().await;
+                if phase != ServicePhase::DaemonStopped {
+                    // F7: starting is only ever right when the probe found
+                    // the daemon stopped. `Ready` means the daemon is fine
+                    // and the endpoint handle merely broke -- the CoreActor
+                    // re-adopts via a fresh ChangeHost. `Incompatible` and
+                    // `NotInstalled` have nothing a start would fix.
+                    // `Unknown` (F5) knows nothing, including whether the
+                    // daemon is even down -- starting into that ignorance is
+                    // exactly the "hung probe reads as Stopped" contract
+                    // violation this fixes. The probed phase is already
+                    // published above; the restart budget stays untouched.
+                    return Ok(());
+                }
+                if state.restart_attempts >= state.restart_budget {
+                    state.exhausted = true;
+                    state.publish(ServicePhase::Exhausted, ServiceCompat::Unknown);
+                    return Ok(());
+                }
+                state.restart_attempts += 1;
+                state.publish(ServicePhase::Restarting, ServiceCompat::Unknown);
+                if let Err(error) = state.bounded(state.adapter.start_daemon()).await {
+                    tracing::warn!("daemon auto-restart failed: {error}");
+                }
+                let _ = state.probe_and_publish().await;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Scheduling and mailbox-hop slack layered on top of the worst-case leg sum
+/// for every caller-facing budget below. Mirrors `CoreClient`'s
+/// `CALL_BUDGET_SLACK` in `mod.rs` (F3): not a place to hide another retry,
+/// it only has to cover the time between an internal path finishing
+/// honestly and the reply crossing back to the caller.
+const CALL_BUDGET_SLACK: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Caller bound for [`ServiceClient::probe`]. One leg: `probe_and_publish`'s
+/// single bounded `adapter.probe()` call -- the `Probe` handler does nothing
+/// else.
+fn probe_budget(command_timeout: std::time::Duration) -> std::time::Duration {
+    command_timeout + CALL_BUDGET_SLACK
+}
+
+/// Caller bound for [`ServiceClient::install`], [`ServiceClient::update`],
+/// [`ServiceClient::start_daemon`], and [`ServiceClient::stop_daemon`]. Each
+/// of those four handlers is exactly two bounded legs: the command itself,
+/// then the unconditional follow-up `probe_and_publish` that replaces the
+/// transitional phase it published with what the daemon actually is.
+fn command_and_probe_budget(command_timeout: std::time::Duration) -> std::time::Duration {
+    command_timeout * 2 + CALL_BUDGET_SLACK
+}
+
+/// Caller bound for [`ServiceClient::uninstall`]. Four legs, worst case: the
+/// guard's own preflight probe, the conditional `stop_daemon` (only when
+/// that probe found the daemon `Running`), the `uninstall` call itself, and
+/// the handler's final `probe_and_publish`. All four sit on the same path
+/// when uninstalling a daemon that is running, which is the ordinary case
+/// this call exists for.
+fn uninstall_budget(command_timeout: std::time::Duration) -> std::time::Duration {
+    command_timeout * 4 + CALL_BUDGET_SLACK
+}
+
+/// Caller bound for [`ServiceClient::ensure_ready`]. Six legs, worst case:
+/// `converge` always runs three unconditional `probe_and_publish` calls (the
+/// entry read, the post-install read, and the final gate read) and, between
+/// them, up to two conditional adapter calls -- `install` when the entry
+/// read is `NotInstalled`, `start_daemon` when the post-install read is
+/// `DaemonStopped` -- both of which fire on the same path when installing a
+/// daemon that does not auto-start itself. If the final gate read still is
+/// not `Ready` (e.g. `Incompatible`), `converge` returns `Err` and
+/// `ensure_ready` runs one more recovery `probe_and_publish` so the last
+/// published phase is not left transitional. 3 probes + install + start + 1
+/// recovery probe = 6.
+fn ensure_ready_budget(command_timeout: std::time::Duration) -> std::time::Duration {
+    command_timeout * 6 + CALL_BUDGET_SLACK
+}
+
+// Honesty note: the mailbox is strictly serialized, so any caller can also
+// sit queued behind whatever message is already being handled before its
+// own turn even starts. The budgets above bound a message's own legs once
+// the actor is handling it; queue residence ahead of that is a separate,
+// real exposure this file does not attempt to bound.
+
+/// Typed wrapper; callers never hold the raw `ActorRef`.
+#[derive(Clone)]
+pub struct ServiceClient {
+    actor: ActorRef<ServiceActorMessage>,
+    status_rx: watch::Receiver<ServiceHostStatus>,
+    /// Per-message caller bounds derived from the injected `command_timeout`
+    /// at spawn time -- this actor's twin of `CoreClient`'s F3 fix in
+    /// `mod.rs`. Each must exceed the worst-case sum of bounded legs its
+    /// message can take internally (see the `*_budget` functions above), or
+    /// the client gives up on a call the actor is still legitimately
+    /// working through.
+    probe_budget: std::time::Duration,
+    command_and_probe_budget: std::time::Duration,
+    uninstall_budget: std::time::Duration,
+    ensure_ready_budget: std::time::Duration,
+}
+
+impl ServiceClient {
+    pub async fn spawn(
+        adapter: Arc<dyn ServiceHostAdapter>,
+        restart_budget: u8,
+    ) -> Result<Self, ractor::SpawnErr> {
+        Self::spawn_with_bounds(adapter, restart_budget, DEFAULT_SERVICE_COMMAND_TIMEOUT).await
+    }
+
+    /// Test seam (F6): lets a test inject a short `command_timeout` so a
+    /// hang test is bounded by the actor's own timeout instead of the
+    /// production wall clock. Not `pub` -- production code always goes
+    /// through `spawn`, which pins the policy constant.
+    async fn spawn_with_bounds(
+        adapter: Arc<dyn ServiceHostAdapter>,
+        restart_budget: u8,
+        command_timeout: std::time::Duration,
+    ) -> Result<Self, ractor::SpawnErr> {
+        let (status_tx, status_rx) = watch::channel(ServiceHostStatus {
+            phase: ServicePhase::Probing,
+            compat: ServiceCompat::Unknown,
+            restart_attempts: 0,
+        });
+        let (actor, _handle) = Actor::spawn(
+            None,
+            ServiceActor,
+            ServiceActorArgs {
+                adapter,
+                status_tx,
+                restart_budget,
+                command_timeout,
+            },
+        )
+        .await?;
+        Ok(Self {
+            actor,
+            status_rx,
+            probe_budget: probe_budget(command_timeout),
+            command_and_probe_budget: command_and_probe_budget(command_timeout),
+            uninstall_budget: uninstall_budget(command_timeout),
+            ensure_ready_budget: ensure_ready_budget(command_timeout),
+        })
+    }
+
+    pub fn status(&self) -> ServiceHostStatus {
+        self.status_rx.borrow().clone()
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<ServiceHostStatus> {
+        self.status_rx.clone()
+    }
+
+    pub async fn ensure_ready(&self) -> Result<EndpointHandle, CoreError> {
+        self.call(
+            |reply| ServiceActorMessage::EnsureReady { reply },
+            self.ensure_ready_budget,
+        )
+        .await?
+    }
+
+    pub async fn install(&self) -> Result<(), CoreError> {
+        self.call(
+            |reply| ServiceActorMessage::Install { reply },
+            self.command_and_probe_budget,
+        )
+        .await?
+    }
+
+    pub async fn update(&self) -> Result<(), CoreError> {
+        self.call(
+            |reply| ServiceActorMessage::Update { reply },
+            self.command_and_probe_budget,
+        )
+        .await?
+    }
+
+    pub async fn uninstall(&self) -> Result<(), CoreError> {
+        self.call(
+            |reply| ServiceActorMessage::Uninstall { reply },
+            self.uninstall_budget,
+        )
+        .await?
+    }
+
+    pub async fn start_daemon(&self) -> Result<(), CoreError> {
+        self.call(
+            |reply| ServiceActorMessage::StartDaemon { reply },
+            self.command_and_probe_budget,
+        )
+        .await?
+    }
+
+    pub async fn stop_daemon(&self) -> Result<(), CoreError> {
+        self.call(
+            |reply| ServiceActorMessage::StopDaemon { reply },
+            self.command_and_probe_budget,
+        )
+        .await?
+    }
+
+    pub async fn probe(&self) -> Result<ServiceHostStatus, CoreError> {
+        self.call(
+            |reply| ServiceActorMessage::Probe { reply },
+            self.probe_budget,
+        )
+        .await
+    }
+
+    pub fn report_endpoint_down(&self) {
+        let _ = self.actor.cast(ServiceActorMessage::EndpointDown);
+    }
+
+    async fn call<T: Send + 'static>(
+        &self,
+        message: impl FnOnce(RpcReplyPort<T>) -> ServiceActorMessage,
+        timeout: std::time::Duration,
+    ) -> Result<T, CoreError> {
+        // `timeout` is one of the per-message `*_budget`s above, each
+        // derived to exceed that message's own worst-case leg sum (F6); this
+        // gives up only after the actor could no longer still be honestly
+        // working through it.
+        match self.actor.call(message, Some(timeout)).await {
+            Ok(ractor::rpc::CallResult::Success(value)) => Ok(value),
+            // Past the budget the remaining explanation is mailbox residence
+            // behind another message, which means the elevated command may be
+            // running right now. Saying so is the only honest answer: it is
+            // not retryable, because a blind retry would queue a second
+            // elevated command behind the first.
+            Ok(ractor::rpc::CallResult::Timeout) => Err(CoreError::new(
+                CoreErrorKind::Internal,
+                "the service actor did not answer within its bound; the command may still be running",
+                false,
+            )),
+            Ok(ractor::rpc::CallResult::SenderError) | Err(_) => Err(CoreError::new(
+                CoreErrorKind::Internal,
+                "the service actor is gone",
+                false,
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+
+    use super::*;
+    use crate::core::actor_v2::endpoint::{ControlEndpoint, CoreStatusSnapshot, ExecutionHost};
+    use nyanpasu_ipc::api::status::{CoreInfos, CoreState, StatusResBody};
+    use std::borrow::Cow;
+
+    /// A scriptable daemon: `state` drives what probe answers; commands
+    /// mutate it the way the real SCM would.
+    struct FakeDaemon {
+        /// (installed, running, version)
+        state: Mutex<(bool, bool, String)>,
+        installs: AtomicUsize,
+        starts: AtomicUsize,
+        updates: AtomicUsize,
+        uninstalls: AtomicUsize,
+        /// What `/status` publishes as the core's detail. `None` is a daemon
+        /// that answered without one -- the pre-detail wire.
+        core_detail: Mutex<Option<CoreStateDetail>>,
+        /// A running daemon whose `/status` does not come back at all.
+        probe_blind: AtomicBool,
+        fail_install: AtomicBool,
+        fail_start: AtomicBool,
+        /// F5: the probe call itself fails -- not "answered Stopped", not
+        /// "answered Running without a server body", but no answer at all.
+        probe_fail: AtomicBool,
+        /// F6: `install` never resolves, so only the actor's own bound can
+        /// end it.
+        hang_install: AtomicBool,
+    }
+
+    impl FakeDaemon {
+        fn new(installed: bool, running: bool, version: &str) -> Arc<Self> {
+            Arc::new(Self {
+                state: Mutex::new((installed, running, version.to_owned())),
+                installs: AtomicUsize::new(0),
+                starts: AtomicUsize::new(0),
+                updates: AtomicUsize::new(0),
+                uninstalls: AtomicUsize::new(0),
+                core_detail: Mutex::new(Some(CoreStateDetail::Stopped { reason: None })),
+                probe_blind: AtomicBool::new(false),
+                fail_install: AtomicBool::new(false),
+                fail_start: AtomicBool::new(false),
+                probe_fail: AtomicBool::new(false),
+                hang_install: AtomicBool::new(false),
+            })
+        }
+
+        fn set_detail(&self, detail: Option<CoreStateDetail>) {
+            *self.core_detail.lock().unwrap() = detail;
+        }
+    }
+
+    struct NullEndpoint;
+    impl ControlEndpoint for NullEndpoint {
+        fn host(&self) -> ExecutionHost {
+            ExecutionHost::Service
+        }
+        fn submit<'a>(
+            &'a self,
+            _envelope: nyanpasu_core_manager::CoreCommandEnvelope,
+        ) -> BoxFuture<'a, Result<nyanpasu_ipc::api::core::v2::OperationInfo, CoreError>> {
+            unimplemented!("routing is the CoreActor business")
+        }
+        fn wait_operation<'a>(
+            &'a self,
+            _id: nyanpasu_core_manager::OperationId,
+            _timeout: std::time::Duration,
+        ) -> BoxFuture<'a, Option<nyanpasu_ipc::api::core::v2::OperationInfo>> {
+            unimplemented!()
+        }
+        fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
+            unimplemented!()
+        }
+    }
+
+    impl ServiceHostAdapter for FakeDaemon {
+        fn probe(&self) -> BoxFuture<'_, Result<StatusInfo<'static>, String>> {
+            Box::pin(async move {
+                if self.probe_fail.load(Ordering::SeqCst) {
+                    return Err("probe unreachable".to_owned());
+                }
+                let (installed, running, version) = self.state.lock().unwrap().clone();
+                let status = match (installed, running) {
+                    (false, _) => ServiceStatus::NotInstalled,
+                    (true, false) => ServiceStatus::Stopped,
+                    (true, true) => ServiceStatus::Running,
+                };
+                let detail = self.core_detail.lock().unwrap().clone();
+                let blind = self.probe_blind.load(Ordering::SeqCst);
+                let server = (installed && running && !blind).then(|| StatusResBody {
+                    version: Cow::Owned(version.clone()),
+                    core_infos: CoreInfos {
+                        r#type: None,
+                        // The coarse projection a real daemon publishes: every
+                        // transitional detail collapses into one of these two
+                        // shapes, which is exactly why it cannot be a guard.
+                        state: match detail {
+                            Some(CoreStateDetail::Running { .. })
+                            | Some(CoreStateDetail::Switching { .. })
+                            | Some(CoreStateDetail::Stopping { .. }) => CoreState::Running,
+                            _ => CoreState::Stopped(None),
+                        },
+                        state_changed_at: 0,
+                        config_path: None,
+                        controller: None,
+                        health: None,
+                        revision: None,
+                        detail,
+                    },
+                    runtime_infos: nyanpasu_ipc::api::status::RuntimeInfos {
+                        service_data_dir: Cow::Owned(std::path::PathBuf::new()),
+                        service_config_dir: Cow::Owned(std::path::PathBuf::new()),
+                        nyanpasu_config_dir: Cow::Owned(std::path::PathBuf::new()),
+                        nyanpasu_data_dir: Cow::Owned(std::path::PathBuf::new()),
+                    },
+                    logs: None,
+                });
+                Ok(StatusInfo {
+                    name: Cow::Borrowed("nyanpasu-service"),
+                    version: Cow::Borrowed("test"),
+                    status,
+                    server,
+                })
+            })
+        }
+        fn install(&self) -> BoxFuture<'_, Result<(), String>> {
+            if self.hang_install.load(Ordering::SeqCst) {
+                // Never resolves: only the actor's own `command_timeout`
+                // bound (F6) can end this call.
+                return Box::pin(std::future::pending::<Result<(), String>>());
+            }
+            Box::pin(async move {
+                self.installs.fetch_add(1, Ordering::SeqCst);
+                if self.fail_install.load(Ordering::SeqCst) {
+                    return Err("install refused".to_owned());
+                }
+                let mut state = self.state.lock().unwrap();
+                state.0 = true;
+                state.1 = true; // install auto-starts, like most platforms
+                Ok(())
+            })
+        }
+        fn uninstall(&self) -> BoxFuture<'_, Result<(), String>> {
+            Box::pin(async move {
+                self.uninstalls.fetch_add(1, Ordering::SeqCst);
+                *self.state.lock().unwrap() = (false, false, String::new());
+                Ok(())
+            })
+        }
+        fn start_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
+            Box::pin(async move {
+                self.starts.fetch_add(1, Ordering::SeqCst);
+                if self.fail_start.load(Ordering::SeqCst) {
+                    return Err("start refused".to_owned());
+                }
+                self.state.lock().unwrap().1 = true;
+                Ok(())
+            })
+        }
+        fn stop_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
+            Box::pin(async move {
+                self.state.lock().unwrap().1 = false;
+                Ok(())
+            })
+        }
+        fn update(&self) -> BoxFuture<'_, Result<(), String>> {
+            Box::pin(async move {
+                self.updates.fetch_add(1, Ordering::SeqCst);
+                self.state.lock().unwrap().2 = "2.0.0".to_owned();
+                Ok(())
+            })
+        }
+        fn endpoint(&self) -> EndpointHandle {
+            Arc::new(NullEndpoint)
+        }
+    }
+
+    #[tokio::test]
+    async fn ensure_ready_converges_from_not_installed_through_the_gate() {
+        let daemon = FakeDaemon::new(false, false, "2.0.0");
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        let endpoint = client.ensure_ready().await.unwrap();
+        assert_eq!(endpoint.host(), ExecutionHost::Service);
+        assert_eq!(daemon.installs.load(Ordering::SeqCst), 1);
+        assert_eq!(client.status().phase, ServicePhase::Ready);
+        assert!(matches!(
+            client.status().compat,
+            ServiceCompat::Compatible { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_outdated_daemon_is_upgraded_once_at_startup() {
+        let daemon = FakeDaemon::new(true, true, "1.4.5");
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+        // pre_start already reconciled: one update, then the gate passes.
+        assert_eq!(daemon.updates.load(Ordering::SeqCst), 1);
+        assert_eq!(client.probe().await.unwrap().phase, ServicePhase::Ready);
+    }
+
+    #[tokio::test]
+    async fn the_version_gate_fails_closed() {
+        let daemon = FakeDaemon::new(true, true, "1.4.5");
+        // The startup auto-update is stubbed into a no-op that leaves the old
+        // version in place.
+        struct StubbornDaemon(Arc<FakeDaemon>);
+        impl ServiceHostAdapter for StubbornDaemon {
+            fn probe(&self) -> BoxFuture<'_, Result<StatusInfo<'static>, String>> {
+                self.0.probe()
+            }
+            fn install(&self) -> BoxFuture<'_, Result<(), String>> {
+                self.0.install()
+            }
+            fn uninstall(&self) -> BoxFuture<'_, Result<(), String>> {
+                self.0.uninstall()
+            }
+            fn start_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
+                self.0.start_daemon()
+            }
+            fn stop_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
+                self.0.stop_daemon()
+            }
+            fn update(&self) -> BoxFuture<'_, Result<(), String>> {
+                Box::pin(async { Ok(()) }) // succeeds without changing anything
+            }
+            fn endpoint(&self) -> EndpointHandle {
+                self.0.endpoint()
+            }
+        }
+        let client = ServiceClient::spawn(Arc::new(StubbornDaemon(daemon)), 2)
+            .await
+            .unwrap();
+        let error = client
+            .ensure_ready()
+            .await
+            .err()
+            .expect("the gate must fail closed");
+        assert!(!error.retryable, "fail-closed is not a retry loop");
+        assert_eq!(client.status().phase, ServicePhase::Incompatible);
+    }
+
+    #[tokio::test]
+    async fn uninstall_refuses_while_the_daemon_owns_a_running_core() {
+        let daemon = FakeDaemon::new(true, true, "2.0.0");
+        daemon.set_detail(Some(CoreStateDetail::Running { epoch: 1, pid: 42 }));
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        let error = client.uninstall().await.unwrap_err();
+        assert_eq!(error.kind, Some(CoreErrorKind::AlreadyRunning));
+        assert_eq!(daemon.uninstalls.load(Ordering::SeqCst), 0);
+
+        // After the core is handed off, uninstall proceeds (stop + uninstall).
+        daemon.set_detail(Some(CoreStateDetail::Stopped { reason: None }));
+        client.uninstall().await.unwrap();
+        assert_eq!(daemon.uninstalls.load(Ordering::SeqCst), 1);
+        assert_eq!(client.status().phase, ServicePhase::NotInstalled);
+    }
+
+    #[tokio::test]
+    async fn endpoint_down_restarts_within_budget_then_latches_exhausted() {
+        let daemon = FakeDaemon::new(true, true, "2.0.0");
+        let client = ServiceClient::spawn(daemon.clone(), 1).await.unwrap();
+
+        // Daemon dies; the first report restarts it within budget.
+        daemon.state.lock().unwrap().1 = false;
+        client.report_endpoint_down();
+        let status = client.probe().await.unwrap();
+        assert_eq!(status.phase, ServicePhase::Ready);
+        assert_eq!(daemon.starts.load(Ordering::SeqCst), 1);
+
+        // Dies again with the budget spent: honest exhaustion latch.
+        daemon.state.lock().unwrap().1 = false;
+        client.report_endpoint_down(); // attempt 2 > budget 1 -> Exhausted
+        let mut status_rx = client.subscribe();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if status_rx.borrow_and_update().phase == ServicePhase::Exhausted {
+                    break;
+                }
+                status_rx.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("the spent budget must latch Exhausted");
+
+        // EnsureReady is the explicit escape: it resets the budget and
+        // converges again.
+        client.ensure_ready().await.unwrap();
+        assert_eq!(client.status().phase, ServicePhase::Ready);
+    }
+
+    /// M-10: a transitional detail is not a terminal state. The coarse
+    /// `CoreState` a real daemon publishes alongside `Starting` is
+    /// `Stopped`-shaped, so a guard reading it would uninstall out from under
+    /// a core that is coming up.
+    #[tokio::test]
+    async fn uninstall_refuses_on_transitional_detail() {
+        let daemon = FakeDaemon::new(true, true, "2.0.0");
+        daemon.set_detail(Some(CoreStateDetail::Starting { epoch: 3 }));
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        let error = client.uninstall().await.unwrap_err();
+        assert_eq!(error.kind, Some(CoreErrorKind::AlreadyRunning));
+        assert_eq!(daemon.uninstalls.load(Ordering::SeqCst), 0);
+    }
+
+    /// A running daemon that does not answer its probe tells us nothing, and
+    /// nothing is not permission.
+    #[tokio::test]
+    async fn uninstall_refuses_when_the_running_daemon_cannot_be_probed() {
+        let daemon = FakeDaemon::new(true, true, "2.0.0");
+        daemon.probe_blind.store(true, Ordering::SeqCst);
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        let error = client.uninstall().await.unwrap_err();
+        assert_eq!(
+            error.kind, None,
+            "the daemon might own a core; that it does is not something we know"
+        );
+        assert!(
+            error.message.contains("cannot be determined"),
+            "an unknown is reported as one, got: {}",
+            error.message
+        );
+        assert_eq!(daemon.uninstalls.load(Ordering::SeqCst), 0);
+    }
+
+    /// A daemon too old to publish `detail` is equally unknown. It is
+    /// `Incompatible` under the version gate anyway; the way out is
+    /// `StopDaemon` first, which makes the answer knowable.
+    #[tokio::test]
+    async fn uninstall_refuses_when_detail_is_missing() {
+        let daemon = FakeDaemon::new(true, true, "2.0.0");
+        daemon.set_detail(None);
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        let error = client.uninstall().await.unwrap_err();
+        assert_eq!(
+            error.kind, None,
+            "the daemon might own a core; that it does is not something we know"
+        );
+        assert!(
+            error.message.contains("cannot be determined"),
+            "an unknown is reported as one, got: {}",
+            error.message
+        );
+        assert_eq!(daemon.uninstalls.load(Ordering::SeqCst), 0);
+    }
+
+    /// The escape hatch the refusals point at: a stopped daemon holds no core,
+    /// whatever its last published detail said.
+    #[tokio::test]
+    async fn uninstall_proceeds_when_the_daemon_is_stopped() {
+        let daemon = FakeDaemon::new(true, false, "2.0.0");
+        daemon.set_detail(Some(CoreStateDetail::Running { epoch: 1, pid: 42 }));
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        client.uninstall().await.unwrap();
+        assert_eq!(daemon.uninstalls.load(Ordering::SeqCst), 1);
+        assert_eq!(client.status().phase, ServicePhase::NotInstalled);
+    }
+
+    /// M-11: the latch is a latch. A probe that happens to find the daemon up
+    /// must not publish `Ready` for a host nobody re-armed, and must not let
+    /// the next `EndpointDown` restart it.
+    #[tokio::test]
+    async fn exhausted_survives_probes_until_an_explicit_ensure_ready() {
+        let daemon = FakeDaemon::new(true, true, "2.0.0");
+        let client = ServiceClient::spawn(daemon.clone(), 0).await.unwrap();
+
+        daemon.state.lock().unwrap().1 = false;
+        client.report_endpoint_down();
+        let mut status_rx = client.subscribe();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if status_rx.borrow_and_update().phase == ServicePhase::Exhausted {
+                    break;
+                }
+                status_rx.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("a spent budget must latch Exhausted");
+
+        // The daemon comes back on its own; a probe still reports the latch.
+        daemon.state.lock().unwrap().1 = true;
+        assert_eq!(client.probe().await.unwrap().phase, ServicePhase::Exhausted);
+
+        // And a further down report does not pull it up behind our back.
+        let starts = daemon.starts.load(Ordering::SeqCst);
+        client.report_endpoint_down();
+        assert_eq!(client.probe().await.unwrap().phase, ServicePhase::Exhausted);
+        assert_eq!(daemon.starts.load(Ordering::SeqCst), starts);
+
+        // The one escape.
+        client.ensure_ready().await.unwrap();
+        let status = client.status();
+        assert_eq!(status.phase, ServicePhase::Ready);
+        assert_eq!(status.restart_attempts, 0);
+    }
+
+    /// Minor-A3: a convergence that fails must not leave a transitional phase
+    /// published. `Installing` forever reads as "still working".
+    #[tokio::test]
+    async fn a_failed_install_leaves_the_probed_phase_not_the_transitional_one() {
+        let daemon = FakeDaemon::new(false, false, "2.0.0");
+        daemon.fail_install.store(true, Ordering::SeqCst);
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        let error = client
+            .ensure_ready()
+            .await
+            .err()
+            .expect("the convergence must fail");
+        assert!(
+            error.message.contains("install refused"),
+            "the adapter's own error is what returns, got: {}",
+            error.message
+        );
+        assert_eq!(client.status().phase, ServicePhase::NotInstalled);
+    }
+
+    #[tokio::test]
+    async fn a_failed_start_leaves_the_probed_phase_not_the_transitional_one() {
+        let daemon = FakeDaemon::new(true, false, "2.0.0");
+        daemon.fail_start.store(true, Ordering::SeqCst);
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        let error = client
+            .ensure_ready()
+            .await
+            .err()
+            .expect("the convergence must fail");
+        assert!(
+            error.message.contains("start refused"),
+            "the adapter's own error is what returns, got: {}",
+            error.message
+        );
+        assert_eq!(client.status().phase, ServicePhase::DaemonStopped);
+    }
+
+    /// F5: pre-fix, `probe` had no error channel at all, so a probe failure
+    /// could only be represented as `ServiceStatus::Stopped` -- which the
+    /// uninstall guard's `(NotInstalled | Stopped, _) => None` arm read as
+    /// "no core held" and let straight through. An unreachable probe must
+    /// refuse exactly like the in-band "running but blind" case, with a
+    /// `kind: None` (nothing is known, not even that a core is running) and
+    /// a "cannot be determined" message.
+    #[tokio::test]
+    async fn uninstall_refuses_when_the_probe_fails_outright() {
+        let daemon = FakeDaemon::new(true, true, "2.0.0");
+        daemon.probe_fail.store(true, Ordering::SeqCst);
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        let error = client.uninstall().await.unwrap_err();
+        assert_eq!(
+            error.kind, None,
+            "an unreachable probe proves nothing about a held core"
+        );
+        assert!(
+            error.message.contains("cannot be determined"),
+            "an unknown probe is reported as one, got: {}",
+            error.message
+        );
+        assert_eq!(daemon.uninstalls.load(Ordering::SeqCst), 0);
+    }
+
+    /// F5: `converge`'s final match already treats any non-Ready/Incompatible
+    /// phase as a retryable `BackendUnavailable`. Pre-fix this could not even
+    /// be exercised -- there was no way for `probe` to fail -- and the
+    /// nearest equivalent (a hung probe) was defined to answer `Stopped`,
+    /// which would have driven `ensure_ready` into a doomed install/start
+    /// loop instead of reporting the true, retryable unknown.
+    #[tokio::test]
+    async fn ensure_ready_reports_a_retryable_error_when_the_probe_fails() {
+        let daemon = FakeDaemon::new(true, true, "2.0.0");
+        daemon.probe_fail.store(true, Ordering::SeqCst);
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        // `EndpointHandle` is a trait object and has no `Debug`, so the error
+        // has to be taken by match rather than `unwrap_err`.
+        let Err(error) = client.ensure_ready().await else {
+            panic!("an undetermined probe must not hand out an endpoint");
+        };
+        assert!(
+            error.retryable,
+            "an undetermined probe is a retry candidate, not a fatal gate"
+        );
+        assert_eq!(client.status().phase, ServicePhase::Unknown);
+    }
+
+    /// F5 x F7: the literal contract this fixes -- the trait doc used to say
+    /// a hung probe "answers Stopped-shaped", which is exactly the phase
+    /// `EndpointDown` restarts from. An unreachable probe must not start
+    /// anything: it does not know there is nothing already running.
+    #[tokio::test]
+    async fn endpoint_down_does_not_start_when_the_probe_fails() {
+        let daemon = FakeDaemon::new(true, true, "2.0.0");
+        daemon.probe_fail.store(true, Ordering::SeqCst);
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        let starts = daemon.starts.load(Ordering::SeqCst);
+        client.report_endpoint_down();
+        let status = client.probe().await.unwrap();
+        assert_eq!(status.phase, ServicePhase::Unknown);
+        assert_eq!(daemon.starts.load(Ordering::SeqCst), starts);
+    }
+
+    /// F6: every adapter call the actor makes is bounded, `install` included.
+    /// Pre-fix there was no timeout anywhere in this file, so a wedged
+    /// `install` would hang `ensure_ready` -- and with it the actor's single
+    /// serialized mailbox -- forever. `spawn_with_bounds` injects a short
+    /// bound so the assertion is reached by the actor's own timer, not the
+    /// test's wall clock.
+    #[tokio::test]
+    async fn ensure_ready_times_out_a_hung_install_and_the_actor_stays_responsive() {
+        let daemon = FakeDaemon::new(false, false, "2.0.0");
+        daemon.hang_install.store(true, Ordering::SeqCst);
+        let client = ServiceClient::spawn_with_bounds(
+            daemon.clone(),
+            2,
+            std::time::Duration::from_millis(50),
+        )
+        .await
+        .unwrap();
+
+        let outcome =
+            tokio::time::timeout(std::time::Duration::from_secs(5), client.ensure_ready())
+                .await
+                .expect("a bounded adapter call must not hang the actor");
+        let Err(error) = outcome else {
+            panic!("a wedged install must not hand out a ready endpoint");
+        };
+        assert!(
+            error.message.contains("timed out"),
+            "got: {}",
+            error.message
+        );
+
+        // The mailbox is still alive and answering after the bounded call
+        // gave up.
+        let status = client.probe().await.unwrap();
+        assert_eq!(status.phase, ServicePhase::NotInstalled);
+    }
+
+    /// F7: `EndpointDown` must only call `start_daemon` when the probed
+    /// phase is `DaemonStopped`. Pre-fix the guard excluded only `Ready`, so
+    /// an incompatible-but-running daemon fell through to a pointless
+    /// restart of a daemon that was never stopped.
+    #[tokio::test]
+    async fn endpoint_down_does_not_restart_an_incompatible_running_daemon() {
+        let daemon = FakeDaemon::new(true, true, "1.4.5");
+        // Stub the startup auto-update so the daemon stays `Incompatible`
+        // instead of being upgraded by `pre_start`.
+        struct StubbornDaemon(Arc<FakeDaemon>);
+        impl ServiceHostAdapter for StubbornDaemon {
+            fn probe(&self) -> BoxFuture<'_, Result<StatusInfo<'static>, String>> {
+                self.0.probe()
+            }
+            fn install(&self) -> BoxFuture<'_, Result<(), String>> {
+                self.0.install()
+            }
+            fn uninstall(&self) -> BoxFuture<'_, Result<(), String>> {
+                self.0.uninstall()
+            }
+            fn start_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
+                self.0.start_daemon()
+            }
+            fn stop_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
+                self.0.stop_daemon()
+            }
+            fn update(&self) -> BoxFuture<'_, Result<(), String>> {
+                Box::pin(async { Ok(()) }) // succeeds without changing anything
+            }
+            fn endpoint(&self) -> EndpointHandle {
+                self.0.endpoint()
+            }
+        }
+        let client = ServiceClient::spawn(Arc::new(StubbornDaemon(daemon.clone())), 2)
+            .await
+            .unwrap();
+        assert_eq!(client.status().phase, ServicePhase::Incompatible);
+
+        let starts = daemon.starts.load(Ordering::SeqCst);
+        client.report_endpoint_down();
+        let status = client.probe().await.unwrap();
+        assert_eq!(status.phase, ServicePhase::Incompatible);
+        assert_eq!(daemon.starts.load(Ordering::SeqCst), starts);
+    }
+
+    /// The `ServiceClient` twin of `CoreClient`'s F3 fix: a caller bound has
+    /// to outlast the sum of every internal leg its message can honestly
+    /// take, not one fixed number shared by all of them. Pre-fix,
+    /// `call_timeout` was a single `command_timeout + 30s` used for every
+    /// message; `EnsureReady`'s own worst case is six sequential bounded legs
+    /// (`converge`'s three probes plus its conditional install and start,
+    /// plus `ensure_ready`'s recovery probe on failure -- see
+    /// `ensure_ready_budget`'s doc), and `Uninstall`'s is four. A timing test
+    /// cannot discriminate this at safe-for-CI durations: shrinking
+    /// `command_timeout` shrinks every leg together, so the fixed 30s slack
+    /// swamps the gap at any tiny bound and the pre-fix code would pass a
+    /// 50ms timing test regardless. The arithmetic itself is what has to be
+    /// tested, at both a tiny bound and the production one. This test does
+    /// not compile against the pre-fix module, which has no per-message
+    /// `*_budget` functions at all -- only a single `call_timeout` field.
+    #[test]
+    fn every_message_budget_outlasts_its_own_worst_case_leg_sum() {
+        for command_timeout in [
+            std::time::Duration::from_millis(50),
+            DEFAULT_SERVICE_COMMAND_TIMEOUT,
+        ] {
+            let one_leg = command_timeout;
+            let two_legs = command_timeout * 2;
+            let four_legs = command_timeout * 4;
+            let six_legs = command_timeout * 6;
+
+            assert!(
+                probe_budget(command_timeout) > one_leg,
+                "probe_budget must outlast {one_leg:?} at command_timeout={command_timeout:?}"
+            );
+            assert!(
+                command_and_probe_budget(command_timeout) > two_legs,
+                "command_and_probe_budget must outlast {two_legs:?} at command_timeout={command_timeout:?}"
+            );
+            assert!(
+                uninstall_budget(command_timeout) > four_legs,
+                "uninstall_budget must outlast {four_legs:?} at command_timeout={command_timeout:?}"
+            );
+            assert!(
+                ensure_ready_budget(command_timeout) > six_legs,
+                "ensure_ready_budget must outlast {six_legs:?} at command_timeout={command_timeout:?}"
+            );
+        }
+
+        // The exact numbers this fixes: at the production 100s
+        // `command_timeout`, the old fixed `command_timeout + 30s` (130s)
+        // caller bound was far short of `EnsureReady`'s ~600s worst case (and
+        // `Uninstall`'s ~400s), so a caller received a non-retryable
+        // `Internal` while the actor kept going with elevated install/stop/
+        // uninstall side effects still in flight.
+        let old_fixed_budget = DEFAULT_SERVICE_COMMAND_TIMEOUT + std::time::Duration::from_secs(30);
+        let ensure_ready_worst_case = DEFAULT_SERVICE_COMMAND_TIMEOUT * 6;
+        let uninstall_worst_case = DEFAULT_SERVICE_COMMAND_TIMEOUT * 4;
+        assert!(ensure_ready_worst_case > old_fixed_budget);
+        assert!(uninstall_worst_case > old_fixed_budget);
+        assert!(ensure_ready_budget(DEFAULT_SERVICE_COMMAND_TIMEOUT) > ensure_ready_worst_case);
+        assert!(uninstall_budget(DEFAULT_SERVICE_COMMAND_TIMEOUT) > uninstall_worst_case);
+    }
+}

--- a/backend/tauri/src/core/actor_v2/service_actor.rs
+++ b/backend/tauri/src/core/actor_v2/service_actor.rs
@@ -422,3 +422,261 @@ impl ServiceClient {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::*;
+    use crate::core::actor_v2::endpoint::{ControlEndpoint, CoreStatusSnapshot, ExecutionHost};
+    use nyanpasu_ipc::api::status::{CoreInfos, CoreState, StatusResBody};
+    use std::borrow::Cow;
+
+    /// A scriptable daemon: `state` drives what probe answers; commands
+    /// mutate it the way the real SCM would.
+    struct FakeDaemon {
+        /// (installed, running, version)
+        state: Mutex<(bool, bool, String)>,
+        installs: AtomicUsize,
+        starts: AtomicUsize,
+        updates: AtomicUsize,
+        uninstalls: AtomicUsize,
+        core_running: std::sync::atomic::AtomicBool,
+    }
+
+    impl FakeDaemon {
+        fn new(installed: bool, running: bool, version: &str) -> Arc<Self> {
+            Arc::new(Self {
+                state: Mutex::new((installed, running, version.to_owned())),
+                installs: AtomicUsize::new(0),
+                starts: AtomicUsize::new(0),
+                updates: AtomicUsize::new(0),
+                uninstalls: AtomicUsize::new(0),
+                core_running: std::sync::atomic::AtomicBool::new(false),
+            })
+        }
+    }
+
+    struct NullEndpoint;
+    impl ControlEndpoint for NullEndpoint {
+        fn host(&self) -> ExecutionHost {
+            ExecutionHost::Service
+        }
+        fn submit<'a>(
+            &'a self,
+            _envelope: nyanpasu_core_manager::CoreCommandEnvelope,
+        ) -> BoxFuture<'a, Result<nyanpasu_ipc::api::core::v2::OperationInfo, CoreError>> {
+            unimplemented!("routing is the CoreActor business")
+        }
+        fn wait_operation<'a>(
+            &'a self,
+            _id: nyanpasu_core_manager::OperationId,
+            _timeout: std::time::Duration,
+        ) -> BoxFuture<'a, Option<nyanpasu_ipc::api::core::v2::OperationInfo>> {
+            unimplemented!()
+        }
+        fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
+            unimplemented!()
+        }
+    }
+
+    impl ServiceHostAdapter for FakeDaemon {
+        fn probe(&self) -> BoxFuture<'_, StatusInfo<'static>> {
+            Box::pin(async move {
+                let (installed, running, version) = self.state.lock().unwrap().clone();
+                let status = match (installed, running) {
+                    (false, _) => ServiceStatus::NotInstalled,
+                    (true, false) => ServiceStatus::Stopped,
+                    (true, true) => ServiceStatus::Running,
+                };
+                let server = (installed && running).then(|| StatusResBody {
+                    version: Cow::Owned(version.clone()),
+                    core_infos: CoreInfos {
+                        r#type: None,
+                        state: if self.core_running.load(Ordering::SeqCst) {
+                            CoreState::Running
+                        } else {
+                            CoreState::Stopped(None)
+                        },
+                        state_changed_at: 0,
+                        config_path: None,
+                        controller: None,
+                        health: None,
+                        revision: None,
+                        detail: None,
+                    },
+                    runtime_infos: nyanpasu_ipc::api::status::RuntimeInfos {
+                        service_data_dir: Cow::Owned(std::path::PathBuf::new()),
+                        service_config_dir: Cow::Owned(std::path::PathBuf::new()),
+                        nyanpasu_config_dir: Cow::Owned(std::path::PathBuf::new()),
+                        nyanpasu_data_dir: Cow::Owned(std::path::PathBuf::new()),
+                    },
+                    logs: None,
+                });
+                StatusInfo {
+                    name: Cow::Borrowed("nyanpasu-service"),
+                    version: Cow::Borrowed("test"),
+                    status,
+                    server,
+                }
+            })
+        }
+        fn install(&self) -> BoxFuture<'_, Result<(), String>> {
+            Box::pin(async move {
+                self.installs.fetch_add(1, Ordering::SeqCst);
+                let mut state = self.state.lock().unwrap();
+                state.0 = true;
+                state.1 = true; // install auto-starts, like most platforms
+                Ok(())
+            })
+        }
+        fn uninstall(&self) -> BoxFuture<'_, Result<(), String>> {
+            Box::pin(async move {
+                self.uninstalls.fetch_add(1, Ordering::SeqCst);
+                *self.state.lock().unwrap() = (false, false, String::new());
+                Ok(())
+            })
+        }
+        fn start_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
+            Box::pin(async move {
+                self.starts.fetch_add(1, Ordering::SeqCst);
+                self.state.lock().unwrap().1 = true;
+                Ok(())
+            })
+        }
+        fn stop_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
+            Box::pin(async move {
+                self.state.lock().unwrap().1 = false;
+                Ok(())
+            })
+        }
+        fn update(&self) -> BoxFuture<'_, Result<(), String>> {
+            Box::pin(async move {
+                self.updates.fetch_add(1, Ordering::SeqCst);
+                self.state.lock().unwrap().2 = "2.0.0".to_owned();
+                Ok(())
+            })
+        }
+        fn endpoint(&self) -> EndpointHandle {
+            Arc::new(NullEndpoint)
+        }
+    }
+
+    #[tokio::test]
+    async fn ensure_ready_converges_from_not_installed_through_the_gate() {
+        let daemon = FakeDaemon::new(false, false, "2.0.0");
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        let endpoint = client.ensure_ready().await.unwrap();
+        assert_eq!(endpoint.host(), ExecutionHost::Service);
+        assert_eq!(daemon.installs.load(Ordering::SeqCst), 1);
+        assert_eq!(client.status().phase, ServicePhase::Ready);
+        assert!(matches!(
+            client.status().compat,
+            ServiceCompat::Compatible { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_outdated_daemon_is_upgraded_once_at_startup() {
+        let daemon = FakeDaemon::new(true, true, "1.4.5");
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+        // pre_start already reconciled: one update, then the gate passes.
+        assert_eq!(daemon.updates.load(Ordering::SeqCst), 1);
+        assert_eq!(client.probe().await.unwrap().phase, ServicePhase::Ready);
+    }
+
+    #[tokio::test]
+    async fn the_version_gate_fails_closed() {
+        let daemon = FakeDaemon::new(true, true, "1.4.5");
+        // The startup auto-update is stubbed into a no-op that leaves the old
+        // version in place.
+        struct StubbornDaemon(Arc<FakeDaemon>);
+        impl ServiceHostAdapter for StubbornDaemon {
+            fn probe(&self) -> BoxFuture<'_, StatusInfo<'static>> {
+                self.0.probe()
+            }
+            fn install(&self) -> BoxFuture<'_, Result<(), String>> {
+                self.0.install()
+            }
+            fn uninstall(&self) -> BoxFuture<'_, Result<(), String>> {
+                self.0.uninstall()
+            }
+            fn start_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
+                self.0.start_daemon()
+            }
+            fn stop_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
+                self.0.stop_daemon()
+            }
+            fn update(&self) -> BoxFuture<'_, Result<(), String>> {
+                Box::pin(async { Ok(()) }) // succeeds without changing anything
+            }
+            fn endpoint(&self) -> EndpointHandle {
+                self.0.endpoint()
+            }
+        }
+        let client = ServiceClient::spawn(Arc::new(StubbornDaemon(daemon)), 2)
+            .await
+            .unwrap();
+        let error = client
+            .ensure_ready()
+            .await
+            .err()
+            .expect("the gate must fail closed");
+        assert!(!error.retryable, "fail-closed is not a retry loop");
+        assert_eq!(client.status().phase, ServicePhase::Incompatible);
+    }
+
+    #[tokio::test]
+    async fn uninstall_refuses_while_the_daemon_owns_a_running_core() {
+        let daemon = FakeDaemon::new(true, true, "2.0.0");
+        daemon.core_running.store(true, Ordering::SeqCst);
+        let client = ServiceClient::spawn(daemon.clone(), 2).await.unwrap();
+
+        let error = client.uninstall().await.unwrap_err();
+        assert_eq!(error.kind, Some(CoreErrorKind::AlreadyRunning));
+        assert_eq!(daemon.uninstalls.load(Ordering::SeqCst), 0);
+
+        // After the core is handed off, uninstall proceeds (stop + uninstall).
+        daemon.core_running.store(false, Ordering::SeqCst);
+        client.uninstall().await.unwrap();
+        assert_eq!(daemon.uninstalls.load(Ordering::SeqCst), 1);
+        assert_eq!(client.status().phase, ServicePhase::NotInstalled);
+    }
+
+    #[tokio::test]
+    async fn endpoint_down_restarts_within_budget_then_latches_exhausted() {
+        let daemon = FakeDaemon::new(true, true, "2.0.0");
+        let client = ServiceClient::spawn(daemon.clone(), 1).await.unwrap();
+
+        // Daemon dies; the first report restarts it within budget.
+        daemon.state.lock().unwrap().1 = false;
+        client.report_endpoint_down();
+        let status = client.probe().await.unwrap();
+        assert_eq!(status.phase, ServicePhase::Ready);
+        assert_eq!(daemon.starts.load(Ordering::SeqCst), 1);
+
+        // Dies again with the budget spent: honest exhaustion latch.
+        daemon.state.lock().unwrap().1 = false;
+        client.report_endpoint_down(); // attempt 2 > budget 1 -> Exhausted
+        let mut status_rx = client.subscribe();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if status_rx.borrow_and_update().phase == ServicePhase::Exhausted {
+                    break;
+                }
+                status_rx.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("the spent budget must latch Exhausted");
+
+        // EnsureReady is the explicit escape: it resets the budget and
+        // converges again.
+        client.ensure_ready().await.unwrap();
+        assert_eq!(client.status().phase, ServicePhase::Ready);
+    }
+}

--- a/backend/tauri/src/core/actor_v2/service_actor.rs
+++ b/backend/tauri/src/core/actor_v2/service_actor.rs
@@ -1,0 +1,424 @@
+//! ServiceActor: the daemon as a managed OS resource (integration design §6).
+//!
+//! Owns install/uninstall/start/stop/update of the privileged daemon —
+//! serialized by the mailbox because elevated commands must never interleave —
+//! plus health observation, the fail-closed version gate (its only
+//! implementation point), endpoint supply, and a bounded auto-restart with an
+//! exhaustion latch. It never touches core lifecycle: that belongs to the
+//! `CoreControl` running *inside* the daemon.
+//!
+//! Desired state arrives by facade orchestration, never by config-watch
+//! subscription — two owners racing one change was the audited 5d/5e failure
+//! shape.
+
+use std::sync::Arc;
+
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+use tokio::sync::watch;
+
+use nyanpasu_core_manager::{CoreError, CoreErrorKind};
+use nyanpasu_ipc::types::{ServiceStatus, StatusInfo};
+
+use super::endpoint::{BoxFuture, EndpointHandle};
+use crate::core::service::compat::ServiceCompat;
+
+/// Elevated daemon mechanics behind one narrow boundary. The probe carries
+/// its own internal timeout; a hung daemon answers as `Stopped`-shaped, never
+/// hangs the actor.
+pub trait ServiceHostAdapter: Send + Sync {
+    fn probe(&self) -> BoxFuture<'_, StatusInfo<'static>>;
+    fn install(&self) -> BoxFuture<'_, Result<(), String>>;
+    fn uninstall(&self) -> BoxFuture<'_, Result<(), String>>;
+    fn start_daemon(&self) -> BoxFuture<'_, Result<(), String>>;
+    fn stop_daemon(&self) -> BoxFuture<'_, Result<(), String>>;
+    fn update(&self) -> BoxFuture<'_, Result<(), String>>;
+    /// The v2 control endpoint for a daemon that passed the version gate.
+    fn endpoint(&self) -> EndpointHandle;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServicePhase {
+    Probing,
+    NotInstalled,
+    DaemonStopped,
+    Installing,
+    StartingDaemon,
+    Ready,
+    /// Version gate failed closed: upgrade required, never downgraded to.
+    Incompatible,
+    Restarting,
+    /// Auto-restart budget spent; waits for an explicit `EnsureReady`.
+    Exhausted,
+    Uninstalling,
+}
+
+/// The watch projection (UI settings page + facade). Daemon state, never a
+/// second copy of core state.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ServiceHostStatus {
+    pub phase: ServicePhase,
+    pub compat: ServiceCompat,
+    pub restart_attempts: u8,
+}
+
+pub enum ServiceActorMessage {
+    /// Idempotent convergence to `Ready`: install → start → probe → gate, as
+    /// needed. The reply carries the endpoint the CoreActor will route to.
+    EnsureReady {
+        reply: RpcReplyPort<Result<EndpointHandle, CoreError>>,
+    },
+    Install {
+        reply: RpcReplyPort<Result<(), CoreError>>,
+    },
+    Update {
+        reply: RpcReplyPort<Result<(), CoreError>>,
+    },
+    /// Guarded twice: the facade only reaches this after a handoff away from
+    /// Service, and the actor itself refuses while the daemon owns a running
+    /// core.
+    Uninstall {
+        reply: RpcReplyPort<Result<(), CoreError>>,
+    },
+    StartDaemon {
+        reply: RpcReplyPort<Result<(), CoreError>>,
+    },
+    StopDaemon {
+        reply: RpcReplyPort<Result<(), CoreError>>,
+    },
+    /// Explicit probe; also the escape from `Exhausted`.
+    Probe {
+        reply: RpcReplyPort<ServiceHostStatus>,
+    },
+    /// CoreActor feedback: the service endpoint stopped answering.
+    EndpointDown,
+}
+
+pub struct ServiceActor;
+
+pub struct ServiceActorArgs {
+    pub adapter: Arc<dyn ServiceHostAdapter>,
+    pub status_tx: watch::Sender<ServiceHostStatus>,
+    /// Auto-restart attempts before the exhaustion latch (design OQ-6; the
+    /// number is host policy, injected).
+    pub restart_budget: u8,
+}
+
+pub struct ServiceActorState {
+    adapter: Arc<dyn ServiceHostAdapter>,
+    status_tx: watch::Sender<ServiceHostStatus>,
+    restart_budget: u8,
+    restart_attempts: u8,
+}
+
+impl ServiceActorState {
+    fn publish(&self, phase: ServicePhase, compat: ServiceCompat) {
+        self.status_tx.send_replace(ServiceHostStatus {
+            phase,
+            compat,
+            restart_attempts: self.restart_attempts,
+        });
+    }
+
+    fn command_error(what: &str, error: String) -> CoreError {
+        CoreError::new(
+            CoreErrorKind::BackendUnavailable,
+            format!("service {what} failed: {error}"),
+            true,
+        )
+    }
+
+    /// One probe, classified. Also publishes the resulting phase.
+    async fn probe_and_publish(&self) -> (StatusInfo<'static>, ServiceCompat, ServicePhase) {
+        let info = self.adapter.probe().await;
+        let compat = ServiceCompat::classify(&info);
+        let phase = match info.status {
+            ServiceStatus::Running if compat.allows_service_backend() => ServicePhase::Ready,
+            ServiceStatus::Running => ServicePhase::Incompatible,
+            ServiceStatus::Stopped => ServicePhase::DaemonStopped,
+            ServiceStatus::NotInstalled => ServicePhase::NotInstalled,
+        };
+        self.publish(phase, compat.clone());
+        (info, compat, phase)
+    }
+
+    /// The idempotent convergence: at most one install and one start per
+    /// call, then the gate decides.
+    async fn ensure_ready(&mut self) -> Result<EndpointHandle, CoreError> {
+        // An explicit convergence request resets the exhaustion latch.
+        self.restart_attempts = 0;
+        let (_, _, phase) = self.probe_and_publish().await;
+        if phase == ServicePhase::NotInstalled {
+            self.publish(ServicePhase::Installing, ServiceCompat::Unknown);
+            self.adapter
+                .install()
+                .await
+                .map_err(|error| Self::command_error("install", error))?;
+        }
+        let (_, _, phase) = self.probe_and_publish().await;
+        if phase == ServicePhase::DaemonStopped {
+            self.publish(ServicePhase::StartingDaemon, ServiceCompat::Unknown);
+            self.adapter
+                .start_daemon()
+                .await
+                .map_err(|error| Self::command_error("start", error))?;
+        }
+        let (_, compat, phase) = self.probe_and_publish().await;
+        match phase {
+            ServicePhase::Ready => Ok(self.adapter.endpoint()),
+            ServicePhase::Incompatible => Err(CoreError::new(
+                CoreErrorKind::BackendUnavailable,
+                format!("daemon version gate failed closed: {compat:?}; upgrade required"),
+                false,
+            )),
+            other => Err(CoreError::new(
+                CoreErrorKind::BackendUnavailable,
+                format!("daemon did not reach Ready: {other:?}"),
+                true,
+            )),
+        }
+    }
+}
+
+impl Actor for ServiceActor {
+    type Msg = ServiceActorMessage;
+    type State = ServiceActorState;
+    type Arguments = ServiceActorArgs;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let state = ServiceActorState {
+            adapter: args.adapter,
+            status_tx: args.status_tx,
+            restart_budget: args.restart_budget,
+            restart_attempts: 0,
+        };
+        // Startup version reconcile: an outdated-but-running daemon is
+        // upgraded once, preserving the product's auto `update_service`
+        // (UAC prompt) semantic. Fail-closed either way — a still-incompatible
+        // daemon never passes the gate.
+        let (_, compat, phase) = state.probe_and_publish().await;
+        if phase == ServicePhase::Incompatible {
+            tracing::info!("daemon incompatible at startup ({compat:?}); attempting one update");
+            if let Err(error) = state.adapter.update().await {
+                tracing::warn!("startup daemon update failed: {error}");
+            }
+            let _ = state.probe_and_publish().await;
+        }
+        Ok(state)
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            ServiceActorMessage::EnsureReady { reply } => {
+                let _ = reply.send(state.ensure_ready().await);
+            }
+            ServiceActorMessage::Install { reply } => {
+                state.publish(ServicePhase::Installing, ServiceCompat::Unknown);
+                let result = state
+                    .adapter
+                    .install()
+                    .await
+                    .map_err(|error| ServiceActorState::command_error("install", error));
+                let _ = state.probe_and_publish().await;
+                let _ = reply.send(result);
+            }
+            ServiceActorMessage::Update { reply } => {
+                let result = state
+                    .adapter
+                    .update()
+                    .await
+                    .map_err(|error| ServiceActorState::command_error("update", error));
+                let _ = state.probe_and_publish().await;
+                let _ = reply.send(result);
+            }
+            ServiceActorMessage::Uninstall { reply } => {
+                let result = async {
+                    // Self-check half of the double guard: never uninstall
+                    // under a daemon that still owns a running core.
+                    let info = state.adapter.probe().await;
+                    let owns_runtime = info.server.as_ref().is_some_and(|server| {
+                        !matches!(
+                            server.core_infos.state,
+                            nyanpasu_ipc::api::status::CoreState::Stopped(_)
+                        )
+                    });
+                    if owns_runtime {
+                        return Err(CoreError::new(
+                            CoreErrorKind::AlreadyRunning,
+                            "the daemon still owns a running core; hand off to Local first",
+                            false,
+                        ));
+                    }
+                    state.publish(ServicePhase::Uninstalling, ServiceCompat::Unknown);
+                    if info.status == ServiceStatus::Running {
+                        state
+                            .adapter
+                            .stop_daemon()
+                            .await
+                            .map_err(|error| ServiceActorState::command_error("stop", error))?;
+                    }
+                    state
+                        .adapter
+                        .uninstall()
+                        .await
+                        .map_err(|error| ServiceActorState::command_error("uninstall", error))
+                }
+                .await;
+                let _ = state.probe_and_publish().await;
+                let _ = reply.send(result);
+            }
+            ServiceActorMessage::StartDaemon { reply } => {
+                let result = state
+                    .adapter
+                    .start_daemon()
+                    .await
+                    .map_err(|error| ServiceActorState::command_error("start", error));
+                let _ = state.probe_and_publish().await;
+                let _ = reply.send(result);
+            }
+            ServiceActorMessage::StopDaemon { reply } => {
+                let result = state
+                    .adapter
+                    .stop_daemon()
+                    .await
+                    .map_err(|error| ServiceActorState::command_error("stop", error));
+                let _ = state.probe_and_publish().await;
+                let _ = reply.send(result);
+            }
+            ServiceActorMessage::Probe { reply } => {
+                let _ = state.probe_and_publish().await;
+                let _ = reply.send(state.status_tx.borrow().clone());
+            }
+            ServiceActorMessage::EndpointDown => {
+                let (_, _, phase) = state.probe_and_publish().await;
+                if phase == ServicePhase::Ready {
+                    // The daemon is fine; the endpoint handle broke. The
+                    // CoreActor re-adopts via a fresh ChangeHost — nothing to
+                    // do here beyond confirming health.
+                    return Ok(());
+                }
+                if state.restart_attempts >= state.restart_budget {
+                    state.publish(ServicePhase::Exhausted, ServiceCompat::Unknown);
+                    return Ok(());
+                }
+                state.restart_attempts += 1;
+                state.publish(ServicePhase::Restarting, ServiceCompat::Unknown);
+                if let Err(error) = state.adapter.start_daemon().await {
+                    tracing::warn!("daemon auto-restart failed: {error}");
+                }
+                let _ = state.probe_and_publish().await;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Typed wrapper; callers never hold the raw `ActorRef`.
+#[derive(Clone)]
+pub struct ServiceClient {
+    actor: ActorRef<ServiceActorMessage>,
+    status_rx: watch::Receiver<ServiceHostStatus>,
+}
+
+impl ServiceClient {
+    pub async fn spawn(
+        adapter: Arc<dyn ServiceHostAdapter>,
+        restart_budget: u8,
+    ) -> Result<Self, ractor::SpawnErr> {
+        let (status_tx, status_rx) = watch::channel(ServiceHostStatus {
+            phase: ServicePhase::Probing,
+            compat: ServiceCompat::Unknown,
+            restart_attempts: 0,
+        });
+        let (actor, _handle) = Actor::spawn(
+            None,
+            ServiceActor,
+            ServiceActorArgs {
+                adapter,
+                status_tx,
+                restart_budget,
+            },
+        )
+        .await?;
+        Ok(Self { actor, status_rx })
+    }
+
+    pub fn status(&self) -> ServiceHostStatus {
+        self.status_rx.borrow().clone()
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<ServiceHostStatus> {
+        self.status_rx.clone()
+    }
+
+    pub async fn ensure_ready(&self) -> Result<EndpointHandle, CoreError> {
+        self.call(|reply| ServiceActorMessage::EnsureReady { reply })
+            .await?
+    }
+
+    pub async fn install(&self) -> Result<(), CoreError> {
+        self.call(|reply| ServiceActorMessage::Install { reply })
+            .await?
+    }
+
+    pub async fn update(&self) -> Result<(), CoreError> {
+        self.call(|reply| ServiceActorMessage::Update { reply })
+            .await?
+    }
+
+    pub async fn uninstall(&self) -> Result<(), CoreError> {
+        self.call(|reply| ServiceActorMessage::Uninstall { reply })
+            .await?
+    }
+
+    pub async fn start_daemon(&self) -> Result<(), CoreError> {
+        self.call(|reply| ServiceActorMessage::StartDaemon { reply })
+            .await?
+    }
+
+    pub async fn stop_daemon(&self) -> Result<(), CoreError> {
+        self.call(|reply| ServiceActorMessage::StopDaemon { reply })
+            .await?
+    }
+
+    pub async fn probe(&self) -> Result<ServiceHostStatus, CoreError> {
+        self.call(|reply| ServiceActorMessage::Probe { reply })
+            .await
+    }
+
+    pub fn report_endpoint_down(&self) {
+        let _ = self.actor.cast(ServiceActorMessage::EndpointDown);
+    }
+
+    async fn call<T: Send + 'static>(
+        &self,
+        message: impl FnOnce(RpcReplyPort<T>) -> ServiceActorMessage,
+    ) -> Result<T, CoreError> {
+        // Elevated commands are slow (UAC + SCM); generous but finite.
+        match self
+            .actor
+            .call(message, Some(std::time::Duration::from_secs(120)))
+            .await
+        {
+            Ok(ractor::rpc::CallResult::Success(value)) => Ok(value),
+            Ok(ractor::rpc::CallResult::Timeout) => Err(CoreError::new(
+                CoreErrorKind::Internal,
+                "the service actor did not answer within its bound",
+                false,
+            )),
+            Ok(ractor::rpc::CallResult::SenderError) | Err(_) => Err(CoreError::new(
+                CoreErrorKind::Internal,
+                "the service actor is gone",
+                false,
+            )),
+        }
+    }
+}

--- a/backend/tauri/src/core/actor_v2/tests.rs
+++ b/backend/tauri/src/core/actor_v2/tests.rs
@@ -1,0 +1,310 @@
+//! Router tests over a fake endpoint: routing, handoff, fencing, degradation.
+//! No sleeps; every wait is a request/reply or a bounded watch.
+
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use nyanpasu_core_manager::{
+    CoreCommand, CoreCommandEnvelope, CoreError, CoreErrorKind, OperationId,
+};
+use nyanpasu_ipc::api::{
+    core::v2::{OperationInfo, OperationPhase},
+    status::CoreStateDetail,
+};
+
+use super::{
+    CoreClient, EndpointConnectivity, HandoffReport,
+    endpoint::{BoxFuture, ControlEndpoint, CoreStatusSnapshot, ExecutionHost},
+};
+
+struct FakeEndpoint {
+    host: ExecutionHost,
+    /// What `status` answers; `Err` simulates transport loss.
+    status: Mutex<Result<CoreStatusSnapshot, String>>,
+    submits: AtomicUsize,
+    stops: AtomicUsize,
+    /// When true, a submitted stop fails with `stop_unconfirmed`.
+    refuse_stop: std::sync::atomic::AtomicBool,
+}
+
+impl FakeEndpoint {
+    fn new(host: ExecutionHost, state: CoreStateDetail) -> Arc<Self> {
+        Arc::new(Self {
+            host,
+            status: Mutex::new(Ok(snapshot(state))),
+            submits: AtomicUsize::new(0),
+            stops: AtomicUsize::new(0),
+            refuse_stop: std::sync::atomic::AtomicBool::new(false),
+        })
+    }
+}
+
+fn snapshot(state: CoreStateDetail) -> CoreStatusSnapshot {
+    CoreStatusSnapshot {
+        state,
+        state_changed_at: 0,
+        revision: None,
+        healthy: None,
+    }
+}
+
+impl ControlEndpoint for FakeEndpoint {
+    fn host(&self) -> ExecutionHost {
+        self.host
+    }
+
+    fn submit<'a>(
+        &'a self,
+        envelope: CoreCommandEnvelope,
+    ) -> BoxFuture<'a, Result<OperationInfo, CoreError>> {
+        Box::pin(async move {
+            self.submits.fetch_add(1, Ordering::SeqCst);
+            let id = envelope.operation_id.to_string();
+            if matches!(envelope.command, CoreCommand::Stop) {
+                self.stops.fetch_add(1, Ordering::SeqCst);
+                if self.refuse_stop.load(Ordering::SeqCst) {
+                    return Ok(OperationInfo {
+                        id,
+                        phase: OperationPhase::Failed,
+                        output: None,
+                        error: Some(nyanpasu_ipc::api::core::v2::OperationErrorInfo {
+                            kind: Some("stop_unconfirmed".into()),
+                            message: "injected".into(),
+                            retryable: false,
+                        }),
+                    });
+                }
+                *self.status.lock().unwrap() =
+                    Ok(snapshot(CoreStateDetail::Stopped { reason: None }));
+                return Ok(OperationInfo {
+                    id,
+                    phase: OperationPhase::Succeeded,
+                    output: Some(nyanpasu_ipc::api::core::v2::OperationOutputInfo::Stopped),
+                    error: None,
+                });
+            }
+            Ok(OperationInfo {
+                id,
+                phase: OperationPhase::Queued,
+                output: None,
+                error: None,
+            })
+        })
+    }
+
+    fn wait_operation<'a>(
+        &'a self,
+        id: OperationId,
+        _timeout: std::time::Duration,
+    ) -> BoxFuture<'a, Option<OperationInfo>> {
+        Box::pin(async move {
+            // The fake resolves synchronously in submit; echo the terminal
+            // state a real registry would replay.
+            let stopped = matches!(
+                *self.status.lock().unwrap(),
+                Ok(CoreStatusSnapshot {
+                    state: CoreStateDetail::Stopped { .. },
+                    ..
+                })
+            );
+            if self.refuse_stop.load(Ordering::SeqCst) {
+                return Some(OperationInfo {
+                    id: id.to_string(),
+                    phase: OperationPhase::Failed,
+                    output: None,
+                    error: Some(nyanpasu_ipc::api::core::v2::OperationErrorInfo {
+                        kind: Some("stop_unconfirmed".into()),
+                        message: "injected".into(),
+                        retryable: false,
+                    }),
+                });
+            }
+            Some(OperationInfo {
+                id: id.to_string(),
+                phase: OperationPhase::Succeeded,
+                output: Some(if stopped {
+                    nyanpasu_ipc::api::core::v2::OperationOutputInfo::Stopped
+                } else {
+                    nyanpasu_ipc::api::core::v2::OperationOutputInfo::Recovered
+                }),
+                error: None,
+            })
+        })
+    }
+
+    fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
+        Box::pin(async move {
+            self.status
+                .lock()
+                .unwrap()
+                .clone()
+                .map_err(|reason| CoreError::new(CoreErrorKind::BackendUnavailable, reason, true))
+        })
+    }
+}
+
+fn reconcile_envelope() -> CoreCommandEnvelope {
+    CoreCommandEnvelope {
+        operation_id: OperationId::generate(),
+        command: CoreCommand::Recover,
+    }
+}
+
+#[tokio::test]
+async fn submit_routes_to_the_active_endpoint() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let ticket = client.submit(reconcile_envelope()).await.unwrap();
+    assert_eq!(ticket.generation, 0);
+    assert_eq!(local.submits.load(Ordering::SeqCst), 1);
+    assert_eq!(ticket.endpoint.host(), ExecutionHost::Local);
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn a_completed_handoff_advances_the_generation_and_moves_routing() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let report = client.change_host(service.clone()).await.unwrap();
+    assert_eq!(report, HandoffReport::Completed { generation: 1 });
+    // The source was stopped exactly once, with proof demanded.
+    assert_eq!(local.stops.load(Ordering::SeqCst), 1);
+
+    // Routing follows ownership.
+    let ticket = client.submit(reconcile_envelope()).await.unwrap();
+    assert_eq!(ticket.endpoint.host(), ExecutionHost::Service);
+    assert_eq!(ticket.generation, 1);
+    assert_eq!(service.submits.load(Ordering::SeqCst), 1);
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn a_failed_preflight_leaves_the_endpoint_unchanged() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    *service.status.lock().unwrap() = Err("daemon unreachable".into());
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let error = client.change_host(service).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::BackendUnavailable));
+    assert!(error.retryable);
+    assert_eq!(local.stops.load(Ordering::SeqCst), 0, "nothing was stopped");
+
+    // The original endpoint still routes.
+    let ticket = client.submit(reconcile_envelope()).await.unwrap();
+    assert_eq!(ticket.endpoint.host(), ExecutionHost::Local);
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn an_unproven_source_stop_aborts_the_handoff_and_never_starts_the_target() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    local.refuse_stop.store(true, Ordering::SeqCst);
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let error = client.change_host(service.clone()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::StopUnconfirmed));
+    assert_eq!(
+        service.submits.load(Ordering::SeqCst),
+        0,
+        "no StopProof, no next owner"
+    );
+    // The slot stays with the (quarantined) source; generation unmoved.
+    let ticket_error = client.status();
+    assert_eq!(ticket_error.generation, 0);
+    assert_eq!(ticket_error.host, ExecutionHost::Local);
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn endpoint_down_degrades_honestly_and_stale_reports_are_fenced() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+    let mut status_rx = client.subscribe();
+
+    // A stale-generation down report is dropped entirely.
+    client
+        .actor
+        .cast(super::CoreActorMessage::EndpointDown {
+            generation: 99,
+            reason: "stale".into(),
+        })
+        .unwrap();
+    // A current-generation down report degrades the slot.
+    client
+        .actor
+        .cast(super::CoreActorMessage::EndpointDown {
+            generation: 0,
+            reason: "pump broke".into(),
+        })
+        .unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if matches!(
+                status_rx.borrow_and_update().connectivity,
+                EndpointConnectivity::Degraded { .. }
+            ) {
+                break;
+            }
+            status_rx.changed().await.unwrap();
+        }
+    })
+    .await
+    .expect("the down report must degrade the projection");
+
+    let projection = client.status();
+    let EndpointConnectivity::Degraded { desired, reason } = projection.connectivity else {
+        panic!("expected Degraded, got {projection:?}");
+    };
+    assert_eq!(desired, ExecutionHost::Local, "commit-first: no fallback");
+    assert_eq!(reason, "pump broke");
+
+    // Submits are refused retryably while degraded.
+    let error = client.submit(reconcile_envelope()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::BackendUnavailable));
+    assert!(error.retryable);
+
+    // Recovery is explicit: adopt a fresh endpoint.
+    let fresh = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let report = client.change_host(fresh).await.unwrap();
+    assert_eq!(report, HandoffReport::Completed { generation: 1 });
+
+    client.shutdown().await.unwrap();
+}

--- a/backend/tauri/src/core/actor_v2/tests.rs
+++ b/backend/tauri/src/core/actor_v2/tests.rs
@@ -1,0 +1,1237 @@
+//! Router tests over a fake endpoint: routing, handoff, fencing, degradation.
+//! No sleeps; every wait is a request/reply or a bounded watch.
+
+use std::{
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use tokio::sync::Notify;
+
+use nyanpasu_core_manager::{
+    CoreCommand, CoreCommandEnvelope, CoreError, CoreErrorKind, OperationId,
+};
+use nyanpasu_ipc::api::{
+    core::v2::{OperationErrorInfo, OperationInfo, OperationOutputInfo, OperationPhase},
+    status::CoreStateDetail,
+};
+
+use super::{
+    CoreActorMessage, CoreClient, EndpointConnectivity, HandoffReport, STOP_WAIT, ShutdownReport,
+    endpoint::{BoxFuture, ControlEndpoint, CoreStatusSnapshot, EndpointHandle, ExecutionHost},
+};
+
+/// The three answers a host gives are scripted independently, because the
+/// defect class this suite guards against is a router filling one in from
+/// another: a lost `wait_operation` result must not be reconstructed from a
+/// status the fake happened to flip on the way past.
+///
+/// Admission is deliberately uniform -- always `Queued`, like a real host that
+/// has only enqueued the work. A fake that answered the terminal result at
+/// submit would let a router that never waits pass every stop-proof test here.
+struct FakeEndpoint {
+    host: ExecutionHost,
+    /// What `status` answers; `Err` simulates transport loss.
+    status: Mutex<Result<CoreStatusSnapshot, String>>,
+    /// What `wait_operation` answers. Nothing else consults it.
+    stop_result: Mutex<StopScript>,
+    /// An id to echo at admission instead of the requested one.
+    echo_id: Mutex<Option<String>>,
+    submits: AtomicUsize,
+    stops: AtomicUsize,
+    waits: AtomicUsize,
+    /// Parks the stop leg so a handoff can be observed mid-flight.
+    gate_stop: AtomicBool,
+    stop_started: Notify,
+    release_stop: Notify,
+    /// Makes `status` never answer, the way an endpoint that accepted the
+    /// call and then wedged would.
+    hang_status: AtomicBool,
+    /// Dropped together with a hung `status` future, so cancellation is
+    /// observable from the test instead of merely assumed.
+    status_dropped: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    /// Makes `submit` never answer, the way an endpoint that accepted the
+    /// call and then wedged would (F4).
+    hang_submit: AtomicBool,
+    never: Notify,
+}
+
+/// How the fake host answers a stop. Nothing here is derived from `status`.
+#[derive(Clone)]
+enum StopScript {
+    /// Succeeded, carrying the stop output — the only genuine proof.
+    Proven,
+    /// Succeeded with some other output. A real host doing this is a bug; the
+    /// router must not read it as proof.
+    Succeeded(OperationOutputInfo),
+    Failed {
+        kind: Option<&'static str>,
+        retryable: bool,
+    },
+    /// `wait_operation` answers `None`: registry evicted or transport broke.
+    Lost,
+}
+
+impl FakeEndpoint {
+    fn new(host: ExecutionHost, state: CoreStateDetail) -> Arc<Self> {
+        Arc::new(Self {
+            host,
+            status: Mutex::new(Ok(snapshot(state))),
+            stop_result: Mutex::new(StopScript::Proven),
+            echo_id: Mutex::new(None),
+            submits: AtomicUsize::new(0),
+            stops: AtomicUsize::new(0),
+            waits: AtomicUsize::new(0),
+            gate_stop: AtomicBool::new(false),
+            stop_started: Notify::new(),
+            release_stop: Notify::new(),
+            hang_status: AtomicBool::new(false),
+            status_dropped: Mutex::new(None),
+            hang_submit: AtomicBool::new(false),
+            never: Notify::new(),
+        })
+    }
+
+    /// Parks every stop between admission and its answer.
+    fn gate_stop(&self) {
+        self.gate_stop.store(true, Ordering::SeqCst);
+    }
+
+    /// `notify_one` rather than `notify_waiters`: it stores a permit, so the
+    /// gate cannot be lost to whichever side happens to arrive first.
+    fn release_stop(&self) {
+        self.release_stop.notify_one();
+    }
+
+    /// Makes `status` hang forever and hands back the receiver that resolves
+    /// (with an error) once the hung future is dropped.
+    fn hang_status(&self) -> tokio::sync::oneshot::Receiver<()> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        *self.status_dropped.lock().unwrap() = Some(tx);
+        self.hang_status.store(true, Ordering::SeqCst);
+        rx
+    }
+
+    /// Makes `submit` hang forever, the way an endpoint that accepted the
+    /// call and then wedged would (F4).
+    fn hang_submit(&self) {
+        self.hang_submit.store(true, Ordering::SeqCst);
+    }
+
+    fn script_stop(&self, script: StopScript) {
+        *self.stop_result.lock().unwrap() = script;
+    }
+
+    fn stop_info(&self, id: String) -> OperationInfo {
+        match self.stop_result.lock().unwrap().clone() {
+            StopScript::Proven => OperationInfo {
+                id,
+                phase: OperationPhase::Succeeded,
+                output: Some(OperationOutputInfo::Stopped),
+                error: None,
+            },
+            StopScript::Succeeded(output) => OperationInfo {
+                id,
+                phase: OperationPhase::Succeeded,
+                output: Some(output),
+                error: None,
+            },
+            StopScript::Failed { kind, retryable } => OperationInfo {
+                id,
+                phase: OperationPhase::Failed,
+                output: None,
+                error: Some(OperationErrorInfo {
+                    kind: kind.map(Into::into),
+                    message: "injected".into(),
+                    retryable,
+                }),
+            },
+            StopScript::Lost => unreachable!("a lost stop has no operation info"),
+        }
+    }
+}
+
+fn snapshot(state: CoreStateDetail) -> CoreStatusSnapshot {
+    CoreStatusSnapshot {
+        state: Some(state),
+        state_changed_at: 0,
+        revision: None,
+        healthy: None,
+    }
+}
+
+impl ControlEndpoint for FakeEndpoint {
+    fn host(&self) -> ExecutionHost {
+        self.host
+    }
+
+    fn submit<'a>(
+        &'a self,
+        envelope: CoreCommandEnvelope,
+    ) -> BoxFuture<'a, Result<OperationInfo, CoreError>> {
+        Box::pin(async move {
+            if self.hang_submit.load(Ordering::SeqCst) {
+                self.never.notified().await;
+                unreachable!("nothing notifies `never`");
+            }
+            self.submits.fetch_add(1, Ordering::SeqCst);
+            let id = envelope.operation_id.to_string();
+            if matches!(envelope.command, CoreCommand::Stop) {
+                self.stops.fetch_add(1, Ordering::SeqCst);
+            }
+            Ok(OperationInfo {
+                id: self.echo_id.lock().unwrap().clone().unwrap_or(id),
+                phase: OperationPhase::Queued,
+                output: None,
+                error: None,
+            })
+        })
+    }
+
+    fn wait_operation<'a>(
+        &'a self,
+        id: OperationId,
+        _timeout: std::time::Duration,
+    ) -> BoxFuture<'a, Option<OperationInfo>> {
+        Box::pin(async move {
+            self.waits.fetch_add(1, Ordering::SeqCst);
+            // The gate lives on the long poll, which is where a real stop
+            // spends its time.
+            if self.gate_stop.load(Ordering::SeqCst) {
+                self.stop_started.notify_one();
+                self.release_stop.notified().await;
+            }
+            if matches!(*self.stop_result.lock().unwrap(), StopScript::Lost) {
+                return None;
+            }
+            Some(self.stop_info(id.to_string()))
+        })
+    }
+
+    fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
+        Box::pin(async move {
+            if self.hang_status.load(Ordering::SeqCst) {
+                let _dropped = self.status_dropped.lock().unwrap().take();
+                self.never.notified().await;
+                unreachable!("nothing notifies `never`");
+            }
+            self.status
+                .lock()
+                .unwrap()
+                .clone()
+                .map_err(|reason| CoreError::new(CoreErrorKind::BackendUnavailable, reason, true))
+        })
+    }
+}
+
+fn reconcile_envelope() -> CoreCommandEnvelope {
+    CoreCommandEnvelope {
+        operation_id: OperationId::generate(),
+        command: CoreCommand::Recover,
+    }
+}
+
+#[tokio::test]
+async fn submit_routes_to_the_active_endpoint() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let ticket = client.submit(reconcile_envelope()).await.unwrap();
+    assert_eq!(ticket.generation, 0);
+    assert_eq!(local.submits.load(Ordering::SeqCst), 1);
+    assert_eq!(ticket.endpoint.host(), ExecutionHost::Local);
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn a_completed_handoff_advances_the_generation_and_moves_routing() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let report = client.change_host(service.clone()).await.unwrap();
+    assert_eq!(report, HandoffReport::Completed { generation: 1 });
+    // The source was stopped exactly once, with proof demanded.
+    assert_eq!(local.stops.load(Ordering::SeqCst), 1);
+
+    // Routing follows ownership.
+    let ticket = client.submit(reconcile_envelope()).await.unwrap();
+    assert_eq!(ticket.endpoint.host(), ExecutionHost::Service);
+    assert_eq!(ticket.generation, 1);
+    assert_eq!(service.submits.load(Ordering::SeqCst), 1);
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn a_failed_preflight_leaves_the_endpoint_unchanged() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    *service.status.lock().unwrap() = Err("daemon unreachable".into());
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let error = client.change_host(service).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::BackendUnavailable));
+    assert!(error.retryable);
+    assert_eq!(local.stops.load(Ordering::SeqCst), 0, "nothing was stopped");
+
+    // The original endpoint still routes.
+    let ticket = client.submit(reconcile_envelope()).await.unwrap();
+    assert_eq!(ticket.endpoint.host(), ExecutionHost::Local);
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn an_unproven_source_stop_aborts_the_handoff_and_never_starts_the_target() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    local.script_stop(StopScript::Failed {
+        kind: Some("stop_unconfirmed"),
+        retryable: false,
+    });
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let error = client.change_host(service.clone()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::StopUnconfirmed));
+    assert_eq!(
+        service.submits.load(Ordering::SeqCst),
+        0,
+        "no StopProof, no next owner"
+    );
+    // The slot stays with the (quarantined) source; generation unmoved.
+    let ticket_error = client.status();
+    assert_eq!(ticket_error.generation, 0);
+    assert_eq!(ticket_error.host, ExecutionHost::Local);
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn endpoint_down_degrades_honestly_and_stale_reports_are_fenced() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+    let mut status_rx = client.subscribe();
+
+    // A stale-generation down report is dropped entirely.
+    client
+        .actor
+        .cast(super::CoreActorMessage::EndpointDown {
+            generation: 99,
+            reason: "stale".into(),
+        })
+        .unwrap();
+    // A current-generation down report degrades the slot.
+    client
+        .actor
+        .cast(super::CoreActorMessage::EndpointDown {
+            generation: 0,
+            reason: "pump broke".into(),
+        })
+        .unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if matches!(
+                status_rx.borrow_and_update().connectivity,
+                EndpointConnectivity::Degraded { .. }
+            ) {
+                break;
+            }
+            status_rx.changed().await.unwrap();
+        }
+    })
+    .await
+    .expect("the down report must degrade the projection");
+
+    let projection = client.status();
+    let EndpointConnectivity::Degraded { desired, reason } = projection.connectivity else {
+        panic!("expected Degraded, got {projection:?}");
+    };
+    assert_eq!(desired, ExecutionHost::Local, "commit-first: no fallback");
+    assert_eq!(reason, "pump broke");
+
+    // Submits are refused retryably while degraded.
+    let error = client.submit(reconcile_envelope()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::BackendUnavailable));
+    assert!(error.retryable);
+
+    // Recovery is explicit: adopt a fresh endpoint.
+    let fresh = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let report = client.change_host(fresh).await.unwrap();
+    assert_eq!(report, HandoffReport::Completed { generation: 1 });
+
+    client.shutdown().await.unwrap();
+}
+
+/// C-1: a lost stop result plus an unknown status is not a stop proof. Before
+/// the fix the unknown state was folded into `Stopped` and the handoff took
+/// ownership of a runtime nobody had proven dead.
+#[tokio::test]
+async fn a_lost_stop_result_with_an_unknown_status_is_not_a_stop_proof() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    local.script_stop(StopScript::Lost);
+    *local.status.lock().unwrap() = Ok(CoreStatusSnapshot {
+        state: None,
+        state_changed_at: 0,
+        revision: None,
+        healthy: None,
+    });
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let error = client.change_host(service.clone()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::StopUnconfirmed));
+    assert_eq!(
+        service.submits.load(Ordering::SeqCst),
+        0,
+        "no StopProof, no next owner"
+    );
+    let projection = client.status();
+    assert_eq!(projection.generation, 0);
+    assert_eq!(projection.host, ExecutionHost::Local);
+
+    client.shutdown().await.unwrap();
+}
+
+/// The control case: the same lost result over a host that *does* publish
+/// `Stopped` is a proof, and the handoff completes.
+#[tokio::test]
+async fn a_lost_stop_result_with_a_stopped_status_is_accepted() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    local.script_stop(StopScript::Lost);
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let report = client.change_host(service).await.unwrap();
+    assert_eq!(report, HandoffReport::Completed { generation: 1 });
+
+    client.shutdown().await.unwrap();
+}
+
+/// Minor-A1: succeeding at something else is not succeeding at stopping.
+#[tokio::test]
+async fn succeeded_recovered_is_not_stop_proof() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    local.script_stop(StopScript::Succeeded(OperationOutputInfo::Recovered));
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let error = client.change_host(service.clone()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::StopUnconfirmed));
+    assert_eq!(service.submits.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        local.waits.load(Ordering::SeqCst),
+        1,
+        "the proof has to come from the wait, not from the admission"
+    );
+
+    client.shutdown().await.unwrap();
+}
+
+/// A syntactically valid operation id is not the id we asked about. Accepting
+/// another operation's `Stopped` would adopt the target on the strength of a
+/// stop that never ran.
+#[tokio::test]
+async fn an_admission_echoing_another_id_is_not_a_stop_proof() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    *local.echo_id.lock().unwrap() = Some(OperationId::generate().to_string());
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let error = client.change_host(service.clone()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::StopUnconfirmed));
+    assert_eq!(service.submits.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        local.waits.load(Ordering::SeqCst),
+        0,
+        "there is nothing to wait on once the ids disagree"
+    );
+
+    client.shutdown().await.unwrap();
+}
+
+/// The host decides retryability per failure; the router forwards it instead
+/// of flattening every stop failure to non-retryable.
+#[tokio::test]
+async fn a_failed_stop_preserves_the_wire_retryable_flag() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    local.script_stop(StopScript::Failed {
+        kind: Some("backend_unavailable"),
+        retryable: true,
+    });
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let error = client.change_host(service).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::BackendUnavailable));
+    assert!(error.retryable, "the host said this one is worth retrying");
+
+    client.shutdown().await.unwrap();
+}
+
+/// A kind this build has no variant for stays unclassified. Calling it
+/// `Internal` would tell the caller the control plane broke when all that
+/// happened is that the daemon is newer.
+#[tokio::test]
+async fn an_unknown_stop_failure_kind_stays_unclassified() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    local.script_stop(StopScript::Failed {
+        kind: Some("a_future_kind"),
+        retryable: false,
+    });
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let error = client.change_host(service).await.unwrap_err();
+    assert_eq!(error.kind, None);
+    assert!(!error.retryable);
+
+    client.shutdown().await.unwrap();
+}
+
+/// Waits for the projection to satisfy `predicate`, or fails the test.
+async fn await_projection(
+    client: &CoreClient,
+    what: &str,
+    predicate: impl Fn(&super::CoreStatusProjection) -> bool,
+) {
+    let mut status_rx = client.subscribe();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if predicate(&status_rx.borrow_and_update()) {
+                break;
+            }
+            status_rx.changed().await.unwrap();
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("the projection never reached: {what}"));
+}
+
+/// Degrades `client`'s current endpoint through the same message its pump
+/// would send.
+async fn degrade(client: &CoreClient, reason: &str) {
+    client
+        .actor
+        .cast(CoreActorMessage::EndpointDown {
+            generation: client.status().generation,
+            reason: reason.to_owned(),
+        })
+        .unwrap();
+    await_projection(client, "degraded", |projection| {
+        matches!(
+            projection.connectivity,
+            EndpointConnectivity::Degraded { .. }
+        )
+    })
+    .await;
+}
+
+/// Starts a handoff and returns once its stop leg is parked at the gate.
+async fn handoff_in_flight(
+    client: &CoreClient,
+    source: &Arc<FakeEndpoint>,
+    target: EndpointHandle,
+) -> tokio::task::JoinHandle<Result<HandoffReport, CoreError>> {
+    source.gate_stop();
+    let handle = {
+        let client = client.clone();
+        tokio::spawn(async move { client.change_host(target).await })
+    };
+    tokio::time::timeout(Duration::from_secs(5), source.stop_started.notified())
+        .await
+        .expect("the stop leg must start");
+    handle
+}
+
+/// M-7: the stop leg is a minute long in the worst case. Parking a submit
+/// behind it means the caller's own 10s bound expires and reports `Internal`,
+/// which says "the router broke" for what is really "try again in a moment".
+#[tokio::test]
+async fn a_submit_during_a_handoff_is_refused_with_operation_conflict() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+    let handoff = handoff_in_flight(&client, &local, service.clone()).await;
+
+    let error = client.submit(reconcile_envelope()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::OperationConflict));
+    assert!(error.retryable, "the caller should retry after the handoff");
+    assert_eq!(
+        client.status().connectivity,
+        EndpointConnectivity::HandingOff {
+            from: ExecutionHost::Local,
+            to: ExecutionHost::Service,
+        }
+    );
+
+    local.release_stop();
+    assert_eq!(
+        handoff.await.unwrap().unwrap(),
+        HandoffReport::Completed { generation: 1 }
+    );
+
+    let ticket = client.submit(reconcile_envelope()).await.unwrap();
+    assert_eq!(ticket.endpoint.host(), ExecutionHost::Service);
+    assert_eq!(
+        local.submits.load(Ordering::SeqCst),
+        1,
+        "the refused submit must not run late on the source"
+    );
+
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn a_second_change_host_during_a_handoff_is_refused() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+    let handoff = handoff_in_flight(&client, &local, service.clone()).await;
+
+    let other = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let error = client.change_host(other.clone()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::OperationConflict));
+    assert!(error.retryable);
+
+    local.release_stop();
+    handoff.await.unwrap().unwrap();
+    assert_eq!(
+        local.stops.load(Ordering::SeqCst),
+        1,
+        "one handoff, one stop"
+    );
+
+    client.shutdown().await.unwrap();
+}
+
+/// Fencing use #2: a completion belonging to an abandoned handoff must not
+/// move ownership.
+#[tokio::test]
+async fn a_stale_handoff_completion_is_fenced() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+    let handoff = handoff_in_flight(&client, &local, service.clone()).await;
+
+    let (reply, _stale_rx) = ractor::concurrency::oneshot();
+    client
+        .actor
+        .cast(CoreActorMessage::HandoffStopped {
+            generation: 99,
+            result: Ok(None),
+            reply: reply.into(),
+        })
+        .unwrap();
+
+    // The refusal doubles as a mailbox flush: the stale completion has been
+    // processed by the time this answers, and it adopted nothing.
+    let error = client.submit(reconcile_envelope()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::OperationConflict));
+    assert_eq!(client.status().generation, 0);
+    assert_eq!(service.submits.load(Ordering::SeqCst), 0);
+
+    local.release_stop();
+    assert_eq!(
+        handoff.await.unwrap().unwrap(),
+        HandoffReport::Completed { generation: 1 }
+    );
+
+    client.shutdown().await.unwrap();
+}
+
+/// An unproven stop leaves ownership exactly where it was, and routing has to
+/// keep working there.
+#[tokio::test]
+async fn a_handoff_whose_stop_fails_returns_to_connected_routing() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    local.script_stop(StopScript::Failed {
+        kind: Some("stop_unconfirmed"),
+        retryable: false,
+    });
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let error = client.change_host(service.clone()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::StopUnconfirmed));
+    let projection = client.status();
+    assert_eq!(projection.connectivity, EndpointConnectivity::Connected);
+    assert_eq!(projection.host, ExecutionHost::Local);
+    assert_eq!(projection.generation, 0);
+
+    let ticket = client.submit(reconcile_envelope()).await.unwrap();
+    assert_eq!(ticket.endpoint.host(), ExecutionHost::Local);
+    assert_eq!(service.submits.load(Ordering::SeqCst), 0);
+}
+
+/// Missed-4: a shutdown that lands mid-handoff must settle from the stop
+/// already in flight. A second stop would be a second lifecycle command for
+/// one runtime.
+#[tokio::test]
+async fn shutdown_during_a_handoff_settles_once_and_stops_nothing_twice() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+    let handoff = handoff_in_flight(&client, &local, service.clone()).await;
+
+    // Cast rather than call: the gate is still closed, so this is provably in
+    // the mailbox ahead of the handoff's continuation.
+    let (reply, shutdown_rx) = ractor::concurrency::oneshot::<ShutdownReport>();
+    client
+        .actor
+        .cast(CoreActorMessage::Shutdown {
+            reply: reply.into(),
+        })
+        .unwrap();
+
+    local.release_stop();
+    let error = handoff.await.unwrap().unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::ShuttingDown));
+
+    let report = shutdown_rx.await.unwrap();
+    assert!(
+        matches!(report.stop, Ok(Some(_))),
+        "the handoff's stop is the shutdown's stop, got {:?}",
+        report.stop
+    );
+    assert_eq!(local.stops.load(Ordering::SeqCst), 1);
+    assert_eq!(service.submits.load(Ordering::SeqCst), 0);
+}
+
+/// C-3: an unreachable source is exactly the case where nothing can prove its
+/// runtime stopped. Adopting another host there is how two owners end up
+/// driving one core.
+#[tokio::test]
+async fn a_degraded_source_cannot_be_replaced_by_another_host_without_proof() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+    degrade(&client, "pump broke").await;
+
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let error = client.change_host(service.clone()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::StopUnconfirmed));
+    assert!(error.retryable, "recoverable once the source answers again");
+    assert_eq!(service.submits.load(Ordering::SeqCst), 0);
+    assert_eq!(client.status().generation, 0);
+
+    // The recovery path is a fresh endpoint on the *same* host: ownership
+    // never moved, so there is nothing to prove.
+    let fresh = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    assert_eq!(
+        client.change_host(fresh).await.unwrap(),
+        HandoffReport::Completed { generation: 1 }
+    );
+
+    client.shutdown().await.unwrap();
+}
+
+/// M-8: the first frame of a new generation must not carry the previous
+/// host's runtime. It is the previous owner's state, and the UI would read it
+/// as the new one's.
+#[tokio::test]
+async fn adoption_publishes_no_snapshot_from_the_previous_host() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+    await_projection(&client, "the source's first snapshot", |projection| {
+        projection.snapshot.is_some()
+    })
+    .await;
+
+    let mut events = client.subscribe_events();
+    assert_eq!(
+        client.change_host(service).await.unwrap(),
+        HandoffReport::Completed { generation: 1 }
+    );
+
+    let frame = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let projection = events.recv().await.unwrap();
+            if projection.generation == 1 {
+                return projection;
+            }
+        }
+    })
+    .await
+    .expect("adoption must publish a generation-1 frame");
+    assert_eq!(frame.host, ExecutionHost::Service);
+    assert_eq!(frame.connectivity, EndpointConnectivity::Connected);
+    assert_eq!(frame.snapshot, None, "the old host's state must not carry");
+
+    client.shutdown().await.unwrap();
+}
+
+/// M-12: an unproven shutdown stop is reported, not logged and dropped.
+#[tokio::test]
+async fn a_shutdown_reports_an_unproven_stop_instead_of_swallowing_it() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    local.script_stop(StopScript::Failed {
+        kind: Some("stop_unconfirmed"),
+        retryable: false,
+    });
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+    await_projection(&client, "the first snapshot", |projection| {
+        projection.snapshot.is_some()
+    })
+    .await;
+
+    let report = client.shutdown().await.unwrap();
+    let error = report.stop.expect_err("an unproven stop is not an Ok");
+    assert_eq!(error.kind, Some(CoreErrorKind::StopUnconfirmed));
+    assert_eq!(
+        report.final_status,
+        Some(snapshot(CoreStateDetail::Running { epoch: 1, pid: 42 }))
+    );
+}
+
+#[tokio::test]
+async fn a_degraded_shutdown_reports_that_no_stop_was_attempted() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+    degrade(&client, "pump broke").await;
+
+    let report = client.shutdown().await.unwrap();
+    let error = report
+        .stop
+        .expect_err("a degraded endpoint stopped nothing");
+    assert_eq!(error.kind, Some(CoreErrorKind::BackendUnavailable));
+    assert_eq!(local.stops.load(Ordering::SeqCst), 0);
+}
+
+/// Minor-A2: an endpoint that accepts the read and never answers must degrade
+/// the projection. Unbounded, the pump would wait on it forever and the app
+/// would keep showing the last frame as if it were current.
+#[tokio::test]
+async fn a_hung_endpoint_read_degrades_the_projection() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let _dropped = local.hang_status();
+    let client = CoreClient::spawn_with_bounds(local.clone(), Duration::from_millis(50), STOP_WAIT)
+        .await
+        .unwrap();
+
+    await_projection(&client, "degraded by a hung read", |projection| {
+        matches!(
+            projection.connectivity,
+            EndpointConnectivity::Degraded { .. }
+        )
+    })
+    .await;
+}
+
+/// The pump holds an `ActorRef` and an endpoint; a read in flight keeps both
+/// alive past the mailbox unless `post_stop` cancels it.
+#[tokio::test]
+async fn actor_stop_cancels_the_status_pump() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let dropped = local.hang_status();
+    let client = CoreClient::spawn_with_bounds(local.clone(), Duration::from_secs(30), STOP_WAIT)
+        .await
+        .unwrap();
+
+    client.actor.stop(Some("test".into()));
+    tokio::time::timeout(Duration::from_secs(5), dropped)
+        .await
+        .expect("the hung status future must be dropped when the actor stops")
+        .expect_err("the guard is dropped, never sent");
+}
+
+/// The handoff's own calls have to be bounded too. Unbounded, a source that
+/// accepts the long poll and never answers parks the router in `HandingOff`
+/// forever: every submit is refused, no shutdown settles, and the projection
+/// never degrades.
+#[tokio::test]
+async fn a_handoff_whose_source_never_answers_still_ends() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    local.gate_stop();
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn_with_bounds(
+        local.clone(),
+        Duration::from_millis(50),
+        Duration::from_millis(50),
+    )
+    .await
+    .unwrap();
+
+    // The gate is never released: the stop leg has to time out on its own.
+    let error = client.change_host(service.clone()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::StopUnconfirmed));
+    assert_eq!(service.submits.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        client.status().connectivity,
+        EndpointConnectivity::Connected
+    );
+
+    // And routing works again, which is what "the phase ended" means.
+    let ticket = client.submit(reconcile_envelope()).await.unwrap();
+    assert_eq!(ticket.endpoint.host(), ExecutionHost::Local);
+}
+
+/// Two shutdowns during one handoff both have to be answered. Replacing the
+/// first reply port drops it, and its caller sees a sender error from a router
+/// that is still running.
+#[tokio::test]
+async fn two_shutdowns_during_a_handoff_are_both_answered() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+    let handoff = handoff_in_flight(&client, &local, service.clone()).await;
+
+    let (first, first_rx) = ractor::concurrency::oneshot::<ShutdownReport>();
+    let (second, second_rx) = ractor::concurrency::oneshot::<ShutdownReport>();
+    for reply in [first, second] {
+        client
+            .actor
+            .cast(CoreActorMessage::Shutdown {
+                reply: reply.into(),
+            })
+            .unwrap();
+    }
+
+    local.release_stop();
+    let error = handoff.await.unwrap().unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::ShuttingDown));
+
+    for rx in [first_rx, second_rx] {
+        let report = rx.await.expect("every parked shutdown is answered");
+        assert!(matches!(report.stop, Ok(Some(_))), "got {:?}", report.stop);
+    }
+    assert_eq!(
+        local.stops.load(Ordering::SeqCst),
+        1,
+        "one runtime, one stop"
+    );
+}
+
+/// The stop leg holds the source endpoint, an `ActorRef` and the caller's
+/// reply port. The actor's own termination has to take it down, or all three
+/// outlive the mailbox.
+#[tokio::test]
+async fn actor_stop_cancels_an_in_flight_handoff() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    let service = FakeEndpoint::new(
+        ExecutionHost::Service,
+        CoreStateDetail::Stopped { reason: None },
+    );
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+    let handoff = handoff_in_flight(&client, &local, service).await;
+
+    client.actor.stop(Some("test".into()));
+    // The gate is never released; the caller is answered because the port is
+    // dropped with the cancelled task, not because the leg finished.
+    let error = tokio::time::timeout(Duration::from_secs(5), handoff)
+        .await
+        .expect("the handoff task must not outlive the actor")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::Internal));
+}
+
+/// F3: a caller bound has to outlast the sum of every internal leg the call
+/// can honestly take, not just one of them. Before the fix,
+/// `CoreClient::change_host` used a fixed `STOP_WAIT + 30s` (90s at
+/// production bounds) while `change_host`'s own worst case is a preflight
+/// read, a stop admission, a stop long poll (itself `stop_wait +
+/// status_timeout`), and a lost-result status fallback — four
+/// `status_timeout` legs plus `stop_wait`, 100s at production bounds. A
+/// timing test cannot discriminate this at safe-for-CI durations: shrinking
+/// `status_timeout`/`stop_wait` shrinks the real worst case far below even
+/// the old fixed 90s, so the old bug would pass any tiny-bound timing test
+/// too. The bound only ever breaks at the actual production sizes, so the
+/// arithmetic itself -- not a wall-clock race -- is what has to be tested.
+/// This test does not compile against the pre-fix module, which has no
+/// `handoff_budget` function at all.
+#[test]
+fn handoff_budget_outlasts_every_internal_leg_it_covers() {
+    for (status_timeout, stop_wait) in [
+        (Duration::from_millis(50), Duration::from_millis(100)),
+        (super::PUMP_STATUS_TIMEOUT, STOP_WAIT),
+    ] {
+        // Leg-by-leg, mirroring `change_host` and `stop_and_confirm` as they
+        // exist after this fix: preflight + admission + (stop_wait +
+        // call_timeout) long poll + status fallback.
+        let worst_case = status_timeout * 4 + stop_wait;
+        assert!(
+            super::handoff_budget(status_timeout, stop_wait) > worst_case,
+            "budget must outlast {worst_case:?} for status_timeout={status_timeout:?}, stop_wait={stop_wait:?}"
+        );
+    }
+
+    // The exact numbers this fixes: at production bounds the old hardcoded
+    // caller budget (90s) was smaller than the worst case it had to cover
+    // (100s), so an internal path that legitimately used its full bounds
+    // reported `Internal` to a caller while ownership kept moving.
+    let old_hardcoded_budget = STOP_WAIT + Duration::from_secs(30);
+    let production_worst_case = super::PUMP_STATUS_TIMEOUT * 4 + STOP_WAIT;
+    assert!(production_worst_case > old_hardcoded_budget);
+    assert!(super::handoff_budget(super::PUMP_STATUS_TIMEOUT, STOP_WAIT) > production_worst_case);
+}
+
+/// The coherence requirement's shutdown half: `Shutdown` never preflights a
+/// target, so its worst case is the stop's three legs (admission, long poll,
+/// status fallback) without the extra `status_timeout` `change_host` spends
+/// on the preflight.
+#[test]
+fn shutdown_budget_outlasts_every_internal_leg_it_covers() {
+    let status_timeout = Duration::from_millis(50);
+    let stop_wait = Duration::from_millis(100);
+    let worst_case = status_timeout * 3 + stop_wait;
+    assert!(super::shutdown_budget(status_timeout, stop_wait) > worst_case);
+}
+
+/// The coherence requirement's submit half: once F4 bounds the `Submit`
+/// handler's one endpoint call by `status_timeout`, the caller has to
+/// outlast that leg or it races the actor's own honest `BackendUnavailable`.
+#[test]
+fn submit_budget_outlasts_the_bounded_submit_leg() {
+    let status_timeout = Duration::from_millis(50);
+    assert!(super::submit_budget(status_timeout) > status_timeout);
+}
+
+/// F4: an endpoint that accepts a submit and never answers must not park the
+/// mailbox behind it. Before the fix, `Submit` awaited `endpoint.submit`
+/// unbounded; the fake here never releases, so on the pre-fix handler the
+/// first `submit` call would only return once the caller-side RPC timeout
+/// elapsed (reporting `Internal`, not `BackendUnavailable`), and the actor
+/// task itself would stay stuck inside that one `handle()` call forever --
+/// every later message queued behind it never runs, so the following
+/// `shutdown()` would hang until its own RPC timeout and then fail rather
+/// than returning `Ok`.
+#[tokio::test]
+async fn a_hung_submit_is_bounded_and_the_mailbox_survives() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    local.hang_submit();
+    let client = CoreClient::spawn_with_bounds(local.clone(), Duration::from_millis(50), STOP_WAIT)
+        .await
+        .unwrap();
+
+    let error = client.submit(reconcile_envelope()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::BackendUnavailable));
+    assert!(error.retryable, "the same operation id can be retried");
+
+    // The mailbox is free: a shutdown right after is answered instead of
+    // queuing behind the hung submit forever.
+    client.shutdown().await.unwrap();
+}
+
+/// F8: an ordinary submit's echoed id has to match the one that was sent --
+/// the same check the stop path already makes. Before the fix, only the stop
+/// path verified this; an ordinary submit trusted whatever id the endpoint
+/// echoed back and would hand the caller a ticket for the wrong operation.
+#[tokio::test]
+async fn a_submit_echoing_another_id_is_rejected() {
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    *local.echo_id.lock().unwrap() = Some(OperationId::generate().to_string());
+    let client = CoreClient::spawn(local.clone()).await.unwrap();
+
+    let error = client.submit(reconcile_envelope()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::Internal));
+    assert!(!error.retryable);
+
+    client.shutdown().await.unwrap();
+}
+
+/// The finding this closes: `submit_budget` (like every caller-facing budget
+/// in `mod.rs`) bounds only a message's own execution legs, never how long it
+/// waits in the mailbox behind other messages -- the mailbox is unbounded by
+/// construction. Before the fix, a submit's caller-side timeout was reported
+/// as a non-retryable `Internal` no matter what caused it, including one
+/// caused entirely by queueing: a submit stuck behind enough other work can
+/// clear its own `submit_budget` before it is even dequeued, let alone before
+/// its own endpoint call starts, and then be admitted a moment later. That is
+/// exactly the situation the `Submit` handler's own internal timeout already
+/// answers with a retryable `BackendUnavailable`; the caller-side timeout has
+/// to carry the same contract.
+///
+/// This casts enough hung submits directly onto the mailbox -- synchronously,
+/// so their queue order ahead of the submit under test is guaranteed rather
+/// than raced -- that the cumulative time to resolve them each internally
+/// (F4's own `status_timeout` bound) exceeds `submit_budget` before the last
+/// one is even dequeued. `start_paused` makes every duration here virtual, so
+/// the ordering is exact, not a wall-clock race: on the fixed router this
+/// reports the same retryable `BackendUnavailable` `submit` always promises;
+/// on the pre-fix router, the hardcoded `CallResult::Timeout` arm in
+/// `CoreClient::call` reports a non-retryable `Internal` instead.
+#[tokio::test(start_paused = true)]
+async fn a_submit_queued_behind_other_work_is_reported_retryable_not_internal() {
+    let status_timeout = Duration::from_secs(5);
+    let local = FakeEndpoint::new(
+        ExecutionHost::Local,
+        CoreStateDetail::Running { epoch: 1, pid: 42 },
+    );
+    local.hang_submit();
+    let client = CoreClient::spawn_with_bounds(local.clone(), status_timeout, STOP_WAIT)
+        .await
+        .unwrap();
+
+    // Each hung submit resolves internally in exactly `status_timeout` (F4).
+    // Enough of them queued ahead of the one under test push its residence
+    // past its own `submit_budget`, independent of when its own endpoint call
+    // would otherwise have started.
+    let budget = super::submit_budget(status_timeout);
+    let ahead = (budget.as_nanos() / status_timeout.as_nanos()) as usize + 1;
+    for _ in 0..ahead {
+        let (reply, _rx) = ractor::concurrency::oneshot();
+        client
+            .actor
+            .cast(CoreActorMessage::Submit {
+                envelope: reconcile_envelope(),
+                reply: reply.into(),
+            })
+            .unwrap();
+    }
+
+    let error = client.submit(reconcile_envelope()).await.unwrap_err();
+    assert_eq!(error.kind, Some(CoreErrorKind::BackendUnavailable));
+    assert!(
+        error.retryable,
+        "mailbox residence must not turn a submit's caller-side timeout into a non-retryable Internal"
+    );
+}

--- a/backend/tauri/src/core/mod.rs
+++ b/backend/tauri/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod actor_v2;
 pub mod clash;
 pub mod connection_interruption;
 pub mod download;

--- a/docs/audit/2026-08-12-core-actor-audit-verification.md
+++ b/docs/audit/2026-08-12-core-actor-audit-verification.md
@@ -1,0 +1,136 @@
+# CoreActor 迁移方向审计复核报告
+
+- **日期**：2026-08-12
+- **复核对象**：外部审计结论（ChatGPT 会话 `chatgpt.com/share/6a7c67e6-4cb4-83ea-8a2e-f675949c4487`，审计基线 `refactor/core-manager-actor` @ `2a247cca`）
+- **复核基线**：同一提交 `2a247cca248cf0d4ec9d3e3b46bf7ead9118c200`；submodule `nyanpasu-runtime` @ v2.0.0-rc.1
+- **关联输入**：
+  - `docs/design/2026-08-08-core-manager-control-plane-runtime-backend-design.md`（控制面目标架构，用户指定的迭代方向）
+  - `docs/superpowers/plans/2026-08-04-pr5d-v8-pr5e-v2-review-findings.md`（PR-5d v8 / PR-5e v2 对抗审结果）
+- **用户裁定（2026-08-12）**：认同审计对当前设计的驳斥；BC 不是约束；CoreManager 须处理一切边界情况；每个操作事务化；check→change 改为直接 change，check 由 CoreManager 内部触发，失败经 `error_kind` 返回。
+- **结论**：**审计的全部关键事实断言经逐条源码核实成立**；三个 P0 结构性指控成立；另有两处审计未写到的加重情节。方向按审计 + 2026-08-08 设计文档执行，app 侧集成设计见 `docs/design/2026-08-12-core-actor-v2-app-integration.md`。
+
+---
+
+## 1. 事实复核（逐条对源码，全部在 `2a247cca`）
+
+| #    | 审计断言                                                                                          | 结果               | 证据（file:line）                                                                                                                                                                                                   |
+| ---- | ------------------------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P0-1 | `replace_backend` 先发布 synthetic `Stopped`、后停旧核，且无论旧核停没停成都安装新 backend        | **属实**           | `backend/tauri/src/core/actor/mod.rs:266-306`：`take()` → `running = None` → `commit(synthetic_stopped)` → 旧 `shutdown().err()` 仅存入变量 → `CoreBackend::new` 安装新 backend → **装完之后**才返回 shutdown_error |
+| P0-2 | `Shutdown` 发布假 `Stopped`、吞掉停失败、向调用方回 `Ok(())`                                      | **属实**           | `actor/mod.rs:603-614`：`commit(synthetic_stopped)` 在 `backend.shutdown().await` **之前**；失败仅 `tracing::warn!`；`client/core.rs:277-283` 的 `let _ =` 再吞一层                                                 |
+| P0-3 | 运行模式切换是 `set_backend` + `run` 两条消息，非原子事务                                         | **属实**           | `core/actor/request.rs:88` 与 `:90` 是两次独立的守卫校验 RPC；`OperationGuard` 只防插队，不提供跨消息原子性                                                                                                         |
+| 2.1  | 三重串行化（gate → mailbox → manager mutex）                                                      | **属实**           | `core/actor/gate.rs`（`OperationGate`）→ ractor mailbox → submodule `nyanpasu-core-manager/src/manager/mod.rs:107`（`ctrl: tokio::sync::Mutex<Ctrl>`）                                                              |
+| 2.2  | `OperationId` 被实现为跨调用租约（Acquire/Release/validate）                                      | **属实**           | 5a 设计即如此（`AcquireOperation`/`ReleaseOperation`/`validate_operation`，`actor/mod.rs:185-190`）                                                                                                                 |
+| 2.3  | Service 被建模为 `RuntimeBackend` 变体；GUI 侧 `ServiceBackend::run` 自行编排 status→(stop)→start | **属实**           | `core/actor/backend.rs:70-74`（`CoreBackend::{Local, Service, Test}`）；`:277-289`（status → 条件 stop → `start_core`）                                                                                             |
+| 2.4  | GUI 维护第二份 lifecycle truth；`(None, Running)` 可构造                                          | **属实**           | `pre_start` 将 `observe_status()`（可为 Running）写入 `observed`，但 state 以 `running: None` 构造（`actor/mod.rs:411`）——`running` 是"GUI 发过什么命令"的影子，不是事实                                            |
+| 2.5  | `RefreshHint`/`hint_pending` 是状态所有权错位的补丁                                               | **属实**           | `client/core.rs`（`hint_refresh` + `hint_pending: AtomicBool`）                                                                                                                                                     |
+| 2.6  | GUI transport retry：5 次 × 250ms 盲重试 apply                                                    | **属实，数字精确** | `client/core.rs:549-565`：`for attempt in 0..5` + `attempt < 4` + `sleep(250ms)`；transport error 无法证明服务端未执行 → 重发业务操作可产生 duplicate/revision conflict                                             |
+| 3    | legacy DNS 以内存回滚假设"写 Err ⇒ 外部无变化"                                                    | **属实，精确**     | `core/clash/core.rs:61`（`previous_dns: Mutex<Option<Vec<IpAddr>>>`）；`:121-122`（写失败即 `*previous_dns = previous_dns_clone; return Err`）——直接违反 PR-5e §0 第一原则                                          |
+
+审计自述无法读取 findings 文档（属实：该文档只在工作区、未提交），其"存活 BLOCKING 集中在 C3/接缝"的推断与文档相符（5d 五条 BLOCKING 中四条 C3 耦合）。一处未独立核验：`cleanup_processes()` 无条件继续退出——不影响任何结论。
+
+### 1.1 复核补充的两处加重情节（审计未写到）
+
+1. **`replace_backend` 在新 backend `observe_status()` 失败分支（`actor/mod.rs:302`）把 shutdown_error 整个丢弃**——旧核没停成这个事实连返回值都进不去。
+2. **跨 owner 双核场景没有任何隔离语义**：submodule 的 quarantine（`manager/mod.rs:321` `reject_quarantine`）只护住单个 manager 内部。Local→Service 切换时旧 Local 核停不掉 + Service 起新核 = **双核并存，且没有任何状态能表达它**。这是"Service 是另一个控制器、不是 backend 变体"的最硬证据。
+
+---
+
+## 2. 设计结论评估
+
+审计的目标架构与 2026-08-08 设计文档同构（`CoreControl` / `ControlExecutor` / `CoreOrchestrator` / `RuntimeBackend`；`OperationId` = 幂等身份而非租约；D6 executor 拥有事务）。审计**超出**文档的三项新增全部成立且必要：
+
+1. **`CoreEndpointRouter` + `ControllerGeneration` handoff**——文档只覆盖单 host 内部；Local↔Service 是跨控制器所有权转移（§1.1 第 2 条正是它要解的问题）；
+2. **`MacosDnsController` 挂进 orchestrator 的固定阶段**——DNS 与生命周期进入同一事务，PR-5d/5e 的 S1–S4 接缝无物可依；
+3. **结构化 `ShutdownReport`**——直接治 P0-2 的吞错。
+
+两处与文档冲突，按"BC 不是问题"裁定修订（已写入设计文档修订记录）：
+
+- 文档 G7 / §19.2 / §27 的 v1 wire 兼容与 legacy adapter 保真 → **只保留协议版本 fail-closed 门**（PR-5-pre 已建），不做 v1 行为仿真；
+- 文档 §27.1 的 `CoreManager` facade 兼容包装 → 删除，直接切 `CoreControlHandle`。
+
+**DNS 机制收口**：审计的 `DnsOverrideRecord` 仍是值比较归属，但把所有权/寿命修对了（持久化记录 + owner generation + host 启动 orphan reconcile）。机制层是否换 scutil `State:` 键（结构性归属，restore = 删自己的键）是 `MacosDnsController` 内部实现选择，接口不变，留作该组件的 Phase-0 spike，不阻塞架构。
+
+---
+
+## 3. 用户指令的规范化：直接 change、check 内部化、error_kind 返回
+
+此指令修掉了旧协议一个未被点破的 TOCTOU：caller 侧 check→change 两步之间世界可变，check 结论到 change 执行时已过期。check 收进事务内后，校验的就是**本次事务将要提交的那份 bytes/artifact**。
+
+### 3.1 事务信封（单一 mutating 命令）
+
+```text
+Reconcile{ operation_id, intent_revision, artifact, config_bytes+digest,
+           expected_applied, effects, force_restart }
+
+① admission        closing? → ShuttingDown        队列满 → QueueFull
+② idempotency      同 id+digest → 返回原 operation   同 id 异 payload → OperationConflict
+③ CAS              expected_applied ≠ current → RevisionConflict
+④ 内部 check       解析失败 → InvalidConfig        语义/dry-run 失败 → ConfigCheckFailed
+   ―― 以上零副作用，Err 即干净中止 ――
+⑤ stage artifact   提交 runtime 产物（可回滚点）
+⑥ classify         Noop / Patch / Reload / Restart / Switch（内部决策，不再是调用方协议）
+⑦ execute          停旧必须 StopProof；拿不到 → StopUnconfirmed + SafetyState::Quarantined
+⑧ verify           read-back 观测态
+⑨ fallback/rollback 失败降级重启；回滚失败 → RollbackFailed（标安全影响）
+⑩ publish          原子发布 revision + status → ApplyOutcome（RolledBack 是成功完成的事务）
+```
+
+- 独立 `Check` 命令保留但**降格为咨询**：只读、semaphore 限并发、不进 mutating 队列，永远不是 change 的前置门。
+- 调用方对 `ConfigCheckFailed` / `InvalidConfig` / `RevisionConflict` 按 kind 分支——落在 R0（nyanpasu-runtime PR #390）已铺好的 typed `CoreErrorKind` wire 上。**#390 合并 + submodule pin 移动由此成为本方向的硬前置。**
+
+### 3.2 边界情况清单（CoreManager 必须处理，逐条固化为 contract test）
+
+| 边界                    | 事务内处置                                                      | 治的旧病                    |
+| ----------------------- | --------------------------------------------------------------- | --------------------------- |
+| caller 取消/断线 mid-op | executor 拥有 task，跑到终态或补偿完                            | `OperationGuard` 租约全家   |
+| 响应丢失但已执行        | 同 id 重查 registry，不重执行                                   | 5×250ms 盲重试              |
+| 停旧不可确认            | `Quarantined`，禁起冲突实例，绝不假 `Stopped`                   | P0-1 / P0-2                 |
+| 跨 host 切换中途死亡    | handoff 协议 + generation fencing，唯一 owner 或显式 quarantine | 双核并存                    |
+| check 失败              | ④ 干净中止，`error_kind` 返回                                   | check/change TOCTOU         |
+| 并发修改                | ③ CAS → `RevisionConflict`                                      | revision 冲突静默覆盖       |
+| shutdown 与 apply 并发  | closing latch 拒新 + 在飞事务到安全点                           | `ControlAdmission`/选举全家 |
+| daemon 重启丢 registry  | status 为事实源，client 重读（第一阶段接受）                    | —                           |
+| stale runtime 事件      | epoch/generation 过滤，不污染新 owner                           | shadow state                |
+
+---
+
+## 4. 资产处置
+
+审计 §八删除表与 §九保留表全部认可，无修订。要点：
+
+- **删除**（app 侧）：`OperationGate` / `AcquireOperation`-`ReleaseOperation` / `CoreOperationGuard` / `CoreLifecyclePort`-`Lease` / GUI `CoreActor` 生命周期所有权 / `CoreBackend::{Local,Service}` / `BackendSlot`-`replace_backend`-`SetBackend` / `running` shadow / `CoreStatusView`+`FaithfulLifecycle` 双模型 / `RefreshStatus`-`RefreshHint`-`hint_pending` / `PublishPromoted`-`PublishApplied` / transport retry / legacy DNS singleton / `RunType::default()` / S1–S4 接缝 / 旧 wire 兼容桥。
+- **保留并下沉**：epoch-revision-apply 分类-rollback-quarantine（→ `CoreOrchestrator`）、`stop_and_confirm_dead`-PID reaper-runtime store（→ `ProcessRuntimeBackend`）、`CoreErrorKind`（→ portable model）、协议 fail-closed 门（→ RPC adapter）、fake-core/barrier/failure-injection（→ backend contract tests）、Desired/Applied 分离与 `CommittedDegraded`（→ canonical status）、PR-5d/5e failure matrix（→ 验收测试）。
+- 5c 中与 actor 形态无关的部分（ledger 扫描器三态化、`Logger` global 删除）可独立摘取。
+
+**实施顺序**：runtime 仓先行（PR-A 控制面内聚 → PR-B service 成为 CoreControl RPC host），app 仓 lockstep 一次性切（PR-C），随后 PR-D（handoff + DNS）、PR-E（清算）。不做双轨迁移——#5070 已 CONFLICTING、栈上 CI 从未跑过、BC 不设限，双轨的全部理由都不存在。
+
+---
+
+## 5. nyanpasu-service 修改盘点与 revert 评估
+
+**改动全集**：对 service（`nyanpasu-runtime` 仓）的全部修改只有 **R0 一项** = PR [#390](https://github.com/libnyanpasu/nyanpasu-runtime/pull/390)（OPEN，未合并），5 提交、9 文件：
+
+| 文件                                                              | 内容                                                         |
+| ----------------------------------------------------------------- | ------------------------------------------------------------ |
+| `nyanpasu-core-metadata/src/error_kind.rs` (+152)                 | `CoreErrorKind` 单一 wire 表                                 |
+| `nyanpasu-core-manager/src/error.rs` (+142)                       | `Error::kind()` 类型化分类                                   |
+| `nyanpasu-service-runtime/src/server/manager_bridge.rs` (+10/−86) | service 从 manager 读 kind，删除自维护字符串表               |
+| `nyanpasu_ipc/src/api/mod.rs` (+19/−45)                           | 字符串常量 → typed enum（serde 值不变，v2 wire golden 全绿） |
+| `nyanpasu_ipc/src/client/mod.rs` (+57/−2)                         | client error 暴露 typed kind                                 |
+| 测试 ×2                                                           | roundtrip / wire golden                                      |
+
+纯错误协议收敛，**零生命周期行为变化、零 wire 值变化**；未合并，对任何已发布产物零影响；父仓 submodule pin 从未被移动。
+
+**授权轨迹**：R0 属于 2026-08-01 定稿、经用户批准的 PR-5 规格（roadmap §6.R0 且明写"未经用户显式授权不得 push"）；push + 开 PR 于 2026-08-02 经用户单独授权。若"上游仓库改动需先做内容级专项确认"应成为常驻规则，请明示，将记录为标准流程。
+
+**Revert 评估：不值得，且方向相反。** R0 是 PR-5 全部产出中**唯一被新架构原样消费**的部分：审计 §九保留表将 `CoreErrorKind` 列为 portable control model 资产；2026-08-08 文档 §25 的错误模型直接扩展它；用户"check 出错经 error_kind 判断"的指令**依赖**它。revert 等于回到字符串嗅探，再在 PR-A 里重做一遍同样的事。正确处置是**合并 #390 并 bump pin**——它已从"暂缓"升格为新方向的硬前置。
+
+---
+
+## 6. 未决项（需用户裁定）
+
+1. PR 栈 #5070–#5074 处置：按审计降级为历史证据关闭，或先摘取可独立成立部分；
+2. **#390 合并 + submodule pin 移动授权**（硬前置）；
+3. 新方向 spec 是否替代 5d/5e 计划的槽位地位（本报告与两份设计文档即为基础）；
+4. Service 模式下 app 退出是否停核（现行为停核；新设计默认保留，见 app 集成设计 OQ-2）；
+5. 5d/5e 计划与 findings 文档归档方式；roadmap 中 🟡 规划中章节已同步改判（见 `actor-migration-roadmap.md` §6.5）。

--- a/docs/audit/2026-08-13-v2-implementation-audit-guide.md
+++ b/docs/audit/2026-08-13-v2-implementation-audit-guide.md
@@ -1,0 +1,71 @@
+# v2 实施审计入口（2026-08-13，停止线交付）
+
+按用户指令实施到 **legacy bridge 阶段之前停止**。本文是审计的入口清单：代码在哪、对照哪节设计、测试怎么跑、哪些是已知偏离与限制。旧代码零改动（除 `core/mod.rs` 一行模块声明与 Cargo 依赖增行）、Tauri commands 未换线、v1 wire 未删。
+
+## 1. 代码位置
+
+| 分支                                                              | 内容           | 提交                      |
+| ----------------------------------------------------------------- | -------------- | ------------------------- |
+| submodule `feat/core-control-plane`（自 upstream `e899bce`=#390） | PR-A+PR-B 全部 | `1be4afd`→`faa76a0` 11 个 |
+| app `refactor/core-actor-v2`（自 `pr5/1-pre` tip）                | C1/C2/C3/D1    | `108c393d`+`c9adbad9`     |
+
+### runtime 仓（backend/nyanpasu-runtime）
+
+| 模块                                                                           | 对照设计   | 内容                                                                                                                                                                               |
+| ------------------------------------------------------------------------------ | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `crates/nyanpasu-core-metadata/src/error_kind.rs`                              | 修订 A4    | wire 表 12→17 kind（+shutting_down/queue_full/operation_conflict/backend_unavailable/internal）                                                                                    |
+| `crates/nyanpasu-core-manager/src/control/mod.rs`                              | §9         | OperationId/ConfigInput/CoreCommand/CoreControl handle/OperationHandle/ControlOptions                                                                                              |
+| `.../control/executor.rs`                                                      | §10        | 单 task 串行、幂等 registry（同 id+digest 附着/异 payload 冲突/有界淘汰）、closing latch、取消隔离、long-poll                                                                      |
+| `.../manager/reconcile.rs`                                                     | A2/A3 修订 | 统一 `reconcile` 事务（CAS→内部 check→分派 start/apply/switch）；`ApplyOutcome::Started` 新变体                                                                                    |
+| `.../runtime/{mod,process}.rs`                                                 | §12        | RuntimeBackend/RuntimeInstance trait 边界 + 进程实现平移                                                                                                                           |
+| `.../dns.rs` + `.../manager/dns_sync.rs`                                       | A5③/§8     | DnsController trait + DnsOverrideRecord + 固定阶段挂点（reconcile converge 尾/stop·shutdown 头 restore/recover 尾）+ 建构期 orphan reconcile + `cfg(macos)` scutil State:-key 骨架 |
+| `nyanpasu_ipc/src/api/core/v2.rs` + contract + shortcuts                       | §19.3      | `/v2/core/{submit,operation,status}` 加法 wire                                                                                                                                     |
+| `crates/nyanpasu-service-runtime/.../manager_bridge.rs` + `routing/core/v2.rs` | PR-B       | daemon 内嵌 CoreControl；submit-query；断线不取消                                                                                                                                  |
+
+### app 仓（backend/tauri/src/core/actor_v2/）
+
+| 文件                                  | 对照设计（2026-08-12 app 集成） | 内容                                                                                                                                                                       |
+| ------------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mod.rs`                              | §3/§4/§5.2                      | CoreActor v2：Submit/ChangeHost/EndpointEvent/EndpointDown/Shutdown；EndpointSlot；I-R1/2/3；handoff 三阶段+StopProof+generation fencing；投影 watch+broadcast；CoreClient |
+| `endpoint.rs`                         | §3.3                            | ControlEndpoint port + LocalEndpoint(CoreControl)/ServiceEndpoint(IPC v2) 双适配器 + 逐字段投影映射                                                                        |
+| `service_actor.rs`                    | §6                              | ServiceActor：EnsureReady 收敛/版本门唯一实现点（复用 `service/compat.rs`）/Uninstall 自查守卫/有界重启+Exhausted latch/启动版本对账(auto-update UAC 语义)                 |
+| `intent.rs`                           | §2                              | RuntimeIntentBuilder 纯服务（document→text+digest+CAS token）                                                                                                              |
+| `tests.rs` + service_actor 内联 tests | —                               | 12 个测试全绿                                                                                                                                                              |
+
+## 2. 测试跑法
+
+```bash
+# runtime 仓（461 全绿）
+cd backend/nyanpasu-runtime && cargo test --workspace
+# 重点套件：control_plane / fake_backend / dns_override / reconcile
+
+# app 仓（12 个 actor_v2 测试）
+cd backend && cargo test -p clash-nyanpasu --lib actor_v2
+```
+
+## 3. 记录在案的实现偏离（各模块 doc 注释均有原文）
+
+1. **Check 不是 CoreCommand 变体**（A2 降格为咨询后，独立方法比不可能的 registry 状态更诚实）。
+2. **CoreError.kind 保持 `Option`**（R0 "不猜 kind" 原则压过设计 §25 的"kind 必在"）。
+3. **retryable 由产生点决定**而非 kind 决定（OperationConflict 两义性）。
+4. **ChangeHost 携带目标 endpoint**（编排送达，actor 不自取——§6.4 原则的强化）。
+5. **handoff 完成 = 目标已采纳、runtime 停止**；目标侧 Reconcile 与 CommittedDegraded 归 facade 编排（actor 不构造 intent）。
+6. **ControlEndpoint trait 替代具体 EndpointHandle enum**（同形状 + 测试缝）。
+7. **PR-B 不删 v1**（停止线要求旧代码可编译；删除属 bridge 阶段，计划文档 §0 已记）。
+8. **投影泵为 2s 轮询**（phase-1；push 流不改消息协议即可替换，OQ-6）。
+
+## 4. 已知限制 / 审计关注点（诚实清单）
+
+| #   | 事项                                                                                                                                                     | 去向                                                 |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| L1  | macOS DNS scutil 实现在 Windows 上零编译零验证；仅结构+fake 测试可信                                                                                     | Phase-0 spike（判据在 `dns.rs` doc）                 |
+| L2  | quarantine recovery 的死亡证明走 pid-file（进程后端机制），未经 RuntimeBackend trait——fake backend 下 Recover 诚实地失败                                 | 后续把证明路由进 trait（`fake_backend.rs` 测试注释） |
+| L3  | `CoreKind→CoreType` wire 映射有损（alpha 通道塌缩、Meow 无 wire 表示）；bridge 阶段 facade 须携带 intent 的原 `CoreType`                                 | `endpoint.rs::app_core_kind_to_type` doc             |
+| L4  | facade 编排（reconcile_core/service_mode 时序/shutdown shared-future）**未实现**——§6.4 时序已定，属 bridge 前的最后一块                                  | 审计后实施                                           |
+| L5  | v2 submit admission 错误经 R 信封丢 retryable（客户端按 kind 推导）                                                                                      | `v2.rs` doc                                          |
+| L6  | app 共享 target 存在损坏 rlib+usvg ICE（环境问题非代码），两个 app 提交按既有先例 `--no-verify`，补证=check exit 0+测试全绿；门禁应在隔离 target/CI 复跑 | 用户知悉                                             |
+| L7  | Service 泵/事件流为轮询+断线报告；daemon ws 事件流接入留待 PR-D 精化                                                                                     | OQ-6                                                 |
+
+## 5. 与既有 PR 栈的关系
+
+`#5070–#5074` 处置仍待用户裁定（本实施未动它们）；本工作基于 `pr5/1-pre` 分支内容但未 rebase/merge #5070。submodule pin 未移动（path deps 读工作树）。

--- a/docs/audit/2026-08-13-v2-implementation-audit-guide.md
+++ b/docs/audit/2026-08-13-v2-implementation-audit-guide.md
@@ -69,3 +69,11 @@ cd backend && cargo test -p clash-nyanpasu --lib actor_v2
 ## 5. 与既有 PR 栈的关系
 
 `#5070–#5074` 处置仍待用户裁定（本实施未动它们）；本工作基于 `pr5/1-pre` 分支内容但未 rebase/merge #5070。submodule pin 未移动（path deps 读工作树）。
+
+## 6. 独立测绘交叉核对（runtime-mapper 代理，基于 PR-A 前的 `e899bce` 快照）
+
+一个独立的探索代理对 pre-PR-A 树做了全量测绘，其结论与本实施相互印证，可作审计旁证：
+
+- 其"缺失清单"逐项即本次填补：无 OperationId/幂等键 → A1；无 executor 队列（公有方法即队列，一把 `ctrl` Mutex 横跨进程 spawn 与 fs I/O，RPC handler 直调、无取消隔离）→ A4；回滚补偿逐路径手写无通用事务抽象 → A3 的 `reconcile` 统一入口；无 RuntimeBackend/RuntimeInstance 接缝 → A2；core-manager 内无任何 DNS 组件 → A6；v1 wire 零版本协商机制 → 按修订 A1 裁定，fail-closed 门不建在 wire 握手而建在 app 侧 `ServiceCompat` 主版本比较（ServiceActor 为唯一实现点）。
+- 其"已有资产"确认了保留决策：`stop_and_confirm_dead` 是真 StopProof 原语（超时+独立 pid-file 权威兜底）；quarantine latch-until-recovered；publish 路径的 epoch fencing（`apply_epoch_status` 拒陈旧 epoch 帧）正是 D1 generation fencing 的同构先例；`IpcOperation` 契约对称性被 v2 三个新 op 沿用；fake-core 进程基建被 A7/控制面测试复用。
+- 另两处其标记的既有全局单例（`Logger::global()`、`Client::service_default()` OnceLock）为 pre-existing 边界代码，不在本次范围；`ServiceEndpoint::new` 以参数注入 client，bridge 阶段组合时不必经由该单例。

--- a/docs/audit/2026-08-13-v2-implementation-audit-guide.md
+++ b/docs/audit/2026-08-13-v2-implementation-audit-guide.md
@@ -1,0 +1,171 @@
+# v2 实施审计入口（2026-08-13，停止线交付）
+
+按用户指令实施到 **legacy bridge 阶段之前停止**。本文是审计的入口清单：代码在哪、对照哪节设计、测试怎么跑、哪些是已知偏离与限制。旧代码零改动（除 `core/mod.rs` 一行模块声明与 Cargo 依赖增行）、Tauri commands 未换线、v1 wire 未删。
+
+## 1. 代码位置
+
+| 分支                                                                 | 内容                                                      | 提交                                                                                                                                                                                                    |
+| -------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| submodule runtime `main`（`feat/core-control-plane` 已由 #391 合入） | PR-A+PR-B 全部 + 2026-08-27 修复轮                        | gitlink 现为 `6717e44`，即 #391 的 merge commit，其 tree 与被合入的 `e523ada` 相同；`git -C backend/nyanpasu-runtime describe --tags` 报 `v2.0.0-rc.1-29-g6717e44`，即自 `v2.0.0-rc.1` 标签起 29 个提交 |
+| app `refactor/core-actor-v2`（自 `pr5/1-pre` tip）                   | C1/C2/C3/D1 + 2026-08-27/2026-08-30 两轮复审修复（见 §5） | 分支已重组为 7 个原子提交，不再按 hash 索引（见 §5 顶部说明）                                                                                                                                           |
+
+### runtime 仓（backend/nyanpasu-runtime）
+
+| 模块                                                                           | 对照设计   | 内容                                                                                                                                                                               |
+| ------------------------------------------------------------------------------ | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `crates/nyanpasu-core-metadata/src/error_kind.rs`                              | 修订 A4    | wire 表 12→17 kind（+shutting_down/queue_full/operation_conflict/backend_unavailable/internal）                                                                                    |
+| `crates/nyanpasu-core-manager/src/control/mod.rs`                              | §9         | OperationId/ConfigInput/CoreCommand/CoreControl handle/OperationHandle/ControlOptions                                                                                              |
+| `.../control/executor.rs`                                                      | §10        | 单 task 串行、幂等 registry（同 id+digest 附着/异 payload 冲突/有界淘汰）、closing latch、取消隔离、long-poll                                                                      |
+| `.../manager/reconcile.rs`                                                     | A2/A3 修订 | 统一 `reconcile` 事务（CAS→内部 check→分派 start/apply/switch）；`ApplyOutcome::Started` 新变体                                                                                    |
+| `.../runtime/{mod,process}.rs`                                                 | §12        | RuntimeBackend/RuntimeInstance trait 边界 + 进程实现平移                                                                                                                           |
+| `.../dns.rs` + `.../manager/dns_sync.rs`                                       | A5③/§8     | DnsController trait + DnsOverrideRecord + 固定阶段挂点（reconcile converge 尾/stop·shutdown 头 restore/recover 尾）+ 建构期 orphan reconcile + `cfg(macos)` scutil State:-key 骨架 |
+| `nyanpasu_ipc/src/api/core/v2.rs` + contract + shortcuts                       | §19.3      | `/v2/core/{submit,operation,status}` 加法 wire                                                                                                                                     |
+| `crates/nyanpasu-service-runtime/.../manager_bridge.rs` + `routing/core/v2.rs` | PR-B       | daemon 内嵌 CoreControl；submit-query；断线不取消                                                                                                                                  |
+
+### app 仓（backend/tauri/src/core/actor_v2/）
+
+| 文件                                  | 对照设计（2026-08-12 app 集成） | 内容                                                                                                                                                                       |
+| ------------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mod.rs`                              | §3/§4/§5.2                      | CoreActor v2：Submit/ChangeHost/EndpointEvent/EndpointDown/Shutdown；EndpointSlot；I-R1/2/3；handoff 三阶段+StopProof+generation fencing；投影 watch+broadcast；CoreClient |
+| `endpoint.rs`                         | §3.3                            | ControlEndpoint port + LocalEndpoint(CoreControl)/ServiceEndpoint(IPC v2) 双适配器 + 逐字段投影映射                                                                        |
+| `service_actor.rs`                    | §6                              | ServiceActor：EnsureReady 收敛/版本门唯一实现点（复用 `service/compat.rs`）/Uninstall 自查守卫/有界重启+Exhausted latch/启动版本对账(auto-update UAC 语义)                 |
+| `intent.rs`                           | §2                              | RuntimeIntentBuilder 纯服务（document→text+digest+CAS token）                                                                                                              |
+| `tests.rs` + service_actor 内联 tests | —                               | 54 个测试全绿（含 2026-08-30 复审轮新增回归测试；见 §2）                                                                                                                   |
+
+## 2. 测试跑法
+
+```bash
+# runtime 仓（2026-08-30 本轮未改动 submodule，计数不变：484 全绿 / 24 ignored；PowerShell 下加 --config build.rustc-wrapper=''）
+cd backend/nyanpasu-runtime && cargo test --workspace --all-features
+# 重点套件：control_plane / fake_backend / dns_override / reconcile / routing
+
+# app 仓（2026-08-30 复审轮后：447 passed / 0 failed / 1 ignored；其中 core::actor_v2::* 54 个、core::service::*（compat+ipc）14 个）
+cd backend && cargo build -p fake-core   # process_core_bridge 的 11 个测试需要它，否则必红
+cd backend && cargo test -p clash-nyanpasu --lib
+
+# `cargo check` 在本 workspace 不可用（确定性 ICE，见 §5 已知环境问题）；要纯编译检查改用：
+cd backend && cargo build -p clash-nyanpasu --lib
+```
+
+## 3. 记录在案的实现偏离（各模块 doc 注释均有原文）
+
+1. **Check 不是 CoreCommand 变体**（A2 降格为咨询后，独立方法比不可能的 registry 状态更诚实）。
+2. **CoreError.kind 保持 `Option`**（R0 "不猜 kind" 原则压过设计 §25 的"kind 必在"）。
+3. **retryable 由产生点决定**而非 kind 决定（OperationConflict 两义性）。
+4. **ChangeHost 携带目标 endpoint**（编排送达，actor 不自取——§6.4 原则的强化）。
+5. **handoff 完成 = 目标已采纳、runtime 停止**；目标侧 Reconcile 与 CommittedDegraded 归 facade 编排（actor 不构造 intent）。
+6. **ControlEndpoint trait 替代具体 EndpointHandle enum**（同形状 + 测试缝）。
+7. **PR-B 不删 v1**（停止线要求旧代码可编译；删除属 bridge 阶段，计划文档 §0 已记）。
+8. **投影泵为 2s 轮询**（phase-1；push 流不改消息协议即可替换，OQ-6）。
+
+## 4. 已知限制 / 审计关注点（诚实清单）
+
+| #   | 事项                                                                                                                                                                                                                                                                                                                                                                                                                    | 去向                                                                        |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| L1  | macOS DNS scutil 实现在 Windows 上零编译零验证；仅结构+fake 测试可信。修复轮补了 `kill_on_drop`（编排超时丢弃 future 时不留子进程），**这不构成验证**                                                                                                                                                                                                                                                                   | Phase-0 spike（判据在 `dns.rs` doc）                                        |
+| L2  | quarantine recovery 的死亡证明走 pid-file（进程后端机制），未经 RuntimeBackend trait——fake backend 下 Recover 诚实地失败                                                                                                                                                                                                                                                                                                | 后续把证明路由进 trait（`fake_backend.rs` 测试注释）                        |
+| L3  | `CoreKind→CoreType` wire 映射有损（alpha 通道塌缩、Meow 无 wire 表示）；bridge 阶段 facade 须携带 intent 的原 `CoreType`                                                                                                                                                                                                                                                                                                | `endpoint.rs::app_core_kind_to_type` doc                                    |
+| L4  | facade 编排（reconcile_core/service_mode 时序/shutdown shared-future）**未实现**——§6.4 时序已定，属 bridge 前的最后一块                                                                                                                                                                                                                                                                                                 | 审计后实施                                                                  |
+| L5  | ~~v2 submit admission 错误经 R 信封丢 retryable~~ **已收口**：R 信封加法字段 `retryable`（R6），app 侧 `map_client_error` 保真（Step 7.2）；旧 daemon 无该字段时回落到 `CoreErrorKind::default_retryable`                                                                                                                                                                                                               | 已闭                                                                        |
+| L6  | app 共享 target 曾出现损坏 rlib+usvg ICE（环境问题非代码），停止线的两个 app 提交按既有先例 `--no-verify`。修复轮的三个 app 提交未再 `--no-verify`：pre-commit 的 `clippy --all-targets --all-features` 与 `fmt` 均实跑通过。**2026-08-30 复审轮的提交同样未 `--no-verify`**：共享 target 又出现 `拒绝访问 (os error 5)` 式增量损坏，改用干净的隔离 target dir 让 pre-commit 的 clippy 真跑通过（详见 §5 已知环境问题） | 用户知悉                                                                    |
+| L7  | Service 泵/事件流为轮询+断线报告；daemon ws 事件流接入留待 PR-D 精化                                                                                                                                                                                                                                                                                                                                                    | OQ-6                                                                        |
+| L8  | `DnsController` 契约仅支持**结构性拥有**的 override（restore 删除自有产物，不回放 `record.previous`）。写回型机制（`networksetup -setdnsservers` 一类）在"首次 apply 副作用已落地但调用未返回"的窗口内不可恢复：预记录此时还没有基线可写回                                                                                                                                                                              | 加入写回型控制器前先做 prepare/commit 拆分（`dns.rs` trait doc 有完整判据） |
+| L9  | uninstall 与 service 侧 `Reconcile` 跨两个 actor 的竞态：`ServiceActor` 的 uninstall 守卫与 daemon 自己的 control plane 是两个独立的所有者，守卫探测和 uninstall 之间被放行的一次 `Reconcile` 不会被排除。今天仅靠 facade 时序封闭（uninstall 只有从 Service 交接走之后才可达）；结构性互斥是 bridge 阶段的工作                                                                                                         | bridge 阶段实施结构性互斥                                                   |
+| L10 | runtime submodule 的 `nyanpasu_service/Cargo.toml` 仍声明 `2.0.0-rc.1`，而 gitlink 已领先 28 个提交；`scripts/check.ts:674-710` 按该 crate 版本号推导 sidecar 下载，于是 `pnpm prepare:check` 拉到的是 rc.1 daemon——比 app 编译所依赖的 IPC 协议更旧的二进制，却能通过只比较 major 版本的 compat gate（major == 2），同时缺 `/v2/core/*` 路由。今天无害（actor_v2 未接线，出货路径是 v1）；bridge 一旦落地即成活陷阱    | 修复是 submodule 版本号提升，非本仓改动                                     |
+| L11 | 调用方预算只框定一条消息自身的执行分支耗时，从不框定它在串行、无界 mailbox 里排在其它消息后面等待的时间。给一个无深度上限的队列定一个"正确"的有限数字没有依据，所以改由超时的**错误**携带恢复契约：submit 的超时可重试，并点名同 id 幂等重试；handoff、shutdown 与需要提权的 service 命令仍不可重试，但会声明工作可能仍在进行中                                                                                         | 设计已定案，不再谋求扩大调用方超时以覆盖排队（见 §5）                       |
+| L12 | ledger 词法器现在能正确处理注释、转义、字符字面量与生命周期撇号的区分、原始字符串（`r`/`br`/`cr`，任意 `#` 计数）与嵌套块注释，但一个跨行的双引号字符串（内含真实换行）仍不能跨行延续，且大括号/条目扫描器每次调用都从全新词法状态起步。`backend/` 下今天不存在这两种形状                                                                                                                                               | 若出现需扩展词法状态跨调用保持                                              |
+| L13 | **已接受的 Minor**：`Connected` 状态下连续两次 shutdown，第二个调用方会收到"router 已消失"；真正的修复需要一个终态 `ShutDown` slot 状态，属 bridge 阶段工作。今天因退出时只有单一 facade 调用点而不可达                                                                                                                                                                                                                 | bridge 阶段补终态 `ShutDown` slot state                                     |
+
+## 5. 审查发现 → 修复提交映射（2026-08-27 修复轮）
+
+停止线交付后的 v2 实施审查（计划 `.claude/plan/v2-review-remediation.md`）逐项落地。每个修复都带一个**先在基线上失败**的回归测试；下表是审计从"发现编号"直达"改了什么"的索引。
+
+**app 侧提交索引说明**：app 分支已重组为 7 个原子提交，本节及全文不再以 app 侧提交哈希索引——app 仓 actor_v2 的全部修复（含下表与「2026-08-30 复审轮（codex reviewer ×3 轮）」）收敛进单个提交 `feat(core): add CoreActor v2, the ServiceActor, and the runtime intent builder (unwired)`；compat gate 相关修复收敛进 `feat(service): add a fail-closed daemon compat gate`。runtime 仓（submodule）的提交哈希不受影响，稳定，仍如下表按哈希索引。
+
+### runtime 仓（`feat/core-control-plane`，已随 #391 合入 `main`；下列哈希在 `main` 上仍然可达）
+
+| 提交      | 发现                       | 修复                                                                                                                                                                                                                                                                                                                                                                            |
+| --------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0580bac` | M-1 / Minor-R1/R2/R3       | admission 与入队合并进同一临界区（失败即回滚，不留幽灵条目）；registry 容量硬钳到 `queue+1`；`expected_digest` 进身份（纠正后的同 id 是冲突不是附着）；check 源文件按 payload 摘要+操作 id 命名                                                                                                                                                                                 |
+| `4e70b15` | M-2                        | executor 逐操作 `tokio::spawn`：一次 panic 不再让每个在途操作永远 Queued；`ExecutorExit::Died` 排空队列并给出终态                                                                                                                                                                                                                                                               |
+| `070cfae` | C-2                        | daemon shutdown 走 executor（closing latch 对新提交生效），server `select!` 增第三臂监督 executor 退出                                                                                                                                                                                                                                                                          |
+| `452cd75` | M-4                        | 线上 core type echo 只在"新注册且非 RolledBack 的 reconcile"上提交                                                                                                                                                                                                                                                                                                              |
+| `c4155b9` | M-5 / M-6 / M-7 / L8 / D-1 | DNS 记录原子发布 + fail-closed（写不进就不 override）；`previous` 基线只在首次取得所有权时捕获；每次控制器调用（含建构期 orphan restore）都有 `dns_timeout` 上界；被拒绝且什么都没改的事务跳过 converge，失败且什么都没留下的事务仍 converge                                                                                                                                    |
+| `18169b7` | M-9 前置 / L5              | `R` 信封加法携带 `retryable`；`CoreErrorKind::default_retryable` 提升为公有                                                                                                                                                                                                                                                                                                     |
+| `4311ed8` | 复审 R#1/2/3/4/5           | `Registry::set` 改 `send_replace`（`send` 在无接收者时**不写入**，fire-and-forget 提交的操作会永远停在 `Queued`）；drain 改 `recv().await`（`close()` 不作废已发出的 `reserve` 许可，`try_recv` 会漏掉）；echo 按 admission 临界区内分配的执行序号应用；DNS 基线判据改为“记录带 interface”（`RestorePending` 与空 `previous` 都是合法基线）；记录发布加 flush/sync_all/sync_dir |
+
+### app 仓 `refactor/core-actor-v2`
+
+| 改动位置                                  | 发现                                                | 修复                                                                                                                                                                                                                                                                                                                                                                               |
+| ----------------------------------------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mod.rs`（状态与错误映射）                | C-1 / M-9 / Minor-A1                                | `CoreStatusSnapshot.state` 变 `Option`（未知不再被合成为 `Stopped`，因而不再冒充停止证明）；`map_client_error` 保真服务端 kind 与 retryable，未知 kind 保持 `None`；停止证明要求 `Stopped` 输出，失败侧沿用线上 retryable                                                                                                                                                          |
+| `mod.rs`（handoff 相位）                  | M-7 / CS-3 / Missed-4 / C-3 / M-12 / M-8 / Minor-A2 | handoff 显式相位 `HandingOff` + `HandoffStopped` 续传（期间 submit 立即拒绝而非排队）；handoff 期间的 shutdown 延后到同一个 stop 结算；Degraded 跨 host 采纳被拒（无证明）；`ShutdownReport.stop` 变 `Result`；adopt 清空快照；泵/预检有界 + `post_stop`                                                                                                                           |
+| `service_actor.rs`（Uninstall 守卫）      | M-10 / M-11 / Minor-A3                              | Uninstall 守卫读 `CoreStateDetail` 且未知即拒（粗态 `CoreState` 不参与判断）；`Exhausted` 成严格闩锁；过渡相位失败后回探                                                                                                                                                                                                                                                           |
+| `mod.rs` + `service_actor.rs`（复审修复） | 复审 A#1~A#6                                        | stop 的每次调用都有上界（`stop_wait` 也改为可注入）；admission 与终态都要求 operation id 相符；`pending_shutdown` 改 `Vec`（第二个 shutdown 曾顶掉第一个的 reply port）；handoff 任务收归 actor state 并在 `post_stop` 取消；Uninstall 的“探不到/无 detail”两种未知改为 `kind: None`（`AlreadyRunning` 是断言而非未知）；FakeEndpoint 的 admission 统一为 `Queued`，闸门移到长轮询 |
+
+### 复审（Phase 5，codex reviewer 双仓各一轮）
+
+runtime 侧 `4311ed8` 与 app 侧「`mod.rs` + `service_actor.rs`（复审修复）」行（见上表）来自对上表全部改动的独立复审。复审确认并已修的高危项见上表；下面是复审提出但本轮**未做**的，连同理由：
+
+| 项                                                      | 复审意见                                                                                       | 处置                                                                                                                                                                                                                                                                     |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| M-1 的回归测试不判别                                    | `a_full_queue_answers_queue_full` 在旧实现下同样通过（旧代码入队失败后也会 `registry.remove`） | 属实。竞态窗口由结构消除；可判别的测试需要在“注册”与“入队失败”之间加生产侧测试钩子，本轮不加                                                                                                                                                                             |
+| DNS 记录原子性测试不判别                                | 写完再读，`fs::write` 也能通过                                                                 | 属实。已改名为 `the_published_record_parses_and_leaves_no_staging_file`（这才是它证明的）；原子发布本身由 `atomic_fs` 的 `atomic_replace_readers_only_observe_complete_documents` 覆盖。补写的并发读者测试在 Windows 上同样不判别（小文件 `fs::write` 亦不可分割），已删 |
+| handoff 续传消息缺唯一 id                               | generation 不是 handoff 的唯一标识，重试型生产者会碰撞                                         | 当前只有一个不重试的生产者，属健壮性储备而非可达路径；续传若引入重试再加                                                                                                                                                                                                 |
+| `succeeded_recovered_is_not_stop_proof` 的 `waits == 1` | —                                                                                              | 该断言是测试质量强化（fake 不再在 admission 处给出终态），无法靠“还原生产代码”变红；它挡的是未来“不等待即采信”的实现                                                                                                                                                     |
+
+未纳入本轮（决策项）：D-4 推送、D-7 handoff `force` 旗标、D-8 submodule 指针推进。
+
+### 2026-08-30 复审轮（codex reviewer ×3 轮）
+
+在 2026-08-27 修复轮基础上，针对 app 仓 actor_v2 与 `scripts/architecture-ledger.ts` 又跑了三轮 codex 复审；第三轮报告 **PASS，无残留 Critical/Major**。下表 (a) 是本轮修的发现 → 改了什么，(b) 是复审提出但本轮**未做**的，连同理由。
+
+#### (a) 本轮修复
+
+| 本轮修复                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1 ledger 漏计：一个出现在 `//` 行注释里的 `/*` 打开了一个没人关闭的块注释，导致 `core/clash/core.rs` 里提到 `/core/*` 路径的一句文档注释盖住了整个文件的其余部分（漏计 3 处 `Config::verge()`、1 处 `Config::clash()`、2 处 `CoreManager::global()`、3 处 `Logger::global()`、1 处 `Self::global()`，这正是快照与实际之间的全部差额）。修复：按源码顺序词法化 `//` 与 `/*`；随后加固到能处理转义、字符字面量 vs 生命周期撇号的区分、原始字符串与嵌套块注释，并把同一词法器共享给 `#[cfg(test)]` 大括号/条目扫描器（该扫描器有同样的缺陷，使 `test_real_dirs` 这个硬性门禁本身也漏计） |
+| F2 规范性的 2026-08-12 app 集成设计此前只存在于另一分支，本仓无法对照它声称实现的文档做核验。已移植进本仓，并在 roadmap §6 与 PR-5 task 文件补了取代说明                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| F3 调用方超时是固定数字，而它等待的内部路径由注入的界限构建：`change_host` 在 100s 最坏情形上 90s 就放弃。三个调用方预算改为按各自路径逐段推导，算术写在旁边                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| F4 `Submit` handler 无界等待 endpoint，且 ipc client 本身也不设请求超时，一次挂起会让 actor 单一的串行 mailbox 永久卡住，包括后续的 shutdown                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| F5 探测契约承诺"挂起时也要给出 `Stopped` 形状的答案"，而 uninstall 守卫把 `Stopped` 读作"未持有 core"——这让契约本想兜底的那种情形，恰好把一个不可达的 daemon 变成了在运行中的 core 之下执行 uninstall。`probe` 现在返回 `Result`，失败或超时是 `ServicePhase::Unknown`，uninstall 据此拒绝，`EndpointDown` 也不再据此启动重启                                                                                                                                                                                                                                                          |
+| F6 `ServiceActor` 发起的其余 adapter 调用都没有边界，`pre_start` 也不例外；现在都跑在注入的 `command_timeout` 下                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| F7 `EndpointDown` 会从除 `Ready` 外的所有相位重启 daemon，包括已在运行的不兼容 daemon、未安装的 daemon 与状态未知的 daemon；改为只有确认探测到"已停止"才重启                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| F8 普通 submit 不校验回显的操作 id，尽管 stop 路径已经校验；现在统一按 stop 路径处理                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| F9 健康检查每 5s 轮询一次，对不兼容 daemon 持续在每次轮询都告警，长会话下淹没其它日志；改为状态锁存，只在进入该状态时报一次，daemon 恢复响应后重新武装                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| F10 `ServiceEndpoint` 持有一个 `&'static` 的 ipc client，迫使组合方去泄漏一个实例；client 本身可 `Clone`，改为按值持有                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| Round 2：`ServiceActor` 客户端的整体超时（一次命令边界 + 30s）比自身 handler 实际要跑的路径更短（2/4/6 段调用在生产边界下分别是 200s/400s/600s），导致提权操作还在跑时调用方就先收到失败；同时调用方超时对一个可能仍被接纳的 submit 回答不可重试的 `Internal`，堵死唯一安全的恢复路径。修复：每条消息的预算改由注入边界逐段推导；submit 的超时答案改为可重试并点名同 id 重试，handoff/shutdown/提权命令仍不可重试但声明工作可能仍在进行                                                                                                                                                |
+| Round 3：测试区域掩码仍走 F1 之前的旧剥离器，同样会被行注释里的 `/*`、生命周期撇号误伤；另发现 `cr"` 原始 C 字符串未被识别为原始字符串开符，且字面量内容会被原样计入扫描文本（字面量里写的 `Config::global()` 会被误计为调用，字面量里的花括号会被误计为大括号）                                                                                                                                                                                                                                                                                                                       |
+| Leader-found：`backend/Cargo.toml` 的注释仍声称 submodule 钉在 `v2.0.0-rc.1` tag，而 gitlink 早已前移（见 L10）；已改口                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+
+#### (b) 复审提出但本轮未做
+
+| 项                                | 复审意见                                                       | 处置                                                                                 |
+| --------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| 扩大调用方预算以覆盖排队          | 建议把调用方超时也扩到能盖住 mailbox 排队等待的时间            | 拒绝：无界深度的队列没有一个有依据的有限数字；改为让超时的错误携带恢复契约（见 L11） |
+| `ServiceClient` 超时改为可重试    | 建议让提权 service 命令的超时也标记可重试                      | 拒绝：这些命令不是 id 幂等的，盲目重试会排入第二条提权命令                           |
+| 改写 `core/clash/core.rs` 的注释  | 建议把触发 ledger 漏计的 `/core/*` 一句文档注释改写掉          | 拒绝：一个只因注释被改写才能工作的扫描器算不上修复；该文件保留原状，兼作回归用例     |
+| ledger 词法器支持跨行非原始字符串 | 指出双引号字符串内含真实换行时仍不能跨行延续                   | 见 L12；`backend/` 下不出现此形状，本轮不做                                          |
+| runtime crate 版本号提升          | 指出 L10 的根因是 submodule 内 `nyanpasu_service` 版本号未跟上 | submodule 侧工作，不属本仓改动范围                                                   |
+
+除预算类修复外，本轮每个代码修复都带一个**在修复前的代码上会失败**的回归测试；预算修复（F3/Round 2）的判据是算术而非计时测试——收缩注入的界限会把真实最坏情形也一并缩到旧的固定预算之下，计时测试无法判别这类改动，这一点在此明说。
+
+### 已知环境问题
+
+`cd backend/nyanpasu-runtime && cargo clippy --workspace --all-targets --all-features` 在本机确定性 ICE：`clash-api/src/api/connections.rs:208` 的 opaque type（`OpaqueTypeStorage`）。与本轮改动无关——`clash-api` 未被触及；同参数的 `cargo check` / `cargo test` 全通过，逐 crate `cargo clippy -p <crate> --all-targets --all-features` 也全通过；app 仓 pre-commit 的 `cargo clippy --manifest-path=./backend/Cargo.toml --all-targets --all-features`（feature 组合不同）正常通过。
+
+**2026-08-30 复审轮追加**：共享的 `backend/target` 反复无法收尾增量会话，报 `拒绝访问 (os error 5)`，产生的损坏让每个 `--emit=metadata` 构建都不可靠——`cargo check -p clash-nyanpasu --lib` 在 `boa_engine` 内部确定性 ICE，pre-commit hook 的 clippy 也先后在 `tungstenite` 的增量数据、`nyanpasu-core-metadata` 的 rmeta、`clash-api` 的 drop-check 上 ICE。`cargo build` / `cargo test` 全程未受影响（447 全绿）。因此 clippy 改用一个干净的隔离 target dir 跑（`CARGO_TARGET_DIR=G:/Programs/Rust/_clippy-target-pr5 CARGO_INCREMENTAL=0`），该目录下 `cargo clippy --manifest-path=./backend/Cargo.toml --all-targets --all-features` 在 900 余个 crate 上 exit 0；每个提交都导出了这个目录，让 pre-commit hook 真跑了一遍。全程未 pin 或更换工具链。
+
+另记 ledger 总数：`main` 为 120/80/18，本分支为 120/80/19（多出的那个 marker 是 compat gate 自己的 `TODO(actor-migration)`）；分支中途出现过的 116/74 一对纯粹是 F1 描述的扫描器伪影。
+
+## 6. 与既有 PR 栈的关系
+
+`#5070–#5074` 处置仍待用户裁定（本实施未动它们）；本工作基于 `pr5/1-pre` 分支内容但未 rebase/merge #5070。"submodule pin 未移动" 已不成立：gitlink 现已推进到 `6717e44`（见 §1），干净 checkout 因此可以直接构建，不再依赖一个脏的 submodule 工作树。
+
+## 7. 独立测绘交叉核对（runtime-mapper 代理，基于 PR-A 前的 `e899bce` 快照）
+
+一个独立的探索代理对 pre-PR-A 树做了全量测绘，其结论与本实施相互印证，可作审计旁证：
+
+- 其"缺失清单"逐项即本次填补：无 OperationId/幂等键 → A1；无 executor 队列（公有方法即队列，一把 `ctrl` Mutex 横跨进程 spawn 与 fs I/O，RPC handler 直调、无取消隔离）→ A4；回滚补偿逐路径手写无通用事务抽象 → A3 的 `reconcile` 统一入口；无 RuntimeBackend/RuntimeInstance 接缝 → A2；core-manager 内无任何 DNS 组件 → A6；v1 wire 零版本协商机制 → 按修订 A1 裁定，fail-closed 门不建在 wire 握手而建在 app 侧 `ServiceCompat` 主版本比较（ServiceActor 为唯一实现点）。
+- 其"已有资产"确认了保留决策：`stop_and_confirm_dead` 是真 StopProof 原语（超时+独立 pid-file 权威兜底）；quarantine latch-until-recovered；publish 路径的 epoch fencing（`apply_epoch_status` 拒陈旧 epoch 帧）正是 D1 generation fencing 的同构先例；`IpcOperation` 契约对称性被 v2 三个新 op 沿用；fake-core 进程基建被 A7/控制面测试复用。
+- 另两处其标记的既有全局单例（`Logger::global()`、`Client::service_default()` OnceLock）为 pre-existing 边界代码，不在本次范围；`ServiceEndpoint::new` 以参数注入 client，bridge 阶段组合时不必经由该单例。

--- a/docs/design/2026-08-08-core-manager-control-plane-runtime-backend-design.md
+++ b/docs/design/2026-08-08-core-manager-control-plane-runtime-backend-design.md
@@ -1,0 +1,1840 @@
+# Nyanpasu CoreManager 控制面与运行时后端解耦设计
+
+- **日期**：2026-08-08
+- **状态**：**Adopted with amendments（2026-08-12）** — 原稿正文保留为基线，下方修订记录为规范性裁定，与正文冲突处**以修订记录为准**
+- **目标仓库**：`libnyanpasu/nyanpasu-runtime`
+- **基线**：`main@0c67f56d78ce5165ae11c8118020fa86fe288e4f`
+- **主要范围**：`nyanpasu-core-manager`、`nyanpasu-service-runtime`、`nyanpasu-ipc`
+- **关联方向**：桌面提权服务、Android `VpnService`、iOS Packet Tunnel Provider、FFI/UniFFI
+
+---
+
+## 修订记录（2026-08-12，用户裁定；规范性）
+
+依据：`docs/audit/2026-08-12-core-actor-audit-verification.md`（外部审计复核，事实全部过验）。app 侧集成设计（CoreActor v2 对外接口 / 状态机 / 与 service 的关系 / 时序图）见配套文档 `docs/design/2026-08-12-core-actor-v2-app-integration.md`。
+
+| #   | 修订                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 覆盖的原文                                             |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| A1  | **BC 不是约束。** 删除 v1 wire 行为仿真与 legacy adapter 保真义务；仅保留**协议版本 fail-closed 门**（app 5-pre 已建：主版本比较，旧 daemon 拒绝进入并要求升级）。v1 endpoints / legacy error 文本 golden / `CoreManager` facade 兼容包装全部不做。                                                                                                                                                                                                              | G7、§19.2、§27、§28-PR-0 中 legacy golden 部分、§34-Q9 |
+| A2  | **直接 change，check 内部化。** 调用方不再走 check→change 两步协议（该拆分本身是 TOCTOU：check 结论到 change 执行时已过期）。唯一 mutating 命令 `Reconcile`（含 §9.1 的 Start/Apply 语义合并）在事务内部执行校验：解析失败 → `CoreErrorKind::InvalidConfig`，语义/dry-run 失败 → `ConfigCheckFailed`，均发生在任何提交点之前 = 干净中止、零补偿。独立 `Check` 命令保留但**降格为咨询**（只读、semaphore 限并发、不进 mutating 队列），永远不是 change 的前置门。 | §9.1、§17.1/§17.2/§17.4                                |
+| A3  | **每个操作事务化。** mutating 命令统一走十阶段事务信封：admission → idempotency → revision CAS → 内部 check → stage → classify → execute（停旧必须 `StopProof`，否则 `Quarantined`）→ verify → fallback/rollback → 原子 publish。边界情况清单与 contract tests 见审计报告 §3.2。                                                                                                                                                                                 | §17 整节的规范化                                       |
+| A4  | **`CoreErrorKind` 基线 = R0（nyanpasu-runtime PR #390）。** §25 的 kind 表是 R0 wire 表的超集扩展（新增 `QueueFull` / `OperationConflict` / `Quarantined` / `StopUnconfirmed` 等）；#390 合并 + submodule pin bump 是本方向硬前置。                                                                                                                                                                                                                              | §25                                                    |
+| A5  | **app 侧三项扩展**（本文档范围外，规范在配套文档）：① `CoreEndpointRouter`（app 内 CoreActor v2）负责 Local/Service endpoint 选择；② Local↔Service 是 **显式 controller handoff + `ControllerGeneration` fencing**，不是 backend 替换；③ `MacosDnsController` 归属各 host 的 orchestrator 固定阶段（start/stop/handoff），DNS 与生命周期同一事务。                                                                                                               | §8 拓扑的 app 侧延伸                                   |
+| A6  | **实施顺序改判**：不做"兼容 seam → 新 actor → 删 seam"双轨。runtime 仓先行（PR-A ≈ 原 PR-1+2+3 合并；PR-B = service 成为 CoreControl RPC host），app 仓 lockstep 一次性切（PR-C），随后 PR-D（handoff+DNS）、PR-E（清算）。移动端 PR-6/7/8 顺延不变。                                                                                                                                                                                                            | §28                                                    |
+
+---
+
+## 1. 摘要
+
+当前 `nyanpasu-core-manager` 已经不只是一个“启动和停止代理内核”的工具，而是同时承担了：
+
+1. 代理内核生命周期管理；
+2. epoch / generation / revision 管理；
+3. 配置派生、校验、PATCH、reload、restart、switch 与 rollback；
+4. 健康检查、崩溃恢复、死亡确认与 quarantine；
+5. runtime 文件、PID 文件、socket、目录锁和日志归档；
+6. 对 service 暴露状态、日志和控制接口。
+
+其中，**事务编排、安全状态机和配置切换策略应继续由 CoreManager 统一拥有**；但外部进程、PID、文件路径、stdout/stderr、HTTP/Named Pipe/Unix Socket 等桌面运行机制，不应继续成为 CoreManager 公共模型的硬前提。
+
+本文决定将现有结构演进为：
+
+```text
+CoreControl                 统一控制面语义
+    │
+    ▼
+CoreOrchestrator            epoch / revision / rollback / switch / quarantine
+    │
+    ▼
+RuntimeBackend              平台运行后端
+    ├── ProcessRuntimeBackend       桌面外部进程
+    └── EmbeddedRuntimeBackend      iOS / Android 嵌入式内核
+```
+
+RPC 与 FFI 都位于 `CoreControl` 之外：
+
+- 桌面 service：`RPC Adapter -> CoreControl -> ProcessRuntimeBackend`
+- Android：`JNI/UniFFI Adapter -> CoreControl -> EmbeddedRuntimeBackend`
+- iOS：`Swift/UniFFI Adapter -> CoreControl -> EmbeddedRuntimeBackend`
+
+本文明确不在第一阶段把 `CoreOrchestrator -> RuntimeBackend` 之间远程化。远程 runner 会把本地事务升级为分布式事务，引入 fencing、断线恢复、双 owner 和不确定提交等问题，当前没有足够收益。
+
+---
+
+## 2. 核心决策
+
+| 编号 | 决策                                                                                    |
+| ---- | --------------------------------------------------------------------------------------- |
+| D1   | 保留 CoreManager 的配置事务、epoch、revision、switch、rollback 和 quarantine 语义。     |
+| D2   | 把平台执行机制抽象为 `RuntimeBackend` / `RuntimeInstance`。                             |
+| D3   | 对上定义平台无关的 `CoreControl`，service、RPC、FFI 都只消费该端口。                    |
+| D4   | 状态模型不再要求 PID、runtime path 或本地 controller 地址；这些变为可选诊断信息。       |
+| D5   | 引入 `OperationId` 作为控制请求的关联、幂等和事件追踪标识；它不是 Lease、Session 或锁。 |
+| D6   | 状态变更操作由独立 control executor 串行执行，避免 RPC 断开直接取消事务。               |
+| D7   | JSONL 日志归档属于 host/observability 层，不属于可移植的 CoreOrchestrator。             |
+| D8   | 第一阶段不引入完整 actor 框架；使用有界 `mpsc + oneshot + watch/broadcast` 即可。       |
+| D9   | 第一阶段不拆出大量新 crate；先建立模块边界，再按移动端编译依赖需要抽取。                |
+| D10  | iOS/Android 使用嵌入式 backend；抽象控制面不能自动把仅提供 CLI 的内核变成可嵌入库。     |
+
+---
+
+## 3. 背景与现状
+
+### 3.1 当前拓扑
+
+当前实现大致为：
+
+```text
+nyanpasu-service-runtime
+    └── CoreManagerService
+            └── nyanpasu-core-manager::CoreManager
+                    ├── Instance
+                    │     ├── nyanpasu-utils::process::Supervisor
+                    │     ├── readiness / liveness probe
+                    │     ├── stdout/stderr parser
+                    │     └── stop proof / orphan reap
+                    ├── RuntimeConfigStore
+                    ├── apply / switching / quarantine
+                    ├── status watch
+                    └── log broadcast + JSONL sink
+```
+
+当前分层已经比旧 service 直接管理进程明显更合理：
+
+- service 负责 wire 类型、路径解析、binary 查找和 RPC 映射；
+- CoreManager 负责编排；
+- Instance 管理单 epoch；
+- Supervisor 管理外部进程树。
+
+问题不在于“CoreManager 代码很多”，而在于**领域编排和桌面执行机制仍然粘连**。
+
+### 3.2 当前 CoreManager 中合理的重职责
+
+以下工作必须由单一编排器拥有，不能下放给 RPC 客户端或分别复制到移动端：
+
+- epoch 分配；
+- revision CAS；
+- source/effective config hash；
+- `Noop / Patch / Reload / Restart / Switch` 分类；
+- runtime 配置提交与 durability warning；
+- PATCH/PUT 后验证；
+- restart compensation；
+- rollback；
+- graceful switch 降级矩阵；
+- stop 无法确认时 quarantine；
+- 最终状态和 revision 原子发布。
+
+这些行为共同构成安全关键的控制事务，不应拆散。
+
+### 3.3 当前不适合成为通用 CoreManager 前提的职责
+
+以下内容是 process backend 或 host policy：
+
+- `binary_path`；
+- 命令行参数和环境变量；
+- PID、PID file 和进程树；
+- stdout/stderr 管道；
+- 进程 supervisor；
+- runtime 目录、目录锁和 ACL；
+- config 文件原子替换；
+- Named Pipe / Unix Socket / HTTP controller；
+- JSONL 文件归档和日志轮转。
+
+这些假设在桌面端成立，但在 iOS/Android 嵌入式运行时并不成立。
+
+---
+
+## 4. 问题陈述
+
+### P1. 公共模型被桌面进程语义污染
+
+当前规格和状态包含：
+
+```rust
+binary_path: Utf8PathBuf
+config_path: Utf8PathBuf
+working_dir: Utf8PathBuf
+pid_file: Option<Utf8PathBuf>
+Running { pid: u32 }
+runtime_path: Utf8PathBuf
+```
+
+移动端嵌入式内核没有独立可执行文件、PID、进程树或本地 controller socket，这些字段不应是可移植控制面的必填语义。
+
+### P2. RPC 请求生命周期可能取消控制事务
+
+若 HTTP/RPC handler 直接执行 `manager.apply_config(...).await`，客户端断开、请求超时或 handler future 被 drop，可能中断一个处于 stage、commit、stop、rollback 中间阶段的操作。
+
+控制事务的生命周期必须属于服务端控制器，而不能属于某一条连接。
+
+### P3. 当前 RPC 输入仍是同机文件路径
+
+现有 start/apply 请求以 `PathBuf` 传入配置。该模型：
+
+- 假设调用方与 service 共享文件系统；
+- 允许提权 service 读取调用方指定路径；
+- 无法自然映射到 iOS app extension 或 Android native runtime；
+- 使配置内容、hash 与路径身份混在一起。
+
+### P4. 日志归档属于 host policy
+
+CoreManager 可以产生规范化 `LogFrame`，但是否写 JSONL、写到哪里、保留多少、是否使用平台日志系统，应由 service 或 mobile host 决定。
+
+### P5. 移动端不能使用外部进程模型
+
+- iOS Packet Tunnel Provider 不能依赖任意外部可执行文件；
+- Android 最自然的模型是 `VpnService + JNI/FFI + native library`；
+- 两端都需要把 TUN/packet flow 作为 host resource 注入 embedded backend。
+
+### P6. 如果直接远程化底层 runner，会引入分布式事务
+
+在 Orchestrator 与 RuntimeBackend 之间增加 RPC 后，需要处理：
+
+- start 响应丢失但实际已启动；
+- switch 中途断线；
+- client 和 server 双 owner；
+- stale manager 控制新 runtime；
+- stop 返回不确定；
+- operation fencing；
+- rollback 期间 runner 重启。
+
+当前无需承担这些复杂度。
+
+---
+
+## 5. 目标与非目标
+
+### 5.1 目标
+
+- **G1**：建立平台无关的 `CoreControl` 控制面。
+- **G2**：保留并复用当前 CoreManager 的安全事务语义。
+- **G3**：把外部进程机制封装为 `ProcessRuntimeBackend`。
+- **G4**：允许实现不依赖 PID、文件路径和 controller socket 的 `EmbeddedRuntimeBackend`。
+- **G5**：让同一套 start/apply/stop/switch/rollback 语义可被本地 Rust、RPC 和 FFI 使用。
+- **G6**：控制操作不因 RPC/FFI 调用方取消而中断。
+- **G7**：保持现有桌面 IPC wire 行为兼容，并提供新的 portable v2 协议。
+- **G8**：明确 service、orchestrator、backend 和 mobile host 的安全边界。
+- **G9**：用最少的新抽象完成第一轮改造，不提前实现未证明需要的远程 runner。
+
+### 5.2 非目标
+
+- 不在本设计中实现具体 mihomo/clash-rs 的移动端嵌入版本。
+- 不承诺所有现有代理内核均可在 iOS/Android 嵌入。
+- 不在第一阶段实现跨机器 RPC。
+- 不在第一阶段实现 Orchestrator 与 Backend 分进程部署。
+- 不实现 durable operation ledger；`OperationId` 幂等缓存先保持进程内。
+- 不实现运行中进程的跨 service 重启 reattach；保持现有 orphan cleanup 语义。
+- 不为了控制串行化引入 ractor/actix 等完整 actor 框架。
+- 不在第一阶段一次性拆出多个新 crate。
+
+---
+
+## 6. 术语
+
+| 术语                       | 定义                                                                     |
+| -------------------------- | ------------------------------------------------------------------------ |
+| **Proxy Core**             | mihomo、clash-rs、meow 等实际代理实现。                                  |
+| **CoreControl**            | 面向 GUI、service、RPC、FFI 的平台无关控制端口。                         |
+| **CoreOrchestrator**       | 管理 epoch、revision、apply、switch、rollback、quarantine 的领域编排器。 |
+| **RuntimeBackend**         | 把代理内核运行在某个平台上的机制。                                       |
+| **RuntimeInstance**        | 某次已启动 runtime 的句柄，对应当前 epoch 中的实际执行实体。             |
+| **ProcessRuntimeBackend**  | 通过子进程、Supervisor、PID 和 controller API 运行代理内核。             |
+| **EmbeddedRuntimeBackend** | 通过 native library/FFI 在当前 host 进程内运行代理内核。                 |
+| **Host Adapter**           | service、Android `VpnService`、iOS Packet Tunnel Provider 等平台入口。   |
+| **OperationId**            | 控制请求的唯一关联标识，用于幂等、查询和事件追踪。不是锁或租约。         |
+| **RuntimeInstanceId**      | backend 分配的 opaque instance identity，不等价于 PID。                  |
+| **StopProof**              | backend 对“该 runtime 已不能继续提供服务或占用资源”的确认。              |
+
+> 本设计不把底层执行层命名为 “Kernel”，以避免和 Proxy Core/代理内核混淆；统一使用 `RuntimeBackend`。
+
+---
+
+## 7. 设计原则
+
+### 7.1 策略与机制分离
+
+- Orchestrator 决定**要达到什么状态**以及失败后如何补偿；
+- Backend 决定**在当前平台如何运行、探测、应用和停止**。
+
+### 7.2 单一事务所有者
+
+一个 state-changing operation 从入队到终态都由控制器拥有。客户端断线只意味着收不到结果，不意味着事务被取消。
+
+### 7.3 可移植模型不泄露平台资源
+
+PID、fd、path、socket、Objective-C 对象和 JNI handle 不进入 portable RPC DTO。
+
+### 7.4 死亡确认优先于“尽力停止”
+
+任何 backend 都必须实现等价于当前 `stop_and_confirm_dead` 的语义。无法确认时进入 quarantine，不允许盲目启动冲突实例。
+
+### 7.5 能力驱动，而不是按平台硬编码
+
+是否支持 PATCH、reload、parallel instances、graceful switch、in-process control，应由 capability 组合决定。
+
+### 7.6 兼容先行，物理拆分后置
+
+先在现有 crate 中形成清晰模块边界；只有移动端编译依赖或独立复用确有需要时再拆 crate。
+
+---
+
+## 8. 目标架构
+
+```mermaid
+flowchart TB
+    GUI[Desktop GUI]
+    CLI[CLI]
+    IOS[iOS App / Packet Tunnel]
+    ANDROID[Android App / VpnService]
+
+    RPC[RPC Adapter\nnyanpasu-ipc]
+    FFI[FFI Adapter\nC ABI / UniFFI]
+    CONTROL[CoreControl Handle]
+    EXEC[Control Executor\noperation queue]
+    ORCH[CoreOrchestrator\nepoch / revision / rollback]
+    BACKEND[RuntimeBackend]
+    PROCESS[ProcessRuntimeBackend\nSupervisor / PID / Controller API]
+    EMBED[EmbeddedRuntimeBackend\nNative library / Packet I/O]
+
+    GUI --> RPC
+    CLI --> RPC
+    RPC --> CONTROL
+    IOS --> FFI
+    ANDROID --> FFI
+    FFI --> CONTROL
+    CONTROL --> EXEC
+    EXEC --> ORCH
+    ORCH --> BACKEND
+    BACKEND --> PROCESS
+    BACKEND --> EMBED
+```
+
+### 8.1 分层职责
+
+| 层               | 负责                                                                  | 不负责                     |
+| ---------------- | --------------------------------------------------------------------- | -------------------------- |
+| Host Adapter     | 平台生命周期、权限、RPC/FFI、用户身份、artifact resolution、日志 sink | apply/switch/rollback 事务 |
+| CoreControl      | 命令、OperationId、状态和事件的稳定语义                               | PID、文件路径、socket 细节 |
+| Control Executor | 操作排队、串行化、幂等、取消隔离、shutdown gate                       | 具体平台启动机制           |
+| CoreOrchestrator | epoch、revision、desired/observed state、配置事务、补偿、quarantine   | 子进程/JNI/Swift API       |
+| RuntimeBackend   | prepare/check/launch/reconcile/stop proof、backend events             | RPC、用户配置管理、UI wire |
+| Process Backend  | binary、CLI、Supervisor、PID、runtime dir、controller client          | 移动端 packet flow         |
+| Embedded Backend | native handle、packet I/O、direct control、embedded shutdown          | 桌面 service 安装和 ACL    |
+
+---
+
+## 9. CoreControl 控制面
+
+### 9.1 控制模型
+
+控制面以命令和操作为中心：
+
+```rust
+pub struct CoreCommandEnvelope {
+    pub operation_id: OperationId,
+    pub command: CoreCommand,
+}
+
+pub enum CoreCommand {
+    Start(StartRequest),
+    Stop(StopRequest),
+    Apply(ApplyRequest),
+    Check(CheckRequest),
+    Recover(RecoverRequest),
+    Shutdown(ShutdownRequest),
+}
+```
+
+`restart` 不必成为领域层独立原语，可表示为：
+
+- 使用当前 desired spec 的 `Apply`/`Switch`；或
+- 保留 convenience command，但内部转为同一编排路径。
+
+### 9.2 OperationId
+
+```rust
+pub struct OperationId([u8; 16]);
+```
+
+语义：
+
+- 由调用方生成，或由本地 convenience API 自动生成；
+- 同一 `OperationId + 相同 payload digest` 返回同一 operation；
+- 同一 `OperationId + 不同 payload` 返回 `OperationConflict`；
+- 用于日志、事件、状态和 RPC 重试关联；
+- 不代表对 CoreManager 的所有权；
+- 不阻止其他 operation，只由 control executor 决定串行顺序；
+- 第一阶段只做进程内 bounded cache，不做持久化。
+
+### 9.3 Rust 侧 API 草案
+
+```rust
+pub trait CoreControl: Send + Sync {
+    fn submit(
+        &self,
+        request: CoreCommandEnvelope,
+    ) -> Result<OperationHandle, SubmitError>;
+
+    fn status(&self) -> CoreStatus;
+
+    fn subscribe_events(&self) -> CoreEventReceiver;
+
+    fn subscribe_logs(&self) -> CoreLogReceiver;
+}
+
+pub struct OperationHandle {
+    pub id: OperationId,
+    // Rust convenience API；wire/FFI 不直接暴露 oneshot。
+    result: tokio::sync::oneshot::Receiver<OperationResult>,
+}
+```
+
+本地调用可以：
+
+```rust
+let result = control.submit(command)?.wait().await?;
+```
+
+RPC 可以立即返回 accepted，也可以在请求 deadline 内等待；无论调用方是否继续等待，后台 operation 都继续运行到安全终态。
+
+### 9.4 Operation 状态
+
+```rust
+pub enum OperationState {
+    Queued,
+    Running,
+    Succeeded(OperationResult),
+    Failed(CoreError),
+}
+```
+
+控制器维护有界的最近 operation cache，供：
+
+- 重试幂等；
+- RPC 查询；
+- UI 展示失败原因；
+- 断线后恢复结果。
+
+缓存丢失不影响 core runtime 的最终状态；客户端应重新读取 `CoreStatus`。
+
+---
+
+## 10. Control Executor 与并发模型
+
+### 10.1 为什么不继续让 RPC handler 直接调用 manager
+
+长事务可能跨越：
+
+```text
+load -> validate -> stage -> commit -> stop -> launch -> probe -> verify -> rollback
+```
+
+若 handler future 被取消，事务可能停在中间阶段。控制面需要拥有 operation 的 task。
+
+### 10.2 推荐实现
+
+```text
+CoreControlHandle
+    │ bounded mpsc
+    ▼
+ControlExecutor task
+    ├── mutable OrchestratorState
+    ├── operation registry
+    ├── status watch sender
+    └── event broadcast sender
+```
+
+规则：
+
+- `Start / Stop / Apply / Recover / Shutdown` 串行；
+- `Check` 不改变 active state，可交给独立有界 semaphore 并发执行；
+- status/read-only 查询直接读取 watch snapshot；
+- operation queue 必须有界，满时返回 `QueueFull`；
+- `Shutdown` 设置 closing latch，拒绝新 operation，等待或终止已有 operation 后关闭 backend；
+- reply receiver 被 drop 时，executor 不取消 operation；
+- executor panic 必须被 host 检测并转为 fatal service state。
+
+### 10.3 是否使用 ractor
+
+第一阶段不需要。
+
+`mpsc + oneshot + watch + broadcast` 已经覆盖：
+
+- mailbox；
+- request/reply；
+- snapshot；
+- event fan-out；
+- cancellation isolation。
+
+若后续出现多 runtime、多 tenant、supervision tree 等需求，再评估 ractor。
+
+---
+
+## 11. CoreOrchestrator
+
+### 11.1 应保留的职责
+
+```text
+- active desired spec
+- active observed runtime
+- epoch allocator
+- config generation
+- revision CAS
+- change planning
+- runtime artifact transaction
+- start/restart/switch compensation
+- rollback
+- state publication
+- quarantine / recovery gate
+```
+
+### 11.2 Orchestrator 状态草案
+
+```rust
+struct OrchestratorState {
+    active: Option<ActiveRuntime>,
+    last_desired: Option<DesiredCore>,
+    next_epoch: u64,
+    safety: SafetyState,
+    closing: bool,
+}
+
+struct ActiveRuntime {
+    epoch: u64,
+    instance: Box<dyn RuntimeInstance>,
+    desired: DesiredCore,
+    revision: ConfigRevision,
+    effective_capabilities: EffectiveCapabilities,
+}
+```
+
+### 11.3 生命周期与安全状态分离
+
+```rust
+pub struct CoreStatus {
+    pub lifecycle: CoreLifecycle,
+    pub safety: SafetyState,
+    pub health: Option<HealthStatus>,
+    pub artifact: Option<CoreArtifactSummary>,
+    pub revision: Option<ConfigRevision>,
+    pub active_operation: Option<OperationSummary>,
+    pub runtime: Option<RuntimeIdentity>,
+}
+```
+
+```rust
+pub enum SafetyState {
+    Normal,
+    Quarantined {
+        uncertain_instances: Vec<RuntimeInstanceId>,
+        reason: String,
+    },
+    Closing,
+}
+```
+
+quarantine 不应只隐藏在下一次操作错误里，portable status 应明确暴露当前控制面是否被安全锁定。
+
+### 11.4 可移植 runtime identity
+
+```rust
+pub struct RuntimeIdentity {
+    pub instance_id: RuntimeInstanceId,
+    pub process: Option<ProcessInfo>,
+    pub control_transport: Option<ControlTransportInfo>,
+}
+
+pub struct ProcessInfo {
+    pub pid: u32,
+}
+```
+
+移动端 embedded runtime：
+
+```text
+instance_id = opaque UUID/counter
+process = None
+control_transport = InProcess
+```
+
+桌面 process runtime：
+
+```text
+instance_id = epoch/process identity
+process = Some(pid)
+control_transport = LocalIpc | Http
+```
+
+---
+
+## 12. RuntimeBackend
+
+### 12.1 最小接口
+
+```rust
+pub trait RuntimeBackend: Send + Sync {
+    fn backend_kind(&self) -> RuntimeBackendKind;
+
+    fn capabilities(&self, artifact: &ResolvedArtifact)
+        -> BackendCapabilities;
+
+    fn check(
+        &self,
+        request: RuntimeCheckRequest,
+    ) -> BoxFuture<'static, Result<CheckReport, RuntimeError>>;
+
+    fn launch(
+        &self,
+        request: RuntimeLaunchRequest,
+    ) -> BoxFuture<'static, Result<Box<dyn RuntimeInstance>, RuntimeError>>;
+}
+
+pub trait RuntimeInstance: Send {
+    fn identity(&self) -> RuntimeIdentity;
+
+    fn subscribe(&self) -> RuntimeEventReceiver;
+
+    fn reconcile(
+        &mut self,
+        request: RuntimeReconcileRequest,
+    ) -> BoxFuture<'_, Result<RuntimeReconcileResult, RuntimeError>>;
+
+    fn stop_and_confirm(
+        self: Box<Self>,
+        deadline: Duration,
+    ) -> BoxFuture<'static, Result<StopProof, RuntimeError>>;
+}
+```
+
+> 上述代码是边界草案，不要求第一版直接采用 `async_trait`、GAT 或某一种 BoxFuture 实现。
+
+### 12.2 Backend 事件
+
+```rust
+pub enum RuntimeEvent {
+    Started {
+        identity: RuntimeIdentity,
+    },
+    Ready,
+    HealthChanged(HealthStatus),
+    Restarting {
+        attempt: u32,
+    },
+    Exited {
+        reason: RuntimeExitReason,
+    },
+    Log(Arc<LogFrame>),
+}
+```
+
+Orchestrator 只消费标准事件，不解析 stdout/stderr。
+
+### 12.3 StopProof
+
+```rust
+pub enum StopProof {
+    Confirmed {
+        instance_id: RuntimeInstanceId,
+    },
+    AlreadyStopped {
+        instance_id: RuntimeInstanceId,
+    },
+}
+```
+
+`RuntimeError::StopUnconfirmed` 必须触发 quarantine。
+
+不同 backend 的确认方式可以不同：
+
+| Backend       | StopProof 来源                                                                         |
+| ------------- | -------------------------------------------------------------------------------------- |
+| Process       | Supervisor stop + process identity/PID record reaper + process tree death confirmation |
+| Embedded      | shutdown API 成功 + event loop/join handle 终止 + native handle 作废                   |
+| Future remote | runner fencing token + instance terminal state；不在本阶段实现                         |
+
+### 12.4 Core-specific driver 是否单独抽象
+
+概念上存在两类变化：
+
+1. **CoreDriver**：配置格式、capability、change classification、control API；
+2. **ExecutionBackend**：process/embedded 的启动和停止机制。
+
+但第一阶段不立即定义两套 public trait。先由 `RuntimeBackend` 聚合这两类实现，避免在只有一个成熟实现时提前泛化。
+
+当出现以下任一条件时再拆 `CoreDriver`：
+
+- 同一 core driver 同时被 process 和 embedded backend 复用；
+- 第二种 embedded core 需要共享通用 execution backend；
+- 当前 `kind.rs/config/mihomo` 逻辑已能形成稳定的纯语义边界。
+
+---
+
+## 13. ProcessRuntimeBackend
+
+### 13.1 当前代码映射
+
+| 当前模块                              | 目标归属                                              |
+| ------------------------------------- | ----------------------------------------------------- |
+| `instance.rs`                         | `runtime/process/instance.rs`，实现 `RuntimeInstance` |
+| `nyanpasu-utils::process::Supervisor` | 保持底层进程机制                                      |
+| `kind.rs` 中 CLI 参数                 | process backend，未来可下沉 CoreDriver                |
+| `health/probe.rs` controller probe    | process backend/control driver                        |
+| PID file / orphan reap                | process backend                                       |
+| `RuntimeConfigStore`                  | process backend 的 artifact store                     |
+| local IPC / HTTP controller           | process backend 的 reconcile transport                |
+| stdout/stderr parser                  | process backend，输出标准 `LogFrame`                  |
+| JSONL `log_sink`                      | 移至 service host/可选 subscriber                     |
+
+### 13.2 Process backend 配置
+
+```rust
+pub struct ProcessBackendOptions {
+    pub runtime_dir: Utf8PathBuf,
+    pub local_ipc_policy: LocalIpcPolicy,
+    pub controller_template: Option<String>,
+    pub control_timeout: Duration,
+    pub stop_timeout: Duration,
+}
+```
+
+这些字段不再出现在 portable `CoreControl` 请求中，而是在 service 构造 backend 时注入。
+
+### 13.3 Artifact resolution
+
+portable 控制请求不接受 raw binary path：
+
+```rust
+pub struct CoreArtifactRef {
+    pub id: CoreArtifactId,
+    pub expected_digest: Option<Digest>,
+}
+```
+
+service host 使用受信任 resolver：
+
+```text
+CoreArtifactId
+    -> manifest/install registry
+    -> verified binary path
+    -> version/distribution/capabilities
+    -> ResolvedArtifact::Process
+```
+
+旧 IPC `CoreType` 由 legacy adapter 映射到 `CoreArtifactId`。
+
+---
+
+## 14. EmbeddedRuntimeBackend
+
+### 14.1 运行模型
+
+Embedded backend 不 spawn 外部程序，而是：
+
+- 加载或静态链接 native core library；
+- 创建 native runtime handle；
+- 注入配置 bytes；
+- 注入 packet I/O / TUN resource；
+- 通过 direct API 探测、apply 和 shutdown；
+- 将 native callbacks 归一化为 `RuntimeEvent`。
+
+### 14.2 Host resource 不进入 portable DTO
+
+Android TUN fd、iOS packet flow/回调对象属于 host-local capability，不能出现在 RPC JSON：
+
+```rust
+pub trait PacketIo: Send + Sync {
+    fn read_packet(&self, buffer: &mut [u8]) -> IoResult<usize>;
+    fn write_packet(&self, packet: &[u8]) -> IoResult<()>;
+}
+```
+
+实际实现可以是：
+
+- Android：基于 detached fd；
+- iOS：Swift/Objective-C bridge 提供的 packet callback；
+- 测试：in-memory packet channel。
+
+`EmbeddedRuntimeBackend` 在构造时获得这些 host resources，而不是由普通 `StartRequest` 传入。
+
+### 14.3 Embedded backend 的最小能力
+
+第一版只要求：
+
+- start；
+- readiness；
+- stop confirmation；
+- log/event；
+- full config restart。
+
+PATCH、reload、parallel instance 和 graceful switch 都是可选能力。移动端第一版可安全降级到 hard restart，不应为了对齐桌面能力阻塞基础支持。
+
+---
+
+## 15. Capability 模型
+
+### 15.1 三类能力
+
+```text
+ArtifactCapabilities    该内核构建本身支持什么
+DriverCapabilities      当前 core adapter 能表达什么
+BackendCapabilities     当前平台执行机制能做什么
+```
+
+最终能力：
+
+```text
+EffectiveCapabilities = Artifact ∩ Driver ∩ Backend
+```
+
+### 15.2 示例
+
+```rust
+pub struct BackendCapabilities {
+    pub parallel_instances: bool,
+    pub in_place_patch: bool,
+    pub full_reload: bool,
+    pub isolated_control_channel: bool,
+    pub stop_proof: bool,
+    pub direct_control: bool,
+    pub log_stream: bool,
+}
+```
+
+### 15.3 Graceful switch 条件
+
+只有同时满足以下条件才允许 graceful switch：
+
+1. backend 支持并行实例；
+2. 每个实例具有隔离 control channel；
+3. core driver 能构造安全的 zero-inbound bootstrap；
+4. 配置没有不能安全重叠的监听面；
+5. 新实例 readiness 可在不占用正式监听端口时完成；
+6. 旧实例 stop 可确认；
+7. full config restore 可验证。
+
+否则返回 typed degradation reason 并执行 hard switch。
+
+---
+
+## 16. 配置模型
+
+### 16.1 Portable ConfigInput
+
+```rust
+pub enum ConfigInput {
+    Inline {
+        bytes: Vec<u8>,
+        media_type: ConfigMediaType,
+        expected_digest: Option<Digest>,
+    },
+    Resource {
+        id: ConfigResourceId,
+        expected_digest: Option<Digest>,
+    },
+}
+```
+
+第一版 v2 RPC 至少支持 `Inline`。`Resource` 用于未来与 profile/config store 集成。
+
+### 16.2 Legacy Path adapter
+
+现有：
+
+```text
+config_file: PathBuf
+```
+
+兼容层执行：
+
+```text
+canonicalize
+-> 安全校验
+-> 限制大小
+-> read bytes
+-> compute digest
+-> ConfigInput::Inline
+```
+
+portable CoreControl 从此不再看到调用方路径。
+
+### 16.3 Revision
+
+```rust
+pub struct ConfigRevision {
+    pub epoch: u64,
+    pub generation: u64,
+    pub source_hash: Digest,
+    pub effective_hash: Digest,
+}
+```
+
+`runtime_path` 从 portable revision 移除；process backend 可以在 diagnostics extension 中暴露，但不得作为 CAS token 的组成部分。
+
+### 16.4 Runtime artifact store
+
+Orchestrator 需要“可提交、可备份、可恢复”的抽象语义；process backend 可以继续使用现有 `RuntimeConfigStore`。
+
+第一阶段不急于抽象通用 `StateStore`。embedded backend 可以在内存中持有 effective config，持久化 desired config 由 mobile host 负责。
+
+---
+
+## 17. 核心操作语义
+
+### 17.1 Start
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant CP as CoreControl
+    participant E as ControlExecutor
+    participant O as Orchestrator
+    participant B as RuntimeBackend
+    participant I as RuntimeInstance
+
+    C->>CP: submit(Start, OperationId)
+    CP->>E: enqueue
+    CP-->>C: accepted / handle
+    E->>O: start(request)
+    O->>O: resolve artifact + validate config
+    O->>O: allocate epoch + prepare revision
+    O->>B: launch(runtime request)
+    B-->>O: RuntimeInstance
+    O->>I: wait readiness through events
+    alt ready
+        O->>O: install active + publish Running
+        O-->>E: StartResult
+    else failed
+        O->>I: stop_and_confirm
+        alt confirmed
+            O->>O: cleanup + publish Stopped
+        else unconfirmed
+            O->>O: enter Quarantined
+        end
+        O-->>E: CoreError
+    end
+    E-->>CP: complete operation
+```
+
+### 17.2 Apply
+
+Apply 的语义继续保持：
+
+```text
+expected revision check
+-> prepare desired config
+-> classify change
+-> commit desired runtime artifact
+-> try cheapest reconcile path
+-> verify observed state
+-> fallback restart/switch
+-> rollback on failure
+-> publish actual running revision
+```
+
+结果仍应是 typed outcome：
+
+```rust
+pub enum ApplyOutcome {
+    Noop,
+    Patched,
+    Reloaded,
+    Restarted,
+    Switched,
+    RolledBack {
+        failed_apply: String,
+    },
+}
+```
+
+`RolledBack` 是成功完成的控制事务，但 desired config 未生效；返回值必须包含当前实际 revision。
+
+### 17.3 Stop
+
+```text
+set Stopping
+-> backend.stop_and_confirm
+-> Confirmed: cleanup + Stopped(User)
+-> StopUnconfirmed: SafetyState::Quarantined
+```
+
+不得把 timeout 简单映射为“可能停止成功”。
+
+### 17.4 Check
+
+- 不读取或修改 active runtime；
+- 由 backend/driver 对 config + artifact 做 dry run；
+- 有界并发；
+- 不进入 state-changing queue；
+- 返回结构化 `CheckReport`，避免只返回无法分类的文本。
+
+### 17.5 Recover
+
+recover 仅清除能够重新证明安全的 quarantine：
+
+```text
+inspect uncertain runtime identity
+-> backend-specific proof/reap
+-> all confirmed dead: clear quarantine
+-> any uncertain: keep quarantine and return details
+```
+
+### 17.6 Shutdown
+
+- 设置 closing；
+- 拒绝新 operation；
+- 当前 mutating operation 必须运行到可补偿点；
+- stop active runtime；
+- flush/close host log sinks；
+- 关闭事件通道；
+- 返回最终 shutdown result。
+
+---
+
+## 18. 状态机
+
+```mermaid
+stateDiagram-v2
+    [*] --> Stopped
+    Stopped --> Starting: Start
+    Starting --> Running: Ready
+    Starting --> Stopped: Launch/probe failed + stop confirmed
+    Starting --> Quarantined: stop unconfirmed
+
+    Running --> Restarting: crash recovery / hard apply
+    Restarting --> Running: replacement ready
+    Restarting --> Stopped: failure + rollback unavailable
+    Restarting --> Quarantined: stop unconfirmed
+
+    Running --> Switching: switch
+    Switching --> Running: new runtime installed / old retained after rollback
+    Switching --> Stopped: terminal failure
+    Switching --> Quarantined: uncertain runtime
+
+    Running --> Stopping: Stop/Shutdown
+    Stopping --> Stopped: stop proof
+    Stopping --> Quarantined: stop unconfirmed
+
+    Quarantined --> Stopped: Recover proves all dead
+```
+
+实现上 lifecycle 和 safety 可保持两个正交字段；图中 `Quarantined` 用于表达组合状态。
+
+---
+
+## 19. RPC 设计
+
+### 19.1 RPC 所在位置
+
+正确边界：
+
+```text
+RPC Client -> CoreControl RPC Adapter -> local CoreControl
+```
+
+暂不采用：
+
+```text
+CoreOrchestrator -> RPC -> remote RuntimeBackend
+```
+
+### 19.2 现有 IPC 兼容
+
+保留现有端点和 wire：
+
+```text
+/core/start
+/core/stop
+/core/restart
+/core/apply
+/core/check
+/core/recover
+/status
+/ws/events
+```
+
+现有 route handler 改为 legacy adapter：
+
+1. 转换 `CoreType -> CoreArtifactId`；
+2. 读取 `PathBuf -> ConfigInput::Inline`；
+3. 生成 `OperationId`；
+4. 调用 `CoreControl`；
+5. 映射回旧错误文本、旧状态和旧 response。
+
+### 19.3 Portable v2 协议
+
+建议增加 versioned contract，而不是修改旧 wire：
+
+```text
+POST /v2/core/start
+POST /v2/core/stop
+POST /v2/core/apply
+POST /v2/core/check
+POST /v2/core/recover
+GET  /v2/core/status
+GET  /v2/core/operations/{operation_id}
+WS   /v2/core/events
+WS   /v2/core/logs
+```
+
+每个 mutating 请求包含：
+
+```json
+{
+  "operation_id": "...",
+  "...": "typed request fields"
+}
+```
+
+### 19.4 RPC completion 模式
+
+支持两种调用方式：
+
+1. **wait**：handler 在自己的响应 deadline 内等待 operation；
+2. **accepted**：立即返回 operation id，客户端通过 operation endpoint/event 获取结果。
+
+无论哪种方式，operation 都由 executor 拥有。
+
+### 19.5 事件顺序与重连
+
+```rust
+pub struct CoreEventEnvelope {
+    pub sequence: u64,
+    pub operation_id: Option<OperationId>,
+    pub at: i64,
+    pub event: CoreEvent,
+}
+```
+
+- `sequence` 只保证单 controller 生命周期内单调；
+- event stream 允许丢帧；
+- 客户端发现 gap 后重新读取 `/status`；
+- status 是事实来源，event 是增量提示；
+- 日志和状态事件使用独立 channel，避免日志洪峰阻塞控制状态。
+
+### 19.6 RPC 安全
+
+- 继续使用 named pipe / Unix socket ACL；
+- v2 不接受 raw binary path；
+- v2 默认不接受任意 service-readable config path；
+- 对 config bytes、operation queue、check 并发和日志帧设上限；
+- secret 不进入 status、event、error debug；
+- 客户端依据稳定 `error_kind` 分支，不依据人类文本。
+
+---
+
+## 20. FFI 设计
+
+### 20.1 FFI 不是另一套业务控制面
+
+FFI 只把同一个 `CoreControl` 暴露给 Swift/Kotlin：
+
+```text
+Swift/Kotlin -> FFI Adapter -> CoreControl -> Orchestrator -> EmbeddedBackend
+```
+
+### 20.2 推荐 ABI
+
+底层保持窄 C-like ABI：
+
+```c
+core_result_t nyanpasu_core_create(
+    const uint8_t* options,
+    size_t options_len,
+    const core_callbacks_t* callbacks,
+    core_handle_t** out_handle);
+
+core_result_t nyanpasu_core_submit(
+    core_handle_t* handle,
+    const uint8_t* command,
+    size_t command_len,
+    operation_id_t* out_operation);
+
+core_result_t nyanpasu_core_get_status(
+    core_handle_t* handle,
+    owned_buffer_t* out_status);
+
+core_result_t nyanpasu_core_shutdown(core_handle_t* handle);
+void nyanpasu_core_destroy(core_handle_t* handle);
+```
+
+DTO 可使用稳定 JSON/CBOR bytes，typed UniFFI wrapper 可在其上生成。
+
+### 20.3 FFI 生命周期规则
+
+- Rust 拥有 Tokio runtime 和 control executor；
+- Swift/Kotlin 只持 opaque handle；
+- native callback 不在 Rust 核心锁内调用；
+- callback 进入有界队列，慢 UI 不得阻塞 runtime；
+- `destroy` 只在 `shutdown` 或 force-abort 语义明确后释放；
+- handle generation 防止 use-after-free/stale callback；
+- panic 不跨 FFI 边界；
+- 所有返回 buffer 具有明确的 free 函数；
+- FFI 不暴露 Rust borrow、future、trait object 或 channel 类型。
+
+### 20.4 UniFFI 使用建议
+
+UniFFI 可以作为 Swift/Kotlin bindings 生成器，但不应决定核心对象模型。底层语义仍以：
+
+```text
+opaque handle + command DTO + event callback + explicit shutdown
+```
+
+为准，以便未来更换生成器或补充手写平台桥接。
+
+---
+
+## 21. Android 适配
+
+### 21.1 推荐拓扑
+
+```mermaid
+flowchart LR
+    UI[Android UI] --> SVC[VpnService]
+    SVC --> JNI[JNI / UniFFI]
+    JNI --> CC[CoreControl]
+    CC --> EB[EmbeddedRuntimeBackend]
+    SVC -->|detached TUN fd| EB
+    EB --> CORE[Embedded Proxy Core]
+```
+
+### 21.2 生命周期映射
+
+| Android 生命周期                  | CoreControl 行为                                         |
+| --------------------------------- | -------------------------------------------------------- |
+| 用户授权并启动 `VpnService`       | 创建 control/backend，注入 TUN fd                        |
+| `onStartCommand` / explicit start | submit Start                                             |
+| 配置变化                          | submit Apply                                             |
+| `onRevoke` / stop action          | submit Stop/Shutdown                                     |
+| service 进程终止                  | native handle 销毁；下次由 persisted desired config 重建 |
+
+### 21.3 注意事项
+
+- TUN fd 通过 host-local 构造参数注入，不进入普通 RPC；
+- backend 必须明确 fd ownership，避免 Java 和 native 双重 close；
+- foreground service notification 属于 Android host 层；
+- service 可选择独立 process，但 Rust 控制面语义不变；
+- 第一版不要求 graceful switch；
+- 日志默认进入 Android logging 或有界 in-memory sink，不默认写桌面式 JSONL。
+
+---
+
+## 22. iOS 适配
+
+### 22.1 推荐拓扑
+
+```mermaid
+flowchart LR
+    APP[iOS App] -->|provider message / shared state| EXT[Packet Tunnel Provider]
+    EXT --> SWIFT[Swift FFI Adapter]
+    SWIFT --> CC[CoreControl]
+    CC --> EB[EmbeddedRuntimeBackend]
+    EXT -->|Packet Flow bridge| EB
+    EB --> CORE[Embedded Proxy Core]
+```
+
+### 22.2 生命周期映射
+
+| Packet Tunnel Provider | CoreControl 行为                                                    |
+| ---------------------- | ------------------------------------------------------------------- |
+| `startTunnel`          | 创建 backend，注入 packet flow，submit Start，ready 后完成 callback |
+| provider message       | status/query/apply command adapter                                  |
+| `stopTunnel`           | submit Shutdown，并在 deadline 内完成 provider stop callback        |
+| extension 被系统终止   | 下次 startTunnel 从 shared desired config 重建                      |
+
+### 22.3 注意事项
+
+- 不依赖任意外部 executable；
+- 代理内核必须可编译为 iOS-compatible static library/framework；
+- Packet flow bridge 需要严格背压，不能在 Swift callback 中无限排队；
+- extension 内存和后台运行预算要求日志、缓存和 operation history 有界；
+- App 与 extension 的通信属于 iOS host adapter，不应复用桌面 named pipe RPC；
+- shared App Group 只保存 desired config/必要状态，不保存 native handle。
+
+---
+
+## 23. 日志与可观测性
+
+### 23.1 日志责任拆分
+
+```text
+RuntimeBackend
+    -> 产生规范化 LogFrame
+CoreControl
+    -> broadcast LogFrame
+Host Adapter
+    -> 选择一个或多个 sink
+```
+
+host sink 示例：
+
+- desktop service：rotating JSONL + tracing + WebSocket；
+- Android：logcat + optional ring buffer；
+- iOS：os_log + bounded in-memory diagnostics；
+- tests：in-memory collector。
+
+### 23.2 从 CoreManager 移出的内容
+
+- log directory 创建；
+- JSONL sink task；
+- rotation；
+- file retention；
+- log path status accessor。
+
+CoreManager 只保证：
+
+- backend 日志被标准化；
+- frame 有大小上限；
+- fan-out 不阻塞 control path；
+- lag 有可观测计数。
+
+### 23.3 Metrics
+
+建议至少记录：
+
+```text
+core_operation_total{kind,outcome}
+core_operation_duration_seconds{kind}
+core_runtime_restarts_total
+core_quarantine_total
+core_probe_failures_total
+core_event_lag_total
+core_log_dropped_total
+core_backend_stop_unconfirmed_total
+```
+
+---
+
+## 24. 持久化与恢复
+
+### 24.1 第一阶段语义
+
+- Orchestrator active state：内存；
+- Operation registry：内存、有界、不持久化；
+- process runtime artifacts：继续由 `RuntimeConfigStore` 管理；
+- process service 启动：继续 sweep/reap orphan，不 reattach；
+- mobile desired config：由 App/Provider host 的配置系统持久化；
+- mobile runtime handle：绝不持久化。
+
+### 24.2 为什么不立即抽象通用 StateStore
+
+桌面 runtime 文件事务和移动端 app config persistence 的语义不同。过早统一会产生最低公共分母接口。
+
+当需要以下能力时再引入 `DesiredStateStore`：
+
+- service 重启后自动恢复运行；
+- mobile provider 自动恢复上一配置；
+- durable operation audit；
+- 多 controller 故障转移。
+
+---
+
+## 25. 错误模型
+
+```rust
+pub enum CoreErrorKind {
+    AlreadyRunning,
+    NotStarted,
+    RevisionConflict,
+    ArtifactNotFound,
+    ArtifactUntrusted,
+    InvalidConfig,
+    ConfigCheckFailed,
+    Unsupported,
+    BackendUnavailable,
+    ApplyFailed,
+    RollbackFailed,
+    StopUnconfirmed,
+    Quarantined,
+    OperationConflict,
+    QueueFull,
+    ShuttingDown,
+    Internal,
+}
+
+pub struct CoreError {
+    pub kind: CoreErrorKind,
+    pub message: String,
+    pub retryable: bool,
+    pub operation_id: Option<OperationId>,
+    pub details: Option<ErrorDetails>,
+}
+```
+
+要求：
+
+- `message` 可变，不作为程序分支条件；
+- `kind` 稳定；
+- secret/path 等敏感信息经过 redaction；
+- `StopUnconfirmed` 和 `RollbackFailed` 明确标记安全影响；
+- legacy adapter 保留已有错误文本兼容。
+
+---
+
+## 26. Crate 与模块布局
+
+### 26.1 第一阶段：不拆 crate
+
+```text
+crates/nyanpasu-core-manager/src/
+├── control/
+│   ├── mod.rs              # CoreControl handle / commands / OperationId
+│   ├── executor.rs         # queue + operation registry
+│   └── event.rs
+├── orchestrator/
+│   ├── mod.rs
+│   ├── apply.rs
+│   ├── switching.rs
+│   ├── publish.rs
+│   └── quarantine.rs
+├── runtime/
+│   ├── mod.rs              # RuntimeBackend / RuntimeInstance
+│   └── process/
+│       ├── mod.rs
+│       ├── instance.rs
+│       ├── store.rs
+│       ├── probe.rs
+│       └── logs.rs
+├── model/
+│   ├── spec.rs
+│   ├── state.rs
+│   └── error.rs
+└── lib.rs
+```
+
+### 26.2 后续按真实依赖抽取
+
+当移动端开始构建时，建议目标拓扑：
+
+```text
+nyanpasu-core-control
+    portable DTO / CoreControl trait / events / errors
+
+nyanpasu-core-manager
+    CoreOrchestrator / operation executor / backend interfaces
+
+nyanpasu-core-runtime-process
+    desktop process backend
+
+nyanpasu-core-ffi
+    C ABI / UniFFI wrapper
+
+nyanpasu-ipc
+    desktop RPC adapter
+
+nyanpasu-service-runtime
+    privileged host / artifact resolver / logging / ACL
+```
+
+抽取条件：移动端 crate 必须能依赖 portable control types，而不编译 process、axum、Windows service 或 Unix socket 代码。
+
+---
+
+## 27. 兼容性策略
+
+### 27.1 Rust API
+
+保留 `CoreManager` 作为 facade：
+
+```rust
+impl CoreManager {
+    pub async fn start(&self, spec: InstanceSpec) -> Result<(), Error> {
+        // compatibility wrapper:
+        // legacy spec -> portable request -> generated OperationId -> wait
+    }
+}
+```
+
+内部逐步改为 `CoreControlHandle`。
+
+### 27.2 IPC
+
+- v1 endpoints 和 payload 不变；
+- v1 `PathBuf` 在 service adapter 内读取；
+- v1 `CoreType` 在 service adapter 内解析 artifact；
+- v1 status 继续映射 desktop PID；
+- v2 才暴露 portable status、operation 和 artifact identity。
+
+### 27.3 行为兼容
+
+第一轮 backend 抽取必须保证：
+
+- start readiness 语义不变；
+- restart policy/backoff 不变；
+- stop proof 不变；
+- apply outcome 不变；
+- graceful switch 降级矩阵不变；
+- quarantine gate 不变；
+- runtime config hash/revision 不变；
+- existing tests 全量复用。
+
+---
+
+## 28. 实施计划
+
+### PR-0：基线与行为冻结
+
+- 为现有 start/stop/restart/apply/check/recover 建立 golden/contract tests；
+- 增加 RPC handler cancellation 测试；
+- 记录当前 state/event sequence；
+- 不改架构。
+
+**验收**：后续重构能证明 wire 和状态语义未漂移。
+
+### PR-1：Portable model 与 OperationId
+
+- 新增 portable `CoreStatus`、`ConfigRevision`、`RuntimeIdentity`；
+- PID/path 移入 optional diagnostics；
+- 新增 `CoreCommandEnvelope` 和 `OperationId`；
+- 现有 manager API 继续可用。
+
+**验收**：model 不依赖 `PathBuf`、PID 或 controller host 才能表达 Running。
+
+### PR-2：Control Executor
+
+- 新增有界 command queue；
+- state-changing operation 串行执行；
+- operation registry 与幂等冲突检测；
+- handler 取消不再取消 operation；
+- check 保留有界并发。
+
+**验收**：主动 drop caller future 后，operation 仍完成或回滚到安全状态。
+
+### PR-3：RuntimeBackend 边界
+
+- 定义 `RuntimeBackend` / `RuntimeInstance`；
+- 当前 `Instance` 包装为 process runtime instance；
+- Orchestrator 不直接依赖 Supervisor；
+- stop proof contract tests。
+
+**验收**：现有 process lifecycle tests 经 backend contract 运行。
+
+### PR-4：Process-specific 资源迁移
+
+- `RuntimeConfigStore`、PID、controller、probe、stdout parser 移入 process backend；
+- JSONL sink 移至 service host；
+- portable manager 去除 runtime dir/log dir 必填假设。
+
+**验收**：构造一个不需要 runtime directory 的 fake embedded backend。
+
+### PR-5：RPC v2
+
+- 增加 artifact/config-bytes/operation/status/events v2 contract；
+- v1 变成 compatibility adapter；
+- 错误 kind 与 operation query；
+- event sequence 和 resync。
+
+**验收**：v1 wire golden 全绿，v2 不暴露 raw binary/config path。
+
+### PR-6：Embedded fake backend
+
+- in-memory embedded runtime；
+- direct control；
+- fake packet I/O；
+- start/apply/restart/stop/quarantine contract tests。
+
+**验收**：完整 Orchestrator 测试不依赖外部进程。
+
+### PR-7：Android backend
+
+- JNI/UniFFI wrapper；
+- `VpnService` host；
+- TUN fd ownership；
+- lifecycle integration tests。
+
+### PR-8：iOS backend
+
+- Swift wrapper；
+- Packet Tunnel Provider host；
+- packet flow bridge；
+- provider message adapter；
+- extension lifecycle tests。
+
+---
+
+## 29. 测试策略
+
+### 29.1 Orchestrator 单元测试
+
+- revision CAS；
+- apply classification outcome；
+- rollback；
+- switch compensation；
+- operation idempotency；
+- queue full；
+- shutdown gate；
+- quarantine/recover；
+- stale runtime events 不得污染新 epoch。
+
+### 29.2 RuntimeBackend contract tests
+
+所有 backend 必须通过统一测试：
+
+```text
+launch -> ready
+launch failure -> no leaked instance
+unexpected exit -> terminal/restart event
+stop -> StopProof
+stop timeout -> StopUnconfirmed
+log bounds
+event closure
+double stop behavior
+handle drop behavior
+```
+
+### 29.3 Cancellation 测试
+
+- drop RPC response future；
+- abort caller task；
+- disconnect WebSocket；
+- service shutdown 与 apply 并发；
+- operation reply channel closed；
+- executor 仍完成补偿。
+
+### 29.4 兼容测试
+
+- v1 request/response golden；
+- legacy error text；
+- old CoreState projection；
+- requested core type echo；
+- logs/status event ordering。
+
+### 29.5 移动端测试
+
+- FFI handle misuse；
+- callback after shutdown；
+- double free/double close；
+- Android fd ownership；
+- iOS provider stop deadline；
+- memory pressure下 bounded queue；
+- packet bridge backpressure。
+
+---
+
+## 30. 安全分析
+
+### 30.1 必须保持的安全属性
+
+- runtime owner 唯一；
+- stop 无法确认时禁止启动冲突 runtime；
+- service 不执行客户端提供的任意 binary path；
+- artifact identity 可与 manifest/digest 对接；
+- effective config 为 manager/backend 私有副本；
+- secret 不进入 status/log/error；
+- runtime directory 继续防 symlink/reparse/ACL 绕过；
+- operation queue 和 config payload 有资源上限；
+- RPC caller 不能通过断开连接绕过 rollback；
+- FFI panic 和 stale handle 不跨边界扩散。
+
+### 30.2 新增攻击面
+
+| 攻击面                     | 缓解                                                  |
+| -------------------------- | ----------------------------------------------------- |
+| operation replay           | OperationId + payload digest 冲突检测 + bounded cache |
+| queue exhaustion           | bounded queue + per-client rate limit                 |
+| config payload exhaustion  | hard size cap + streaming/hash validation（必要时）   |
+| event/log flood            | 独立有界 channel + lag/drop 指标                      |
+| arbitrary artifact         | trusted resolver + manifest/digest verification       |
+| FFI stale callback         | handle generation + shutdown token + callback gate    |
+| mobile packet backpressure | bounded ring / explicit drop or flow-control policy   |
+
+---
+
+## 31. 性能与资源约束
+
+- control queue：有界；
+- operation result cache：有界 + TTL/LRU；
+- event ring 与 log ring 分离；
+- `LogFrame` 继续 Arc fan-out；
+- embedded callback 不复制超大 payload；
+- config bytes 只在必要阶段保留，source/effective 大对象使用 Arc/Bytes；
+- process backend 继续使用 manager-owned stable runtime config；
+- mobile 默认关闭磁盘 JSONL；
+- readiness/liveness 不并发重入同一 runtime；
+- `Check` 使用 semaphore，拒绝而不是无限排队。
+
+第一版不规定所有数值，但每个上限必须可配置并有安全默认值。
+
+---
+
+## 32. 备选方案
+
+### A. 保持现状，仅在移动端重写一个 manager
+
+**拒绝。** 会复制 apply/switch/rollback/quarantine 语义，长期必然漂移。
+
+### B. 把所有 CoreManager 逻辑移入 service
+
+**拒绝。** 移动端没有同一 service 形态，而且会把可复用领域逻辑重新绑定到提权 host。
+
+### C. 只抽一个 spawn/kill RPC runner
+
+**暂不采用。** 这会在 Orchestrator 和 runtime 之间制造分布式事务，而移动端仍需另一套 embedded 逻辑。
+
+### D. 直接将现有 CoreManager 编译到移动端，用大量 cfg
+
+**拒绝。** `binary_path/PID/runtime_dir/controller socket` 等公共假设仍会污染 API，cfg 只隐藏编译问题，不解决模型问题。
+
+### E. 立即拆成 5–6 个新 crate
+
+**暂不采用。** 先通过模块和 trait 验证边界；移动端开始依赖 portable types 时再抽取。
+
+### F. 使用完整 actor framework 重写
+
+**暂不采用。** 当前需求可由简单 control executor 满足，避免迁移风险和额外运行时语义。
+
+---
+
+## 33. 风险与缓解
+
+### R1. Backend API 过度抽象
+
+**缓解**：第一版只覆盖现有 process backend 与 fake embedded backend 的共同最小集；不提前抽 CoreDriver。
+
+### R2. Orchestrator 与 Backend 重复维护状态
+
+**缓解**：Backend 只报告 observed runtime；desired state、epoch 和 revision 只由 Orchestrator 拥有。
+
+### R3. Control executor 引入新的消息样板
+
+**缓解**：只为 state-changing operation 使用；status/log 保持 watch/broadcast；不引入 actor framework。
+
+### R4. 日志 sink 移出后 service shutdown 顺序复杂
+
+**缓解**：Host 明确执行：停止接受请求 -> controller shutdown -> drain log subscriber -> sink flush -> release runtime ownership。
+
+### R5. 移动端内核不可嵌入
+
+**缓解**：Artifact capability 明确标注 execution mode；移动端支持按 core 单独交付，不假设桌面 binary 可直接复用。
+
+### R6. FFI 绑定工具升级破坏
+
+**缓解**：底层维持稳定 handle/DTO ABI；UniFFI 仅作为生成层。
+
+### R7. v1/v2 长期双轨
+
+**缓解**：v1 仅是 adapter，不复制领域逻辑；设置明确 deprecation window，但不在本设计中强制移除日期。
+
+---
+
+## 34. 开放问题
+
+1. 第一种移动端 embedded core 选择哪一个，其 native API 是否足以支持 reload/PATCH？
+2. Android 与 iOS 是否共用同一个 Rust packet I/O trait，还是分别实现 backend-specific bridge？
+3. `OperationId` completed cache 的默认容量和 TTL 应是多少？
+4. v2 config 是否只支持 inline bytes，还是首版即支持 `ConfigResourceId`？
+5. mobile provider 是否需要 durable desired-state auto-resume？
+6. portable status 是否需要公开 redacted control transport，还是仅放 diagnostics endpoint？
+7. `CoreControl` portable types 是否在 PR-1 即抽成独立 crate，还是等 PR-6 mobile branch 开始？本文建议后者。
+8. process backend 的 core-specific config planner 是否在 backend 抽取时一并独立为 `CoreDriver`？本文建议先不拆。
+9. desktop GUI 何时迁移到 artifact ID 与 config bytes v2 wire？
+10. 是否需要让 RPC accepted operation 支持显式 cancel？若支持，只有在 Orchestrator 定义的安全取消点才能生效。
+
+---
+
+## 35. 验收标准
+
+### 架构验收
+
+- [ ] `CoreOrchestrator` 不直接依赖 `Supervisor`、PID 或 stdout/stderr。
+- [ ] portable `CoreStatus` 能表达无 PID、无 path 的 embedded runtime。
+- [ ] `RuntimeBackend` 可由 fake embedded implementation 完整驱动。
+- [ ] service 只通过 `CoreControl` 控制 runtime。
+- [ ] JSONL sink 不再由 portable manager 生命周期强制拥有。
+
+### 行为验收
+
+- [ ] 现有 process backend start/stop/apply/switch tests 全绿。
+- [ ] stop unconfirmed 仍进入 quarantine。
+- [ ] apply rollback 后返回实际 revision。
+- [ ] graceful switch 降级矩阵不回归。
+- [ ] RPC caller 取消不取消后台 transaction。
+- [ ] 同一 OperationId 重试不会重复执行相同操作。
+
+### 兼容验收
+
+- [ ] v1 IPC endpoint、payload 和 legacy error 文本不变。
+- [ ] desktop CoreState/PID 映射不变。
+- [ ] v2 不要求调用方提供 binary path 或 service-local config path。
+
+### 移动端验收
+
+- [ ] Android fake/real backend 可通过 injected TUN fd 启停。
+- [ ] iOS fake/real backend 可在 Packet Tunnel Provider 生命周期内启停。
+- [ ] FFI shutdown 后无 callback/use-after-free。
+- [ ] embedded backend 不依赖 runtime directory、PID file 或 local controller socket。
+
+---
+
+## 36. 最终建议
+
+本设计的目标不是让 CoreManager 机械地“少写一些代码”，而是把当前已验证的复杂事务能力变成 Nyanpasu 跨平台 runtime 的核心资产。
+
+最终边界应为：
+
+```text
+CoreControl
+    统一命令、OperationId、状态、事件和错误
+
+CoreOrchestrator
+    统一 epoch、revision、apply、switch、rollback、quarantine
+
+RuntimeBackend
+    统一 launch、reconcile、health、logs、stop proof
+
+Host Adapter
+    分别承载 service RPC、Android VpnService、iOS Packet Tunnel 和 FFI
+```
+
+桌面端继续使用外部进程 backend；移动端使用嵌入式 backend。两者复用相同控制事务，但不强行共享不合适的 PID、路径和 socket 模型。
+
+应优先完成的最小闭环是：
+
+```text
+OperationId + Control Executor
+    -> RuntimeBackend boundary
+    -> Process backend 兼容实现
+    -> Fake embedded backend
+    -> RPC v2 / FFI adapter
+```
+
+在此之前，不建议远程化 RuntimeBackend，也不建议一次性拆分大量 crate。
+
+---
+
+## 附录 A：当前代码到目标层的映射
+
+| 当前路径/类型                        | 目标                                                     |
+| ------------------------------------ | -------------------------------------------------------- |
+| `nyanpasu-core-manager::CoreManager` | public facade；内部转为 `CoreControl + CoreOrchestrator` |
+| `manager/mod.rs`                     | orchestrator state + operation execution                 |
+| `manager/apply.rs`                   | orchestrator apply transaction                           |
+| `manager/switching.rs`               | orchestrator switch transaction                          |
+| `manager/quarantine.rs`              | safety state/recovery                                    |
+| `instance.rs`                        | process runtime instance                                 |
+| `health/*`                           | backend health driver；portable 只保留 health result     |
+| `config/runtime_store.rs`            | process backend runtime artifact store                   |
+| `config/mihomo/*`                    | 初期 backend/core-specific planner；后续可抽 CoreDriver  |
+| `log_sink.rs`                        | service/mobile host observability sink                   |
+| `CoreManagerService`                 | `CoreControlService` / RPC legacy adapter                |
+| `nyanpasu-ipc::IpcOperation`         | v1 contract + 新增 v2 CoreControl contract               |
+| `CoreStartReq.config_file`           | v1 adapter 输入；portable v2 使用 ConfigInput            |
+| `CoreSpec.binary_path`               | process resolver 输出，不进入 portable request           |
+| `CoreState::Running { pid }`         | legacy desktop projection；portable 使用 RuntimeIdentity |
+| `ConfigRevision.runtime_path`        | process diagnostics，不进入 portable revision            |
+
+## 附录 B：实现基线参考
+
+本文基于以下实现位置进行设计：
+
+- `crates/nyanpasu-core-manager/src/manager/mod.rs`
+- `crates/nyanpasu-core-manager/src/manager/apply.rs`
+- `crates/nyanpasu-core-manager/src/manager/switching.rs`
+- `crates/nyanpasu-core-manager/src/instance.rs`
+- `crates/nyanpasu-core-manager/src/spec.rs`
+- `crates/nyanpasu-core-manager/src/state.rs`
+- `crates/nyanpasu-core-manager/src/config/runtime_store.rs`
+- `crates/nyanpasu-core-manager/src/log_sink.rs`
+- `crates/nyanpasu-service-runtime/src/server/manager_bridge.rs`
+- `nyanpasu_ipc/src/api/contract.rs`
+- `nyanpasu_ipc/src/api/core/start.rs`
+- `nyanpasu_ipc/src/api/core/apply.rs`

--- a/docs/design/2026-08-12-core-actor-v2-app-integration.md
+++ b/docs/design/2026-08-12-core-actor-v2-app-integration.md
@@ -1,0 +1,451 @@
+# CoreActor v2 与控制面集成设计（app 侧）
+
+- **日期**：2026-08-12
+- **状态**：Design / Adopted direction（PR-C/PR-D 的规范基础）
+- **仓库**：`libnyanpasu/clash-nyanpasu`（app 侧）；控制面本体见 `2026-08-08-core-manager-control-plane-runtime-backend-design.md`（含 2026-08-12 修订记录，下称"控制面设计"）
+- **裁定来源**：`docs/audit/2026-08-12-core-actor-audit-verification.md`
+- **一句话**：CoreActor 从"生命周期与事务所有者"降格为 **endpoint 路由 + 状态投影**；生命周期真相、事务、补偿、quarantine 全部只存在于各 host 的 `CoreControl`（Local = app 进程内嵌，Service = daemon 进程内）。
+
+---
+
+## 1. 角色再定义
+
+|               | 旧 CoreActor（5a/5b 形态，已否决）                                                                     | **CoreActor v2**                                                    |
+| ------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| 生命周期真相  | 自持（`running`/`CoreStatusView`/`FaithfulLifecycle` 三份影子）                                        | **不持有**。转发 host `CoreControl` 的 canonical `CoreStatus`       |
+| 事务          | caller 持租约跨 check/promote/apply/run 多步                                                           | **不参与**。一次 `submit(Reconcile)`，事务由 host executor 独占     |
+| Local/Service | `CoreBackend` enum 变体互换（`replace_backend`）                                                       | **两个对等控制器**之间的显式 handoff                                |
+| 拥有的状态    | backend 槽位、revision 影子、latch、hint                                                               | **仅**：活跃 endpoint、`ControllerGeneration`、订阅任务、投影 watch |
+| 消息面        | Check/PublishPromoted/ApplyPromoted/PublishApplied/Run/Stop/SetBackend/RefreshStatus/RunningIdentity/… | **4 条**：Submit / ChangeHost / EndpointEvent / Shutdown            |
+
+删除清单与保留资产以审计报告 §4 为准，本文不重复。
+
+---
+
+## 2. 总体拓扑
+
+```mermaid
+flowchart TB
+    subgraph APP["clash-nyanpasu app 进程"]
+        CMD[Tauri commands] --> FAC[NyanpasuClient facade]
+        INTENT["RuntimeIntentBuilder（纯服务）\ntyped snapshots → config bytes + digest\n+ artifact id + intent revision + effects"]
+        FAC --> INTENT
+        FAC --> CA["CoreActor v2\n= endpoint router + 投影"]
+        CA -->|"in-proc handle"| LCC[Local CoreControl]
+        CA -->|"IPC v2 client"| RPCC[CoreControlClient]
+        subgraph LOCALHOST["Local host（app 进程内）"]
+            LCC --> LEX[Control Executor] --> LORCH[CoreOrchestrator]
+            LORCH --> LPB["ProcessRuntimeBackend\n(子进程 / Supervisor / StopProof)"]
+            LORCH --> LDNS["MacosDnsController\n(macOS only)"]
+        end
+    end
+    subgraph SVC["nyanpasu-service daemon（提权）"]
+        RPCA["RPC Adapter（IPC v2）\n认证 / 限额 / DTO / submit-query"] --> SCC[Service CoreControl]
+        SCC --> SEX[Control Executor] --> SORCH[CoreOrchestrator]
+        SORCH --> SPB[ProcessRuntimeBackend]
+        SORCH --> SDNS["MacosDnsController\n(macOS only)"]
+    end
+    RPCC -->|"named pipe / unix socket\nfail-closed 版本门"| RPCA
+    LPB --> CORE1[(proxy core)]
+    SPB --> CORE2[(proxy core)]
+```
+
+要点：
+
+- **同一套 `CoreControl` 实现两处实例化**。Service 不是 backend 变体，是"另一台完整控制器 + RPC host"（审计 §2.3；复核证据：旧模型下双核并存无任何状态可表达）。
+- app 只在两个位置感知 Local/Service 差别：CoreActor 的 endpoint 槽位、以及 handoff 协议。事务语义两侧逐字相同——contract tests 同一套跑两个 host。
+- `RuntimeIntentBuilder` 是纯服务：从 typed snapshots 派生 intent，无 I/O、无全局读；`RunType::default()` 一类隐式输入随之消灭。
+
+---
+
+## 3. CoreActor v2 对外接口
+
+### 3.1 Facade 面（Tauri commands 唯一入口）
+
+```rust
+impl NyanpasuClient {
+    /// 唯一的运行时收敛入口：build intent → submit(Reconcile) → 等待或返回句柄。
+    /// 覆盖旧 start / restart / apply / change-core 四条路径。
+    pub async fn reconcile_core(&self) -> Result<ReconcileReport, CoreError>;
+
+    /// 换核 = 携带新 artifact 的 Reconcile，无专用事务。
+    pub async fn update_core(&self, core: CoreArtifactId) -> Result<ReconcileReport, CoreError>;
+
+    pub async fn stop_core(&self) -> Result<StopReport, CoreError>;
+    pub async fn recover_core(&self) -> Result<RecoverReport, CoreError>;
+
+    /// 显式 Local↔Service 所有权转移（§5）。
+    pub async fn change_execution_host(&self, host: ExecutionHost)
+        -> Result<HandoffReport, CoreError>;
+
+    /// 咨询性校验（§0 降格裁定）：只读、限并发、非任何 change 的前置门。
+    pub async fn check_config(&self, input: ConfigInput) -> Result<CheckReport, CoreError>;
+
+    /// watch 同步读，零 mailbox。
+    pub fn core_status(&self) -> CoreStatusProjection;
+    pub fn subscribe_core_events(&self) -> CoreEventStream;
+
+    /// 结构化关停（§7）；幂等，followers 等待同一 shared future。
+    pub async fn shutdown(&self) -> ShutdownReport;
+}
+```
+
+调用方错误处理**只依据 `CoreError.kind`**（R0 的 typed `CoreErrorKind`，控制面设计 §25 + 修订 A4）；`message` 仅供展示。
+
+### 3.2 Actor 消息面（内部，`CoreClient` 包装）
+
+```rust
+enum CoreActorMessage {
+    /// 转发到活跃 endpoint。经 mailbox 是为了与 ChangeHost 串行——
+    /// handoff 期间不可能有 submit 落到错误的 host（构造性，非门禁）。
+    Submit {
+        envelope: CoreCommandEnvelope,          // operation_id + Reconcile/Stop/Recover
+        reply: RpcReplyPort<Result<OperationHandle, CoreError>>,
+    },
+    ChangeHost {
+        target: ExecutionHost,
+        reply: RpcReplyPort<Result<HandoffReport, CoreError>>,
+    },
+    /// 订阅泵回注：来自活跃 endpoint 的 status/event 帧。
+    /// 携带 generation，stale 帧直接丢弃（§5.3）。
+    EndpointEvent { generation: ControllerGeneration, event: CoreEventEnvelope },
+    /// 连接丢失：进入重连；期间 Submit 返回 kind=BackendUnavailable（retryable）。
+    EndpointDown { generation: ControllerGeneration },
+    Shutdown { reply: RpcReplyPort<ShutdownReport> },
+}
+```
+
+**没有**的东西即设计：无 Acquire/Release、无 guard 校验、无 Run/SetBackend、无 RefreshStatus/RefreshHint——status 由 endpoint 推（Local: watch 直连；Service: event stream + gap 时重读 `/v2/core/status`），读取无副作用。
+
+### 3.3 Actor 状态
+
+```rust
+struct CoreActorState {
+    endpoint: EndpointSlot,
+    generation: ControllerGeneration,       // 单调，app 侧分配（OQ-1）
+    status_tx: watch::Sender<CoreStatusProjection>,
+    events_tx: broadcast::Sender<CoreEventEnvelope>,
+    subscription: Option<JoinHandle<()>>,   // 每个 endpoint 一条泵任务，换 endpoint 时 abort+重建
+}
+
+enum EndpointSlot {
+    Connected { host: ExecutionHost, control: EndpointHandle },
+    HandingOff { from: ExecutionHost, to: ExecutionHost, phase: HandoffPhase },
+    Degraded { desired: ExecutionHost, reason: CoreError },   // 不偷偷回落（§5.2）
+}
+
+enum EndpointHandle {
+    Local(CoreControlHandle),        // in-proc
+    Service(CoreControlClient),      // IPC v2
+}
+```
+
+注意与旧设计的对照：`CoreStatusProjection` 是 host `CoreStatus` 的**逐字段投影**（前端 DTO 裁剪），不是第二份真相——没有任何字段由 CoreActor 自行推导。
+
+---
+
+## 4. 内部状态机
+
+### 4.1 CoreActor（路由层）
+
+```mermaid
+stateDiagram-v2
+    [*] --> Connected: 启动（读 desired host，探测 + adopt）
+    Connected --> Handoff: ChangeHost(target)
+    Handoff --> Connected: handoff 完成（generation+1）
+    Handoff --> Connected: preflight 失败（原 endpoint 不变，返回 Err）
+    Handoff --> Degraded: 源已停、目标 Reconcile 失败\n（desired=target，运行时=Stopped）
+    Connected --> Degraded: EndpointDown 且重连预算耗尽
+    Degraded --> Connected: 重连成功 / 用户重试 Reconcile 成功
+    Connected --> Closing: Shutdown
+    Degraded --> Closing: Shutdown
+    Closing --> [*]: ShutdownReport 发布
+```
+
+不变量：
+
+- **I-R1**：任一时刻至多一个 `Connected` endpoint；`HandingOff` 期间 Submit 返回 `kind=OperationConflict("handoff in progress")`（retryable）。
+- **I-R2**：`Degraded` 是诚实终态而非过渡遮掩——commit-first：desired host 已提交，运行时未达成，绝不静默改回 Local（对应旧 5d "fail-open-to-Local" 语义的**废除**；用户可见 degradation + 显式重试）。
+- **I-R3**：路由层**永不**合成生命周期状态。`synthetic_stopped` 一类构造在 v2 无对应物；投影 watch 只发布来自 host 的 `CoreStatus`（P0-2 的结构性修复）。
+
+### 4.2 Host 内 Orchestrator（真相层；控制面设计 §18，此处含 safety 正交轴）
+
+```mermaid
+stateDiagram-v2
+    [*] --> Stopped
+    Stopped --> Starting: Reconcile(起核路径)
+    Starting --> Running: Ready
+    Starting --> Stopped: 启动失败 + StopProof
+    Running --> Reconciling: Reconcile(Patch/Reload/Restart/Switch)
+    Reconciling --> Running: 达成 / RolledBack(旧核保留)
+    Reconciling --> Stopped: 终局失败 + StopProof
+    Running --> Stopping: Stop / Shutdown
+    Stopping --> Stopped: StopProof
+    state "SafetyState::Quarantined（正交）" as Q
+    Starting --> Q: StopUnconfirmed
+    Reconciling --> Q: StopUnconfirmed
+    Stopping --> Q: StopUnconfirmed
+    Q --> Stopped: Recover 证实全部死亡
+```
+
+`Quarantined` 期间一切 mutating 命令返回 `kind=Quarantined`；这是 P0-1"旧核失控仍装新 backend"的结构性修复——**没有 StopProof 就没有下一任 owner**。
+
+---
+
+## 5. 与 nyanpasu-service 的关系
+
+### 5.1 契约
+
+| 维度   | 规定                                                                                                                                                          |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 层次   | service = **CoreControl 的 RPC host**（认证/限额/DTO/submit-query），不是 runtime backend                                                                     |
+| wire   | IPC **v2 only**（`/v2/core/*`，控制面设计 §19.3）；v1 删除（修订 A1）；**协议版本 fail-closed 门保留**——版本不匹配 → 拒绝 + 要求升级，绝不降级兼容            |
+| 错误   | 全部经 typed `CoreErrorKind`（R0 #390 基线 + 扩展 kind）；禁止字符串嗅探                                                                                      |
+| 事务   | daemon 内 executor 拥有 operation；**app 断线/退出不取消事务**（控制面设计 D6/G6）                                                                            |
+| 幂等   | 响应丢失 → 同 `OperationId` 重查/重发，daemon 从 registry 返回原结果（替代 5×250ms 盲重试）                                                                   |
+| 状态   | daemon `CoreStatus` 是 Service host 唯一真相；event 是增量提示，seq gap → 重读 status                                                                         |
+| 生存期 | daemon 生存期 ⊃ app 生存期。app 重启后 reconnect + **adopt**（读 status、恢复订阅、对账 generation），不重建事实                                              |
+| DNS    | Service 模式的 DNS 覆写由 **daemon 内 MacosDnsController** 在其 orchestrator 的 start/stop/handoff 固定阶段施加/恢复；app 侧零 DNS 职责（S1–S4 接缝的消灭点） |
+
+### 5.2 Local↔Service = 显式 handoff（不是 SetBackend）
+
+```mermaid
+sequenceDiagram
+    participant U as UI
+    participant CA as CoreActor v2
+    participant L as Local CoreControl
+    participant S as Service CoreControl(daemon)
+
+    U->>CA: ChangeHost(Service)
+    Note over CA: phase=Preflight
+    CA->>S: 版本门 + status 探测（fail-closed）
+    alt preflight 失败
+        CA-->>U: Err(kind=BackendUnavailable)，endpoint 不变
+    end
+    Note over CA: phase=StoppingSource
+    CA->>L: submit(Stop{op_id})
+    L->>L: 在飞事务跑到安全点 → stop_and_confirm
+    alt StopProof=Confirmed
+        L-->>CA: StopReport(Confirmed)
+        Note over CA: generation += 1；订阅泵切到 Service
+        CA->>S: submit(Reconcile{同一 intent_revision, gen+1})
+        alt Reconcile Ok
+            S-->>CA: ReconcileReport
+            CA-->>U: HandoffReport(Completed)
+        else Reconcile Err
+            S-->>CA: CoreError{kind}
+            Note over CA: Degraded{desired: Service}<br/>不回落 Local（commit-first）
+            CA-->>U: HandoffReport(CommittedDegraded)
+        end
+    else StopUnconfirmed
+        L-->>CA: kind=StopUnconfirmed（Local 进入 Quarantined）
+        Note over CA: handoff 中止；目标永不启动
+        CA-->>U: Err(kind=Quarantined)
+    end
+```
+
+对应审计 §六时序的九步收敛；`ControllerGeneration` 的用途恰好三个：stale 事件过滤（§3.2）、拒绝双 owner（host 拒收旧 gen 的 mutating 命令）、handoff 原子推进标记。它与 `OperationId`（一次命令）、`RuntimeInstanceId`（一个 runtime）、`ConfigRevision`（一份配置）互不混用。
+
+### 5.3 Reconcile 事务（直接 change + 内部 check + error_kind）
+
+```mermaid
+sequenceDiagram
+    participant U as UI / rebuild
+    participant F as NyanpasuClient
+    participant CA as CoreActor v2
+    participant CC as host CoreControl
+    participant EX as Executor
+    participant OR as Orchestrator
+    participant B as RuntimeBackend
+
+    U->>F: reconcile_core()
+    F->>F: RuntimeIntentBuilder（纯计算）
+    F->>CA: Submit(Reconcile{op_id, bytes+digest, artifact, expected_applied})
+    CA->>CC: submit(envelope)（按 generation 路由）
+    CC->>EX: enqueue（admission/幂等/队列上限）
+    CC-->>CA: OperationHandle
+    EX->>OR: ①-④ CAS + 内部 check（零副作用段）
+    alt check 失败
+        OR-->>EX: CoreError{kind: InvalidConfig | ConfigCheckFailed}
+        EX-->>F: Err —— 干净中止，无补偿
+    else 进入提交段
+        OR->>OR: ⑤ stage ⑥ classify
+        OR->>B: ⑦ execute（Patch/Reload/Restart/Switch；停旧须 StopProof）
+        OR->>OR: ⑧ verify ⑨ fallback/rollback ⑩ 原子 publish
+        OR-->>EX: ApplyOutcome（Noop..Switched | RolledBack）
+        EX-->>F: ReconcileReport{outcome, applied_revision}
+    end
+    Note over U,F: caller future 被取消 / RPC 断开：<br/>事务照常跑到终态；同 op_id 重查取结果
+```
+
+### 5.4 响应丢失的幂等恢复（替代盲重试）
+
+```mermaid
+sequenceDiagram
+    participant F as app
+    participant S as Service CoreControl
+    F->>S: submit(Reconcile{op_id=X, digest=D})
+    Note over F,S: 响应丢失（transport error）——服务端可能已执行
+    F->>S: submit(Reconcile{op_id=X, digest=D})   ← 同 id 同 payload
+    alt registry 命中
+        S-->>F: 原 operation（进行中 → 等待 / 已终态 → 原结果）
+    else registry 已淘汰
+        S-->>F: 新 operation；③ CAS 由 expected_applied 挡住重复应用 → RevisionConflict
+    end
+```
+
+两层兜底（registry + CAS）保证"至多生效一次"；`RevisionConflict` 时 app 重读 status 对账即可。
+
+---
+
+## 6. ServiceActor —— daemon 作为被管理资源（2026-08-13 增补）
+
+`CoreControl` 运行在 daemon **里面**，管不了 daemon 自己的安装与存活——这层职责必然留在 app 侧，且按 CLAUDE.md §8 分类只能是 actor：长生命周期可变状态（安装/运行/版本/兼容/连接句柄）+ 后台任务（健康观察、重连）+ 必须串行的提权外部命令（install/uninstall 不可交错）。现状反例（refactor/core-manager-actor @ 2a247cca 核实，2026-08-13）：`core/service/ipc.rs:28-30` 三个进程级 statics（`IPC_STATE`/`KILL_FLAG`/`HEALTH_CHECK_RUNNING`）、`control.rs:101,229,324` 三处裸 `spawn_health_check`、七个自由函数入口、`utils/init/mod.rs:251` 游离的启动期 auto-update——全部被 ServiceActor 吸收。
+
+### 6.1 职责边界
+
+| 拥有                                                                                                                                                         | 不拥有                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| daemon 安装/卸载/启动/停止/更新（mailbox 串行；提权命令逐条有界 await，子进程本身不可取消——如实记录，5d R4/R5 残余的延续）                                   | **核生命周期**（`CoreControl` 的，永不越界）              |
+| 健康/兼容观察循环：探针**自带 timeout**（5d 存活资产 `OsServiceProbe` 语义）；fail-closed 版本门在此评定（5-pre `ServiceCompat` 资产迁入）                   | `CoreStatus` 真相（不做第二份投影）                       |
+| `CoreControlClient` 句柄的构造/验证/重建——**Service endpoint 的供给者**，经 watch 发布 `(handle, generation)`，CoreActor 只消费（§2 图中 RPCC 的存活归此处） | 路由决策（CoreActor 持句柄路由）                          |
+| 启动期版本对账（**保留**"版本落后自动 `update_service()`(UAC)"既有产品语义）                                                                                 | DNS（各 host 的 `MacosDnsController`）                    |
+| daemon 死亡的**有界自动重启 + 耗尽 latch**（镜像 5a recovery-exhausted：预算耗尽 → degradation → 等显式重试）                                                | desired state（commit-first，desired 只来自 state actor） |
+
+### 6.2 状态机
+
+```mermaid
+stateDiagram-v2
+    [*] --> Probing: 启动（含版本对账 / auto-update）
+    Probing --> NotInstalled
+    Probing --> DaemonStopped: 已装未运行
+    Probing --> Ready: Running + 版本门通过\n（发布 endpoint + generation）
+    Probing --> Incompatible: 版本门 fail-closed\n（要求升级，绝不降级兼容）
+    NotInstalled --> Installing: Install / EnsureReady
+    DaemonStopped --> StartingDaemon: StartDaemon / EnsureReady
+    Installing --> Probing: 命令返回（install 多数平台自动拉起 daemon）
+    StartingDaemon --> Probing
+    Ready --> Reconnecting: 探针失败 / CoreActor 回报 EndpointDown
+    Reconnecting --> Ready: 重连成功（句柄重建，generation 不变）
+    Reconnecting --> Restarting: 判定 daemon 死亡（有界自动重启）
+    Restarting --> Probing
+    Reconnecting --> Exhausted: 重启预算耗尽\n（degradation，等显式重试）
+    Exhausted --> Probing: 显式 Probe / EnsureReady
+    Ready --> Uninstalling: Uninstall（守卫见 §6.4）
+    DaemonStopped --> Uninstalling
+    Uninstalling --> NotInstalled
+```
+
+### 6.3 消息面与投影
+
+```rust
+enum ServiceActorMessage {
+    /// 幂等收敛到 Ready：按需 install → start → probe → 版本门。
+    EnsureReady { reply: RpcReplyPort<Result<ServiceEndpoint, CoreError>> },
+    Install     { reply: RpcReplyPort<Result<(), CoreError>> },
+    Update      { reply: RpcReplyPort<Result<(), CoreError>> },
+    Uninstall   { reply: RpcReplyPort<Result<(), CoreError>> },   // 守卫见 §6.4
+    StartDaemon { reply: RpcReplyPort<Result<(), CoreError>> },
+    StopDaemon  { reply: RpcReplyPort<Result<(), CoreError>> },
+    Probe       { reply: RpcReplyPort<ProbeOutcome> },            // 显式探测；探针自带 timeout
+    EndpointDown { generation: ControllerGeneration },            // CoreActor 回报
+}
+
+/// watch 投影（UI 设置页 + CoreActor 消费）；daemon 状态 ≠ 核状态。
+struct ServiceHostStatus {
+    install: InstallState,            // NotInstalled | Installed | Installing | Uninstalling
+    daemon:  DaemonState,             // Stopped | Starting | Ready | Reconnecting | Exhausted
+    compat:  ServiceCompat,           // Compatible{version} | Incompatible{..} | Unknown
+    endpoint: Option<(CoreControlClient, ControllerGeneration)>,
+}
+```
+
+### 6.4 与 CoreActor 的编排（config 驱动；desired 由编排送达而非 watch 订阅）
+
+desired 不由 ServiceActor 订阅 config watch 自取——否则它与 handoff 抢同一事件（5d/5e 跨文档矛盾的成因正是两个所有者并发响应同一变更）。commit-first 之后由 facade 编排显式定序：
+
+```mermaid
+sequenceDiagram
+    participant U as UI(settings)
+    participant F as NyanpasuClient
+    participant ST as StateActor
+    participant SA as ServiceActor
+    participant CA as CoreActor v2
+
+    U->>F: service_mode = true
+    F->>ST: commit（typed patch，commit-first）
+    F->>SA: EnsureReady
+    SA->>SA: install?→start?→probe→版本门
+    alt Ready
+        SA-->>F: ServiceEndpoint{handle, gen}
+        F->>CA: ChangeHost(Service)（§5.2 handoff）
+    else 失败
+        SA-->>F: Err(kind)（desired 已提交 → CommittedDegraded，不回滚 state）
+    end
+
+    Note over U,CA: 关闭方向相反：F→CA ChangeHost(Local)【handoff 内含 Service 侧<br/>Stop+StopProof，此刻 daemon 必须还活着】→ 按需 SA.StopDaemon / Uninstall
+```
+
+- **Uninstall 双层守卫**：①编排定序（只有 handoff 完成后才可达）；②SA 自查 daemon status 无 owned runtime，违反 → `Err(kind=AlreadyRunning)`。卸载不可逆，两层都过才发提权命令。
+- **编排非原子，如实声明**：步骤间崩溃留下的是**良性状态**（daemon 装好且 idle、host 仍 Local），无损坏、无双 owner，下次 reconcile 收敛——不为此加补偿事务。
+- app 关停时 SA 只需停观察循环（自身无外部副作用），在 CoreActor 之后关闭。
+- 移动端对应：SA 是桌面专属 Host Adapter 组件；Android/iOS 的对应物是 `VpnService` / Packet Tunnel Provider host 胶水，不复用。
+
+### 6.5 吸收的现状代码
+
+| 现状（本分支核实）                                                        | 去向                                                               |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `control.rs` 七入口（install/update/uninstall/start/stop/restart/status） | SA 消息面（mailbox 串行替代 5d 的 facade `ControlAdmission` 设想） |
+| `ipc.rs:28-30` 三 statics + 三处 `spawn_health_check`                     | SA 内部状态 + 单一观察循环（statics 删除）                         |
+| `utils/init/mod.rs:251` 启动 auto `update_service()`                      | SA 启动期对账（产品语义保留）                                      |
+| 5-pre `ServiceCompat` fail-closed 门                                      | SA compat 评定（版本门唯一实现点）                                 |
+| 5d `OsServiceProbe`（探针内部有界）                                       | SA 探针                                                            |
+
+---
+
+## 7. 关停（结构化，无选举）
+
+```mermaid
+sequenceDiagram
+    participant T as tauri exit hook
+    participant F as NyanpasuClient
+    participant CA as CoreActor v2
+    participant H as active host CoreControl
+
+    T->>F: shutdown()
+    Note over F: closing latch（原子置位）<br/>后续调用 await 同一 shared future——无 leader/follower 选举
+    F->>CA: Shutdown
+    CA->>H: submit(Stop)（有界；daemon 侧事务不依赖本连接存活）
+    H->>H: stop_and_confirm → StopProof / StopUnconfirmed→Quarantined
+    Note over H: DNS restore 在 host 的 Stop 事务内由<br/>MacosDnsController 执行并单独报告
+    H-->>CA: StopReport
+    CA->>CA: 停订阅泵、关 watch/broadcast
+    CA-->>F: ShutdownReport{ runtime, dns: Option<_>, logs, final_status }
+    F-->>T: report（吞错的 Ok(()) 不复存在）
+```
+
+- 取代旧 `ControlAdmission` + leader/follower + `Notify` 选举 + 多文档预算求和的全部机制：**shared-future 幂等**天然无丢唤醒（followers await 同一 future，不经 `Notify` 注册窗口）；剩余步骤幂等，重跑无害。
+- Service 模式默认行为維持现状：app 退出停核、daemon 存活（OQ-2 留给产品裁定"退出保活"选项）。
+- 有界性由**每个外部 I/O 自带 deadline** 组合而成（控制面设计 §17.6），不再有跨文档预算算术。
+
+---
+
+## 8. DNS 归属（app 侧视角）
+
+- app 进程**零 DNS 职责**。`MacosDnsController` 各 host 一份，在其 orchestrator 的固定阶段被调用（start 尾部施加 / stop 头部恢复 / handoff 的源 Stop 内恢复）。
+- 记录形态按审计 §三：`DnsOverrideRecord{interface, previous, applied, owner_generation, runtime_epoch, state}`，host 持久化 + 启动 orphan reconcile；apply/restore 一律 read-back 推进，`Err` 不推断副作用缺席。
+- 机制层（`networksetup` 值比较 vs `scutil` `State:` 键结构性归属）是该组件内部实现选择，由 Phase-0 spike 决定（验收判据：写键后 `scutil --dns` 首选解析器变更；删键后恢复；重启后键不存在）。接口不受影响。
+- Local 模式的写权限问题（非 admin 账户）继承自 5e §9 的分析，作为 `MacosDnsController` 的已知限制记录（OQ-3）。
+
+---
+
+## 9. 开放问题
+
+| #    | 问题                                                                                                             | 现状                                                                                    |
+| ---- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| OQ-1 | `ControllerGeneration` 的分配与持久化（app 侧单调计数是否够；daemon 重启后 gen 对账）                            | 第一阶段：app 分配 + 双方内存持有 + status 暴露；跨重启审计留待 durable ledger 需求出现 |
+| OQ-2 | Service 模式 app 退出是否停核（现行为：停）                                                                      | 默认保留现行为；"退出保活"作为产品选项另议                                              |
+| OQ-3 | Local 模式 macOS DNS 写权限（非 admin 静默失败）                                                                 | `MacosDnsController` 已知限制；若产品裁定"TUN DNS 需要 Service"则整块消失               |
+| OQ-4 | daemon 重启丢 operation registry                                                                                 | 第一阶段接受：status 为事实源 + CAS 兜底（§5.4）                                        |
+| OQ-5 | `check_config` 咨询命令的前端入口保留范围                                                                        | 仅 profile 编辑器"验证配置"；不接任何自动化路径                                         |
+| OQ-6 | ServiceActor 自动重启预算（次数/退避/耗尽判据）与观察循环形态（保留轮询 vs 改 daemon event stream + 断连才探测） | 数值随 PR-D 计划定；v2 事件流可用后倾向后者                                             |

--- a/docs/design/actor-migration-roadmap.md
+++ b/docs/design/actor-migration-roadmap.md
@@ -253,6 +253,16 @@ flowchart LR
 > **语义权威**：`docs/superpowers/specs/2026-08-01-pr5-core-actor/design.md`（设计正文）与同目录 `task.md`（任务清单：R0 / P1–P2 / A1–A3 / B1–B4 / C1–C4）。
 > **release-gate**：dev 渠道接受 rc.1；**stable 渠道发布前 submodule 须 bump 到上游正式 v2.0.0**。
 
+### 6.方向变更（2026-08-12）
+
+> **⚠️ 本节 6.1–6.3 描述的 GUI `CoreActor` 所有权形态（封闭 `CoreBackend` enum、`CoreOperationGuard`、Promoted/Applied 状态机入 actor）已被后续控制面方向取代**，规范见以下三份文档：
+>
+> - [`docs/audit/2026-08-12-core-actor-audit-verification.md`](../audit/2026-08-12-core-actor-audit-verification.md) —— 外部审计复核（事实表 + 事务信封 + 边界清单）；
+> - [`2026-08-08-core-manager-control-plane-runtime-backend-design.md`](./2026-08-08-core-manager-control-plane-runtime-backend-design.md) —— 控制面本体设计：`nyanpasu-runtime` 内的 `CoreControl` 拥有核心生命周期；
+> - [`2026-08-12-core-actor-v2-app-integration.md`](./2026-08-12-core-actor-v2-app-integration.md) —— app 侧集成设计：`CoreActor v2` 收窄为 endpoint router + 投影，`ServiceActor` 作为 `CoreControl` 的 RPC host，Local↔Service 切换改为显式 handoff + `ControllerGeneration` fencing。
+>
+> §6.0 PR-5-pre（依赖与 daemon 兼容门）不受影响，仍是当前阶段的权威实施范围；6.1–6.3 保留作为历史记录，不再是后续实施的规范来源。
+
 ### 6.总览 — 核心收敛
 
 PR-5 **只**新增三样东西：

--- a/docs/superpowers/plans/2026-08-13-pr-abcd-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-13-pr-abcd-implementation-plan.md
@@ -1,0 +1,73 @@
+# PR-A～D 实施编排计划（2026-08-13）
+
+- **依据**：roadmap §6.5、控制面设计（2026-08-08 + 修订 A1–A6）、app 集成设计（2026-08-12）、审计报告 §3
+- **前置已满足**：nyanpasu-runtime #390 已合并（`e899bce`，typed `CoreErrorKind` 12 kind wire 表）
+- **停止线（用户裁定）**：实施到 **legacy bridge 阶段之前停止**——新 CoreActor v2 / ServiceActor / DNS 接线以"并存不接线"形态完成并可测，交用户审计；旧代码零改动、Tauri commands 不换线、v1 wire 不删。
+
+## 0. 关键时序调整（相对 roadmap §6.5 的两处澄清）
+
+1. **PR-B 不删 v1**。roadmap 写"IPC v2 only、删 v1"，前提是 app lockstep 立即切换。审计停止线要求 app 旧代码（v1 client 调用）在停止点仍可编译运行，因此 v1 endpoints 的删除**顺延到 bridge/清算阶段**（停止线之后）。PR-B 只做加法：v2 路由并存。最终态不变。
+2. **PR-C 拆成 C-new / C-switch**。C-new（本计划范围）：新模块并存、单测齐全、不接线。C-switch（停止线之后）：Tauri commands 换线 + 删旧 GUI CoreActor 形态 + 删 v1。"吸收 ipc.rs 三 statics / 七入口"同理属 C-switch——本阶段新代码实现对应职责，旧文件不动。
+
+## 1. 仓库与分支拓扑
+
+| 仓库                                 | 分支                                           | 内容                |
+| ------------------------------------ | ---------------------------------------------- | ------------------- |
+| nyanpasu-runtime（submodule 工作树） | `feat/core-control-plane`（自 `e899bce`）      | PR-A + PR-B         |
+| clash-nyanpasu                       | `refactor/core-actor-v2`（自 `pr5/1-pre` tip） | PR-C-new + PR-D-new |
+
+- app 分支基于 `pr5/1-pre`（path deps 已切 submodule），**不做** #5070 的 rebase/merge——栈处置待用户裁定；path deps 读文件系统工作树，故 submodule pin 无需移动即可开发。
+- 提交纪律：全部显式路径 add；submodule 内提交不动 app 仓 gitlink。
+
+## 2. 现状基线核实（feat/core-control-plane @ e899bce）
+
+已存在且**保留复用**（审计 §4 资产表的落地确认）：
+
+- `manager/mod.rs`：`ctrl: Mutex<Ctrl>` 串行、`watch<CoreStatus>` 发布、`broadcast<LogFrame>`、epoch 分配、quarantine latch（`reject_quarantine`/`latch_quarantine`/`sweep_orphans`）、`stop_and_confirm_dead` 全路径强制、`ApplyOutcome{Noop..RolledBack,DurabilityUncertain}`。
+- `error.rs`：`Error::kind() -> Option<CoreErrorKind>`（诚实缺省——不猜 kind）；R0 wire 表 12 kind 已含 `RevisionConflict`/`Quarantined`/`StopUnconfirmed`。
+- `runtime_store.rs`：staged 提交/备份/epoch 清理；`spec.rs`：`InstanceSpec`（注意：仍是 `config_path` 文件路径输入）。
+
+缺口（PR-A 要补的全部）：无 OperationId/幂等 registry、无 executor 队列（调用方 future 取消=事务暴露）、无统一 Reconcile（start/stop/apply 是分立公有方法、check 是 caller 前置门）、无 RuntimeBackend trait（`Instance` 具体类型直嵌）、无 DNS 组件。
+
+## 3. 任务卡（对应会话任务 #2–#15）
+
+### PR-A（runtime 仓）
+
+| 卡  | 内容                                                                                                                                                                                                                                                                                                                                                                                                                   | 验证                                                  |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| A1  | model 层：`OperationId([u8;16])`、`CoreCommand{Reconcile,Stop,Recover,Shutdown,Check}`+envelope、`OperationState`、`ConfigInput{Inline}`（legacy path adapter 在 host 边界）、`CoreErrorKind` 超集扩展（admission 层：`ShuttingDown`/`QueueFull`/`OperationConflict`；app 路由层 `BackendUnavailable`）。**Rust API 错误保持 `Option<CoreErrorKind>` 的 R0 诚实语义**（设计 §25 "kind 必在"按 R0 原则收窄——不猜 kind） | cargo test（wire 表 golden 更新）                     |
+| A2  | `RuntimeBackend`/`RuntimeInstance` trait 边界：以现 `Instance` 公有面（`wait_ready`/`pid`/`state`/`controller`/`epoch`/`stop_and_confirm_dead`）为准最小化；process 实现=现有代码平移；`StopProof` 显式化                                                                                                                                                                                                              | trait 化后现有测试全绿                                |
+| A3  | Orchestrator：`Reconcile` 统一 mutating 入口（dispatch：未运行→start 路径 / spec 变→switch / 否则 apply 分类），**内部 check**（`InvalidConfig`/`ConfigCheckFailed` 于任何提交点前干净中止）；CAS `expected_applied`；十阶段信封中 ⑤–⑩ 即现有 apply/switch/publish 资产                                                                                                                                                | 单测覆盖审计 §3.2 的 orchestrator 段                  |
+| A4  | `ControlExecutor`：bounded mpsc 单 task；operation registry（同 id+digest→同 op / 同 id 异 payload→`OperationConflict` / 有界 cache）；`Check` 独立 semaphore；`QueueFull`；closing latch；reply drop 不取消；panic→host fatal                                                                                                                                                                                         | 并发测试：caller 取消后事务跑到终态；幂等重发取原结果 |
+| A5  | `CoreControl` handle：`submit→OperationHandle{wait}`/`status`/`subscribe_events`/`subscribe_logs`；builder 显式注入                                                                                                                                                                                                                                                                                                    | 单测                                                  |
+| A6  | DNS：`DnsController` trait + `DnsOverrideRecord`（owner_generation/runtime_epoch/state；read-back 推进）+ 持久化 + orphan reconcile；orchestrator 固定挂点（start 尾/stop 头/事务内报告）；fake 供测试；`cfg(target_os="macos")` scutil 骨架——**本机（Windows）不可实测，Phase-0 spike 判据留注释，如实标注**                                                                                                          | fake 断言挂点次序与 record 推进                       |
+| A7  | contract tests：对 `CoreControl` 泛型套件跑审计 §3.2 边界矩阵（admission/幂等/CAS/干净中止零副作用/StopProof→Quarantined→Recover/RolledBack=成功事务/取消隔离）；复用现有 fake-core 进程测试基建，embedded fake 仅证 trait 边界诚实                                                                                                                                                                                    | cargo test 全绿                                       |
+
+### PR-B（runtime 仓，加法）
+
+| 卡  | 内容                                                                                                                                 | 验证                            |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------- |
+| B1  | IPC v2：`/v2/core/*`（submit/operation query/status/events seq 有序）+ portable DTO + kind 直传；fail-closed 版本门保留；**v1 不删** | DTO roundtrip                   |
+| B2  | service host：v2 路由接 daemon 内 `CoreControl` 实例（submit-query；断线不取消）；ACL 沿用                                           | contract 套件经 IPC client 跑通 |
+
+### PR-C-new / PR-D-new（app 仓，并存不接线）
+
+| 卡  | 内容                                                                                                                                                  | 验证                            |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| C1  | 分支 + `RuntimeIntentBuilder` 纯服务（snapshots→bytes+digest+artifact+revision+effects）                                                              | 纯值单测                        |
+| C2  | CoreActor v2：4+1 消息、`EndpointSlot{Connected,HandingOff,Degraded}`、I-R1/2/3、逐字段投影 watch、订阅泵                                             | fake CoreControl 测试，无 sleep |
+| C3  | ServiceActor：§6 全量（消息面/状态机/探针 timeout/版本门唯一实现点/endpoint watch 供给/有界重启+latch/启动对账 UAC 语义/Uninstall 自查守卫）          | fake daemon 适配器全迁移测试    |
+| D1  | 显式 handoff 三阶段 + `ControllerGeneration` fencing（host 拒旧 gen）+ `CommittedDegraded`                                                            | 四路矩阵测试                    |
+| D2  | DNS 接线核对（两 host 同组件 + handoff 源 Stop 内 restore）+ facade 编排（§6.4 时序 + shutdown shared-future；**不接 Tauri commands**）+ 审计材料汇总 | 停止线交付                      |
+
+## 4. 停止线交付物
+
+1. 两仓分支各自 `cargo test` 全绿 + fmt/clippy 干净；
+2. 审计入口文档：新模块路径清单、与设计逐节对照表、测试运行方式、已知限制（macOS DNS 未实测、v1 并存清单=bridge 阶段删除表）；
+3. 不做：Tauri 换线、旧代码删除、v1 删除、#5070 rebase/merge、PR 创建/推送（除非用户另行指示）。
+
+## 5. 风险与如实声明
+
+- **macOS DNS**：Windows 环境只能交付结构（trait/record/挂点/fake 测试）+ `cfg(macos)` 编译骨架；scutil 行为验收需 macOS spike（设计已预留 Phase-0 判据）。
+- **service host 集成测试**：named pipe 本机可跑，但提权路径（install/UAC）不在自动化内——ServiceActor 用 fake 适配器测。
+- **设计 §25 与 R0 的 kind 必在/可缺省矛盾**：按 R0 原则收窄（见 A1 卡），已在本计划显式记录，审计时可复核。

--- a/docs/superpowers/specs/2026-08-01-pr5-core-actor/task.md
+++ b/docs/superpowers/specs/2026-08-01-pr5-core-actor/task.md
@@ -2,6 +2,8 @@
 
 关联设计：`design.md`（同目录）
 
+> **⚠️ 方向变更（2026-08-12）**：本文件 §0 第 1/3 条约束与 PR-5a / PR-5b / PR-5c 三张卡片描述的 GUI `CoreActor` 所有权形态，已被控制面下沉方向取代，规范见 [`2026-08-12-core-actor-v2-app-integration.md`](../../../design/2026-08-12-core-actor-v2-app-integration.md)、[`2026-08-08-core-manager-control-plane-runtime-backend-design.md`](../../../design/2026-08-08-core-manager-control-plane-runtime-backend-design.md) 与 [`2026-08-12-core-actor-audit-verification.md`](../../../audit/2026-08-12-core-actor-audit-verification.md)。R0 与 PR-5-pre 两张卡片不受影响，仍是当前唯一权威实施范围；下方卡片内容保留存档，不再更新。
+
 ## 0. 全局约束
 
 1. app 只新增一个跨步骤排他机制：`OperationId` + `CoreOperationGuard`；迁移完成后删除 `rebuild_gate`、`clash_patch_gate` 和 legacy lifecycle mutex。


### PR DESCRIPTION
## 概要

控制面下沉的 app 仓部分（**PR-C-new + PR-D-new**，并存不接线），base = `pr5/1-pre`。Draft 状态供审计，**停止线 = legacy bridge 之前**：旧代码零改动（仅 `core/mod.rs` 一行模块声明 + Cargo 依赖增行）、Tauri commands 未换线、v1 wire 未删。

⚠️ **编译前置**：本分支 path deps 读 submodule 工作树，需先把 `backend/nyanpasu-runtime` checkout 到配套分支 `feat/core-control-plane`（tip `faa76a0`，即 runtime 仓配套 draft PR libnyanpasu/nyanpasu-runtime#391）。gitlink 仍钉 `e899bce`——pin 移动待裁定，**CI 在 pin 移动前预期红**。

## 提交 → 任务卡对照

| 提交 | 卡 | 内容 |
| --- | --- | --- |
| `108c393d` | C1+C2+D1 | `actor_v2/`：CoreActor v2（Submit/ChangeHost/EndpointEvent/EndpointDown/Shutdown + EndpointSlot + I-R1/2/3 + handoff 三阶段 + generation fencing）；`ControlEndpoint` port + Local/Service 双适配器；`RuntimeIntentBuilder` 纯服务 |
| `c9adbad9` | C3 | ServiceActor：EnsureReady 收敛 / 版本门唯一实现点（fail-closed）/ Uninstall 自查守卫 / 有界重启+Exhausted latch / 启动版本对账（UAC 语义），可脚本化 fake daemon 全覆盖 |
| `319ce111` | D2 | 审计入口文档 `docs/audit/2026-08-13-v2-implementation-audit-guide.md` |
| `c6d9ac06` | D2 | 独立测绘交叉核对记录（审计旁证 §6） |

## 审计入口

从 `docs/audit/2026-08-13-v2-implementation-audit-guide.md` 进：代码位置、与 2026-08-12 app 集成设计逐节对照、8 项记录在案偏离、L1–L7 限制清单、测试跑法、独立测绘交叉核对。

关键已知项：

- **L4**：facade 编排（`reconcile_core` / service_mode §6.4 时序 / shutdown shared-future）**未实现**——bridge 前最后一块，审计结论后实施。
- **L3**：`CoreKind→CoreType` wire 映射有损（alpha 塌缩、Meow 无 wire 表示），bridge 阶段 facade 须携带 intent 原 `CoreType`。
- **L6**：本机共享 target 存在损坏 rlib（环境问题），两个代码提交按既有先例 `--no-verify`，补证 = `cargo check` exit 0 + 12/12 测试全绿（含链接）；门禁应在隔离 target/CI 复跑。

## 验证

```
cd backend && cargo test -p clash-nyanpasu --lib actor_v2   # 12 通过
```

## 不做（停止线之后）

Tauri commands 换线、旧 GUI CoreActor 删除、v1 wire 删除、#5070–#5074 栈 rebase/merge、submodule pin 移动。
