### PR TITLE
feat(core): introduce revocable instance-bound Clash API access

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1825,7 +1825,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clash-api"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "backon",
  "chrono",
@@ -1869,6 +1869,7 @@ dependencies = [
  "camino",
  "chrono",
  "clap",
+ "clash-api",
  "colored",
  "convert_case",
  "ctrlc",
@@ -6455,7 +6456,7 @@ dependencies = [
 
 [[package]]
 name = "nyanpasu-core-manager"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "camino",
  "chrono",
@@ -6473,12 +6474,13 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
  "zerocopy",
 ]
 
 [[package]]
 name = "nyanpasu-core-metadata"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "constcat",
  "enumset",
@@ -6521,7 +6523,7 @@ dependencies = [
 
 [[package]]
 name = "nyanpasu-ipc"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "anyhow",
  "derive_builder",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -43,6 +43,7 @@ nyanpasu-ipc = { path = "nyanpasu-runtime/nyanpasu_ipc", features = [
   "client",
   "specta",
 ] } # IPC bridge between the UI process and service process
+clash-api = { path = "nyanpasu-runtime/crates/clash-api" }
 nyanpasu-core-manager = { path = "nyanpasu-runtime/crates/nyanpasu-core-manager" } # Local-host CoreControl (v2 control plane)
 
 # --- forks ---

--- a/backend/tauri/Cargo.toml
+++ b/backend/tauri/Cargo.toml
@@ -26,6 +26,7 @@ semver = "1.0"
 # Local Dependencies
 nyanpasu-ipc = { workspace = true }
 nyanpasu-core-manager = { workspace = true }
+clash-api = { workspace = true }
 nyanpasu-macro = { path = "../nyanpasu-macro" }
 nyanpasu-core = { path = "../nyanpasu-core" }
 nyanpasu-config = { path = "../nyanpasu-config" }

--- a/backend/tauri/src/client/clash_api.rs
+++ b/backend/tauri/src/client/clash_api.rs
@@ -1,0 +1,76 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use clash_api::{DelayQuery, ProviderName, ProxyName};
+use indexmap::IndexMap;
+
+use crate::core::clash::api::{ClashVersion, DelayRes};
+
+use super::NyanpasuClient;
+
+fn delay_query(url: Option<String>) -> Result<DelayQuery> {
+    let url = url
+        .filter(|url| !url.is_empty())
+        .unwrap_or_else(|| "http://www.gstatic.com/generate_204".into());
+    Ok(DelayQuery::new(url.parse()?, Duration::from_secs(10))?)
+}
+
+impl NyanpasuClient {
+    pub async fn clash_version(&self) -> Result<ClashVersion> {
+        let version = self.inner.core_api.api_client().await?.version().await?;
+        Ok(ClashVersion {
+            version: version.version,
+            premium: version.premium,
+            meta: Some(version.meta),
+        })
+    }
+
+    pub async fn proxy_delay(
+        &self,
+        name: String,
+        provider: Option<String>,
+        url: Option<String>,
+    ) -> Result<DelayRes> {
+        let query = delay_query(url)?;
+        let provider = provider.map(ProviderName::new);
+        let delay = self
+            .inner
+            .core_api
+            .api_client()
+            .await?
+            .proxy_delay(&ProxyName::new(name), provider.as_ref(), &query)
+            .await?;
+        Ok(DelayRes {
+            delay: u64::from(delay.delay),
+        })
+    }
+
+    pub async fn group_delay(
+        &self,
+        group: String,
+        url: Option<String>,
+    ) -> Result<IndexMap<String, u32>> {
+        let query = delay_query(url)?;
+        let delays = self
+            .inner
+            .core_api
+            .api_client()
+            .await?
+            .group_delay(&ProxyName::new(group), &query)
+            .await?;
+        Ok(delays
+            .into_iter()
+            .map(|(name, delay)| (name.as_str().to_owned(), u32::from(delay)))
+            .collect())
+    }
+
+    pub async fn close_clash_connections(&self, id: Option<String>) -> Result<()> {
+        let id = id.map(|id| id.parse::<uuid::Uuid>()).transpose()?;
+        let api = self.inner.core_api.api_client().await?;
+        match id {
+            Some(id) => api.close_connection(id).await?,
+            None => api.close_all_connections().await?,
+        }
+        Ok(())
+    }
+}

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -1,4 +1,5 @@
 mod application;
+mod clash_api;
 mod clash_config;
 pub mod core_lifecycle;
 mod error;
@@ -257,6 +258,7 @@ struct NyanpasuClientInner {
     runtime_paths: RuntimePaths,
     ui_sink: Arc<dyn UiEventSink>,
     core_lifecycle: core_lifecycle::CoreLifecycleClient,
+    core_api: CoreClientV2,
     system_dns: Arc<dyn SystemDnsCache>,
 }
 
@@ -356,7 +358,7 @@ impl NyanpasuClient {
                 application: application.clone(),
                 clash: clash_config.clone(),
                 profiles: profiles.clone(),
-                core: core_v2,
+                core: core_v2.clone(),
                 service,
                 builder: Arc::new(core_lifecycle::adapters::FsRuntimeBuildAdapter {
                     profiles_dir: profiles_dir.clone(),
@@ -380,6 +382,7 @@ impl NyanpasuClient {
                 runtime_paths,
                 ui_sink,
                 core_lifecycle,
+                core_api: core_v2,
                 system_dns,
             }),
         })
@@ -1783,6 +1786,7 @@ pub(crate) mod tests {
                 server: Some(nyanpasu_ipc::api::status::StatusResBody {
                     version: std::borrow::Cow::Borrowed("2.0.0"),
                     core_infos: nyanpasu_ipc::api::status::CoreInfos {
+                        instance_id: None,
                         r#type: None,
                         state: nyanpasu_ipc::api::status::CoreState::Running,
                         state_changed_at: 0,

--- a/backend/tauri/src/core/actor_v2/api.rs
+++ b/backend/tauri/src/core/actor_v2/api.rs
@@ -1,0 +1,434 @@
+//! Instance-bound Clash API capability. The protocol client never escapes this
+//! adapter: clones share revocation and every operation checks the applied binding.
+
+use std::{future::Future, time::Duration};
+
+use clash_api::{Delay, DelayQuery, ProviderName, ProxyName, Version};
+use nyanpasu_ipc::api::{core::v2::CoreApiConnection, status::CoreControllerInfo};
+use tokio_util::sync::CancellationToken;
+
+use super::endpoint::EndpointHandle;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ApiError {
+    #[error("the Clash API capability belongs to a retired instance")]
+    Stale,
+    #[error("the running core's API is unavailable: {0}")]
+    Unavailable(String),
+    #[error("Clash API operation timed out; a submitted mutation may have taken effect")]
+    Timeout,
+    #[error(transparent)]
+    Protocol(#[from] clash_api::Error),
+}
+
+/// Shared, permanently revocable capability; it cannot be rebound to a new core.
+#[derive(Clone)]
+pub struct ApiClient {
+    client: clash_api::Client,
+    binding: CoreApiConnection,
+    endpoint: EndpointHandle,
+    revoked: CancellationToken,
+}
+
+impl std::fmt::Debug for ApiClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiClient")
+            .field("instance_id", &self.binding.instance_id)
+            .field("revoked", &self.revoked.is_cancelled())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ApiClient {
+    pub(super) fn new(
+        binding: CoreApiConnection,
+        endpoint: EndpointHandle,
+    ) -> Result<Self, ApiError> {
+        let host = match &binding.controller {
+            CoreControllerInfo::Http(url) => clash_api::Host::url(url)?,
+            CoreControllerInfo::UnixSocket(path) => clash_api::Host::unix_socket(path),
+            CoreControllerInfo::NamedPipe(path) => clash_api::Host::named_pipe(path),
+        };
+        let mut builder = clash_api::Client::builder(host);
+        if let Some(secret) = &binding.secret {
+            builder = builder.secret(secret.clone());
+        }
+        Ok(Self {
+            client: builder.build()?,
+            binding,
+            endpoint,
+            revoked: CancellationToken::new(),
+        })
+    }
+
+    pub(super) fn matches(&self, binding: &CoreApiConnection) -> bool {
+        !self.revoked.is_cancelled() && self.binding == *binding
+    }
+
+    pub(super) fn revoke(&self) {
+        self.revoked.cancel();
+    }
+
+    async fn check(&self) -> Result<(), ApiError> {
+        if self.revoked.is_cancelled() {
+            return Err(ApiError::Stale);
+        }
+        match self.endpoint.api_connection().await {
+            Ok(Some(binding)) if self.matches(&binding) => Ok(()),
+            Ok(_) => {
+                self.revoke();
+                Err(ApiError::Stale)
+            }
+            Err(error) => {
+                self.revoke();
+                Err(ApiError::Unavailable(error.to_string()))
+            }
+        }
+    }
+
+    // One bound includes preflight, the complete body decode, and postflight.
+    // No automatic retry: losing a mutation reply does not authorize replay.
+    async fn execute<T>(
+        &self,
+        operation: impl Future<Output = clash_api::Result<T>>,
+    ) -> Result<T, ApiError> {
+        tokio::select! {
+            biased;
+            _ = self.revoked.cancelled() => Err(ApiError::Stale),
+            result = tokio::time::timeout(Duration::from_secs(30), async {
+                self.check().await?;
+                let result = operation.await;
+                self.check().await?;
+                result.map_err(ApiError::Protocol)
+            }) => result.map_err(|_| ApiError::Timeout)?,
+        }
+    }
+
+    pub async fn version(&self) -> Result<Version, ApiError> {
+        self.execute(self.client.version()).await
+    }
+
+    pub async fn proxy_delay(
+        &self,
+        name: &ProxyName,
+        provider: Option<&ProviderName>,
+        query: &DelayQuery,
+    ) -> Result<Delay, ApiError> {
+        match provider {
+            Some(provider) => {
+                self.execute(self.client.provider_proxy_delay(provider, name, query))
+                    .await
+            }
+            None => self.execute(self.client.proxy_delay(name, query)).await,
+        }
+    }
+
+    pub async fn group_delay(
+        &self,
+        group: &ProxyName,
+        query: &DelayQuery,
+    ) -> Result<indexmap::IndexMap<ProxyName, u16>, ApiError> {
+        self.execute(self.client.group_delay(group, query)).await
+    }
+
+    pub async fn close_connection(&self, id: uuid::Uuid) -> Result<(), ApiError> {
+        self.execute(self.client.close_connection(id)).await
+    }
+
+    pub async fn close_all_connections(&self) -> Result<(), ApiError> {
+        self.execute(self.client.close_all_connections()).await
+    }
+}
+
+/// Owned only by CoreActor. Dropping it revokes every outstanding clone even
+/// when actor teardown skips post_stop (for example, actor state unwinding).
+pub(super) struct ApiLease {
+    pub client: ApiClient,
+    monitor: tokio::task::JoinHandle<()>,
+}
+
+impl ApiLease {
+    pub fn new(client: ApiClient) -> Self {
+        let monitored = client.clone();
+        let monitor = tokio::spawn(async move {
+            use futures::StreamExt;
+            let subscription =
+                tokio::time::timeout(Duration::from_secs(10), monitored.endpoint.api_changes())
+                    .await;
+            let mut changes = match subscription {
+                Ok(Ok(Some(changes))) => changes,
+                Ok(Ok(None)) => Box::pin(futures::stream::pending()) as super::endpoint::ApiChanges,
+                _ => {
+                    monitored.revoke();
+                    return;
+                }
+            };
+            let mut timer = tokio::time::interval(Duration::from_secs(2));
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = monitored.revoked.cancelled() => return,
+                    event = changes.next() => {
+                        if !matches!(event, Some(Ok(()))) { monitored.revoke(); return; }
+                    }
+                    _ = timer.tick() => {}
+                }
+                if !matches!(
+                    tokio::time::timeout(Duration::from_secs(10), monitored.check()).await,
+                    Ok(Ok(()))
+                ) {
+                    monitored.revoke();
+                    return;
+                }
+            }
+        });
+        Self { client, monitor }
+    }
+}
+
+impl Drop for ApiLease {
+    fn drop(&mut self) {
+        self.client.revoke();
+        self.monitor.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::{Json, Router, body::Body, response::Response, routing::get};
+    use nyanpasu_core_manager::{CoreError, CoreErrorKind, OperationId};
+    use nyanpasu_ipc::api::{
+        core::v2::{OperationInfo, OperationOutputInfo, OperationPhase},
+        status::CoreStateDetail,
+    };
+    use tokio::sync::{Notify, watch};
+
+    use super::*;
+    use crate::core::actor_v2::{
+        CoreClient,
+        endpoint::{
+            ApiChanges, ControlEndpoint, CoreStatusSnapshot, CoreSubmission, ExecutionHost,
+        },
+    };
+
+    struct Endpoint {
+        host: ExecutionHost,
+        binding: watch::Sender<Option<CoreApiConnection>>,
+    }
+
+    #[async_trait::async_trait]
+    impl ControlEndpoint for Endpoint {
+        fn host(&self) -> ExecutionHost {
+            self.host
+        }
+
+        async fn api_connection(&self) -> Result<Option<CoreApiConnection>, CoreError> {
+            Ok(self.binding.borrow().clone())
+        }
+
+        async fn api_changes(&self) -> Result<Option<ApiChanges>, CoreError> {
+            Ok(Some(Box::pin(futures::stream::unfold(
+                self.binding.subscribe(),
+                |mut rx| async move {
+                    rx.changed().await.ok()?;
+                    Some((Ok(()), rx))
+                },
+            ))))
+        }
+
+        async fn status(&self) -> Result<CoreStatusSnapshot, CoreError> {
+            Ok(CoreStatusSnapshot {
+                state: Some(if self.binding.borrow().is_some() {
+                    CoreStateDetail::Running { epoch: 1, pid: 7 }
+                } else {
+                    CoreStateDetail::Stopped { reason: None }
+                }),
+                state_changed_at: 0,
+                revision: None,
+                healthy: Some(true),
+                applied_kind: None,
+            })
+        }
+
+        async fn submit(&self, submission: CoreSubmission) -> Result<OperationInfo, CoreError> {
+            if !matches!(
+                submission.envelope.command,
+                nyanpasu_core_manager::CoreCommand::Stop
+            ) {
+                return Err(CoreError::new(
+                    CoreErrorKind::Internal,
+                    "test accepts only stop",
+                    false,
+                ));
+            }
+            self.binding.send_replace(None);
+            Ok(OperationInfo {
+                id: submission.envelope.operation_id.to_string(),
+                phase: OperationPhase::Succeeded,
+                output: Some(OperationOutputInfo::Stopped),
+                error: None,
+            })
+        }
+
+        async fn wait_operation(&self, _: OperationId, _: Duration) -> Option<OperationInfo> {
+            None
+        }
+    }
+
+    fn endpoint(url: String) -> Arc<Endpoint> {
+        let (binding, _) = watch::channel(Some(CoreApiConnection {
+            instance_id: "first-process".into(),
+            controller: CoreControllerInfo::Http(url),
+            secret: None,
+        }));
+        Arc::new(Endpoint {
+            binding,
+            host: ExecutionHost::Local,
+        })
+    }
+
+    async fn server(router: Router) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/", listener.local_addr().unwrap());
+        let task = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        (url, task)
+    }
+
+    async fn revoked(api: &ApiClient) {
+        tokio::time::timeout(Duration::from_secs(2), api.revoked.cancelled())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn same_epoch_and_pid_replacement_revokes_every_clone_without_reviving() {
+        let endpoint = endpoint("http://127.0.0.1:1/".into());
+        let core = CoreClient::spawn(endpoint.clone()).await.unwrap();
+        let first = core.api_client().await.unwrap();
+        let clone = first.clone();
+        endpoint
+            .binding
+            .send_modify(|binding| binding.as_mut().unwrap().instance_id = "second-process".into());
+        revoked(&first).await;
+        assert!(matches!(clone.version().await, Err(ApiError::Stale)));
+        let second = core.api_client().await.unwrap();
+        assert_eq!(second.binding.instance_id, "second-process");
+        assert!(!second.revoked.is_cancelled());
+        endpoint
+            .binding
+            .send_modify(|binding| binding.as_mut().unwrap().instance_id = "first-process".into());
+        assert!(matches!(first.version().await, Err(ApiError::Stale)));
+        core.actor.stop(None);
+    }
+
+    #[tokio::test]
+    async fn unchanged_binding_keeps_capability_and_shutdown_revokes_it() {
+        let (url, server) = server(Router::new().route(
+            "/version",
+            get(|| async { Json(serde_json::json!({"version":"test"})) }),
+        ))
+        .await;
+        let endpoint = endpoint(url);
+        let core = CoreClient::spawn(endpoint.clone()).await.unwrap();
+        let api = core.api_client().await.unwrap();
+        // Hot patch notification: revision may change, process and credentials do not.
+        endpoint.binding.send_modify(|_| {});
+        assert_eq!(api.version().await.unwrap().version, "test");
+        let reacquired = core.api_client().await.unwrap();
+        assert!(api.matches(&reacquired.binding));
+        core.shutdown().await.unwrap();
+        assert!(matches!(api.version().await, Err(ApiError::Stale)));
+        assert!(core.api_client().await.is_err());
+        core.actor.stop(None);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn changed_secret_or_endpoint_revokes_cached_capability() {
+        for change_secret in [true, false] {
+            let endpoint = endpoint("http://127.0.0.1:1/".into());
+            let core = CoreClient::spawn(endpoint.clone()).await.unwrap();
+            let api = core.api_client().await.unwrap();
+            endpoint.binding.send_modify(|binding| {
+                let binding = binding.as_mut().unwrap();
+                if change_secret {
+                    binding.secret = Some("replacement-secret".into());
+                } else {
+                    binding.controller = CoreControllerInfo::Http("http://127.0.0.1:2/".into());
+                }
+            });
+            // Acquisition uses an authoritative binding, independent of the status pump.
+            let replacement = core.api_client().await.unwrap();
+            revoked(&api).await;
+            assert!(!replacement.revoked.is_cancelled());
+            assert!(!format!("{replacement:?}").contains("replacement-secret"));
+            core.actor.stop(None);
+        }
+    }
+
+    #[tokio::test]
+    async fn invalidation_cancels_a_partially_received_response_body() {
+        let started = Arc::new(Notify::new());
+        let signal = started.clone();
+        let (url, server) = server(Router::new().route(
+            "/version",
+            get(move || {
+                let signal = signal.clone();
+                async move {
+                    use futures::StreamExt;
+                    let first = futures::stream::once(async move {
+                        signal.notify_one();
+                        Ok::<_, std::io::Error>("{\"version\":")
+                    });
+                    Response::new(Body::from_stream(first.chain(futures::stream::pending())))
+                }
+            }),
+        ))
+        .await;
+        let endpoint = endpoint(url);
+        let core = CoreClient::spawn(endpoint.clone()).await.unwrap();
+        let api = core.api_client().await.unwrap();
+        let call = tokio::spawn(async move { api.version().await });
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
+            .await
+            .unwrap();
+        endpoint.binding.send_replace(None);
+        let result = tokio::time::timeout(Duration::from_secs(2), call)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(result, Err(ApiError::Stale)));
+        core.actor.stop(None);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn actor_termination_revokes_outstanding_client() {
+        let endpoint = endpoint("http://127.0.0.1:1/".into());
+        let core = CoreClient::spawn(endpoint).await.unwrap();
+        let api = core.api_client().await.unwrap();
+        core.actor.stop(None);
+        revoked(&api).await;
+        assert!(matches!(api.version().await, Err(ApiError::Stale)));
+    }
+    #[tokio::test]
+    async fn handoff_revokes_even_when_target_has_the_same_binding() {
+        let source = endpoint("http://127.0.0.1:1/".into());
+        let (binding, _) = watch::channel(source.binding.borrow().clone());
+        let target = Arc::new(Endpoint {
+            binding,
+            host: ExecutionHost::Service,
+        });
+        let core = CoreClient::spawn(source).await.unwrap();
+        let old = core.api_client().await.unwrap();
+        core.change_host(target).await.unwrap();
+        assert!(matches!(old.version().await, Err(ApiError::Stale)));
+        let new = core.api_client().await.unwrap();
+        assert!(!new.revoked.is_cancelled());
+        core.actor.stop(None);
+    }
+}

--- a/backend/tauri/src/core/actor_v2/endpoint.rs
+++ b/backend/tauri/src/core/actor_v2/endpoint.rs
@@ -72,6 +72,24 @@ pub struct CoreSubmission {
 /// read and deliberately not routed through the actor mailbox.
 #[async_trait::async_trait]
 pub trait ControlEndpoint: Send + Sync {
+    /// The applied process binding; absent means no usable API. Old hosts must
+    /// fail explicitly rather than reconstructing credentials from globals.
+    async fn api_connection(
+        &self,
+    ) -> Result<Option<nyanpasu_ipc::api::core::v2::CoreApiConnection>, CoreError> {
+        Err(CoreError::new(
+            CoreErrorKind::BackendUnavailable,
+            "the endpoint does not expose instance-bound API access",
+            false,
+        ))
+    }
+
+    /// Ordered lifecycle notifications, used to wake API revocation checks.
+    /// The periodic authority check also covers lost/coalesced notifications.
+    async fn api_changes(&self) -> Result<Option<ApiChanges>, CoreError> {
+        Ok(None)
+    }
+
     fn host(&self) -> ExecutionHost;
 
     /// Admission into the host's executor. Returns the operation's
@@ -89,6 +107,8 @@ pub trait ControlEndpoint: Send + Sync {
 // Local host: the in-process CoreControl.
 // ---------------------------------------------------------------------------
 
+pub type ApiChanges = std::pin::Pin<Box<dyn futures::Stream<Item = Result<(), CoreError>> + Send>>;
+
 pub struct LocalEndpoint {
     control: CoreControl,
 }
@@ -101,6 +121,45 @@ impl LocalEndpoint {
 
 #[async_trait::async_trait]
 impl ControlEndpoint for LocalEndpoint {
+    async fn api_connection(
+        &self,
+    ) -> Result<Option<nyanpasu_ipc::api::core::v2::CoreApiConnection>, CoreError> {
+        let Some(connection) = self.control.api_connection().await else {
+            return Ok(None);
+        };
+        let controller = match connection.controller.host {
+            clash_api::Host::Http(url) => {
+                nyanpasu_ipc::api::status::CoreControllerInfo::Http(url.to_string())
+            }
+            clash_api::Host::UnixSocket(path) => {
+                nyanpasu_ipc::api::status::CoreControllerInfo::UnixSocket(path)
+            }
+            clash_api::Host::NamedPipe(path) => {
+                nyanpasu_ipc::api::status::CoreControllerInfo::NamedPipe(path)
+            }
+            _ => {
+                return Err(CoreError::new(
+                    CoreErrorKind::BackendUnavailable,
+                    "unsupported API transport",
+                    false,
+                ));
+            }
+        };
+        Ok(Some(nyanpasu_ipc::api::core::v2::CoreApiConnection {
+            instance_id: connection.instance_id.to_string(),
+            controller,
+            secret: connection.controller.secret,
+        }))
+    }
+
+    async fn api_changes(&self) -> Result<Option<ApiChanges>, CoreError> {
+        let changes = futures::stream::unfold(self.control.subscribe(), |mut rx| async move {
+            rx.changed().await.ok()?;
+            Some((Ok(()), rx))
+        });
+        Ok(Some(Box::pin(changes)))
+    }
+
     fn host(&self) -> ExecutionHost {
         ExecutionHost::Local
     }
@@ -286,6 +345,32 @@ fn map_client_error(error: nyanpasu_ipc::client::ClientError) -> CoreError {
 
 #[async_trait::async_trait]
 impl ControlEndpoint for ServiceEndpoint {
+    async fn api_connection(
+        &self,
+    ) -> Result<Option<nyanpasu_ipc::api::core::v2::CoreApiConnection>, CoreError> {
+        self.client
+            .core_api_connection()
+            .await
+            .map_err(map_client_error)
+    }
+
+    async fn api_changes(&self) -> Result<Option<ApiChanges>, CoreError> {
+        use futures::StreamExt;
+        let changes = self
+            .client
+            .events()
+            .await
+            .map_err(map_client_error)?
+            .filter_map(|event| async move {
+                match event {
+                    Ok(nyanpasu_ipc::api::ws::events::Event::CoreStatusChanged(_)) => Some(Ok(())),
+                    Ok(_) => None,
+                    Err(error) => Some(Err(map_client_error(error))),
+                }
+            });
+        Ok(Some(Box::pin(changes)))
+    }
+
     fn host(&self) -> ExecutionHost {
         ExecutionHost::Service
     }
@@ -471,6 +556,7 @@ mod tests {
 
     fn infos(detail: Option<CoreStateDetail>) -> CoreInfos {
         CoreInfos {
+            instance_id: None,
             r#type: None,
             // Deliberately the shape a stopped core would publish: the point
             // is that the coarse state must not be consulted at all.

--- a/backend/tauri/src/core/actor_v2/facade.rs
+++ b/backend/tauri/src/core/actor_v2/facade.rs
@@ -505,6 +505,7 @@ mod tests {
                 server: Some(StatusResBody {
                     version: Cow::Borrowed("2.0.0"),
                     core_infos: CoreInfos {
+                        instance_id: None,
                         r#type: None,
                         state: CoreState::Running,
                         state_changed_at: 1,

--- a/backend/tauri/src/core/actor_v2/mod.rs
+++ b/backend/tauri/src/core/actor_v2/mod.rs
@@ -1,8 +1,8 @@
 //! CoreActor v2: endpoint router + status projection, nothing else.
 //!
 //! Normative design: `docs/design/2026-08-12-core-actor-v2-app-integration.md`
-//! (§3–§5). The actor owns exactly four things — the active endpoint slot, the
-//! `ControllerGeneration`, the subscription pump, and the projection channels.
+//! (§3–§5). The actor owns the active endpoint slot, `ControllerGeneration`,
+//! the subscription pump, projection channels, and revocable API leases.
 //! Lifecycle truth, transactions, compensation and quarantine live only inside
 //! each host's `CoreControl`. Application workflows are serialized above this
 //! router by `CoreLifecycleActor`; direct router submissions still obey I-R1.
@@ -30,6 +30,7 @@
 //!   dropped and the caller sees `Internal: the core router is gone` — the
 //!   same answer any other lost reply gives.
 
+pub mod api;
 pub mod endpoint;
 pub mod facade;
 pub mod intent;
@@ -230,6 +231,9 @@ impl std::fmt::Debug for SubmitTicket {
 }
 
 pub enum CoreActorMessage {
+    ApiClient {
+        reply: RpcReplyPort<Result<api::ApiClient, api::ApiError>>,
+    },
     /// Routed through the mailbox so it serializes with `ChangeHost`: while a
     /// handoff runs, no submit can land on the wrong host (I-R1).
     Submit {
@@ -315,6 +319,7 @@ enum EndpointSlot {
 }
 
 pub struct CoreActorState {
+    api: Option<api::ApiLease>,
     slot: EndpointSlot,
     generation: ControllerGeneration,
     /// The active host's latest snapshot. Owned here rather than read back out
@@ -573,6 +578,7 @@ impl Actor for CoreActor {
         });
         let pump = spawn_pump(myself, args.initial.clone(), 0, args.status_timeout);
         Ok(CoreActorState {
+            api: None,
             slot: EndpointSlot::Connected(args.initial),
             generation: 0,
             snapshot: None,
@@ -591,6 +597,7 @@ impl Actor for CoreActor {
         _myself: ActorRef<Self::Msg>,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
+        state.api.take();
         // The pump outlives the mailbox otherwise: it holds an `ActorRef` and
         // an endpoint, and a status read in flight keeps both alive.
         if let Some(pump) = state.pump.take() {
@@ -611,6 +618,49 @@ impl Actor for CoreActor {
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
         match message {
+            CoreActorMessage::ApiClient { reply } => {
+                let result = match &state.slot {
+                    EndpointSlot::Connected(endpoint) => {
+                        match tokio::time::timeout(state.status_timeout, endpoint.api_connection())
+                            .await
+                        {
+                            Ok(Ok(Some(binding))) => {
+                                if state
+                                    .api
+                                    .as_ref()
+                                    .is_some_and(|lease| lease.client.matches(&binding))
+                                {
+                                    Ok(state.api.as_ref().expect("checked above").client.clone())
+                                } else {
+                                    state.api.take();
+                                    match api::ApiClient::new(binding, endpoint.clone()) {
+                                        Ok(client) => {
+                                            state.api = Some(api::ApiLease::new(client.clone()));
+                                            Ok(client)
+                                        }
+                                        Err(error) => Err(error),
+                                    }
+                                }
+                            }
+                            result => {
+                                state.api.take();
+                                Err(api::ApiError::Unavailable(match result {
+                                    Ok(Ok(None)) => {
+                                        "no running process exposes a usable API".into()
+                                    }
+                                    Ok(Err(error)) => error.to_string(),
+                                    Err(_) => "API binding read timed out".into(),
+                                    _ => unreachable!(),
+                                }))
+                            }
+                        }
+                    }
+                    _ => Err(api::ApiError::Unavailable(
+                        "the core endpoint is not connected".into(),
+                    )),
+                };
+                let _ = reply.send(result);
+            }
             CoreActorMessage::Submit { submission, reply } => {
                 let result = match &state.slot {
                     EndpointSlot::Connected(handle) => {
@@ -757,6 +807,7 @@ impl Actor for CoreActor {
                     // Honest terminal: desired host stays committed, nothing
                     // falls back silently (I-R2).
                     Some(desired) => {
+                        state.api.take();
                         state.slot = EndpointSlot::Degraded { desired, reason };
                         state.publish();
                     }
@@ -773,6 +824,7 @@ impl Actor for CoreActor {
             }
 
             CoreActorMessage::Shutdown { reply } => {
+                state.api.take();
                 if let EndpointSlot::ShutDown { report } = &state.slot {
                     let _ = reply.send(report.clone());
                     return Ok(());
@@ -910,6 +962,7 @@ impl CoreActor {
         // Phase: StoppingSource — no StopProof, no next owner. The source's
         // pump keeps running: its frames are still this generation's truth
         // until ownership actually moves.
+        state.api.take();
         state.slot = EndpointSlot::HandingOff {
             from: source.clone(),
             target,
@@ -1014,6 +1067,7 @@ impl CoreActor {
         // publish is what keeps the new generation's first frame from carrying
         // the old owner's state forward.
         state.snapshot = None;
+        state.api.take();
         state.slot = EndpointSlot::Connected(target.clone());
         state.publish();
         state.pump = Some(spawn_pump(
@@ -1058,6 +1112,23 @@ impl CoreObserver {
 }
 
 impl CoreClient {
+    pub async fn api_client(&self) -> Result<api::ApiClient, api::ApiError> {
+        let reply = self
+            .actor
+            .call(
+                |reply| CoreActorMessage::ApiClient { reply },
+                Some(self.submit_budget),
+            )
+            .await
+            .map_err(|error| api::ApiError::Unavailable(error.to_string()))?;
+        match reply {
+            ractor::rpc::CallResult::Success(result) => result,
+            _ => Err(api::ApiError::Unavailable(
+                "core actor did not answer API acquisition".into(),
+            )),
+        }
+    }
+
     pub(crate) fn observer(&self) -> CoreObserver {
         CoreObserver {
             status: self.status_rx.clone(),

--- a/backend/tauri/src/core/actor_v2/service_actor.rs
+++ b/backend/tauri/src/core/actor_v2/service_actor.rs
@@ -865,6 +865,7 @@ mod tests {
             let server = (installed && running && !blind).then(|| StatusResBody {
                 version: Cow::Owned(version.clone()),
                 core_infos: CoreInfos {
+                    instance_id: None,
                     r#type: None,
                     // The coarse projection a real daemon publishes: every
                     // transitional detail collapses into one of these two

--- a/backend/tauri/src/core/clash/api.rs
+++ b/backend/tauri/src/core/clash/api.rs
@@ -82,14 +82,6 @@ pub async fn get_configs() -> Result<ClashConfig> {
     Ok(resp)
 }
 
-/// GET /version
-#[instrument]
-pub async fn get_version() -> Result<ClashVersion> {
-    let path = "/version";
-    let resp: ClashVersion = perform_request((Method::GET, path)).await?.json().await?;
-    Ok(resp)
-}
-
 /// GET /rules
 #[instrument]
 pub async fn get_rules() -> Result<RulesRes> {
@@ -112,23 +104,6 @@ pub async fn update_providers_rules_group(name: &str) -> Result<()> {
     let path = format!("/providers/rules/{name}");
     let _ = perform_request((Method::PUT, path.as_str())).await?;
     Ok(())
-}
-
-/// GET /group/:name/delay
-#[instrument]
-pub async fn get_group_delay(group: String, url: Option<String>) -> Result<HashMap<String, u32>> {
-    let path = format!("/group/{group}/delay");
-    let default_url = "http://www.gstatic.com/generate_204";
-    let test_url = url
-        .map(|s| if s.is_empty() { default_url.into() } else { s })
-        .unwrap_or(default_url.into());
-
-    let query = Query([("timeout", "10000"), ("url", &test_url)]);
-    let resp: HashMap<String, u32> = perform_request((Method::GET, path.as_str(), query))
-        .await?
-        .json()
-        .await?;
-    Ok(resp)
 }
 
 /// PUT /configs
@@ -383,42 +358,16 @@ pub async fn get_providers_proxies_healthcheck(name: String) -> Result<Mapping> 
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize, Type)]
 pub struct DelayRes {
-    delay: u64,
-}
-
-fn proxy_delay_path(name: &str, provider: Option<&str>) -> String {
-    match provider {
-        Some(provider) => format!("/providers/proxies/{provider}/{name}/healthcheck"),
-        None => format!("/proxies/{name}/delay"),
-    }
-}
-
-/// GET /proxies/{name}/delay or
-/// GET /providers/proxies/{provider}/{name}/healthcheck
-/// 获取代理延迟
-#[instrument]
-pub async fn get_proxy_delay(
-    name: String,
-    provider: Option<String>,
-    test_url: Option<String>,
-) -> Result<DelayRes> {
-    let path = proxy_delay_path(&name, provider.as_deref());
-    let default_url = "http://www.gstatic.com/generate_204";
-    let test_url = test_url
-        .map(|s| if s.is_empty() { default_url.into() } else { s })
-        .unwrap_or(default_url.into());
-
-    let query = Query([("timeout", "10000"), ("url", &test_url)]);
-    let resp: DelayRes = perform_request((Method::GET, path.as_str(), query))
-        .await?
-        .json()
-        .await?;
-    Ok(resp)
+    pub delay: u64,
 }
 
 /// 根据clash info获取clash服务地址和请求头
 #[instrument]
 fn clash_client_info() -> Result<(String, HeaderMap)> {
+    // TODO(actor-migration): temporary bridge to legacy controller configuration.
+    // Reason: remaining config/proxy/rule and policy callers require the actor
+    // and cross-core response migrations in docs/plan/2026-09-06-clash-api-migration.md.
+    // Remove when: those callers use the injected instance-bound ApiClient.
     let client = { Config::clash().data().get_client_info() };
 
     let server = format!("http://{}", client.server);
@@ -435,29 +384,25 @@ fn clash_client_info() -> Result<(String, HeaderMap)> {
 }
 
 /// The Request Parameters
-struct PerformRequest<D = (), Q = ()> {
+struct PerformRequest<D = ()> {
     method: reqwest::Method,
     path: String,
-    query: Option<Q>,
     data: Option<D>,
 }
-/// A newtype wrapper for query parameters
-struct Query<T>(T);
 /// A newtype wrapper for request body
 struct Data<T>(T);
 
-impl From<(reqwest::Method, &str)> for PerformRequest<(), ()> {
+impl From<(reqwest::Method, &str)> for PerformRequest<()> {
     fn from((method, path): (reqwest::Method, &str)) -> Self {
         Self {
             method,
             path: path.to_string(),
             data: None,
-            query: None,
         }
     }
 }
 
-impl<T> From<(reqwest::Method, &str, Data<T>)> for PerformRequest<T, ()>
+impl<T> From<(reqwest::Method, &str, Data<T>)> for PerformRequest<T>
 where
     T: Serialize,
 {
@@ -466,38 +411,6 @@ where
             method,
             path: path.to_string(),
             data: Some(data),
-            query: None,
-        }
-    }
-}
-
-impl<T> From<(reqwest::Method, &str, Query<T>)> for PerformRequest<(), T>
-where
-    T: Serialize,
-{
-    fn from((method, path, Query(query)): (reqwest::Method, &str, Query<T>)) -> Self {
-        Self {
-            method,
-            path: path.to_string(),
-            data: None,
-            query: Some(query),
-        }
-    }
-}
-
-impl<D, Q> From<(reqwest::Method, &str, Query<Q>, Data<D>)> for PerformRequest<D, Q>
-where
-    D: Serialize,
-    Q: Serialize,
-{
-    fn from(
-        (method, path, Query(query), Data(data)): (reqwest::Method, &str, Query<Q>, Data<D>),
-    ) -> Self {
-        Self {
-            method,
-            path: path.to_string(),
-            data: Some(data),
-            query: Some(query),
         }
     }
 }
@@ -505,20 +418,13 @@ where
 #[instrument(skip_all, fields(
     method = tracing::field::Empty,
     url = tracing::field::Empty,
-    query = tracing::field::Empty,
     data = tracing::field::Empty,
 ))]
-async fn perform_request<D, Q>(param: impl Into<PerformRequest<D, Q>>) -> Result<reqwest::Response>
+async fn perform_request<D>(param: impl Into<PerformRequest<D>>) -> Result<reqwest::Response>
 where
-    Q: Serialize + core::fmt::Debug,
     D: Serialize + core::fmt::Debug,
 {
-    let PerformRequest {
-        method,
-        path,
-        data,
-        query,
-    } = param.into();
+    let PerformRequest { method, path, data } = param.into();
     let (host, headers) = clash_client_info().context("failed to get clash client info")?;
     let base_url = Url::parse(&host).context("failed to parse host")?;
     let opts = url::Url::options().base_url(Some(&base_url));
@@ -527,16 +433,12 @@ where
     let span = tracing::Span::current();
     span.record("method", tracing::field::display(&method));
     span.record("url", tracing::field::display(&url));
-    span.record("query", tracing::field::debug(&query));
     span.record("data", tracing::field::debug(&data));
 
     async {
         let client = reqwest::ClientBuilder::new().no_proxy().build()?;
         let mut builder = client.request(method.clone(), url.clone()).headers(headers);
 
-        if let Some(query) = &query {
-            builder = builder.query(query);
-        }
         if let Some(data) = &data {
             builder = builder.json(data);
         }
@@ -567,7 +469,7 @@ where
         Ok(resp)
     }
     .await
-    .inspect_err(|e| tracing::error!(method = %method, url = %url, query = ?query, data = ?data, "failed to perform request: {:?}", e))
+    .inspect_err(|e| tracing::error!(method = %method, url = %url, data = ?data, "failed to perform request: {:?}", e))
 }
 
 /// 缩短clash的日志
@@ -615,15 +517,6 @@ pub fn parse_check_output(log: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn proxy_delay_path_selects_endpoint_by_provider() {
-        assert_eq!(proxy_delay_path("node", None), "/proxies/node/delay");
-        assert_eq!(
-            proxy_delay_path("node", Some("subscription")),
-            "/providers/proxies/subscription/node/healthcheck"
-        );
-    }
 
     #[test]
     fn subscription_info_deserializes_pascal_case() {

--- a/backend/tauri/src/core/service/compat.rs
+++ b/backend/tauri/src/core/service/compat.rs
@@ -13,14 +13,13 @@ use nyanpasu_ipc::types::{ServiceStatus, StatusInfo};
 /// PR-5-pre 起，只有主版本等于此值的 daemon 允许承载核心生命周期。
 pub const REQUIRED_SERVICE_MAJOR: u64 = 2;
 
-/// 换线后 `/v2/core/*` 是唯一路径，而这些路由是在 `2.0.0-rc.2` 才齐的。只比
-/// 主版本的话，一台残留的 `2.0.0-rc.1` daemon（major == 2）会被判为兼容却没有
-/// 该路由——门禁就不再 fail-closed 了。
+/// 实例绑定的 ApiClient 需要 `2.0.0-rc.3` 新增的 `/v2/core/api-connection`。
+/// 旧 rc 即使支持核心生命周期路由，也不能提供进程身份和控制器凭据。
 ///
 /// 存成字符串而非 `semver::Version` 常量：`Prerelease::new` 不是 `const fn`，
 /// 能进 const 上下文的只有不带预发布标识的版本，而那样只能写成 `2.0.0`——按
-/// semver 预发布序 `2.0.0-rc.2 < 2.0.0`，反而会把本轮发布的 rc 系列全拒掉。
-pub const REQUIRED_SERVICE_MIN: &str = "2.0.0-rc.2";
+/// semver 预发布序 `2.0.0-rc.3 < 2.0.0`，反而会把本轮发布的 rc 系列全拒掉。
+pub const REQUIRED_SERVICE_MIN: &str = "2.0.0-rc.3";
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, specta::Type)]
 #[serde(rename_all = "snake_case", tag = "kind")]
@@ -168,6 +167,21 @@ mod tests {
     }
 
     #[test]
+    fn rc2_without_api_connection_is_incompatible() {
+        let mut info = parse_fixture(STATUS_V2_0_0_RC1_FIXTURE);
+        info.server.as_mut().unwrap().version = Cow::Borrowed("2.0.0-rc.2");
+
+        assert_eq!(
+            ServiceCompat::classify(&info),
+            ServiceCompat::Incompatible {
+                server_version: "2.0.0-rc.2".to_owned(),
+                required_major: REQUIRED_SERVICE_MAJOR,
+                required_min: REQUIRED_SERVICE_MIN.to_owned(),
+            }
+        );
+    }
+
+    #[test]
     fn a_daemon_at_the_minimum_is_compatible() {
         let mut info = parse_fixture(STATUS_V2_0_0_RC1_FIXTURE);
         info.server
@@ -185,7 +199,7 @@ mod tests {
         assert!(compat.allows_service_backend());
     }
 
-    /// 最低版本不能连"正式版"一起挡掉：按 semver 预发布序 `2.0.0 > 2.0.0-rc.2`。
+    /// 最低版本不能连"正式版"一起挡掉：按 semver 预发布序 `2.0.0 > 2.0.0-rc.3`。
     #[test]
     fn the_stable_release_outranks_the_minimum() {
         let mut info = parse_fixture(STATUS_V2_0_0_RC1_FIXTURE);

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -9,13 +9,10 @@ use crate::{
 };
 use anyhow::Context;
 use chrono::Local;
+use indexmap::IndexMap;
 use log::debug;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{HashMap, VecDeque},
-    path::PathBuf,
-    result::Result as StdResult,
-};
+use std::{collections::VecDeque, path::PathBuf, result::Result as StdResult};
 use storage::{StorageOperationError, WebStorage};
 use struct_patch::Patch as _;
 use sysproxy::Sysproxy;
@@ -670,14 +667,12 @@ pub async fn inspect_updater(updater_id: usize) -> Result<updater::UpdaterSummar
 #[tauri::command]
 #[specta::specta]
 pub async fn clash_api_get_proxy_delay(
+    client: State<'_, NyanpasuClient>,
     name: String,
     provider: Option<String>,
     url: Option<String>,
 ) -> Result<clash::api::DelayRes> {
-    match clash::api::get_proxy_delay(name, provider, url).await {
-        Ok(res) => Ok(res),
-        Err(err) => Err(err.into()),
-    }
+    Ok(client.proxy_delay(name, provider, url).await?)
 }
 
 #[tauri::command]
@@ -688,14 +683,19 @@ pub async fn clash_api_get_configs() -> Result<clash::api::ClashConfig> {
 
 #[tauri::command]
 #[specta::specta]
-pub async fn clash_api_delete_connections(id: Option<String>) -> Result<()> {
-    Ok(clash::api::delete_connections(id.as_deref()).await?)
+pub async fn clash_api_delete_connections(
+    client: State<'_, NyanpasuClient>,
+    id: Option<String>,
+) -> Result<()> {
+    Ok(client.close_clash_connections(id).await?)
 }
 
 #[tauri::command]
 #[specta::specta]
-pub async fn clash_api_get_version() -> Result<clash::api::ClashVersion> {
-    Ok(clash::api::get_version().await?)
+pub async fn clash_api_get_version(
+    client: State<'_, NyanpasuClient>,
+) -> Result<clash::api::ClashVersion> {
+    Ok(client.clash_version().await?)
 }
 
 #[tauri::command]
@@ -719,10 +719,11 @@ pub async fn clash_api_update_providers_rules(name: String) -> Result<()> {
 #[tauri::command]
 #[specta::specta]
 pub async fn clash_api_get_group_delay(
+    client: State<'_, NyanpasuClient>,
     group: String,
     url: Option<String>,
-) -> Result<HashMap<String, u32>> {
-    Ok(clash::api::get_group_delay(group, url).await?)
+) -> Result<IndexMap<String, u32>> {
+    Ok(client.group_delay(group, url).await?)
 }
 
 #[tauri::command]

--- a/backend/tauri/src/utils/collect.rs
+++ b/backend/tauri/src/utils/collect.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::BTreeMap};
 
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
@@ -30,7 +30,7 @@ pub struct EnvInfo<'a> {
     // pub service_info: xxx
 }
 
-pub type CoreInfo<'a> = HashMap<Cow<'a, str>, Cow<'a, str>>;
+pub type CoreInfo<'a> = BTreeMap<Cow<'a, str>, Cow<'a, str>>;
 
 pub fn collect_envs<'a>() -> Result<EnvInfo<'a>, std::io::Error> {
     let mut system = sysinfo::System::new_all();
@@ -60,7 +60,7 @@ pub fn collect_envs<'a>() -> Result<EnvInfo<'a>, std::io::Error> {
         memory: Cow::Owned(SizeFormatter::new(system.total_memory(), BINARY).to_string()),
     };
 
-    let mut core = HashMap::new();
+    let mut core = BTreeMap::new();
     for c in CoreType::get_supported_cores() {
         let name: &str = c.as_ref();
 

--- a/docs/plan/2026-09-06-clash-api-migration.md
+++ b/docs/plan/2026-09-06-clash-api-migration.md
@@ -1,0 +1,195 @@
+# Clash API caller migration
+
+## Goal and scope
+
+Route application Clash REST and streaming callers through the runtime workspace's
+`clash-api`, with an explicitly injected, instance-bound API capability issued by
+CoreClient. Tauri commands remain adapters over NyanpasuClient. The frontend keeps
+using generated commands/events; dashboard links and unrelated HTTP services are
+outside this migration.
+
+The baseline is application cab2330b and runtime a3512f9. Runtime is a separate
+repository: any runtime changes require a dependency PR and an updated gitlink in
+the application PR. Deliver reviewable changes; do not merge either PR.
+
+## Lifecycle contract
+
+- Runtime epoch is not process identity: restart and rollback may reuse an epoch,
+  and the process supervisor can respawn inside one Instance.
+- Publish a new opaque process identity for each actual process start, including
+  automatic respawn. Preserve it across hot patch and in-process reload.
+- Bind each issued API capability to controller generation, actual endpoint,
+  credentials, and process identity. The endpoint comes from the applied runtime,
+  not the desired config's legacy global mirror.
+- Revoke old capabilities on replacement, handoff, stop, shutdown, unavailable
+  endpoint, or changed credentials. Clones share revocation; they never revive.
+- Check before requests and before returning results; cancel in-flight operations
+  and streams when revoked. Discard delayed events from retired identities.
+- Do not transparently replay mutations on another process. Cancellation cannot
+  undo an already accepted request; a lost mutation reply has an uncertain outcome.
+- A remote status feed has a detection window. Strict prevention of an HTTP request
+  reaching a replacement process on a reused address requires a runtime-side
+  identity fence or an instance-specific transport. Do not claim that polling or
+  cancellation closes this distributed race.
+
+## Architecture and service classification
+
+CoreActor owns the capability lifetime (actor service). ApiClient is an injected
+infrastructure adapter wrapping the typed protocol client with revocation; it must
+not expose a raw Client, RequestBuilder, or unguarded socket. Request execution is
+outside the CoreActor mailbox. ProxiesActor owns proxy cache/selection orchestration;
+Clash streaming actor owns connections/history/subscriptions. DTO conversion and
+connection interruption policy are pure functions. UI event emission stays behind
+ports, with wiring in the composition root.
+
+Configuration/lifecycle writes keep the existing lifecycle actor as their owner;
+opening a typed API must not create a second config writer or expose unmanaged
+restart/upgrade operations.
+
+## Work sequence and checks
+
+1. Establish runtime process identity and controller projection.
+   Verify same-epoch restart/respawn changes identity, patch preserves identity,
+   and Local/Service projections agree. Missing identity is unavailable, never a
+   guessed PID/epoch fallback.
+2. Implement the revocable typed API and CoreClient acquisition.
+   Verify cloned handles, cancellation while reading a response, handoff and
+   shutdown, endpoint/secret changes, hot patch stability, and stale snapshots.
+3. Migrate REST commands through NyanpasuClient, then injected proxy cache and
+   connection interruption call paths. Remove the old URL/request implementation.
+   Verify response fixtures for Mihomo, clash-rs and Premium before replacing DTOs;
+   retain absence/unknown-field semantics instead of manufacturing values.
+4. Migrate streaming connections to clash-api and fence stream updates by
+   capability identity. Verify reconnection, recording controls, history limits,
+   and rejection of old frames after restart.
+5. Regenerate frontend bindings and adapt consumers to changed application DTOs.
+   Verify TypeScript and relevant UI build checks. No frontend controller secrets
+   or generic request transport are introduced.
+6. Review diffs, run focused Rust tests and application compile checks, then
+   commit related paths explicitly and create PR(s) with actual validation and
+   any remaining migration boundary documented here.
+
+## Compatibility risks to resolve
+
+The pinned clash-api is Mihomo-oriented: RuntimeConfig and Proxy require fields
+other cores omit; SubscriptionInfo currently requires every PascalCase field;
+ConnectionsSnapshot requires memory, and Connection requires providerChains.
+Existing application fixtures cover several of these missing-field cases.
+WebSocket helpers currently return raw sockets and need guarded typed consumption.
+The application router polls status every two seconds and can accept a late status
+frame from before RefreshStatus. This display cache is not an authority for
+issuing or reviving an API capability. Runtime IPC publishes the controller but
+intentionally excludes its secret: credential provenance must be explicit.
+
+## Execution record
+
+Runtime dependency: [nyanpasu-runtime #401](https://github.com/libnyanpasu/nyanpasu-runtime/pull/401) is merged. The submodule pins released `v2.0.0-rc.3` (`b14f0d0`); Service compatibility requires at least `2.0.0-rc.3` for `/v2/core/api-connection`.
+
+### First implementation / review boundary
+
+This PR implements steps 1–2 and a bounded part of step 3; it is not a completed
+migration of every caller. The remaining steps are follow-up work, not hidden
+compatibility APIs for new callers.
+
+Delivered:
+
+- Runtime publishes `instance_id` (a UUID generated on each supervisor Started
+  event), including same-epoch restart and automatic respawn. Identity-only
+  changes wake status subscribers even when PID, epoch and health are unchanged.
+- `CoreManager`/`CoreControl::api_connection()` reads the process identity and
+  applied controller credentials under the control lock. Service exposes that
+  binding at `/v2/core/api-connection` over the existing ACL-protected IPC socket;
+  credentials are redacted in Debug and excluded from status/events.
+- `CoreClient::api_client()` issues an `ApiClient` whose private protocol client
+  and shared cancellation token belong to a CoreActor-owned lease. Acquisition
+  reads the authority directly, rather than trusting the router's display cache.
+  Dropping the lease on handoff, degradation, shutdown, or actor destruction
+  revokes every clone. Reacquisition with the same binding reuses a live lease.
+- A lease-owned monitor consumes Local watch / Service event notifications and
+  rechecks the actual binding. A two-second recheck also covers lost/coalesced
+  notifications and secret changes. Notification payloads never revive a lease.
+  Binding/subscription reads are bounded at ten seconds; complete API operations
+  (preflight, network/body decode, postflight) are bounded at thirty seconds.
+- Version, proxy/provider-proxy delay, group delay and explicit close-connection(s)
+  commands now use `NyanpasuClient` and the typed API. Requests and bodies are no
+  longer manually assembled for these callers; the unused legacy query transport
+  was removed. Premium's version flag is preserved by clash-api.
+- Frontend command DTOs remain stable. Generated service-status bindings gain the
+  optional `instance_id`; no credential-bearing type is exported to the frontend.
+
+The monitor provides revocation on observed authority changes. Preflight and
+postflight prevent knowingly using/accepting an obsolete binding; they do not
+provide atomic HTTP admission against a concurrent process replacement. Neither
+Local nor Service can undo an already transmitted mutation on a reused HTTP
+address. Strict process-side fencing and guarded streaming remain future work.
+
+Service deployments must include a daemon built with the runtime dependency PR.
+The compatibility gate rejects older daemons lacking the new endpoint. The
+matching service binary is published in `v2.0.0-rc.3`; the download script reads
+that version from the pinned runtime manifest.
+
+### Remaining migration inventory
+
+| Callers                                                    | Required next change                                                                                                                                                  |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| configs / rules / providers REST reads in `ipc.rs`         | Make cross-core response absence explicit in clash-api before replacing old optional DTOs. Rule also requires `index` and `size`, which the old DTO does not require. |
+| `ProxiesGuard`, tray proxy actions, provider updates       | Introduce injected ProxiesActor ownership and migrate its cache, notifications and selection workflow together.                                                       |
+| `feat::change_clash_mode`, `ConnectionInterruptionService` | Move policy inputs and post-commit side effects into injected application workflows; do not add a second config writer.                                               |
+| `ClashConnectionsActor` and widget/UI subscriptions        | Guard typed stream consumption and queued messages by capability identity, then migrate shared history ownership and UI sinks.                                        |
+
+The remaining legacy controller lookup is explicitly marked `TODO(actor-migration)`
+with this plan as its reason/removal condition. New callers must use the facade.
+
+### Validation
+
+Performed on macOS with debug symbols and incremental compilation disabled to
+keep independent build artifacts small:
+
+- Application library compile and `cargo clippy -p clash-nyanpasu --all-targets
+--all-features --offline`: passed (existing warnings remain).
+- Retained cross-core application API DTO tests: 11 passed.
+- CoreActor tests: 74 passed, including clone invalidation, same-epoch/PID
+  replacement, unchanged binding, credentials/endpoint changes, handoff,
+  shutdown/destruction, and cancelling a partially received response body.
+- Runtime core-manager: 102 unit tests passed, 1 existing ignored test;
+  config_apply: 20 passed; instance_lifecycle: 16 passed. The latter suites
+  exercise actual fake-core processes, preserving identity through patch/reload
+  and changing identity on restart/respawn.
+- Runtime clash-api / IPC / service library tests: 19 / 11 / 84 passed.
+- IPC wire golden tests: 32 passed; clash-api REST / stream integration tests:
+  3 / 2 passed.
+- Specta binding generation and shape assertions, interface build, UI build and
+  all frontend TypeScript checks: passed. The fresh worktree's UI build generates
+  Paraglide assets before the final type check.
+
+One existing core-manager test,
+`config::tests::managed_bootstrap_zeroes_listeners_and_keeps_the_source_snapshot`,
+is skipped on this machine because it unconditionally passes a Windows named-pipe
+path to the Unix controller validator. Its source is unchanged by this PR.
+`TMPDIR=/private/tmp` avoids macOS `/var` versus `/private/var` canonical-path
+mismatches in the other Unix fixtures; socket/process tests run outside the
+filesystem/network sandbox. Windows named-pipe behavior was not executed locally.
+
+### CI and ordered response follow-up
+
+- Refresh the architecture ledger snapshot for the documented remaining legacy
+  controller lookup; the gate still compares exact counts. A temporary-worktree
+  regression test ensures ancestor `tmp` directories do not exclude the source.
+- Preserve clash-api's `IndexMap` order through the group-delay facade and IPC
+  return type. Environment diagnostics return core versions as a `BTreeMap` for
+  stable key order. Both retain the existing JSON object / TypeScript shapes.
+- Other `HashMap` uses in the application are internal state, request inputs or
+  persistence, rather than IPC response types. Runtime clash-api response maps
+  already use ordered collections.
+- Reject Service rc.2 explicitly: it lacks the API connection route even though
+  its lifecycle routes are supported. The bundled-version guard covers rc.3.
+
+Follow-up validation on macOS: `cargo test --all-features --offline` passed
+(application library: 464 passed, 1 existing ignored), including the 12 Service
+compatibility tests and IPC binding export. Full-workspace Clippy passed with
+existing warnings. The ledger's 33 tests, exact snapshot gate, Prettier, Oxlint,
+style checks, all frontend TypeScript checks and Rust formatting passed.
+`lint:deno` formatting passed, but its full script type check could not finish:
+JSR downloads for an unchanged notification script failed with a TLS handshake
+error on both attempts. The changed ledger scripts were type-checked by their
+passing Deno test run.

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -617,9 +617,9 @@ export type CopyEnvOption = 'shell' | 'cmd' | 'pwsh'
  *
  *  A deliberately separate type from `clash_api::Host`: clash-api is an
  *  internal dependency of the core manager and must not leak into the wire
- *  dependency tree. The controller secret is never carried here — it comes
- *  from the caller's own config, and the IPC transport's only gate is the
- *  socket ACL.
+ *  dependency tree. The controller secret is never carried here. Clients read
+ *  applied credentials through the private `/v2/core/api-connection` endpoint;
+ *  the IPC transport's authorization gate is the socket ACL.
  */
 export type CoreControllerInfo =
   | ({ NamedPipe: string } & { Http?: never; UnixSocket?: never })
@@ -648,6 +648,7 @@ export type CoreHealthState = 'Starting' | 'Healthy' | 'Unhealthy'
 export type CoreInfos = CoreInfos_Serialize | CoreInfos_Deserialize
 
 export type CoreInfos_Deserialize = {
+  instance_id?: string | null
   type: CoreType | null
   state: CoreState
   state_changed_at: number
@@ -663,6 +664,7 @@ export type CoreInfos_Deserialize = {
 }
 
 export type CoreInfos_Serialize = {
+  instance_id?: string | null
   type: CoreType | null
   state: CoreState
   state_changed_at: number

--- a/scripts/architecture-ledger.snapshot.json
+++ b/scripts/architecture-ledger.snapshot.json
@@ -24,9 +24,9 @@
       }
     },
     "migration_markers": {
-      "total": 10,
+      "total": 11,
       "byKey": {
-        "TODO(actor-migration)": 8,
+        "TODO(actor-migration)": 9,
         "FIXME(actor-migration)": 2
       }
     },

--- a/scripts/architecture-ledger.ts
+++ b/scripts/architecture-ledger.ts
@@ -455,10 +455,13 @@ function matchAll(
   return out;
 }
 
-async function collectRustFiles(roots: string[]): Promise<string[]> {
+export async function collectRustFiles(
+  roots: string[],
+  repoRoot = ROOT,
+): Promise<string[]> {
   const files: string[] = [];
   for (const root of roots) {
-    const abs = path.isAbsolute(root) ? root : path.join(ROOT, root);
+    const abs = path.isAbsolute(root) ? root : path.join(repoRoot, root);
     try {
       const st = await Deno.stat(abs);
       if (!st.isDirectory) continue;
@@ -475,7 +478,7 @@ async function collectRustFiles(roots: string[]): Promise<string[]> {
         skip: [/[/\\]target[/\\]/, /[/\\]node_modules[/\\]/],
       })
     ) {
-      const parts = entry.path.split(path.SEPARATOR);
+      const parts = path.relative(repoRoot, entry.path).split(path.SEPARATOR);
       if (parts.some((p) => SKIP_DIR_NAMES.has(p))) continue;
       if (!isRustSource(entry.path)) continue;
       files.push(entry.path);

--- a/scripts/architecture-ledger_test.ts
+++ b/scripts/architecture-ledger_test.ts
@@ -1,6 +1,6 @@
 /**
  * Fixture-only tests for the S10 architecture ledger gate.
- * Does not scan the live repository; all inputs are in-memory fixtures.
+ * Does not scan the live repository; inputs are in-memory or temporary fixtures.
  */
 import {
   assert,
@@ -10,6 +10,7 @@ import {
 } from "jsr:@std/assert@1";
 import {
   cfgInnerEnablesTest,
+  collectRustFiles,
   createBuckets,
   evaluateGate,
   isBridgePath,
@@ -655,4 +656,26 @@ fn braces_in_string() {
       k.includes("app_home_dir")
     ),
   );
+});
+
+Deno.test("collectRustFiles: a tmp ancestor does not exclude the worktree", async () => {
+  const fixture = await Deno.makeTempDir();
+  const repo = `${fixture}/tmp/worktree`;
+  try {
+    for (const dir of ["src", "tmp", "target", "nyanpasu-runtime"]) {
+      await Deno.mkdir(`${repo}/backend/${dir}`, { recursive: true });
+      await Deno.writeTextFile(
+        `${repo}/backend/${dir}/sample.rs`,
+        "fn sample() {}",
+      );
+    }
+    const files = await collectRustFiles(["backend"], repo);
+    assertEquals(files.length, 1);
+    assertEquals(
+      await Deno.realPath(files[0]),
+      await Deno.realPath(`${repo}/backend/src/sample.rs`),
+    );
+  } finally {
+    await Deno.remove(fixture, { recursive: true });
+  }
 });


### PR DESCRIPTION
Clash callers currently derive request addresses and credentials from legacy configuration, which can diverge from the applied core and cannot distinguish a process replacement inside the same runtime epoch. This first migration routes version queries, proxy/provider-proxy delay, group delay, and explicit connection closure through `NyanpasuClient` and an instance-bound `CoreClient::api_client()`.

The CoreActor owns a revocable lease over a private `clash-api::Client`. Clones share cancellation; authoritative binding checks run before and after each complete request, and lifecycle notifications plus periodic checks revoke idle handles. Handoff, degradation, shutdown, actor destruction, endpoint/secret changes and process replacement retire the lease. Hot patch/reload with the same binding retain it. Network operations run outside the actor mailbox, and mutations are not automatically replayed.

Uses the merged https://github.com/libnyanpasu/nyanpasu-runtime/pull/401 via released `v2.0.0-rc.3` (gitlink `b14f0d0`). The runtime adds per-process identity and a separate private IPC query for applied controller credentials. No secret-bearing type is exported to the frontend; existing command DTOs stay stable, and generated service-status bindings add optional `instance_id`.

The plan and complete remaining inventory are in [docs/plan/2026-09-06-clash-api-migration.md](https://github.com/libnyanpasu/clash-nyanpasu/blob/feat/instance-bound-clash-api/docs/plan/2026-09-06-clash-api-migration.md). This is **not the full caller migration**: config/proxy/rule response compatibility, ProxiesActor ownership, policy-triggered connection interruption and guarded WS streams remain separate steps. The remaining legacy controller lookup is explicitly marked with its removal condition.

Kept as draft for review of this first stage. The matching Service binary is released in rc.3; the compatibility gate now rejects rc.2, which lacks the API connection route. Revocation is based on observed authority changes and does not atomically fence an already transmitted HTTP mutation against concurrent replacement on a reused address.

Group-delay responses preserve the native `IndexMap` order through the facade and IPC. Environment diagnostics use `BTreeMap` for stable core-version output; TypeScript object shapes stay unchanged. The architecture ledger records the explicit remaining migration marker, and a regression test prevents worktrees under `tmp` from being silently excluded.

Validation on macOS:

- Application library compile and Clippy across all targets/features passed (existing warnings remain).
- CoreActor tests: 74 passed, including six new capability tests for clones, unchanged binding, process identity/credentials/endpoint changes, handoff/shutdown/destruction, and cancellation during response-body reading.
- Retained cross-core API DTO fixtures: 11 passed.
- Specta binding generation/shape assertions, interface build, UI build, all frontend TypeScript checks and Rust formatting passed.
- Dependency validation: core-manager 102 unit + 20 config-apply + 16 lifecycle tests; clash-api/IPC/service libraries 19/11/84; wire golden 32; REST/stream integration 3/2 passed.

The dependency skips one unchanged Windows named-pipe fixture that is invalid on Unix, and one pre-existing test remains ignored. Windows transport execution and packaged-daemon deployment were not performed. Exact constraints and worktree prerequisites are recorded in the plan.


Follow-up validation against runtime rc.3: full-workspace `cargo test --all-features --offline` passed (application library: 464 passed, 1 existing ignored), including 12 Service compatibility tests and binding export. Full-workspace Clippy passed with existing warnings. Architecture-ledger tests (33), the exact snapshot gate, Prettier, Oxlint, styles, all frontend TypeScript checks and Rust formatting passed. The full Deno script type check remains locally blocked by repeated JSR TLS download failures in an unchanged notification script; the changed ledger scripts type-checked and passed their tests.
