### PR TITLE
fix(ci): check out the runtime submodule with LF on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,15 @@ jobs:
           - os: windows-latest
     runs-on: ${{ matrix.targets.os }}
     steps:
+      # The nyanpasu-runtime submodule pins `newline_style = "Unix"` in its own
+      # rustfmt.toml, but its .gitattributes is only `* text=auto`. Without this,
+      # Windows checks the submodule out with CRLF and `lint:rustfmt` rejects every
+      # file in it. The submodule's own workflows set the same two options before
+      # checkout; the superproject has to do it too now that it vendors the crates.
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - uses: actions/checkout@v7
         with:
           # `backend/nyanpasu-runtime` is a submodule that itself nests
@@ -129,6 +138,11 @@ jobs:
     runs-on: ${{ matrix.targets.os }}
     needs: lint
     steps:
+      # Same reason as the lint job: the submodule must not arrive with CRLF.
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - uses: actions/checkout@v7
         with:
           submodules: recursive
@@ -218,6 +232,11 @@ jobs:
 
     # the steps our job runs **in order**
     steps:
+      # Same reason as the lint job: the submodule must not arrive with CRLF.
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       # checkout the code on the workflow runner
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
`Lint (windows-latest)` has been red on `main` since [f8e09521](https://github.com/libnyanpasu/clash-nyanpasu/commit/f8e09521) vendored nyanpasu-runtime as a submodule (2026-08-31). This is not a new failure and not specific to any open PR — it reproduces on `main` itself.

## Cause

`lint:rustfmt` is `cargo fmt --manifest-path ./backend/Cargo.toml --all -- --check`. That workspace now reaches the submodule crates, and rustfmt resolves the *nearest* config per file — so files under `backend/nyanpasu-runtime/` are checked against the submodule's own `rustfmt.toml`, which pins:

```toml
newline_style = "Unix"
```

The submodule's `.gitattributes` is only `* text=auto`, so under git-for-Windows' default `core.autocrlf=true` the runner checks those files out with CRLF. rustfmt then reports `Incorrect newline style` for essentially every file in the submodule.

## Why it cost more than one red check

`build` and `test_unit` both declare `needs: lint`, and `needs` waits on the entire matrix. One failing Windows leg has therefore skipped **Tauri builds and unit tests on all three platforms** for the past week — visible as `skipping :: Build Tauri` / `skipping :: Unit Test` on open PRs.

## Fix

Set `core.autocrlf=false` / `core.eol=lf` before checkout. This is not a new idea in this codebase: the submodule's own four workflows already do exactly this, for exactly this reason. The superproject needs it too now that it vendors the crates.

Applied to all three jobs rather than only `lint`, because all three check the submodule out and only `lint` has been able to report what happens next — `build` and `test_unit` have not actually run on Windows since the submodule landed.

## Verification

The mechanism is verified end to end from CI logs rather than inferred: the failing job list on `main` runs 33385143254 (f8e09521) and 33390036275 (3d5a518d) both name `Lint (windows-latest)` and both fail with `Incorrect newline style` on submodule paths. The fix itself is CI-only and cannot be exercised locally; this PR's own Windows run is the test.

https://claude.ai/code/session_01BsiU6nsZN2i4fcNntm2xZd
