### PR TITLE
chore(deps): update dependency @tanstack/react-table to v9

### DIFF
--- a/frontend/nyanpasu/package.json
+++ b/frontend/nyanpasu/package.json
@@ -23,7 +23,7 @@
     "@paper-design/shaders-react": "0.0.80",
     "@radix-ui/react-use-controllable-state": "1.2.6",
     "@tailwindcss/postcss": "4.3.3",
-    "@tanstack/react-table": "8.21.3",
+    "@tanstack/react-table": "9.2.4",
     "@tanstack/react-virtual": "3.14.10",
     "@tanstack/router-zod-adapter": "1.81.5",
     "@tauri-apps/api": "2.11.1",

--- a/frontend/nyanpasu/src/pages/(main)/main/connections/index.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/connections/index.tsx
@@ -24,12 +24,16 @@ import { ClashConnectionItem, useClashConnections } from '@nyanpasu/interface'
 import { cn } from '@nyanpasu/utils'
 import { createFileRoute } from '@tanstack/react-router'
 import {
-  ColumnDef,
-  ColumnSizingState,
+  columnResizingFeature,
+  columnSizingFeature,
+  columnVisibilityFeature,
+  createSortedRowModel,
   flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
-  useReactTable,
+  rowSortingFeature,
+  tableFeatures,
+  useTable,
+  type ColumnDef,
+  type ColumnSizingState,
   type Updater,
 } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
@@ -42,6 +46,14 @@ export type ConnectionRow = ClashConnectionItem & {
   downloadSpeed: number
   uploadSpeed: number
 }
+
+const features = tableFeatures({
+  rowSortingFeature,
+  columnSizingFeature,
+  columnResizingFeature,
+  columnVisibilityFeature,
+  sortedRowModel: createSortedRowModel(),
+})
 
 const COLUMN_SIZING_STORAGE_KEY = 'connections-column-sizing-v2'
 
