### PR TITLE
refactor(core): migrate rule provider reads to the bound API

### DIFF
--- a/backend/tauri/src/client/clash_api.rs
+++ b/backend/tauri/src/client/clash_api.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use clash_api::{DelayQuery, ProviderName, ProxyName};
 use indexmap::IndexMap;
 
-use crate::core::clash::api::{ClashRule, ClashVersion, DelayRes, RulesRes};
+use crate::core::clash::api::{
+    ClashRule, ClashVersion, DelayRes, ProvidersRulesRes, RuleProviderItem, RulesRes,
+};
 
 use super::NyanpasuClient;
 
@@ -16,6 +18,24 @@ fn delay_query(url: Option<String>) -> Result<DelayQuery> {
 }
 
 impl NyanpasuClient {
+    pub async fn clash_rule_providers(&self) -> Result<ProvidersRulesRes> {
+        let providers = self
+            .inner
+            .core_api
+            .api_client()
+            .await?
+            .rule_providers()
+            .await?;
+        Ok(ProvidersRulesRes {
+            providers: providers
+                .into_iter()
+                .map(|(name, provider)| {
+                    Ok((name.as_str().to_owned(), rule_provider_item(provider)?))
+                })
+                .collect::<Result<_>>()?,
+        })
+    }
+
     pub async fn clash_rules(&self) -> Result<RulesRes> {
         let rules = self.inner.core_api.api_client().await?.rules().await?;
         Ok(RulesRes {
@@ -96,5 +116,52 @@ impl NyanpasuClient {
             None => api.close_all_connections().await?,
         }
         Ok(())
+    }
+}
+
+fn rule_provider_item(provider: clash_api::RuleProvider) -> Result<RuleProviderItem> {
+    Ok(RuleProviderItem {
+        name: provider.name.as_str().to_owned(),
+        behavior: provider.behavior.map(|value| value.as_str().to_owned()),
+        format: provider.format.map(|value| value.as_str().to_owned()),
+        rule_count: provider.rule_count.map(u32::try_from).transpose()?,
+        r#type: provider
+            .provider_type
+            .map(|value| value.as_str().to_owned()),
+        vehicle_type: provider.vehicle_type.map(|value| value.as_str().to_owned()),
+        updated_at: provider.updated_at.map(|value| value.to_rfc3339()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rule_provider_item;
+
+    #[test]
+    fn provider_dto_preserves_unknown_values_and_absence() {
+        let provider = serde_json::from_value(serde_json::json!({
+            "name":"provider", "behavior":"future", "format":"format-v2",
+            "type":"remote-v2", "vehicleType":"transport-v2",
+            "updatedAt":"2026-09-07T10:00:00+08:00"
+        }))
+        .unwrap();
+        let item = serde_json::to_value(rule_provider_item(provider).unwrap()).unwrap();
+        assert_eq!(
+            item,
+            serde_json::json!({
+                "name":"provider", "behavior":"future", "format":"format-v2",
+                "type":"remote-v2", "vehicleType":"transport-v2", "ruleCount":null,
+                "updatedAt":"2026-09-07T10:00:00+08:00"
+            })
+        );
+    }
+
+    #[test]
+    fn provider_dto_rejects_counts_outside_the_ui_contract() {
+        for count in [-1, i64::from(u32::MAX) + 1] {
+            let provider =
+                serde_json::from_value(serde_json::json!({"name":"p","ruleCount":count})).unwrap();
+            assert!(rule_provider_item(provider).is_err());
+        }
     }
 }

--- a/backend/tauri/src/core/actor_v2/api.rs
+++ b/backend/tauri/src/core/actor_v2/api.rs
@@ -104,6 +104,13 @@ impl ApiClient {
         }
     }
 
+    pub async fn rule_providers(
+        &self,
+    ) -> Result<indexmap::IndexMap<clash_api::RuleProviderName, clash_api::RuleProvider>, ApiError>
+    {
+        self.execute(self.client.rule_providers()).await
+    }
+
     pub async fn rules(&self) -> Result<Vec<clash_api::Rule>, ApiError> {
         self.execute(self.client.rules()).await
     }
@@ -313,6 +320,37 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), api.revoked.cancelled())
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn provider_reads_preserve_order_and_reject_retired_instances() {
+        let (url, server) = server(Router::new().route(
+            "/providers/rules/",
+            get(|| async {
+                Response::builder()
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"providers":{"z":{"name":"z"},"a":{"name":"a"}}}"#,
+                    ))
+                    .unwrap()
+            }),
+        ))
+        .await;
+        let endpoint = endpoint(url);
+        let core = CoreClient::spawn(endpoint.clone()).await.unwrap();
+        let api = core.api_client().await.unwrap();
+        let providers = api.rule_providers().await.unwrap();
+        assert_eq!(
+            providers
+                .keys()
+                .map(|name| name.as_str())
+                .collect::<Vec<_>>(),
+            ["z", "a"]
+        );
+        endpoint.binding.send_replace(None);
+        assert!(matches!(api.rule_providers().await, Err(ApiError::Stale)));
+        core.actor.stop(None);
+        server.abort();
     }
 
     #[tokio::test]

