### PR TITLE
refactor(core): migrate rule operations to the bound Clash API

### DIFF
--- a/backend/tauri/src/client/clash_api.rs
+++ b/backend/tauri/src/client/clash_api.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use clash_api::{DelayQuery, ProviderName, ProxyName};
 use indexmap::IndexMap;
 
-use crate::core::clash::api::{ClashVersion, DelayRes};
+use crate::core::clash::api::{ClashRule, ClashVersion, DelayRes, RulesRes};
 
 use super::NyanpasuClient;
 
@@ -16,6 +16,30 @@ fn delay_query(url: Option<String>) -> Result<DelayQuery> {
 }
 
 impl NyanpasuClient {
+    pub async fn clash_rules(&self) -> Result<RulesRes> {
+        let rules = self.inner.core_api.api_client().await?.rules().await?;
+        Ok(RulesRes {
+            rules: rules
+                .into_iter()
+                .map(|rule| ClashRule {
+                    r#type: rule.rule_type,
+                    payload: rule.payload,
+                    proxy: rule.proxy,
+                })
+                .collect(),
+        })
+    }
+
+    pub async fn update_clash_rule_provider(&self, name: String) -> Result<()> {
+        self.inner
+            .core_api
+            .api_client()
+            .await?
+            .update_rule_provider(&clash_api::RuleProviderName::new(name))
+            .await?;
+        Ok(())
+    }
+
     pub async fn clash_version(&self) -> Result<ClashVersion> {
         let version = self.inner.core_api.api_client().await?.version().await?;
         Ok(ClashVersion {

--- a/backend/tauri/src/core/actor_v2/api.rs
+++ b/backend/tauri/src/core/actor_v2/api.rs
@@ -104,6 +104,17 @@ impl ApiClient {
         }
     }
 
+    pub async fn rules(&self) -> Result<Vec<clash_api::Rule>, ApiError> {
+        self.execute(self.client.rules()).await
+    }
+
+    pub async fn update_rule_provider(
+        &self,
+        name: &clash_api::RuleProviderName,
+    ) -> Result<(), ApiError> {
+        self.execute(self.client.update_rule_provider(name)).await
+    }
+
     pub async fn version(&self) -> Result<Version, ApiError> {
         self.execute(self.client.version()).await
     }
@@ -302,6 +313,46 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), api.revoked.cancelled())
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn rules_and_provider_refresh_use_the_bound_client() {
+        use axum::{extract::Path, http::StatusCode, routing::put};
+        let (url, server) = server(
+            Router::new()
+                .route(
+                    "/rules/",
+                    get(|| async {
+                        Json(serde_json::json!({"rules":[
+                            {"type":"Match","payload":"","proxy":"DIRECT"}
+                        ]}))
+                    }),
+                )
+                .route(
+                    "/providers/rules/{name}/",
+                    put(|Path(name): Path<String>| async move {
+                        assert_eq!(name, "rules/日本 ?#");
+                        StatusCode::NO_CONTENT
+                    }),
+                ),
+        )
+        .await;
+        let endpoint = endpoint(url);
+        let core = CoreClient::spawn(endpoint.clone()).await.unwrap();
+        let api = core.api_client().await.unwrap();
+        let rules = api.rules().await.unwrap();
+        assert_eq!(rules[0].proxy, "DIRECT");
+        assert_eq!(rules[0].index, None);
+        let provider = clash_api::RuleProviderName::new("rules/日本 ?#");
+        api.update_rule_provider(&provider).await.unwrap();
+        endpoint.binding.send_replace(None);
+        assert!(matches!(api.rules().await, Err(ApiError::Stale)));
+        assert!(matches!(
+            api.update_rule_provider(&provider).await,
+            Err(ApiError::Stale)
+        ));
+        core.actor.stop(None);
+        server.abort();
     }
 
     #[tokio::test]

--- a/backend/tauri/src/core/clash/api.rs
+++ b/backend/tauri/src/core/clash/api.rs
@@ -82,28 +82,12 @@ pub async fn get_configs() -> Result<ClashConfig> {
     Ok(resp)
 }
 
-/// GET /rules
-#[instrument]
-pub async fn get_rules() -> Result<RulesRes> {
-    let path = "/rules";
-    let resp: RulesRes = perform_request((Method::GET, path)).await?.json().await?;
-    Ok(resp)
-}
-
 /// GET /providers/rules
 #[instrument]
 pub async fn get_providers_rules() -> Result<ProvidersRulesRes> {
     let path = "/providers/rules";
     let resp: ProvidersRulesRes = perform_request((Method::GET, path)).await?.json().await?;
     Ok(resp)
-}
-
-/// PUT /providers/rules/:name
-#[instrument]
-pub async fn update_providers_rules_group(name: &str) -> Result<()> {
-    let path = format!("/providers/rules/{name}");
-    let _ = perform_request((Method::PUT, path.as_str())).await?;
-    Ok(())
 }
 
 /// PUT /configs

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -700,8 +700,10 @@ pub async fn clash_api_get_version(
 
 #[tauri::command]
 #[specta::specta]
-pub async fn clash_api_get_rules() -> Result<clash::api::RulesRes> {
-    Ok(clash::api::get_rules().await?)
+pub async fn clash_api_get_rules(
+    client: State<'_, NyanpasuClient>,
+) -> Result<clash::api::RulesRes> {
+    Ok(client.clash_rules().await?)
 }
 
 #[tauri::command]
@@ -712,8 +714,11 @@ pub async fn clash_api_get_providers_rules() -> Result<clash::api::ProvidersRule
 
 #[tauri::command]
 #[specta::specta]
-pub async fn clash_api_update_providers_rules(name: String) -> Result<()> {
-    Ok(clash::api::update_providers_rules_group(&name).await?)
+pub async fn clash_api_update_providers_rules(
+    client: State<'_, NyanpasuClient>,
+    name: String,
+) -> Result<()> {
+    Ok(client.update_clash_rule_provider(name).await?)
 }
 
 #[tauri::command]

--- a/docs/plan/2026-09-06-clash-api-migration.md
+++ b/docs/plan/2026-09-06-clash-api-migration.md
@@ -130,12 +130,12 @@ that version from the pinned runtime manifest.
 
 ### Remaining migration inventory
 
-| Callers                                                    | Required next change                                                                                                                                                  |
-| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| configs / rules / providers REST reads in `ipc.rs`         | Make cross-core response absence explicit in clash-api before replacing old optional DTOs. Rule also requires `index` and `size`, which the old DTO does not require. |
-| `ProxiesGuard`, tray proxy actions, provider updates       | Introduce injected ProxiesActor ownership and migrate its cache, notifications and selection workflow together.                                                       |
-| `feat::change_clash_mode`, `ConnectionInterruptionService` | Move policy inputs and post-commit side effects into injected application workflows; do not add a second config writer.                                               |
-| `ClashConnectionsActor` and widget/UI subscriptions        | Guard typed stream consumption and queued messages by capability identity, then migrate shared history ownership and UI sinks.                                        |
+| Callers                                                    | Required next change                                                                                                                                                                                               |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| configs / provider REST reads in `ipc.rs`                  | Make cross-core response absence and unknown enum values explicit before replacing old optional DTOs. Rule reads and provider refresh are covered by [the next migration](2026-09-07-clash-rule-api-migration.md). |
+| `ProxiesGuard`, tray proxy actions, provider updates       | Introduce injected ProxiesActor ownership and migrate its cache, notifications and selection workflow together.                                                                                                    |
+| `feat::change_clash_mode`, `ConnectionInterruptionService` | Move policy inputs and post-commit side effects into injected application workflows; do not add a second config writer.                                                                                            |
+| `ClashConnectionsActor` and widget/UI subscriptions        | Guard typed stream consumption and queued messages by capability identity, then migrate shared history ownership and UI sinks.                                                                                     |
 
 The remaining legacy controller lookup is explicitly marked `TODO(actor-migration)`
 with this plan as its reason/removal condition. New callers must use the facade.

--- a/docs/plan/2026-09-07-clash-rule-api-migration.md
+++ b/docs/plan/2026-09-07-clash-rule-api-migration.md
@@ -1,0 +1,59 @@
+# Clash rule API migration
+
+## Scope and verification
+
+1. Make clash-api rule extensions optional without inventing values. Verify base,
+   extended and malformed responses through an HTTP fixture.
+2. Migrate rule reads and provider refresh through NyanpasuClient and the existing
+   instance-bound ApiClient. Verify revocation and encoded provider names with a
+   fake endpoint. Remove the corresponding legacy URL-building functions.
+3. Run Rust tests, bindings generation, frontend types and the architecture gate;
+   deliver runtime and application PRs with the dependency explicitly pinned.
+
+## FeatureSet boundary
+
+The current runtime metadata exposes FeatureSupport::features as an EnumSet.
+Its features describe named-pipe IPC, Unix-socket IPC and disabling the TCP
+controller. None describes rule indices, sizes, counters or provider metadata.
+These flags cannot select a response schema safely.
+
+Keep required common fields (type, payload, proxy) strongly typed and required.
+Represent optional index/size fields explicitly as Option, as extra already is;
+missing is not zero. Reject invalid types even for optional fields. The existing
+UI consumes only common rule fields, so its DTO remains stable.
+
+Future API-specific features should describe operations with verified core/version
+support (for example rule disabling). They can gate those operations, but must
+not synthesize absent response data or skip wire validation. Bind such metadata
+to the same applied instance as the ApiClient, not the configured core choice.
+
+Runtime dependency: [nyanpasu-runtime #402](https://github.com/libnyanpasu/nyanpasu-runtime/pull/402), pinned at `05fb304`. Merge it before the application PR.
+
+## Service and lifecycle
+
+This change requires a newer clash-api source dependency but introduces no new
+Service IPC contract; rc.3 remains sufficient. Both operations use the existing
+preflight/postflight authority checks, timeout and shared revocation. Provider
+refresh is a mutation and is not retried automatically.
+
+## Remaining callers
+
+Provider listing still needs response-model work: optional metadata and unknown
+string enum values must retain their meaning across cores. Config, proxy/cache,
+policy and stream migration remain as listed in the preceding plan. This PR
+migrates the complete rule-read and explicit rule-provider-refresh call paths.
+
+## Validation
+
+- Runtime: 19 unit, 4 REST, 2 stream and 5 traffic tests passed. The existing
+  real-Mihomo integration test remains ignored; its index consumer was updated
+  and compiled. Runtime Clippy across all targets and formatting passed.
+- Application: full-workspace tests with all features passed; application library
+  465 passed, 1 existing ignored. The added HTTP test verifies base-rule decoding,
+  encoded provider names and rejection of both operations after revocation.
+- Application full-target/full-feature Clippy passed with existing warnings.
+- Specta binding export produced no diff. All three frontend TypeScript checks,
+  Prettier on touched documents/bindings, Oxlint, Rust formatting and the exact
+  architecture ledger gate passed.
+- Validation ran on macOS. Real-core and Windows transport behavior were not
+  exercised in this follow-up.


### PR DESCRIPTION
Rule-list reads and explicit rule-provider refresh currently reconstruct URLs and credentials from legacy configuration. Route both commands through NyanpasuClient and the existing instance-bound CoreClient ApiClient, then delete their legacy request functions. Provider names are encoded by clash-api; stale capabilities reject both reads and mutations.

Depends on https://github.com/libnyanpasu/nyanpasu-runtime/pull/402 (pinned `05fb304`), which represents optional rule index/size fields as Option rather than requiring them or inventing zero values. Merge that PR first. No new Service IPC is introduced; Service rc.3 remains sufficient. The UI keeps its existing common rule DTO and generated bindings are unchanged.

FeatureSet assessment: current FeatureSupport metadata describes controller transports, not response fields. Those flags cannot safely select rule response types. Future API-specific capabilities should gate verified operations and be bound to the applied instance; wire decoding must still preserve absent fields and reject invalid data. The plan explains this boundary in `docs/plan/2026-09-07-clash-rule-api-migration.md`.

Validation on macOS:

- Full-workspace Rust tests with all features passed; application library 465 passed, 1 existing ignored.
- Added HTTP test covers base rules, provider names containing slash/Unicode/query/fragment characters, and rejection after instance revocation.
- Application and dependency Clippy passed; runtime tests passed (19 unit, 4 REST, 2 stream, 5 traffic).
- Specta export produced no diff; all frontend TypeScript checks, changed-document formatting, Oxlint, Rust formatting and architecture-ledger gate passed.

The existing real-Mihomo test remains ignored and Windows transports were not executed locally. Provider listing still needs optional metadata and unknown-enum compatibility; configs, proxy ownership, policy workflows and guarded streams remain in the migration inventory. This PR covers the complete rule-read and explicit rule-provider-refresh paths.