@@ -124,7 +136,7 @@ const Viewer = ({ search }: { search: string }) => {
         {
           header: 'Downloaded',
           accessorFn: ({ download }) => parseTraffic(download).join(' '),
-          sortingFn: (rowA, rowB) =>
+          sortFn: (rowA, rowB) =>
             rowA.original.download - rowB.original.download,
           size: 120,
           cell: (info) => (
@@ -136,8 +148,7 @@ const Viewer = ({ search }: { search: string }) => {
         {
           header: 'Uploaded',
           accessorFn: ({ upload }) => parseTraffic(upload).join(' '),
-          sortingFn: (rowA, rowB) =>
-            rowA.original.upload - rowB.original.upload,
+          sortFn: (rowA, rowB) => rowA.original.upload - rowB.original.upload,
           size: 120,
           cell: (info) => (
             <span>{parseTraffic(info.row.original.upload).join(' ')}</span>
@@ -147,7 +158,7 @@ const Viewer = ({ search }: { search: string }) => {
           header: 'DL Speed',
           accessorFn: ({ downloadSpeed }) =>
             parseTraffic(downloadSpeed).join(' ') + '/s',
-          sortingFn: (rowA, rowB) =>
+          sortFn: (rowA, rowB) =>
             rowA.original.downloadSpeed - rowB.original.downloadSpeed,
           size: 120,
           cell: (info) => (
@@ -160,7 +171,7 @@ const Viewer = ({ search }: { search: string }) => {
           header: 'UL Speed',
           accessorFn: ({ uploadSpeed }) =>
             parseTraffic(uploadSpeed).join(' ') + '/s',
-          sortingFn: (rowA, rowB) =>
+          sortFn: (rowA, rowB) =>
             rowA.original.uploadSpeed - rowB.original.uploadSpeed,
           size: 120,
           cell: (info) => (
@@ -195,7 +206,7 @@ const Viewer = ({ search }: { search: string }) => {
         {
           header: 'Time',
           accessorFn: ({ start }) => dayjs(start).fromNow(),
-          sortingFn: (rowA, rowB) =>
+          sortFn: (rowA, rowB) =>
             dayjs(rowA.original.start).diff(rowB.original.start),
           size: 120,
           cell: (info) => (
@@ -241,19 +252,18 @@ const Viewer = ({ search }: { search: string }) => {
             </HighlightText>
           ),
         },
-      ] satisfies Array<ColumnDef<ConnectionRow>>,
+      ] satisfies Array<ColumnDef<typeof features, ConnectionRow>>,
     [search],
   )
 
-  const table = useReactTable({
+  const table = useTable({
+    features,
     data,
     columns,
     state: {
       columnSizing,
     },
     onColumnSizingChange: handleColumnSizingChange,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
     enableColumnResizing: true,
     columnResizeMode: 'onChange',
   })
@@ -402,13 +412,15 @@ const Viewer = ({ search }: { search: string }) => {
                 }}
                 data={row.original}
               >
-                {row.getVisibleCells().map(({ column, id, getContext }) => (
+                {row.getVisibleCells().map((cell) => (
                   <td
-                    key={id}
+                    key={cell.id}
                     className="border-outline-variant/30 max-w-0 truncate border-b px-3 text-sm"
-                    style={{ width: column.getSize() + extraWidthPerColumn }}
+                    style={{
+                      width: cell.column.getSize() + extraWidthPerColumn,
+                    }}
                   >
-                    {flexRender(column.columnDef.cell, getContext())}
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>
                 ))}
               </TableRow>

--- a/frontend/nyanpasu/src/pages/(main)/main/rules/index.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/rules/index.tsx
@@ -5,16 +5,24 @@ import { useClashRules } from '@nyanpasu/interface'
 import { cn } from '@nyanpasu/utils'
 import { createFileRoute } from '@tanstack/react-router'
 import {
+  columnVisibilityFeature,
+  createSortedRowModel,
   flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
-  useReactTable,
+  rowSortingFeature,
+  tableFeatures,
+  useTable,
 } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { Route as IndexRoute } from './route'
 
 export const Route = createFileRoute('/(main)/main/rules/')({
   component: RouteComponent,
+})
+
+const features = tableFeatures({
+  rowSortingFeature,
+  columnVisibilityFeature,
+  sortedRowModel: createSortedRowModel(),
 })
 
 const Viewer = ({ search }: { search: string }) => {
@@ -56,7 +64,8 @@ const Viewer = ({ search }: { search: string }) => {
 
   const virtualItems = rowVirtualizer.getVirtualItems()
 
-  const table = useReactTable({
+  const table = useTable({
+    features,
     data: filteredRules,
     columns: [
       {
@@ -96,8 +105,6 @@ const Viewer = ({ search }: { search: string }) => {
     //   sorting,
     // },
     // onSortingChange: setSorting,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
     debugTable: true,
   })
 
@@ -136,9 +143,9 @@ const Viewer = ({ search }: { search: string }) => {
                   transform: `translateY(${offset}px)`,
                 }}
               >
-                {row.getVisibleCells().map(({ column, id, getContext }) => (
-                  <td key={id} data-slot="rules-virtual-td">
-                    {flexRender(column.columnDef.cell, getContext())}
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id} data-slot="rules-virtual-td">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>
                 ))}
               </tr>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,8 +259,8 @@ importers:
         specifier: 4.3.3
         version: 4.3.3
       '@tanstack/react-table':
-        specifier: 8.21.3
-        version: 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 9.2.4
+        version: 9.2.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-virtual':
         specifier: 3.14.10
         version: 3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3272,18 +3272,23 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
+  '@tanstack/react-store@0.11.1':
+    resolution: {integrity: sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/react-store@0.9.3':
     resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/react-table@8.21.3':
-    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
-    engines: {node: '>=12'}
+  '@tanstack/react-table@9.2.4':
+    resolution: {integrity: sha512-Rzp1Q4e0/nIgEjmISYR5HeEgLTNtrG+C7NFZf/AbCxPO5hg+zC3yNGwcoECigUk8SFzzvhXbd2rFdtP2ZiGrfA==}
+    engines: {node: '>=20'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: '>=18'
 
   '@tanstack/react-virtual@3.14.10':
     resolution: {integrity: sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==}
@@ -3341,12 +3346,15 @@ packages:
       '@tanstack/react-router': '>=1.43.2'
       zod: '>=3'
 
+  '@tanstack/store@0.11.1':
+    resolution: {integrity: sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA==}
+
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
-    engines: {node: '>=12'}
+  '@tanstack/table-core@9.2.4':
+    resolution: {integrity: sha512-GwdDyGGr6UXAtubF14yAwcXvdaogqfsQgIk89Suebjxob/Rjq2xvfmXsjDF1rQmKmhHsJm9TOY7myxv3i6geJw==}
+    engines: {node: '>=20'}
 
   '@tanstack/virtual-core@3.17.8':
     resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
@@ -9508,6 +9516,13 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
+  '@tanstack/react-store@0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/store': 0.11.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
   '@tanstack/react-store@0.9.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/store': 0.9.3
@@ -9515,11 +9530,13 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
 
-  '@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-table@9.2.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tanstack/table-core': 8.21.3
+      '@tanstack/react-store': 0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/table-core': 9.2.4
       react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
+    transitivePeerDependencies:
+      - react-dom
 
   '@tanstack/react-virtual@3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -9597,9 +9614,13 @@ snapshots:
       '@tanstack/react-router': 1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       zod: 4.5.4
 
+  '@tanstack/store@0.11.1': {}
+
   '@tanstack/store@0.9.3': {}
 
-  '@tanstack/table-core@8.21.3': {}
+  '@tanstack/table-core@9.2.4':
+    dependencies:
+      '@tanstack/store': 0.11.1
 
   '@tanstack/virtual-core@3.17.8': {}
 


### PR DESCRIPTION
## Summary

Upgrade `@tanstack/react-table` from 8.21.3 to 9.2.4 and migrate the two call sites to the v9 API. Migration follows the official [v9 migration guide](https://tanstack.com/table/latest/docs/framework/react/guide/migrating) using the full v9 API (not the deprecated `useLegacyTable` shim).

## Changes

- `useReactTable` → `useTable`, with a required `features` option built via `tableFeatures()` — only the features each table actually uses are registered (sorting, sizing/resizing, visibility), instead of bundling everything as in v8.
- Row model factories moved onto `tableFeatures()` (`getSortedRowModel()` → `sortedRowModel: createSortedRowModel()`); the core row model is always included.
- Column defs: `sortingFn` → `sortFn`; `ColumnDef<TData>` → `ColumnDef<typeof features, TData>`.
- v9 moves row/cell methods onto the prototype, so destructured methods lose `this` — `row.getVisibleCells().map(({ column, id, getContext }) => ...)` rewritten to call methods on the `cell` instance.
- `columnVisibilityFeature` added explicitly: `row.getVisibleCells()` / `table.getVisibleLeafColumns()` are feature-gated in v9.
- Connections page: persisted `columnSizing` state, `onColumnSizingChange`, `enableColumnResizing` and `columnResizeMode: 'onChange'` behavior unchanged.

## Verification

- `pnpm lint:ts:nyanpasu` (tsc --noEmit) passes
- `prettier --check` / `oxlint` on touched files pass
- `pnpm web:build` succeeds

Note: table markup and rendering are unchanged per the v9 guide; no visual changes expected on the connections and rules pages.