### PR TITLE
fix: upgrade Boa to 0.22 and preserve YAML template nesting

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror 2.0.20",
  "v_frame",
@@ -1112,27 +1112,29 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
+checksum = "9221b0a090572b4a118b46c5874c0781fe4bc9546b85f0a615b8bfb609ca4ed7"
 dependencies = [
  "bitflags 2.13.1",
  "boa_interner",
  "boa_macros",
  "boa_string",
  "indexmap 2.14.1",
- "num-bigint",
+ "num-bigint 0.5.1",
  "rustc-hash 2.1.3",
+ "strum",
 ]
 
 [[package]]
 name = "boa_engine"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
+checksum = "5d6aaf7fdc4299df68adb67e1a5440a51d34630a1f5271b9698fd74bc97b60d9"
 dependencies = [
  "aligned-vec",
  "arrayvec",
+ "async-channel",
  "bitflags 2.13.1",
  "boa_ast",
  "boa_gc",
@@ -1147,21 +1149,22 @@ dependencies = [
  "dynify",
  "fast-float2",
  "float16",
- "futures-channel",
  "futures-concurrency",
  "futures-lite",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
+ "icu_calendar",
  "icu_normalizer",
  "indexmap 2.14.1",
  "intrusive-collections",
- "itertools 0.14.0",
- "num-bigint",
+ "itertools 0.15.0",
+ "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
  "num_enum",
- "paste",
+ "oneshot",
+ "pastey 0.2.3",
  "portable-atomic",
- "rand 0.9.5",
+ "rand 0.10.2",
  "regress",
  "rustc-hash 2.1.3",
  "ryu-js",
@@ -1171,59 +1174,62 @@ dependencies = [
  "static_assertions",
  "tag_ptr",
  "tap",
+ "temporal_rs",
  "thin-vec",
  "thiserror 2.0.20",
  "time",
+ "timezone_provider",
  "xsum",
 ]
 
 [[package]]
 name = "boa_gc"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
+checksum = "af82119558ab1002d1978c8459b53a3ebb506177d29a3aca37c07c1777b1d966"
 dependencies = [
+ "arrayvec",
  "boa_macros",
  "boa_string",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "thin-vec",
 ]
 
 [[package]]
 name = "boa_interner"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
+checksum = "317c631e791f5cb7d0017e43c0a758b0eaffd40c34c4c360e2a6be7752b78cd1"
 dependencies = [
  "boa_gc",
  "boa_macros",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.1",
  "once_cell",
- "phf 0.13.1",
+ "phf 0.14.0",
  "rustc-hash 2.1.3",
  "static_assertions",
 ]
 
 [[package]]
 name = "boa_macros"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
+checksum = "b882fd440dc0f4b7441367cf89567bb077920356750c9a76a16c002d8ec2fa5c"
 dependencies = [
  "cfg-if",
  "cow-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
- "synstructure",
+ "syn 3.0.4",
+ "synstructure 0.14.0",
 ]
 
 [[package]]
 name = "boa_parser"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
+checksum = "641e81b3c8cbb7a2140547fb3ea534e9edf210b4e8c920b5fa864a919e11fbcf"
 dependencies = [
  "bitflags 2.13.1",
  "boa_ast",
@@ -1231,7 +1237,7 @@ dependencies = [
  "boa_macros",
  "fast-float2",
  "icu_properties",
- "num-bigint",
+ "num-bigint 0.5.1",
  "num-traits",
  "regress",
  "rustc-hash 2.1.3",
@@ -1239,13 +1245,13 @@ dependencies = [
 
 [[package]]
 name = "boa_string"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
+checksum = "30bf86c2bcff5bf2547acbfc516c5d3108ca527cb131511d749bf6fbef762c0e"
 dependencies = [
  "fast-float2",
  "itoa",
- "paste",
+ "pastey 0.2.3",
  "rustc-hash 2.1.3",
  "ryu-js",
  "static_assertions",
@@ -1516,6 +1522,16 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "calendrical_calculations"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5abbd6eeda6885048d357edc66748eea6e0268e3dd11f326fff5bd248d779c26"
+dependencies = [
+ "core_maths",
+ "displaydoc",
 ]
 
 [[package]]
@@ -3483,9 +3499,9 @@ version = "0.1.0"
 
 [[package]]
 name = "fast-float2"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+checksum = "c6e8948ce679d00a02a94739ea185595dca7118ed04feb991127e443bd3d761f"
 
 [[package]]
 name = "fast_image_resize"
@@ -4475,8 +4491,6 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -4487,6 +4501,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -4746,13 +4762,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.0.0"
+name = "icu_calendar"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "58655df2f728e46e4eee80bddebefacf52ec3e77cdb925014b47c5a5905eb55c"
+dependencies = [
+ "calendrical_calculations",
+ "displaydoc",
+ "icu_calendar_data",
+ "icu_locale_core",
+ "icu_locale_fallback",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_calendar_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc00caaa3fb3201ff7a18aa458e8c3ab042b9da154cfdf948bdde3936c31c36e"
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -4760,9 +4799,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -4773,12 +4812,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_normalizer"
-version = "2.0.1"
+name = "icu_locale_fallback"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
+checksum = "251af8e57c9400e3eb58242fe5b8b1152b2a64fdf4cf632f923c38ccee6f2fa9"
 dependencies = [
- "displaydoc",
+ "icu_locale_core",
+ "icu_locale_fallback_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_fallback_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf2a22ec8fa68f1a0c1129a3f8583f8f8bc24e8b9ccbe98ead99f62a4dc3a8"
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -4791,37 +4849,36 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
  "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -5068,12 +5125,9 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.9.7"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
-dependencies = [
- "memoffset 0.9.1",
-]
+checksum = "4275b20e6057cd7733fd8df8a5a31701e4fe44497dad0f3fa0e1c4fb971506be"
 
 [[package]]
 name = "ipc-channel"
@@ -5197,6 +5251,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "ixdtf"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3667095d64c3ecffc96463a21157b04bf3e252f6e8d5750b20c02e33c194e3"
 
 [[package]]
 name = "javascriptcore-rs"
@@ -6245,6 +6305,16 @@ checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
  "serde",
 ]
 
@@ -6288,9 +6358,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -6301,7 +6371,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -7258,7 +7328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eef5f3e346539b48dbda9d0b618021ba6bb781f7a192476e4bf9b18df7ccaab4"
 dependencies = [
  "cow-utils",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "oxc_allocator",
  "oxc_ast",
@@ -7292,7 +7362,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cow-utils",
  "memchr",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "oxc_allocator",
  "oxc_ast",
@@ -7437,6 +7507,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pathsearch"
@@ -7801,9 +7877,9 @@ checksum = "325a6d2ac5dee293c3b2612d4993b98aec1dff096b0a2dae70ed7d95784a05da"
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -7833,6 +7909,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -8521,11 +8599,10 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "regress"
-version = "0.10.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+checksum = "32eef8b209c3c1c15dbad02c1f30f9539f00dc7253e0cbcdaae442a50a09d7c1"
 dependencies = [
- "hashbrown 0.16.1",
  "memchr",
 ]
 
@@ -10153,6 +10230,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901704edd0dfe137f1987838ee4f259e4e063c31371bdb423f7ae38ec6f77f02"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "sys-locale"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10802,6 +10890,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "temporal_rs"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a978fef907a27736827d336c0bfaab14fb8a7509dd6dc2b43c44e51d59aca5b"
+dependencies = [
+ "calendrical_calculations",
+ "core_maths",
+ "icu_calendar",
+ "icu_locale_core",
+ "ixdtf",
+ "num-traits",
+ "timezone_provider",
+ "tinystr",
+ "writeable",
+]
+
+[[package]]
 name = "tendril"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10924,9 +11029,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
 
 [[package]]
 name = "thiserror"
@@ -11035,6 +11140,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "timezone_provider"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ec4f4eebb4817fde02a411aedc7ac5f66c89c68c49e5d4b17a8139f077af52"
+dependencies = [
+ "tinystr",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11062,9 +11179,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -13391,9 +13508,9 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wry"
@@ -13592,7 +13709,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -13731,7 +13848,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -13742,9 +13859,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -13754,9 +13871,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "serde",
  "yoke",
@@ -13766,13 +13883,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1269,7 +1269,6 @@ dependencies = [
  "brotli",
  "futures-concurrency",
  "futures-util",
- "include-compress-bytes",
  "include_url_macro",
  "indoc",
  "log",
@@ -1599,12 +1598,6 @@ name = "cargo-emit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d1d6b8077d27443822a547d1ef816eadd2dc4a75de9105aff614192729cf6d3"
-
-[[package]]
-name = "cargo-emit"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1582e1c9e755dd6ad6b224dcffb135d199399a4568d454bd89fe515ca8425695"
 
 [[package]]
 name = "cargo-platform"
@@ -4981,26 +4974,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
-name = "include-compress-bytes"
-version = "0.1.0"
-source = "git+https://github.com/libnyanpasu/include-compress-bytes?rev=4e4f25b794ed0b9a323a893bcdaf22f5024ab58a#4e4f25b794ed0b9a323a893bcdaf22f5024ab58a"
-dependencies = [
- "brotli",
- "cargo-emit 0.2.1",
- "proc-macro2",
- "quote",
- "sha2 0.10.9",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "include_url_macro"
 version = "0.1.0"
 source = "git+https://github.com/libnyanpasu/include_url_macro?rev=fbe47bd71047892a218e3166a2a1bac474488218#fbe47bd71047892a218e3166a2a1bac474488218"
 dependencies = [
  "brotli",
  "bytes",
- "cargo-emit 0.1.1",
+ "cargo-emit",
  "proc-macro2",
  "quote",
  "reqwest 0.12.28",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -64,7 +64,7 @@ include-compress-bytes = { git = "https://github.com/libnyanpasu/include-compres
 # --- registry ---
 thiserror = "2"
 tracing = "0.1"
-boa_engine = { version = "0.21", features = ["annex-b"] }
+boa_engine = { version = "0.22", features = ["annex-b"] }
 reqwest = { version = "0.12", default-features = false, features = [
   "charset",
   "http2",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -59,7 +59,6 @@ auto-launch = { git = "https://github.com/libnyanpasu/auto-launch.git", version 
 delay_timer = { version = "0.11", git = "https://github.com/libnyanpasu/delay-timer.git", rev = "76615d9b0c1bb830212fe84b5d18ee5444831625" } # Task scheduler with timer
 runas = { git = "https://github.com/libnyanpasu/rust-runas.git", rev = "29bdb2501c05b7d78e63628bedbd4a190b71bad3" }
 include_url_macro = { git = "https://github.com/libnyanpasu/include_url_macro", rev = "fbe47bd71047892a218e3166a2a1bac474488218" }
-include-compress-bytes = { git = "https://github.com/libnyanpasu/include-compress-bytes", rev = "4e4f25b794ed0b9a323a893bcdaf22f5024ab58a" }
 
 # --- registry ---
 thiserror = "2"

--- a/backend/boa_utils/Cargo.toml
+++ b/backend/boa_utils/Cargo.toml
@@ -12,8 +12,8 @@ doctest = false
 [dependencies]
 rustc-hash = { version = "2", features = ["std"] }
 boa_engine = { workspace = true, features = ["annex-b"] }
-boa_gc = { version = "0.21" }
-boa_parser = { version = "0.21", features = ["annex-b"] }
+boa_gc = { version = "0.22" }
+boa_parser = { version = "0.22", features = ["annex-b"] }
 tokio = { workspace = true }
 nyanpasu-utils = { workspace = true }
 reqwest = { workspace = true }

--- a/backend/boa_utils/Cargo.toml
+++ b/backend/boa_utils/Cargo.toml
@@ -25,7 +25,6 @@ url = "2"
 log = "0.4"
 anyhow = "1.0"
 include_url_macro = { workspace = true }
-include-compress-bytes = { workspace = true }
 phf = { version = "0.14.0", features = ["macros"] }
 
 # for cacheing

--- a/backend/boa_utils/src/lib.rs
+++ b/backend/boa_utils/src/lib.rs
@@ -253,7 +253,7 @@ pub(crate) mod test {
                         ),
                     };
 
-                    assert_eq!(&native.kind, &kind, "{}", fmt_test(&source, i));
+                    assert_eq!(native.kind(), &kind, "{}", fmt_test(&source, i));
                     assert_eq!(native.message(), message, "{}", fmt_test(&source, i));
                     i += 1;
                 }

--- a/backend/boa_utils/src/module/builtin.rs
+++ b/backend/boa_utils/src/module/builtin.rs
@@ -6,7 +6,6 @@ use boa_engine::{
     module::{ModuleLoader, ModuleRequest},
 };
 use boa_parser::Source;
-use include_compress_bytes::include_bytes_brotli;
 use include_url_macro::include_url_bytes_with_brotli;
 use phf::phf_map;
 
@@ -18,9 +17,6 @@ static BUILTIN_MODULES: phf::Map<&str, &[u8]> = phf_map! {
     "yaml" => include_url_bytes_with_brotli!("https://fastly.jsdelivr.net/npm/yaml@2.8.1/+esm"),
     "dedent" => include_url_bytes_with_brotli!("https://fastly.jsdelivr.net/npm/dedent@1.7.0/+esm"),
     "js-base64" => include_url_bytes_with_brotli!("https://fastly.jsdelivr.net/npm/js-base64@3.7.8/+esm"),
-
-    // Local utils,
-    "utils" => include_bytes_brotli!("./builtin/utils.js"),
 };
 
 /// A ModuleLoader load resources from builtin static resources
@@ -38,6 +34,10 @@ impl ModuleLoader for BuiltinModuleLoader {
             let module_name = specifier_str
                 .strip_prefix(BUILTIN_MODULE_PREFIX)
                 .context("Not builtin module prefix")?;
+            // Embed the local helper directly so Cargo tracks source changes.
+            if module_name == "utils" {
+                return Ok(include_bytes!("builtin/utils.js").to_vec());
+            }
             log::trace!("Trying to reading builtin module: {}", module_name);
             let module_data = BUILTIN_MODULES
                 .get(module_name)
@@ -76,6 +76,131 @@ mod tests {
     use boa_engine::{JsValue, job::SimpleJobExecutor};
 
     use super::*;
+
+    fn evaluate_builtin_json(source: &str) -> JsResult<serde_json::Value> {
+        use boa_engine::{builtins::promise::PromiseState, js_string};
+
+        let mut context = Context::builder()
+            .job_executor(Rc::new(SimpleJobExecutor::new()))
+            .module_loader(Rc::new(BuiltinModuleLoader))
+            .build()?;
+        let module = Module::parse(Source::from_bytes(source), None, &mut context)?;
+        let promise = module.load_link_evaluate(&mut context);
+        context.run_jobs()?;
+        assert!(
+            matches!(promise.state(), PromiseState::Fulfilled(_)),
+            "module failed: {:?}",
+            promise.state()
+        );
+        let result = module
+            .namespace(&mut context)
+            .get(js_string!("default"), &mut context)?;
+        Ok(result.to_json(&mut context)?.expect("JSON export"))
+    }
+
+    #[test_log::test]
+    fn dedent_preserves_relative_indentation() -> JsResult<()> {
+        for input in [
+            "\n    a:\n     b: 1\n     c: 2\n",
+            "\n  a:\n    b: 1\n\n    c: 2\n",
+            "\r\n    a:\r\n      b: 1\r\n      c: 2\r\n",
+        ] {
+            let source = format!(
+                "import dedent from 'nyan:dedent';
+                 import YAML from 'nyan:yaml';
+                 export default YAML.parse(dedent({}));",
+                serde_json::to_string(input).unwrap()
+            );
+            assert_eq!(
+                evaluate_builtin_json(&source)?,
+                serde_json::json!({"a": {"b": 1.0, "c": 2.0}}),
+                "{input:?}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test_log::test]
+    fn dedent_tag_preserves_nested_interpolation() -> JsResult<()> {
+        let source = r#"
+            import dedent from 'nyan:dedent';
+            import YAML from 'nyan:yaml';
+            export default YAML.parse(dedent`
+                a:
+                  b: ${"first"}
+                  c:
+                    - ${"second"}
+                    - ${"third"}
+            `);
+        "#;
+        assert_eq!(
+            evaluate_builtin_json(source)?,
+            serde_json::json!({
+                "a": {"b": "first", "c": ["second", "third"]}
+            })
+        );
+        Ok(())
+    }
+
+    #[test_log::test]
+    fn yaml_preserves_nested_mappings() -> JsResult<()> {
+        for template in [
+            "a:\n b: 1\n c: 2",
+            "\na:\n b: 1\n c: 2\n",
+            "\n    a:\n     b: 1\n     c: 2\n",
+            "\n    a:\n      b: 1\n\n      c: 2\n",
+            "\r\na:\r\n  b: 1\r\n  c: 2\r\n",
+            "a:\n b: ${1}\n c: ${2}",
+        ] {
+            let source =
+                format!("import {{ yaml }} from 'nyan:utils'; export default yaml`{template}`;");
+            assert_eq!(
+                evaluate_builtin_json(&source)?,
+                serde_json::json!({"a": {"b": 1.0, "c": 2.0}}),
+                "{template:?}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test_log::test]
+    fn yaml_preserves_empty_child_values() -> JsResult<()> {
+        let source = "import { yaml } from 'nyan:utils'; export default yaml`a:\n b:\n c:\n`;";
+        assert_eq!(
+            evaluate_builtin_json(source)?,
+            serde_json::json!({"a": {"b": null, "c": null}})
+        );
+        Ok(())
+    }
+
+    #[test_log::test]
+    fn yaml_preserves_sequences_scalars_and_root_siblings() -> JsResult<()> {
+        let source = r#"
+            import { yaml } from 'nyan:utils';
+            export default yaml`a:
+  b:
+    - name: first
+      enabled: true
+    - name: second
+      enabled: false
+  c: |
+    first line
+      indented line
+sibling: null
+`;
+        "#;
+        assert_eq!(
+            evaluate_builtin_json(source)?,
+            serde_json::json!({
+                "a": {
+                    "b": [{"name": "first", "enabled": true}, {"name": "second", "enabled": false}],
+                    "c": "first line\n  indented line\n"
+                },
+                "sibling": null
+            })
+        );
+        Ok(())
+    }
 
     #[test_log::test]
     fn test_builtin_module_loader() -> JsResult<()> {

--- a/backend/boa_utils/src/module/builtin.rs
+++ b/backend/boa_utils/src/module/builtin.rs
@@ -1,7 +1,10 @@
 use std::{cell::RefCell, io::Read, rc::Rc};
 
 use anyhow::Context as _;
-use boa_engine::{Context, JsNativeError, JsResult, JsString, Module, module::ModuleLoader};
+use boa_engine::{
+    Context, JsNativeError, JsResult, Module,
+    module::{ModuleLoader, ModuleRequest},
+};
 use boa_parser::Source;
 use include_compress_bytes::include_bytes_brotli;
 use include_url_macro::include_url_bytes_with_brotli;
@@ -27,10 +30,10 @@ impl ModuleLoader for BuiltinModuleLoader {
     async fn load_imported_module(
         self: Rc<Self>,
         _referrer: boa_engine::module::Referrer,
-        specifier: JsString,
+        request: ModuleRequest,
         context: &RefCell<&mut Context>,
     ) -> JsResult<Module> {
-        let specifier_str = specifier.to_std_string_escaped();
+        let specifier_str = request.specifier().to_std_string_escaped();
         let result: Result<_, anyhow::Error> = (|| {
             let module_name = specifier_str
                 .strip_prefix(BUILTIN_MODULE_PREFIX)

--- a/backend/boa_utils/src/module/builtin/utils.js
+++ b/backend/boa_utils/src/module/builtin/utils.js
@@ -9,5 +9,7 @@ import YAML from 'nyan:yaml'
  */
 export function yaml(strings, ...values) {
   const str = String.raw({ raw: strings }, ...values)
-  return YAML.parse(dedent(str))
+  // dedent ignores unindented lines when computing the common margin.
+  // A zero-indent YAML root must keep its children's indentation.
+  return YAML.parse(/^\S/m.test(str) ? str : dedent(str))
 }

--- a/backend/boa_utils/src/module/combine.rs
+++ b/backend/boa_utils/src/module/combine.rs
@@ -1,6 +1,9 @@
 use std::{cell::RefCell, rc::Rc};
 
-use boa_engine::{Context, JsResult, JsString, Module, module::ModuleLoader};
+use boa_engine::{
+    Context, JsResult, Module,
+    module::{ModuleLoader, ModuleRequest},
+};
 use url::Url;
 
 use crate::module::builtin::{BUILTIN_MODULE_PREFIX, BuiltinModuleLoader};
@@ -36,27 +39,27 @@ impl ModuleLoader for CombineModuleLoader {
     async fn load_imported_module(
         self: Rc<Self>,
         referrer: boa_engine::module::Referrer,
-        specifier: JsString,
+        request: ModuleRequest,
         context: &RefCell<&mut Context>,
     ) -> JsResult<Module> {
-        let specifier_str = specifier.to_std_string_escaped();
+        let specifier_str = request.specifier().to_std_string_escaped();
         match Url::parse(&specifier_str) {
             Ok(url) if url.scheme() == "http" || url.scheme() == "https" => {
                 self.http
                     .clone()
-                    .load_imported_module(referrer, specifier, context)
+                    .load_imported_module(referrer, request, context)
                     .await
             }
             _ => {
                 if specifier_str.starts_with(BUILTIN_MODULE_PREFIX) {
                     self.builtin
                         .clone()
-                        .load_imported_module(referrer, specifier, context)
+                        .load_imported_module(referrer, request, context)
                         .await
                 } else {
                     self.simple
                         .clone()
-                        .load_imported_module(referrer, specifier, context)
+                        .load_imported_module(referrer, request, context)
                         .await
                 }
             }

--- a/backend/boa_utils/src/module/http.rs
+++ b/backend/boa_utils/src/module/http.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use async_fs::create_dir_all;
-use boa_engine::{Context, JsNativeError, JsResult, JsString, Module, module::ModuleLoader};
+use boa_engine::{
+    Context, JsNativeError, JsResult, Module,
+    module::{ModuleLoader, ModuleRequest},
+};
 use boa_parser::Source;
 use mime::Mime;
 // Tokio sync is not runtime related
@@ -84,10 +87,10 @@ impl ModuleLoader for HttpModuleLoader {
     async fn load_imported_module(
         self: Rc<Self>,
         _referrer: boa_engine::module::Referrer,
-        specifier: JsString,
+        request: ModuleRequest,
         context: &RefCell<&mut Context>,
     ) -> JsResult<Module> {
-        let url = specifier.to_std_string_escaped();
+        let url = request.specifier().to_std_string_escaped();
         let url = Url::from_str(&url).expect("invalid url"); // SAFETY: `url` is a valid URL, if it's not, its caller side issue
         let cache_path = self.mapping_cache_dir(&url);
         let parent_dir = cache_path

--- a/backend/tauri/src/enhance/script/js.rs
+++ b/backend/tauri/src/enhance/script/js.rs
@@ -400,6 +400,28 @@ mod utils {
 
 #[cfg(test)]
 mod test {
+    #[tokio::test]
+    async fn yaml_template_preserves_nested_config_through_runner() {
+        use super::{super::runner::Runner, JSRunner};
+
+        let runner = JSRunner::try_new().unwrap();
+        let input = serde_yaml::from_str("existing: true").unwrap();
+        let script = r#"
+            import { yaml } from 'nyan:utils';
+            export default function main(config) {
+                config.a = yaml`nested:
+  b: 1
+  c: 2
+`.nested;
+                return config;
+            }
+        "#;
+        let (result, _) = runner.process_honey(input, script).await;
+        let expected: serde_yaml::Mapping =
+            serde_yaml::from_str("existing: true\na:\n  b: 1\n  c: 2\n").unwrap();
+        assert_eq!(result.unwrap(), expected);
+    }
+
     #[test]
     fn test_wrap_script_if_not_esm() {
         let script = r#"function main(config) {


### PR DESCRIPTION
Upgrade Boa engine, parser and GC to 0.22.0 and adapt builtin, HTTP and combined module loaders to `ModuleRequest`.

The `nyan:utils` YAML tag previously passed every template through dedent, which excludes zero-indent lines when calculating the common margin. For example, `a:\n b: 1\n c: 2` became `{ a: null, b: 1, c: 2 }`. Preserve templates containing zero-indent content so the result is `{ a: { b: 1, c: 2 } }`, while retaining dedent for uniformly indented templates. The direct `nyan:dedent` export retains upstream semantics.

Embed the small local `utils.js` with `include_bytes!` so Cargo tracks source changes. The previous compression macro cached by path and could embed stale script contents in incremental builds; remove its now-unused dependency.

Regression tests exercise the real Boa builtin loader and application script runner: nested mappings, empty children, sequences, block scalars, root siblings, interpolation, blank lines, CRLF and different indentation widths. The original implementation reproduced the flattened mapping in two regression tests before the fix.

Validation on macOS arm64:
- `cargo test -p boa_utils --lib --locked`: 16 passed.
- `cargo test -p clash-nyanpasu --lib enhance::script::js::test --all-features`: 7 passed, including builtin and HTTP imports.
- `cargo clippy --all-targets --all-features`: passed with existing warnings.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

Two commits separate the dependency/API upgrade from the YAML fix. Built in an isolated worktree with its own target directory and a frontend placeholder for Rust-only validation.