### PR TITLE
ci: disable portable build to fix windows pipeline [skip ci]

### DIFF
--- a/.github/workflows/target-dev-build.yaml
+++ b/.github/workflows/target-dev-build.yaml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.repository, 'libnyanpasu') }}
     uses: ./.github/workflows/deps-build-windows-nsis.yaml
     with:
-      portable: true
+      portable: false
       nightly: true
       bundle-type: 'both'
       arch: 'x86_64'
@@ -31,7 +31,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.repository, 'libnyanpasu') }}
     uses: ./.github/workflows/deps-build-windows-nsis.yaml
     with:
-      portable: true
+      portable: false
       nightly: true
       bundle-type: 'both'
       arch: 'aarch64'


### PR DESCRIPTION
cc @keiko233 @greenhat616 @4o3F