--- a/backend/tauri/src/core/clash/api.rs
+++ b/backend/tauri/src/core/clash/api.rs
@@ -82,14 +82,6 @@ pub async fn get_configs() -> Result<ClashConfig> {
     Ok(resp)
 }
 
-/// GET /providers/rules
-#[instrument]
-pub async fn get_providers_rules() -> Result<ProvidersRulesRes> {
-    let path = "/providers/rules";
-    let resp: ProvidersRulesRes = perform_request((Method::GET, path)).await?.json().await?;
-    Ok(resp)
-}
-
 /// PUT /configs
 /// path 是绝对路径
 #[instrument]

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -708,8 +708,10 @@ pub async fn clash_api_get_rules(
 
 #[tauri::command]
 #[specta::specta]
-pub async fn clash_api_get_providers_rules() -> Result<clash::api::ProvidersRulesRes> {
-    Ok(clash::api::get_providers_rules().await?)
+pub async fn clash_api_get_providers_rules(
+    client: State<'_, NyanpasuClient>,
+) -> Result<clash::api::ProvidersRulesRes> {
+    Ok(client.clash_rule_providers().await?)
 }
 
 #[tauri::command]

--- a/docs/plan/2026-09-07-clash-rule-api-migration.md
+++ b/docs/plan/2026-09-07-clash-rule-api-migration.md
@@ -38,8 +38,7 @@ refresh is a mutation and is not retried automatically.
 
 ## Remaining callers
 
-Provider listing still needs response-model work: optional metadata and unknown
-string enum values must retain their meaning across cores. Config, proxy/cache,
+Provider listing is covered by [the next migration](2026-09-07-rule-provider-api-migration.md), including optional metadata and unknown string enum values. Config, proxy/cache,
 policy and stream migration remain as listed in the preceding plan. This PR
 migrates the complete rule-read and explicit rule-provider-refresh call paths.
 

--- a/docs/plan/2026-09-07-rule-provider-api-migration.md
+++ b/docs/plan/2026-09-07-rule-provider-api-migration.md
@@ -1,0 +1,61 @@
+# Rule provider API migration
+
+## Scope and checks
+
+1. Preserve missing metadata and unknown enum strings in clash-api RuleProvider.
+   Verify typed known variants, unknown-value round trips, invalid fields and
+   HTTP map order.
+2. Route provider listing through NyanpasuClient and the instance-bound ApiClient.
+   Remove its legacy URL-building function. Verify revoked handles, ordered maps
+   and conversion to the existing frontend DTO.
+3. Run runtime and application tests, Clippy, formatting, generated binding and
+   frontend type checks, then deliver linked runtime/application PRs.
+
+## Response contract
+
+Provider names remain required. Behavior, format, count, provider/vehicle type
+and update time may be absent. Present values remain typed; timestamps must be
+valid RFC3339. A malformed present timestamp is rejected, whereas the old
+application DTO accepted any string. The facade formats valid timestamps as
+RFC3339 and preserves their offset, though spelling may normalize (Z to +00:00).
+
+Behavior/format and the shared provider/vehicle enums retain known variants and
+store unknown values in Unknown(String), with lossless serialization and as_str
+accessors. This intentionally removes Copy from those enums. The shared enums
+also occur in proxy responses; their known variants retain the existing wire
+representation. No proxy caller is migrated by this change.
+
+Rule counts stay optional i64 in the protocol model. The existing frontend DTO
+accepts u32, so conversion checks bounds and returns an error for negative or
+oversized counts rather than truncating them. IndexMap order is retained all the
+way to IPC; no unordered response map is introduced.
+
+## Lifecycle and capabilities
+
+The operation uses the existing ApiClient preflight/postflight checks and shared
+revocation. No Service IPC contract or minimum-version change is needed.
+Current FeatureSupport flags describe controller transports, not provider fields;
+response decoding cannot infer complete metadata from those capabilities.
+
+## Remaining migration
+
+This completes the rule-provider listing path after rule reads and provider
+refresh were migrated in the previous PR. Config responses/writes, proxy cache
+ownership and workflows, policy-triggered actions, and guarded streams remain.
+
+## Delivery and validation
+
+Runtime dependency: [nyanpasu-runtime #403](https://github.com/libnyanpasu/nyanpasu-runtime/pull/403), pinned at `28df6d9`. Merge that PR first. Service rc.3 remains sufficient.
+
+Validation on macOS:
+
+- Runtime: 20 unit, 5 REST, 2 stream and 5 traffic tests passed; the existing
+  real-Mihomo test remains ignored. Clippy across all targets passed.
+- Application: full-workspace/all-feature tests passed; application library
+  468 passed, 1 existing ignored. Tests cover provider ordering, revoked reads,
+  lossless DTO conversion and invalid count bounds. Full-target/full-feature
+  Clippy passed with existing warnings.
+- Specta binding export produced no diff. Architecture ledger, frontend types,
+  Oxlint and Rust formatting passed. The isolated worktree dependencies were
+  refreshed from the frozen lockfile after main's table-library upgrade.
+- Windows transports and live-core behavior were not exercised locally.


### PR DESCRIPTION
Rule-provider listing still reconstructs its request from legacy configuration. Route it through NyanpasuClient and the existing instance-bound ApiClient, and delete the old `/providers/rules` request function. The read inherits authoritative preflight/postflight checks and shared revocation.

Depends on https://github.com/libnyanpasu/nyanpasu-runtime/pull/403 (pinned `28df6d9`); merge that PR first. It makes provider metadata optional and retains unknown enum strings. The facade preserves those values and IndexMap order in the existing frontend DTO, while checking rule counts against its u32 range. No Service IPC or minimum-version change is required; rc.3 remains sufficient.

One intentional validation change: present `updatedAt` values must be valid RFC3339, whereas the old DTO accepted arbitrary strings. Valid times preserve their offset but may normalize spelling (Z to +00:00). Current FeatureSupport metadata describes transports and does not establish which provider fields are present. The response contract and remaining migration inventory are recorded in `docs/plan/2026-09-07-rule-provider-api-migration.md`.

Validation on macOS:

- Full-workspace/all-feature Rust tests passed; application library 468 passed, 1 existing ignored.
- New tests verify ordered provider reads, rejection after revocation, unknown strings and absent fields in the frontend DTO, and rejection of invalid count bounds.
- Runtime tests passed (20 unit, 5 REST, 2 stream, 5 traffic); application/runtime Clippy passed.
- Specta export produced no diff. All frontend TypeScript checks, Oxlint, Rust formatting, touched-document formatting and the architecture ledger passed.

The existing real-Mihomo test remains ignored; live-core behavior and Windows transports were not executed locally. Config, proxy/cache ownership, policy workflows and guarded streams remain for subsequent migration.
