### PR TITLE
fix(core): find core binaries in the externalBin dir during dev

### DIFF
--- a/backend/tauri/src/core/clash/mod.rs
+++ b/backend/tauri/src/core/clash/mod.rs
@@ -17,26 +17,60 @@ pub static CLASH_API_DEFAULT_BACKOFF_STRATEGY: Lazy<ExponentialBuilder> = Lazy::
 
 // TODO: support system path search via a config or flag
 // FIXME: move this fn to nyanpasu-utils
-/// Search the binary path of the core: Data Dir -> Sidecar Dir
+/// Search the binary path of the core. See [`binary_candidates`] for the
+/// search locations and their priority.
 pub fn find_binary_path(
     core_type: &nyanpasu_utils::core::CoreType,
 ) -> std::io::Result<std::path::PathBuf> {
-    let data_dir = crate::utils::dirs::app_data_dir()
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::NotFound, err.to_string()))?;
-    let binary_path = data_dir.join(core_type.get_executable_name());
-    if binary_path.exists() {
-        return Ok(binary_path);
+    binary_candidates(core_type)
+        .into_iter()
+        .find(|path| path.exists())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("{} not found", core_type.get_executable_name()),
+            )
+        })
+}
+
+/// Candidate core binary paths in priority order: data dir -> install dir.
+/// Dev builds additionally register the downloaded `externalBin` sidecars
+/// (`<crate>/sidecar/`): unlike `tauri build`, where the bundler copies the
+/// sidecars next to the executable stripping the target-triple suffix,
+/// `tauri dev` copies nothing, so neither the app's exe dir nor Tauri's own
+/// sidecar lookup can find the cores there.
+fn binary_candidates(core_type: &nyanpasu_utils::core::CoreType) -> Vec<std::path::PathBuf> {
+    let name = core_type.get_executable_name();
+    let mut candidates = Vec::new();
+    if let Ok(data_dir) = crate::utils::dirs::app_data_dir() {
+        candidates.push(data_dir.join(name));
     }
-    let app_dir = crate::utils::dirs::app_install_dir()
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::NotFound, err.to_string()))?;
-    let binary_path = app_dir.join(core_type.get_executable_name());
-    if binary_path.exists() {
-        return Ok(binary_path);
+    if let Ok(app_dir) = crate::utils::dirs::app_install_dir() {
+        candidates.push(app_dir.join(name));
     }
-    Err(std::io::Error::new(
-        std::io::ErrorKind::NotFound,
-        format!("{} not found", core_type.get_executable_name()),
-    ))
+    #[cfg(debug_assertions)]
+    if let Some(path) = dev_sidecar_binary_path(core_type) {
+        candidates.push(path);
+    }
+    candidates
+}
+
+/// The sidecars keep the bundler's input naming `<name>-<target_triple>`
+/// (see `tauri::utils::platform::target_triple`).
+#[cfg(debug_assertions)]
+fn dev_sidecar_binary_path(
+    core_type: &nyanpasu_utils::core::CoreType,
+) -> Option<std::path::PathBuf> {
+    let name = core_type.get_executable_name();
+    let stem = name
+        .strip_suffix(std::env::consts::EXE_SUFFIX)
+        .unwrap_or(name);
+    let triple = tauri::utils::platform::target_triple().ok()?;
+    Some(
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("sidecar")
+            .join(format!("{stem}-{triple}{}", std::env::consts::EXE_SUFFIX)),
+    )
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Type, Event)]


### PR DESCRIPTION
## Problem

`pnpm dev` / `pnpm dev:diff` startup reported `BinaryNotFound` (e.g. `mihomo-alpha.exe not found`) from the startup `reconcile_core`, leaving dev instances unable to start any core.

Root cause: `find_binary_path` only looks in the app data dir and the install dir (the executable's directory). In dev the executable lives in `target/<profile>`, and unlike `tauri build` — where the bundler copies `externalBin` sidecars next to the executable, stripping the target-triple suffix — `tauri dev` copies nothing. A fresh dev data dir (the `verge-dev` instance uses a separate `Clash Nyanpasu Dev` dir) holds no cores either, so both locations miss.

## Change

Rework the lookup into a candidate list (data dir -> install dir) and, in debug builds only, register an extra candidate pointing at the sidecars downloaded by `pnpm prepare:check` into `<crate>/sidecar/`. Those files keep the bundler's input naming `<name>-<target_triple>`, resolved via `tauri::utils::platform::target_triple()` — the same helper Tauri's own sidecar resolution is built on.

Release builds are unchanged: the extra candidate only exists under `cfg(debug_assertions)`, and the lookup is read-only (nothing is copied or written).

## Verification

- `cargo check -p clash-nyanpasu --features verge-dev,deadlock-detection` (the `dev:diff` feature set)
- `cargo clippy --all-targets --all-features` + `cargo fmt` (via lint-staged)