### PR TITLE
refactor(core): standardize boxed futures and async trait ports

### DIFF
--- a/backend/tauri/src/bridge/verge.rs
+++ b/backend/tauri/src/bridge/verge.rs
@@ -2293,64 +2293,50 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl crate::core::actor_v2::endpoint::ControlEndpoint for RecordingReconcileEndpoint {
         fn host(&self) -> crate::core::actor_v2::endpoint::ExecutionHost {
             crate::core::actor_v2::endpoint::ExecutionHost::Local
         }
 
-        fn submit<'a>(
-            &'a self,
+        async fn submit(
+            &self,
             submission: crate::core::actor_v2::endpoint::CoreSubmission,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            'a,
-            std::result::Result<
-                nyanpasu_ipc::api::core::v2::OperationInfo,
-                nyanpasu_core_manager::CoreError,
-            >,
+        ) -> std::result::Result<
+            nyanpasu_ipc::api::core::v2::OperationInfo,
+            nyanpasu_core_manager::CoreError,
         > {
-            Box::pin(async move {
-                if let nyanpasu_core_manager::CoreCommand::Reconcile(request) =
-                    &submission.envelope.command
-                {
-                    let nyanpasu_core_manager::ConfigInput::Inline { bytes, .. } = &request.config;
-                    self.submitted_configs.lock().unwrap().push(bytes.clone());
-                }
-                Ok(recording_endpoint_successful_reconcile(
-                    submission.envelope.operation_id,
-                ))
-            })
+            if let nyanpasu_core_manager::CoreCommand::Reconcile(request) =
+                &submission.envelope.command
+            {
+                let nyanpasu_core_manager::ConfigInput::Inline { bytes, .. } = &request.config;
+                self.submitted_configs.lock().unwrap().push(bytes.clone());
+            }
+            Ok(recording_endpoint_successful_reconcile(
+                submission.envelope.operation_id,
+            ))
         }
 
-        fn wait_operation<'a>(
-            &'a self,
+        async fn wait_operation(
+            &self,
             id: nyanpasu_core_manager::OperationId,
             _timeout: std::time::Duration,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            'a,
-            Option<nyanpasu_ipc::api::core::v2::OperationInfo>,
-        > {
-            Box::pin(async move { Some(recording_endpoint_successful_reconcile(id)) })
+        ) -> Option<nyanpasu_ipc::api::core::v2::OperationInfo> {
+            Some(recording_endpoint_successful_reconcile(id))
         }
 
-        fn status<'a>(
-            &'a self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            'a,
-            std::result::Result<
-                crate::core::actor_v2::endpoint::CoreStatusSnapshot,
-                nyanpasu_core_manager::CoreError,
-            >,
+        async fn status(
+            &self,
+        ) -> std::result::Result<
+            crate::core::actor_v2::endpoint::CoreStatusSnapshot,
+            nyanpasu_core_manager::CoreError,
         > {
-            Box::pin(async {
-                Ok(crate::core::actor_v2::endpoint::CoreStatusSnapshot {
-                    state: Some(nyanpasu_ipc::api::status::CoreStateDetail::Stopped {
-                        reason: None,
-                    }),
-                    state_changed_at: 0,
-                    revision: None,
-                    healthy: Some(true),
-                    applied_kind: None,
-                })
+            Ok(crate::core::actor_v2::endpoint::CoreStatusSnapshot {
+                state: Some(nyanpasu_ipc::api::status::CoreStateDetail::Stopped { reason: None }),
+                state_changed_at: 0,
+                revision: None,
+                healthy: Some(true),
+                applied_kind: None,
             })
         }
     }

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -1719,54 +1719,42 @@ pub(crate) mod tests {
 
     struct IdleEndpoint;
 
+    #[async_trait::async_trait]
     impl crate::core::actor_v2::endpoint::ControlEndpoint for IdleEndpoint {
         fn host(&self) -> ExecutionHost {
             ExecutionHost::Local
         }
 
-        fn submit<'a>(
-            &'a self,
+        async fn submit(
+            &self,
             submission: crate::core::actor_v2::endpoint::CoreSubmission,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            'a,
-            std::result::Result<
-                nyanpasu_ipc::api::core::v2::OperationInfo,
-                nyanpasu_core_manager::CoreError,
-            >,
+        ) -> std::result::Result<
+            nyanpasu_ipc::api::core::v2::OperationInfo,
+            nyanpasu_core_manager::CoreError,
         > {
-            Box::pin(async move { Ok(successful_reconcile(submission.envelope.operation_id)) })
+            Ok(successful_reconcile(submission.envelope.operation_id))
         }
 
-        fn wait_operation<'a>(
-            &'a self,
+        async fn wait_operation(
+            &self,
             id: nyanpasu_core_manager::OperationId,
             _timeout: std::time::Duration,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            'a,
-            Option<nyanpasu_ipc::api::core::v2::OperationInfo>,
-        > {
-            Box::pin(async move { Some(successful_reconcile(id)) })
+        ) -> Option<nyanpasu_ipc::api::core::v2::OperationInfo> {
+            Some(successful_reconcile(id))
         }
 
-        fn status<'a>(
-            &'a self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            'a,
-            std::result::Result<
-                crate::core::actor_v2::endpoint::CoreStatusSnapshot,
-                nyanpasu_core_manager::CoreError,
-            >,
+        async fn status(
+            &self,
+        ) -> std::result::Result<
+            crate::core::actor_v2::endpoint::CoreStatusSnapshot,
+            nyanpasu_core_manager::CoreError,
         > {
-            Box::pin(async {
-                Ok(crate::core::actor_v2::endpoint::CoreStatusSnapshot {
-                    state: Some(nyanpasu_ipc::api::status::CoreStateDetail::Stopped {
-                        reason: None,
-                    }),
-                    state_changed_at: 0,
-                    revision: None,
-                    healthy: Some(true),
-                    applied_kind: None,
-                })
+            Ok(crate::core::actor_v2::endpoint::CoreStatusSnapshot {
+                state: Some(nyanpasu_ipc::api::status::CoreStateDetail::Stopped { reason: None }),
+                state_changed_at: 0,
+                revision: None,
+                healthy: Some(true),
+                applied_kind: None,
             })
         }
     }
@@ -1981,68 +1969,54 @@ pub(crate) mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl crate::core::actor_v2::endpoint::ControlEndpoint for TestControlEndpoint {
         fn host(&self) -> ExecutionHost {
             ExecutionHost::Local
         }
 
-        fn submit<'a>(
-            &'a self,
+        async fn submit(
+            &self,
             submission: crate::core::actor_v2::endpoint::CoreSubmission,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            'a,
-            std::result::Result<
-                nyanpasu_ipc::api::core::v2::OperationInfo,
-                nyanpasu_core_manager::CoreError,
-            >,
+        ) -> std::result::Result<
+            nyanpasu_ipc::api::core::v2::OperationInfo,
+            nyanpasu_core_manager::CoreError,
         > {
-            Box::pin(async move {
-                self.submissions
-                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                let info = self.operation(&submission);
-                self.operations
-                    .lock()
-                    .unwrap()
-                    .insert(info.id.clone(), info.clone());
-                Ok(info)
-            })
+            self.submissions
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let info = self.operation(&submission);
+            self.operations
+                .lock()
+                .unwrap()
+                .insert(info.id.clone(), info.clone());
+            Ok(info)
         }
 
-        fn wait_operation<'a>(
-            &'a self,
+        async fn wait_operation(
+            &self,
             id: nyanpasu_core_manager::OperationId,
             _timeout: std::time::Duration,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            'a,
-            Option<nyanpasu_ipc::api::core::v2::OperationInfo>,
-        > {
-            Box::pin(async move {
-                self.operations
-                    .lock()
-                    .unwrap()
-                    .get(&id.to_string())
-                    .cloned()
-            })
+        ) -> Option<nyanpasu_ipc::api::core::v2::OperationInfo> {
+            self.operations
+                .lock()
+                .unwrap()
+                .get(&id.to_string())
+                .cloned()
         }
 
-        fn status<'a>(
-            &'a self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            'a,
-            std::result::Result<
-                crate::core::actor_v2::endpoint::CoreStatusSnapshot,
-                nyanpasu_core_manager::CoreError,
-            >,
+        async fn status(
+            &self,
+        ) -> std::result::Result<
+            crate::core::actor_v2::endpoint::CoreStatusSnapshot,
+            nyanpasu_core_manager::CoreError,
         > {
-            Box::pin(async {
-                let (state, applied_kind) = self.status_override.lock().unwrap().clone();
-                Ok(crate::core::actor_v2::endpoint::CoreStatusSnapshot {
-                    state,
-                    state_changed_at: 0,
-                    revision: Some(self.revision.lock().unwrap().clone()),
-                    healthy: Some(true),
-                    applied_kind,
-                })
+            let (state, applied_kind) = self.status_override.lock().unwrap().clone();
+            Ok(crate::core::actor_v2::endpoint::CoreStatusSnapshot {
+                state,
+                state_changed_at: 0,
+                revision: Some(self.revision.lock().unwrap().clone()),
+                healthy: Some(true),
+                applied_kind,
             })
         }
     }
@@ -2064,93 +2038,79 @@ pub(crate) mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl crate::core::actor_v2::endpoint::ControlEndpoint for HostTransitionEndpoint {
         fn host(&self) -> ExecutionHost {
             self.host
         }
 
-        fn submit<'a>(
-            &'a self,
+        async fn submit(
+            &self,
             submission: crate::core::actor_v2::endpoint::CoreSubmission,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            'a,
-            std::result::Result<
-                nyanpasu_ipc::api::core::v2::OperationInfo,
-                nyanpasu_core_manager::CoreError,
-            >,
+        ) -> std::result::Result<
+            nyanpasu_ipc::api::core::v2::OperationInfo,
+            nyanpasu_core_manager::CoreError,
         > {
-            Box::pin(async move {
-                let output = match submission.envelope.command {
-                    nyanpasu_core_manager::CoreCommand::Stop => {
-                        if self.host == ExecutionHost::Service {
-                            self.calls.lock().unwrap().push("handoff_to_local");
-                        }
-                        nyanpasu_ipc::api::core::v2::OperationOutputInfo::Stopped
+            let output = match submission.envelope.command {
+                nyanpasu_core_manager::CoreCommand::Stop => {
+                    if self.host == ExecutionHost::Service {
+                        self.calls.lock().unwrap().push("handoff_to_local");
                     }
-                    nyanpasu_core_manager::CoreCommand::Reconcile(_) => {
-                        self.calls.lock().unwrap().push(match self.host {
-                            ExecutionHost::Local => "reconcile_local",
-                            ExecutionHost::Service => "reconcile_service",
-                        });
-                        successful_reconcile(submission.envelope.operation_id)
-                            .output
-                            .unwrap()
-                    }
-                    _ => successful_reconcile(submission.envelope.operation_id)
+                    nyanpasu_ipc::api::core::v2::OperationOutputInfo::Stopped
+                }
+                nyanpasu_core_manager::CoreCommand::Reconcile(_) => {
+                    self.calls.lock().unwrap().push(match self.host {
+                        ExecutionHost::Local => "reconcile_local",
+                        ExecutionHost::Service => "reconcile_service",
+                    });
+                    successful_reconcile(submission.envelope.operation_id)
                         .output
-                        .unwrap(),
-                };
-                let info = nyanpasu_ipc::api::core::v2::OperationInfo {
-                    id: submission.envelope.operation_id.to_string(),
-                    phase: nyanpasu_ipc::api::core::v2::OperationPhase::Succeeded,
-                    output: Some(output),
-                    error: None,
-                };
-                self.operations
-                    .lock()
-                    .unwrap()
-                    .insert(info.id.clone(), info.clone());
-                Ok(info)
-            })
+                        .unwrap()
+                }
+                _ => successful_reconcile(submission.envelope.operation_id)
+                    .output
+                    .unwrap(),
+            };
+            let info = nyanpasu_ipc::api::core::v2::OperationInfo {
+                id: submission.envelope.operation_id.to_string(),
+                phase: nyanpasu_ipc::api::core::v2::OperationPhase::Succeeded,
+                output: Some(output),
+                error: None,
+            };
+            self.operations
+                .lock()
+                .unwrap()
+                .insert(info.id.clone(), info.clone());
+            Ok(info)
         }
 
-        fn wait_operation<'a>(
-            &'a self,
+        async fn wait_operation(
+            &self,
             id: nyanpasu_core_manager::OperationId,
             _timeout: std::time::Duration,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            'a,
-            Option<nyanpasu_ipc::api::core::v2::OperationInfo>,
-        > {
-            Box::pin(async move {
-                self.operations
-                    .lock()
-                    .unwrap()
-                    .get(&id.to_string())
-                    .cloned()
-            })
+        ) -> Option<nyanpasu_ipc::api::core::v2::OperationInfo> {
+            self.operations
+                .lock()
+                .unwrap()
+                .get(&id.to_string())
+                .cloned()
         }
 
-        fn status<'a>(
-            &'a self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            'a,
-            std::result::Result<
-                crate::core::actor_v2::endpoint::CoreStatusSnapshot,
-                nyanpasu_core_manager::CoreError,
-            >,
+        async fn status(
+            &self,
+        ) -> std::result::Result<
+            crate::core::actor_v2::endpoint::CoreStatusSnapshot,
+            nyanpasu_core_manager::CoreError,
         > {
-            Box::pin(async {
-                Ok(crate::core::actor_v2::endpoint::CoreStatusSnapshot {
-                    state: Some(nyanpasu_ipc::api::status::CoreStateDetail::Running {
-                        epoch: 1,
-                        pid: 7,
-                    }),
-                    state_changed_at: 0,
-                    revision: None,
-                    healthy: Some(true),
-                    applied_kind: None,
-                })
+            Ok(crate::core::actor_v2::endpoint::CoreStatusSnapshot {
+                state: Some(nyanpasu_ipc::api::status::CoreStateDetail::Running {
+                    epoch: 1,
+                    pid: 7,
+                }),
+                state_changed_at: 0,
+                revision: None,
+                healthy: Some(true),
+                applied_kind: None,
             })
         }
     }
@@ -2160,87 +2120,62 @@ pub(crate) mod tests {
         calls: Arc<StdMutex<Vec<&'static str>>>,
     }
 
+    #[async_trait::async_trait]
     impl crate::core::actor_v2::service_actor::ServiceHostAdapter for HostTransitionServiceAdapter {
-        fn probe(
+        async fn probe(
             &self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            '_,
-            std::result::Result<nyanpasu_ipc::types::StatusInfo<'static>, String>,
-        > {
-            Box::pin(async move {
-                self.calls.lock().unwrap().push("ensure_ready");
-                Ok(nyanpasu_ipc::types::StatusInfo {
-                    name: std::borrow::Cow::Borrowed("test-service"),
+        ) -> std::result::Result<nyanpasu_ipc::types::StatusInfo<'static>, String> {
+            self.calls.lock().unwrap().push("ensure_ready");
+            Ok(nyanpasu_ipc::types::StatusInfo {
+                name: std::borrow::Cow::Borrowed("test-service"),
+                version: std::borrow::Cow::Borrowed("2.0.0"),
+                status: nyanpasu_ipc::types::ServiceStatus::Running,
+                server: Some(nyanpasu_ipc::api::status::StatusResBody {
                     version: std::borrow::Cow::Borrowed("2.0.0"),
-                    status: nyanpasu_ipc::types::ServiceStatus::Running,
-                    server: Some(nyanpasu_ipc::api::status::StatusResBody {
-                        version: std::borrow::Cow::Borrowed("2.0.0"),
-                        core_infos: nyanpasu_ipc::api::status::CoreInfos {
-                            r#type: None,
-                            state: nyanpasu_ipc::api::status::CoreState::Running,
-                            state_changed_at: 0,
-                            config_path: None,
-                            controller: None,
-                            health: None,
-                            revision: None,
-                            detail: Some(nyanpasu_ipc::api::status::CoreStateDetail::Stopped {
-                                reason: None,
-                            }),
-                        },
-                        runtime_infos: nyanpasu_ipc::api::status::RuntimeInfos {
-                            service_data_dir: std::borrow::Cow::Owned(Default::default()),
-                            service_config_dir: std::borrow::Cow::Owned(Default::default()),
-                            nyanpasu_config_dir: std::borrow::Cow::Owned(Default::default()),
-                            nyanpasu_data_dir: std::borrow::Cow::Owned(Default::default()),
-                        },
-                        logs: None,
-                    }),
-                })
+                    core_infos: nyanpasu_ipc::api::status::CoreInfos {
+                        r#type: None,
+                        state: nyanpasu_ipc::api::status::CoreState::Running,
+                        state_changed_at: 0,
+                        config_path: None,
+                        controller: None,
+                        health: None,
+                        revision: None,
+                        detail: Some(nyanpasu_ipc::api::status::CoreStateDetail::Stopped {
+                            reason: None,
+                        }),
+                    },
+                    runtime_infos: nyanpasu_ipc::api::status::RuntimeInfos {
+                        service_data_dir: std::borrow::Cow::Owned(Default::default()),
+                        service_config_dir: std::borrow::Cow::Owned(Default::default()),
+                        nyanpasu_config_dir: std::borrow::Cow::Owned(Default::default()),
+                        nyanpasu_data_dir: std::borrow::Cow::Owned(Default::default()),
+                    },
+                    logs: None,
+                }),
             })
         }
 
-        fn install(
-            &self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<'_, std::result::Result<(), String>>
-        {
-            Box::pin(async move {
-                self.calls.lock().unwrap().push("install");
-                Ok(())
-            })
+        async fn install(&self) -> std::result::Result<(), String> {
+            self.calls.lock().unwrap().push("install");
+            Ok(())
         }
 
-        fn uninstall(
-            &self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<'_, std::result::Result<(), String>>
-        {
-            Box::pin(async { Ok(()) })
+        async fn uninstall(&self) -> std::result::Result<(), String> {
+            Ok(())
         }
 
-        fn start_daemon(
-            &self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<'_, std::result::Result<(), String>>
-        {
-            Box::pin(async move {
-                self.calls.lock().unwrap().push("start_daemon");
-                Ok(())
-            })
+        async fn start_daemon(&self) -> std::result::Result<(), String> {
+            self.calls.lock().unwrap().push("start_daemon");
+            Ok(())
         }
 
-        fn stop_daemon(
-            &self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<'_, std::result::Result<(), String>>
-        {
-            Box::pin(async move {
-                self.calls.lock().unwrap().push("stop_daemon");
-                Ok(())
-            })
+        async fn stop_daemon(&self) -> std::result::Result<(), String> {
+            self.calls.lock().unwrap().push("stop_daemon");
+            Ok(())
         }
 
-        fn update(
-            &self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<'_, std::result::Result<(), String>>
-        {
-            Box::pin(async { Ok(()) })
+        async fn update(&self) -> std::result::Result<(), String> {
+            Ok(())
         }
 
         fn endpoint(&self) -> crate::core::actor_v2::endpoint::EndpointHandle {
@@ -2304,56 +2239,37 @@ pub(crate) mod tests {
 
     struct IdleServiceAdapter;
 
+    #[async_trait::async_trait]
     impl crate::core::actor_v2::service_actor::ServiceHostAdapter for IdleServiceAdapter {
-        fn probe(
+        async fn probe(
             &self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<
-            '_,
-            std::result::Result<nyanpasu_ipc::types::StatusInfo<'static>, String>,
-        > {
-            Box::pin(async {
-                Ok(nyanpasu_ipc::types::StatusInfo {
-                    name: std::borrow::Cow::Borrowed("test-service"),
-                    version: std::borrow::Cow::Borrowed("test"),
-                    status: nyanpasu_ipc::types::ServiceStatus::NotInstalled,
-                    server: None,
-                })
+        ) -> std::result::Result<nyanpasu_ipc::types::StatusInfo<'static>, String> {
+            Ok(nyanpasu_ipc::types::StatusInfo {
+                name: std::borrow::Cow::Borrowed("test-service"),
+                version: std::borrow::Cow::Borrowed("test"),
+                status: nyanpasu_ipc::types::ServiceStatus::NotInstalled,
+                server: None,
             })
         }
 
-        fn install(
-            &self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<'_, std::result::Result<(), String>>
-        {
-            Box::pin(async { Ok(()) })
+        async fn install(&self) -> std::result::Result<(), String> {
+            Ok(())
         }
 
-        fn uninstall(
-            &self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<'_, std::result::Result<(), String>>
-        {
-            Box::pin(async { Ok(()) })
+        async fn uninstall(&self) -> std::result::Result<(), String> {
+            Ok(())
         }
 
-        fn start_daemon(
-            &self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<'_, std::result::Result<(), String>>
-        {
-            Box::pin(async { Ok(()) })
+        async fn start_daemon(&self) -> std::result::Result<(), String> {
+            Ok(())
         }
 
-        fn stop_daemon(
-            &self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<'_, std::result::Result<(), String>>
-        {
-            Box::pin(async { Ok(()) })
+        async fn stop_daemon(&self) -> std::result::Result<(), String> {
+            Ok(())
         }
 
-        fn update(
-            &self,
-        ) -> crate::core::actor_v2::endpoint::BoxFuture<'_, std::result::Result<(), String>>
-        {
-            Box::pin(async { Ok(()) })
+        async fn update(&self) -> std::result::Result<(), String> {
+            Ok(())
         }
 
         fn endpoint(&self) -> crate::core::actor_v2::endpoint::EndpointHandle {

--- a/backend/tauri/src/core/actor_v2/endpoint.rs
+++ b/backend/tauri/src/core/actor_v2/endpoint.rs
@@ -12,7 +12,7 @@
 //! lifecycle state (invariant I-R3). The normalized snapshot below is a
 //! field-by-field projection of what the host published, nothing more.
 
-use std::{borrow::Cow, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{borrow::Cow, sync::Arc, time::Duration};
 
 use nyanpasu_core_manager::{
     ApplyOutcome, CoreCommandEnvelope, CoreControl, CoreError, CoreErrorKind, CoreKind,
@@ -25,8 +25,6 @@ use nyanpasu_ipc::api::{
     },
     status::{CoreInfos, CoreStateDetail},
 };
-
-pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Which controller owns the runtime. The app perceives the difference in
 /// exactly two places: this tag on the endpoint slot, and the handoff
@@ -72,25 +70,19 @@ pub struct CoreSubmission {
 /// One host's control plane, as the router consumes it. Submit is the only
 /// mutating call and is always envelope-shaped; waiting on an operation is a
 /// read and deliberately not routed through the actor mailbox.
+#[async_trait::async_trait]
 pub trait ControlEndpoint: Send + Sync {
     fn host(&self) -> ExecutionHost;
 
     /// Admission into the host's executor. Returns the operation's
     /// admission-time snapshot; the transaction survives this future's drop.
-    fn submit<'a>(
-        &'a self,
-        submission: CoreSubmission,
-    ) -> BoxFuture<'a, Result<OperationInfo, CoreError>>;
+    async fn submit(&self, submission: CoreSubmission) -> Result<OperationInfo, CoreError>;
 
     /// Long-poll the host's registry. `None` = unknown/evicted id (recover by
     /// re-reading status; the revision CAS blocks double application).
-    fn wait_operation<'a>(
-        &'a self,
-        id: OperationId,
-        timeout: Duration,
-    ) -> BoxFuture<'a, Option<OperationInfo>>;
+    async fn wait_operation(&self, id: OperationId, timeout: Duration) -> Option<OperationInfo>;
 
-    fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>>;
+    async fn status(&self) -> Result<CoreStatusSnapshot, CoreError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -107,36 +99,26 @@ impl LocalEndpoint {
     }
 }
 
+#[async_trait::async_trait]
 impl ControlEndpoint for LocalEndpoint {
     fn host(&self) -> ExecutionHost {
         ExecutionHost::Local
     }
 
-    fn submit<'a>(
-        &'a self,
-        submission: CoreSubmission,
-    ) -> BoxFuture<'a, Result<OperationInfo, CoreError>> {
-        Box::pin(async move {
-            let handle = self.control.submit(submission.envelope)?;
-            Ok(map_local_operation(handle.id(), handle.state()))
-        })
+    async fn submit(&self, submission: CoreSubmission) -> Result<OperationInfo, CoreError> {
+        let handle = self.control.submit(submission.envelope)?;
+        Ok(map_local_operation(handle.id(), handle.state()))
     }
 
-    fn wait_operation<'a>(
-        &'a self,
-        id: OperationId,
-        timeout: Duration,
-    ) -> BoxFuture<'a, Option<OperationInfo>> {
-        Box::pin(async move {
-            self.control
-                .wait_operation(id, timeout)
-                .await
-                .map(|state| map_local_operation(id, state))
-        })
+    async fn wait_operation(&self, id: OperationId, timeout: Duration) -> Option<OperationInfo> {
+        self.control
+            .wait_operation(id, timeout)
+            .await
+            .map(|state| map_local_operation(id, state))
     }
 
-    fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
-        Box::pin(async move { Ok(map_local_status(&self.control.status())) })
+    async fn status(&self) -> Result<CoreStatusSnapshot, CoreError> {
+        Ok(map_local_status(&self.control.status()))
     }
 }
 
@@ -302,56 +284,44 @@ fn map_client_error(error: nyanpasu_ipc::client::ClientError) -> CoreError {
     }
 }
 
+#[async_trait::async_trait]
 impl ControlEndpoint for ServiceEndpoint {
     fn host(&self) -> ExecutionHost {
         ExecutionHost::Service
     }
 
-    fn submit<'a>(
-        &'a self,
-        submission: CoreSubmission,
-    ) -> BoxFuture<'a, Result<OperationInfo, CoreError>> {
-        Box::pin(async move {
-            let request = wire_submit_request(&submission)?;
-            self.client
-                .submit_core(&request)
-                .await
-                .map_err(map_client_error)
-        })
+    async fn submit(&self, submission: CoreSubmission) -> Result<OperationInfo, CoreError> {
+        let request = wire_submit_request(&submission)?;
+        self.client
+            .submit_core(&request)
+            .await
+            .map_err(map_client_error)
     }
 
-    fn wait_operation<'a>(
-        &'a self,
-        id: OperationId,
-        timeout: Duration,
-    ) -> BoxFuture<'a, Option<OperationInfo>> {
-        Box::pin(async move {
-            let id = id.to_string();
-            let request = CoreOperationReq {
-                operation_id: Cow::Borrowed(id.as_str()),
-                wait_ms: Some(timeout.as_millis().min(u128::from(u64::MAX)) as u64),
-            };
-            // Transport failure and "unknown id" both surface as None here;
-            // the caller's recovery path (re-read status + CAS) covers both.
-            self.client
-                .core_operation(&request)
-                .await
-                .inspect_err(|error| {
-                    tracing::debug!("operation {id} could not be waited on: {error}");
-                })
-                .ok()
-        })
+    async fn wait_operation(&self, id: OperationId, timeout: Duration) -> Option<OperationInfo> {
+        let id = id.to_string();
+        let request = CoreOperationReq {
+            operation_id: Cow::Borrowed(id.as_str()),
+            wait_ms: Some(timeout.as_millis().min(u128::from(u64::MAX)) as u64),
+        };
+        // Transport failure and "unknown id" both surface as None here;
+        // the caller's recovery path (re-read status + CAS) covers both.
+        self.client
+            .core_operation(&request)
+            .await
+            .inspect_err(|error| {
+                tracing::debug!("operation {id} could not be waited on: {error}");
+            })
+            .ok()
     }
 
-    fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
-        Box::pin(async move {
-            let infos = self
-                .client
-                .core_status_v2()
-                .await
-                .map_err(map_client_error)?;
-            Ok(map_service_status(&infos))
-        })
+    async fn status(&self) -> Result<CoreStatusSnapshot, CoreError> {
+        let infos = self
+            .client
+            .core_status_v2()
+            .await
+            .map_err(map_client_error)?;
+        Ok(map_service_status(&infos))
     }
 }
 

--- a/backend/tauri/src/core/actor_v2/facade.rs
+++ b/backend/tauri/src/core/actor_v2/facade.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use futures_util::future::{BoxFuture, FutureExt, Shared};
+use futures::future::{BoxFuture, FutureExt, Shared};
 use nyanpasu_config::application::ClashCore;
 use nyanpasu_core_manager::{
     ConfigInput, CoreCommand, CoreCommandEnvelope, CoreError, CoreErrorKind, CoreSpec, Epoch,
@@ -361,7 +361,7 @@ mod tests {
 
     use super::*;
     use crate::core::actor_v2::{
-        endpoint::{BoxFuture, ControlEndpoint, CoreStatusSnapshot},
+        endpoint::{ControlEndpoint, CoreStatusSnapshot},
         service_actor::ServiceHostAdapter,
     };
 
@@ -427,47 +427,39 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl ControlEndpoint for RecordingEndpoint {
         fn host(&self) -> ExecutionHost {
             self.host
         }
 
-        fn submit<'a>(
-            &'a self,
-            submission: CoreSubmission,
-        ) -> BoxFuture<'a, Result<OperationInfo, CoreError>> {
-            Box::pin(async move {
-                if matches!(submission.envelope.command, CoreCommand::Stop) {
-                    self.stops.fetch_add(1, Ordering::SeqCst);
-                }
-                let info = self.operation(&submission);
-                self.submissions.lock().unwrap().push(submission);
-                Ok(info)
-            })
+        async fn submit(&self, submission: CoreSubmission) -> Result<OperationInfo, CoreError> {
+            if matches!(submission.envelope.command, CoreCommand::Stop) {
+                self.stops.fetch_add(1, Ordering::SeqCst);
+            }
+            let info = self.operation(&submission);
+            self.submissions.lock().unwrap().push(submission);
+            Ok(info)
         }
 
-        fn wait_operation<'a>(
-            &'a self,
+        async fn wait_operation(
+            &self,
             id: OperationId,
             _timeout: Duration,
-        ) -> BoxFuture<'a, Option<OperationInfo>> {
-            Box::pin(async move {
-                self.submissions
-                    .lock()
-                    .unwrap()
-                    .iter()
-                    .find(|submission| submission.envelope.operation_id == id)
-                    .map(|submission| self.operation(submission))
-            })
+        ) -> Option<OperationInfo> {
+            self.submissions
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|submission| submission.envelope.operation_id == id)
+                .map(|submission| self.operation(submission))
         }
 
-        fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
-            Box::pin(async move {
-                if self.host == ExecutionHost::Service {
-                    self.calls.lock().unwrap().push("change_host");
-                }
-                Ok(self.status.clone())
-            })
+        async fn status(&self) -> Result<CoreStatusSnapshot, CoreError> {
+            if self.host == ExecutionHost::Service {
+                self.calls.lock().unwrap().push("change_host");
+            }
+            Ok(self.status.clone())
         }
     }
 
@@ -476,52 +468,51 @@ mod tests {
         calls: Arc<Mutex<Vec<&'static str>>>,
     }
 
+    #[async_trait::async_trait]
     impl ServiceHostAdapter for ReadyService {
-        fn probe(&self) -> BoxFuture<'_, Result<StatusInfo<'static>, String>> {
-            Box::pin(async move {
-                self.calls.lock().unwrap().push("ensure_ready");
-                Ok(StatusInfo {
-                    name: Cow::Borrowed("nyanpasu-service"),
-                    version: Cow::Borrowed("test"),
-                    status: ServiceStatus::Running,
-                    server: Some(StatusResBody {
-                        version: Cow::Borrowed("2.0.0"),
-                        core_infos: CoreInfos {
-                            r#type: None,
-                            state: CoreState::Running,
-                            state_changed_at: 1,
-                            config_path: None,
-                            controller: None,
-                            health: None,
-                            revision: None,
-                            detail: Some(CoreStateDetail::Stopped { reason: None }),
-                        },
-                        runtime_infos: RuntimeInfos {
-                            service_data_dir: Cow::Owned(Default::default()),
-                            service_config_dir: Cow::Owned(Default::default()),
-                            nyanpasu_config_dir: Cow::Owned(Default::default()),
-                            nyanpasu_data_dir: Cow::Owned(Default::default()),
-                        },
-                        logs: None,
-                    }),
-                })
+        async fn probe(&self) -> Result<StatusInfo<'static>, String> {
+            self.calls.lock().unwrap().push("ensure_ready");
+            Ok(StatusInfo {
+                name: Cow::Borrowed("nyanpasu-service"),
+                version: Cow::Borrowed("test"),
+                status: ServiceStatus::Running,
+                server: Some(StatusResBody {
+                    version: Cow::Borrowed("2.0.0"),
+                    core_infos: CoreInfos {
+                        r#type: None,
+                        state: CoreState::Running,
+                        state_changed_at: 1,
+                        config_path: None,
+                        controller: None,
+                        health: None,
+                        revision: None,
+                        detail: Some(CoreStateDetail::Stopped { reason: None }),
+                    },
+                    runtime_infos: RuntimeInfos {
+                        service_data_dir: Cow::Owned(Default::default()),
+                        service_config_dir: Cow::Owned(Default::default()),
+                        nyanpasu_config_dir: Cow::Owned(Default::default()),
+                        nyanpasu_data_dir: Cow::Owned(Default::default()),
+                    },
+                    logs: None,
+                }),
             })
         }
 
-        fn install(&self) -> BoxFuture<'_, Result<(), String>> {
-            Box::pin(async { Ok(()) })
+        async fn install(&self) -> Result<(), String> {
+            Ok(())
         }
-        fn uninstall(&self) -> BoxFuture<'_, Result<(), String>> {
-            Box::pin(async { Ok(()) })
+        async fn uninstall(&self) -> Result<(), String> {
+            Ok(())
         }
-        fn start_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
-            Box::pin(async { Ok(()) })
+        async fn start_daemon(&self) -> Result<(), String> {
+            Ok(())
         }
-        fn stop_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
-            Box::pin(async { Ok(()) })
+        async fn stop_daemon(&self) -> Result<(), String> {
+            Ok(())
         }
-        fn update(&self) -> BoxFuture<'_, Result<(), String>> {
-            Box::pin(async { Ok(()) })
+        async fn update(&self) -> Result<(), String> {
+            Ok(())
         }
         fn endpoint(&self) -> crate::core::actor_v2::endpoint::EndpointHandle {
             self.endpoint.clone()

--- a/backend/tauri/src/core/actor_v2/service_actor.rs
+++ b/backend/tauri/src/core/actor_v2/service_actor.rs
@@ -18,6 +18,7 @@
 
 use std::sync::Arc;
 
+use futures::future::BoxFuture;
 use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
 use tokio::sync::watch;
 
@@ -27,7 +28,7 @@ use nyanpasu_ipc::{
     types::{ServiceStatus, StatusInfo},
 };
 
-use super::endpoint::{BoxFuture, EndpointHandle};
+use super::endpoint::EndpointHandle;
 use crate::core::service::compat::ServiceCompat;
 
 /// Elevated daemon mechanics behind one narrow boundary. `probe` reports
@@ -36,13 +37,14 @@ use crate::core::service::compat::ServiceCompat;
 /// every call here (including `probe`) with its own timeout and turns an
 /// elapsed bound into the same `Err` shape, so a hung daemon surfaces as
 /// `ServicePhase::Unknown`, not as evidence of anything.
+#[async_trait::async_trait]
 pub trait ServiceHostAdapter: Send + Sync {
-    fn probe(&self) -> BoxFuture<'_, Result<StatusInfo<'static>, String>>;
-    fn install(&self) -> BoxFuture<'_, Result<(), String>>;
-    fn uninstall(&self) -> BoxFuture<'_, Result<(), String>>;
-    fn start_daemon(&self) -> BoxFuture<'_, Result<(), String>>;
-    fn stop_daemon(&self) -> BoxFuture<'_, Result<(), String>>;
-    fn update(&self) -> BoxFuture<'_, Result<(), String>>;
+    async fn probe(&self) -> Result<StatusInfo<'static>, String>;
+    async fn install(&self) -> Result<(), String>;
+    async fn uninstall(&self) -> Result<(), String>;
+    async fn start_daemon(&self) -> Result<(), String>;
+    async fn stop_daemon(&self) -> Result<(), String>;
+    async fn update(&self) -> Result<(), String>;
     /// The v2 control endpoint for a daemon that passed the version gate.
     fn endpoint(&self) -> EndpointHandle;
 }
@@ -822,129 +824,120 @@ mod tests {
     }
 
     struct NullEndpoint;
+    #[async_trait::async_trait]
     impl ControlEndpoint for NullEndpoint {
         fn host(&self) -> ExecutionHost {
             ExecutionHost::Service
         }
-        fn submit<'a>(
-            &'a self,
+        async fn submit(
+            &self,
             _submission: CoreSubmission,
-        ) -> BoxFuture<'a, Result<nyanpasu_ipc::api::core::v2::OperationInfo, CoreError>> {
+        ) -> Result<nyanpasu_ipc::api::core::v2::OperationInfo, CoreError> {
             unimplemented!("routing is the CoreActor business")
         }
-        fn wait_operation<'a>(
-            &'a self,
+        async fn wait_operation(
+            &self,
             _id: nyanpasu_core_manager::OperationId,
             _timeout: std::time::Duration,
-        ) -> BoxFuture<'a, Option<nyanpasu_ipc::api::core::v2::OperationInfo>> {
+        ) -> Option<nyanpasu_ipc::api::core::v2::OperationInfo> {
             unimplemented!()
         }
-        fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
+        async fn status(&self) -> Result<CoreStatusSnapshot, CoreError> {
             unimplemented!()
         }
     }
 
+    #[async_trait::async_trait]
     impl ServiceHostAdapter for FakeDaemon {
-        fn probe(&self) -> BoxFuture<'_, Result<StatusInfo<'static>, String>> {
-            Box::pin(async move {
-                self.calls.lock().unwrap().push("probe");
-                if self.probe_fail.load(Ordering::SeqCst) {
-                    return Err("probe unreachable".to_owned());
-                }
-                let (installed, running, version) = self.state.lock().unwrap().clone();
-                let status = match (installed, running) {
-                    (false, _) => ServiceStatus::NotInstalled,
-                    (true, false) => ServiceStatus::Stopped,
-                    (true, true) => ServiceStatus::Running,
-                };
-                let detail = self.core_detail.lock().unwrap().clone();
-                let blind = self.probe_blind.load(Ordering::SeqCst);
-                let server = (installed && running && !blind).then(|| StatusResBody {
-                    version: Cow::Owned(version.clone()),
-                    core_infos: CoreInfos {
-                        r#type: None,
-                        // The coarse projection a real daemon publishes: every
-                        // transitional detail collapses into one of these two
-                        // shapes, which is exactly why it cannot be a guard.
-                        state: match detail {
-                            Some(CoreStateDetail::Running { .. })
-                            | Some(CoreStateDetail::Switching { .. })
-                            | Some(CoreStateDetail::Stopping { .. }) => CoreState::Running,
-                            _ => CoreState::Stopped(None),
-                        },
-                        state_changed_at: 0,
-                        config_path: None,
-                        controller: None,
-                        health: None,
-                        revision: None,
-                        detail,
+        async fn probe(&self) -> Result<StatusInfo<'static>, String> {
+            self.calls.lock().unwrap().push("probe");
+            if self.probe_fail.load(Ordering::SeqCst) {
+                return Err("probe unreachable".to_owned());
+            }
+            let (installed, running, version) = self.state.lock().unwrap().clone();
+            let status = match (installed, running) {
+                (false, _) => ServiceStatus::NotInstalled,
+                (true, false) => ServiceStatus::Stopped,
+                (true, true) => ServiceStatus::Running,
+            };
+            let detail = self.core_detail.lock().unwrap().clone();
+            let blind = self.probe_blind.load(Ordering::SeqCst);
+            let server = (installed && running && !blind).then(|| StatusResBody {
+                version: Cow::Owned(version.clone()),
+                core_infos: CoreInfos {
+                    r#type: None,
+                    // The coarse projection a real daemon publishes: every
+                    // transitional detail collapses into one of these two
+                    // shapes, which is exactly why it cannot be a guard.
+                    state: match detail {
+                        Some(CoreStateDetail::Running { .. })
+                        | Some(CoreStateDetail::Switching { .. })
+                        | Some(CoreStateDetail::Stopping { .. }) => CoreState::Running,
+                        _ => CoreState::Stopped(None),
                     },
-                    runtime_infos: nyanpasu_ipc::api::status::RuntimeInfos {
-                        service_data_dir: Cow::Owned(std::path::PathBuf::new()),
-                        service_config_dir: Cow::Owned(std::path::PathBuf::new()),
-                        nyanpasu_config_dir: Cow::Owned(std::path::PathBuf::new()),
-                        nyanpasu_data_dir: Cow::Owned(std::path::PathBuf::new()),
-                    },
-                    logs: None,
-                });
-                Ok(StatusInfo {
-                    name: Cow::Borrowed("nyanpasu-service"),
-                    version: Cow::Borrowed("test"),
-                    status,
-                    server,
-                })
+                    state_changed_at: 0,
+                    config_path: None,
+                    controller: None,
+                    health: None,
+                    revision: None,
+                    detail,
+                },
+                runtime_infos: nyanpasu_ipc::api::status::RuntimeInfos {
+                    service_data_dir: Cow::Owned(std::path::PathBuf::new()),
+                    service_config_dir: Cow::Owned(std::path::PathBuf::new()),
+                    nyanpasu_config_dir: Cow::Owned(std::path::PathBuf::new()),
+                    nyanpasu_data_dir: Cow::Owned(std::path::PathBuf::new()),
+                },
+                logs: None,
+            });
+            Ok(StatusInfo {
+                name: Cow::Borrowed("nyanpasu-service"),
+                version: Cow::Borrowed("test"),
+                status,
+                server,
             })
         }
-        fn install(&self) -> BoxFuture<'_, Result<(), String>> {
+        async fn install(&self) -> Result<(), String> {
             if self.hang_install.load(Ordering::SeqCst) {
                 // Never resolves: only the actor's own `command_timeout`
                 // bound (F6) can end this call.
-                return Box::pin(std::future::pending::<Result<(), String>>());
+                return std::future::pending::<Result<(), String>>().await;
             }
-            Box::pin(async move {
-                self.installs.fetch_add(1, Ordering::SeqCst);
-                if self.fail_install.load(Ordering::SeqCst) {
-                    return Err("install refused".to_owned());
-                }
-                let mut state = self.state.lock().unwrap();
-                state.0 = true;
-                state.1 = true; // install auto-starts, like most platforms
-                Ok(())
-            })
+
+            self.installs.fetch_add(1, Ordering::SeqCst);
+            if self.fail_install.load(Ordering::SeqCst) {
+                return Err("install refused".to_owned());
+            }
+            let mut state = self.state.lock().unwrap();
+            state.0 = true;
+            state.1 = true; // install auto-starts, like most platforms
+            Ok(())
         }
-        fn uninstall(&self) -> BoxFuture<'_, Result<(), String>> {
-            Box::pin(async move {
-                self.calls.lock().unwrap().push("uninstall");
-                self.uninstalls.fetch_add(1, Ordering::SeqCst);
-                *self.state.lock().unwrap() = (false, false, String::new());
-                Ok(())
-            })
+        async fn uninstall(&self) -> Result<(), String> {
+            self.calls.lock().unwrap().push("uninstall");
+            self.uninstalls.fetch_add(1, Ordering::SeqCst);
+            *self.state.lock().unwrap() = (false, false, String::new());
+            Ok(())
         }
-        fn start_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
-            Box::pin(async move {
-                self.starts.fetch_add(1, Ordering::SeqCst);
-                if self.fail_start.load(Ordering::SeqCst) {
-                    return Err("start refused".to_owned());
-                }
-                self.state.lock().unwrap().1 = true;
-                Ok(())
-            })
+        async fn start_daemon(&self) -> Result<(), String> {
+            self.starts.fetch_add(1, Ordering::SeqCst);
+            if self.fail_start.load(Ordering::SeqCst) {
+                return Err("start refused".to_owned());
+            }
+            self.state.lock().unwrap().1 = true;
+            Ok(())
         }
-        fn stop_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
-            Box::pin(async move {
-                self.calls.lock().unwrap().push("stop_daemon");
-                if self.stop_succeeds.load(Ordering::SeqCst) {
-                    self.state.lock().unwrap().1 = false;
-                }
-                Ok(())
-            })
+        async fn stop_daemon(&self) -> Result<(), String> {
+            self.calls.lock().unwrap().push("stop_daemon");
+            if self.stop_succeeds.load(Ordering::SeqCst) {
+                self.state.lock().unwrap().1 = false;
+            }
+            Ok(())
         }
-        fn update(&self) -> BoxFuture<'_, Result<(), String>> {
-            Box::pin(async move {
-                self.updates.fetch_add(1, Ordering::SeqCst);
-                self.state.lock().unwrap().2 = "2.0.0".to_owned();
-                Ok(())
-            })
+        async fn update(&self) -> Result<(), String> {
+            self.updates.fetch_add(1, Ordering::SeqCst);
+            self.state.lock().unwrap().2 = "2.0.0".to_owned();
+            Ok(())
         }
         fn endpoint(&self) -> EndpointHandle {
             Arc::new(NullEndpoint)
@@ -981,24 +974,25 @@ mod tests {
         // The startup auto-update is stubbed into a no-op that leaves the old
         // version in place.
         struct StubbornDaemon(Arc<FakeDaemon>);
+        #[async_trait::async_trait]
         impl ServiceHostAdapter for StubbornDaemon {
-            fn probe(&self) -> BoxFuture<'_, Result<StatusInfo<'static>, String>> {
-                self.0.probe()
+            async fn probe(&self) -> Result<StatusInfo<'static>, String> {
+                self.0.probe().await
             }
-            fn install(&self) -> BoxFuture<'_, Result<(), String>> {
-                self.0.install()
+            async fn install(&self) -> Result<(), String> {
+                self.0.install().await
             }
-            fn uninstall(&self) -> BoxFuture<'_, Result<(), String>> {
-                self.0.uninstall()
+            async fn uninstall(&self) -> Result<(), String> {
+                self.0.uninstall().await
             }
-            fn start_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
-                self.0.start_daemon()
+            async fn start_daemon(&self) -> Result<(), String> {
+                self.0.start_daemon().await
             }
-            fn stop_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
-                self.0.stop_daemon()
+            async fn stop_daemon(&self) -> Result<(), String> {
+                self.0.stop_daemon().await
             }
-            fn update(&self) -> BoxFuture<'_, Result<(), String>> {
-                Box::pin(async { Ok(()) }) // succeeds without changing anything
+            async fn update(&self) -> Result<(), String> {
+                Ok(()) // succeeds without changing anything
             }
             fn endpoint(&self) -> EndpointHandle {
                 self.0.endpoint()
@@ -1357,24 +1351,25 @@ mod tests {
         // Stub the startup auto-update so the daemon stays `Incompatible`
         // instead of being upgraded by `pre_start`.
         struct StubbornDaemon(Arc<FakeDaemon>);
+        #[async_trait::async_trait]
         impl ServiceHostAdapter for StubbornDaemon {
-            fn probe(&self) -> BoxFuture<'_, Result<StatusInfo<'static>, String>> {
-                self.0.probe()
+            async fn probe(&self) -> Result<StatusInfo<'static>, String> {
+                self.0.probe().await
             }
-            fn install(&self) -> BoxFuture<'_, Result<(), String>> {
-                self.0.install()
+            async fn install(&self) -> Result<(), String> {
+                self.0.install().await
             }
-            fn uninstall(&self) -> BoxFuture<'_, Result<(), String>> {
-                self.0.uninstall()
+            async fn uninstall(&self) -> Result<(), String> {
+                self.0.uninstall().await
             }
-            fn start_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
-                self.0.start_daemon()
+            async fn start_daemon(&self) -> Result<(), String> {
+                self.0.start_daemon().await
             }
-            fn stop_daemon(&self) -> BoxFuture<'_, Result<(), String>> {
-                self.0.stop_daemon()
+            async fn stop_daemon(&self) -> Result<(), String> {
+                self.0.stop_daemon().await
             }
-            fn update(&self) -> BoxFuture<'_, Result<(), String>> {
-                Box::pin(async { Ok(()) }) // succeeds without changing anything
+            async fn update(&self) -> Result<(), String> {
+                Ok(()) // succeeds without changing anything
             }
             fn endpoint(&self) -> EndpointHandle {
                 self.0.endpoint()

--- a/backend/tauri/src/core/actor_v2/service_host_adapter.rs
+++ b/backend/tauri/src/core/actor_v2/service_host_adapter.rs
@@ -13,56 +13,42 @@ use super::{
 
 pub struct OsServiceHostAdapter;
 
+#[async_trait::async_trait]
 impl ServiceHostAdapter for OsServiceHostAdapter {
-    fn probe(
-        &self,
-    ) -> super::endpoint::BoxFuture<'_, Result<nyanpasu_ipc::types::StatusInfo<'static>, String>>
-    {
-        Box::pin(async {
-            crate::core::service::control::status()
-                .await
-                .map_err(|e| e.to_string())
-        })
+    async fn probe(&self) -> Result<nyanpasu_ipc::types::StatusInfo<'static>, String> {
+        crate::core::service::control::status()
+            .await
+            .map_err(|e| e.to_string())
     }
 
-    fn install(&self) -> super::endpoint::BoxFuture<'_, Result<(), String>> {
-        Box::pin(async {
-            crate::core::service::control::install_service()
-                .await
-                .map_err(|e| e.to_string())
-        })
+    async fn install(&self) -> Result<(), String> {
+        crate::core::service::control::install_service()
+            .await
+            .map_err(|e| e.to_string())
     }
 
-    fn uninstall(&self) -> super::endpoint::BoxFuture<'_, Result<(), String>> {
-        Box::pin(async {
-            crate::core::service::control::uninstall_service()
-                .await
-                .map_err(|e| e.to_string())
-        })
+    async fn uninstall(&self) -> Result<(), String> {
+        crate::core::service::control::uninstall_service()
+            .await
+            .map_err(|e| e.to_string())
     }
 
-    fn start_daemon(&self) -> super::endpoint::BoxFuture<'_, Result<(), String>> {
-        Box::pin(async {
-            crate::core::service::control::start_service()
-                .await
-                .map_err(|e| e.to_string())
-        })
+    async fn start_daemon(&self) -> Result<(), String> {
+        crate::core::service::control::start_service()
+            .await
+            .map_err(|e| e.to_string())
     }
 
-    fn stop_daemon(&self) -> super::endpoint::BoxFuture<'_, Result<(), String>> {
-        Box::pin(async {
-            crate::core::service::control::stop_service()
-                .await
-                .map_err(|e| e.to_string())
-        })
+    async fn stop_daemon(&self) -> Result<(), String> {
+        crate::core::service::control::stop_service()
+            .await
+            .map_err(|e| e.to_string())
     }
 
-    fn update(&self) -> super::endpoint::BoxFuture<'_, Result<(), String>> {
-        Box::pin(async {
-            crate::core::service::control::update_service()
-                .await
-                .map_err(|e| e.to_string())
-        })
+    async fn update(&self) -> Result<(), String> {
+        crate::core::service::control::update_service()
+            .await
+            .map_err(|e| e.to_string())
     }
 
     // TODO(actor-migration): temporary bridge to the process-wide

--- a/backend/tauri/src/core/actor_v2/tests.rs
+++ b/backend/tauri/src/core/actor_v2/tests.rs
@@ -23,7 +23,7 @@ use nyanpasu_ipc::api::{
 use super::{
     CoreActorMessage, CoreClient, CoreSubmission, EndpointConnectivity, HandoffReport, STOP_WAIT,
     ShutdownReport,
-    endpoint::{BoxFuture, ControlEndpoint, CoreStatusSnapshot, EndpointHandle, ExecutionHost},
+    endpoint::{ControlEndpoint, CoreStatusSnapshot, EndpointHandle, ExecutionHost},
 };
 
 /// The three answers a host gives are scripted independently, because the
@@ -168,69 +168,61 @@ fn snapshot(state: CoreStateDetail) -> CoreStatusSnapshot {
     }
 }
 
+#[async_trait::async_trait]
 impl ControlEndpoint for FakeEndpoint {
     fn host(&self) -> ExecutionHost {
         self.host
     }
 
-    fn submit<'a>(
-        &'a self,
-        submission: CoreSubmission,
-    ) -> BoxFuture<'a, Result<OperationInfo, CoreError>> {
-        Box::pin(async move {
-            if self.hang_submit.load(Ordering::SeqCst) {
-                self.never.notified().await;
-                unreachable!("nothing notifies `never`");
-            }
-            self.submits.fetch_add(1, Ordering::SeqCst);
-            *self.last_core_type.lock().unwrap() = Some(submission.core_type.clone());
-            let envelope = submission.envelope;
-            let id = envelope.operation_id.to_string();
-            if matches!(envelope.command, CoreCommand::Stop) {
-                self.stops.fetch_add(1, Ordering::SeqCst);
-            }
-            Ok(OperationInfo {
-                id: self.echo_id.lock().unwrap().clone().unwrap_or(id),
-                phase: OperationPhase::Queued,
-                output: None,
-                error: None,
-            })
+    async fn submit(&self, submission: CoreSubmission) -> Result<OperationInfo, CoreError> {
+        if self.hang_submit.load(Ordering::SeqCst) {
+            self.never.notified().await;
+            unreachable!("nothing notifies `never`");
+        }
+        self.submits.fetch_add(1, Ordering::SeqCst);
+        *self.last_core_type.lock().unwrap() = Some(submission.core_type.clone());
+        let envelope = submission.envelope;
+        let id = envelope.operation_id.to_string();
+        if matches!(envelope.command, CoreCommand::Stop) {
+            self.stops.fetch_add(1, Ordering::SeqCst);
+        }
+        Ok(OperationInfo {
+            id: self.echo_id.lock().unwrap().clone().unwrap_or(id),
+            phase: OperationPhase::Queued,
+            output: None,
+            error: None,
         })
     }
 
-    fn wait_operation<'a>(
-        &'a self,
+    async fn wait_operation(
+        &self,
         id: OperationId,
         _timeout: std::time::Duration,
-    ) -> BoxFuture<'a, Option<OperationInfo>> {
-        Box::pin(async move {
-            self.waits.fetch_add(1, Ordering::SeqCst);
-            // The gate lives on the long poll, which is where a real stop
-            // spends its time.
-            if self.gate_stop.load(Ordering::SeqCst) {
-                self.stop_started.notify_one();
-                self.release_stop.notified().await;
-            }
-            if matches!(*self.stop_result.lock().unwrap(), StopScript::Lost) {
-                return None;
-            }
-            Some(self.stop_info(id.to_string()))
-        })
+    ) -> Option<OperationInfo> {
+        self.waits.fetch_add(1, Ordering::SeqCst);
+        // The gate lives on the long poll, which is where a real stop
+        // spends its time.
+        if self.gate_stop.load(Ordering::SeqCst) {
+            self.stop_started.notify_one();
+            self.release_stop.notified().await;
+        }
+        if matches!(*self.stop_result.lock().unwrap(), StopScript::Lost) {
+            return None;
+        }
+        Some(self.stop_info(id.to_string()))
     }
 
-    fn status<'a>(&'a self) -> BoxFuture<'a, Result<CoreStatusSnapshot, CoreError>> {
-        Box::pin(async move {
-            if self.hang_status.load(Ordering::SeqCst) {
-                let _dropped = self.status_dropped.lock().unwrap().take();
-                self.never.notified().await;
-                unreachable!("nothing notifies `never`");
-            }
-            self.status
-                .lock()
-                .unwrap()
-                .clone()
-                .map_err(|reason| CoreError::new(CoreErrorKind::BackendUnavailable, reason, true))
-        })
+    async fn status(&self) -> Result<CoreStatusSnapshot, CoreError> {
+        if self.hang_status.load(Ordering::SeqCst) {
+            let _dropped = self.status_dropped.lock().unwrap().take();
+            self.never.notified().await;
+            unreachable!("nothing notifies `never`");
+        }
+        self.status
+            .lock()
+            .unwrap()
+            .clone()
+            .map_err(|reason| CoreError::new(CoreErrorKind::BackendUnavailable, reason, true))
     }
 }
 


### PR DESCRIPTION
The control-plane ports required hand-written boxed-future signatures and manual boxing in every adapter and test double. Convert `ControlEndpoint` and `ServiceHostAdapter` to `async-trait`, including all implementations, preserving their injected trait-object boundaries and Send futures.

Remove the local `BoxFuture` alias. The remaining explicit uses, shared shutdown and bounded service calls, now import `futures::future::BoxFuture` directly. No dependency changes are needed. The independently versioned `nyanpasu-runtime` submodule stays on its released pin.

Validation:

- Baseline actor suite: 68 passed.
- Backend library suite: 460 passed, 1 ignored; the binding-export test initially lacked the fresh worktree's Prettier plugins, then passed after `pnpm install --frozen-lockfile` (461 passing tests in total).
- Changed Rust files pass rustfmt; `git diff --check` passes.
- Commit hooks passed: cargo clippy --all-targets --all-features, workspace cargo fmt, and commitlint.
