### PR TITLE
refactor(core): migrate config reads to the bound Clash API

### DIFF
--- a/backend/tauri/src/client/clash_api.rs
+++ b/backend/tauri/src/client/clash_api.rs
@@ -5,7 +5,7 @@ use clash_api::{DelayQuery, ProviderName, ProxyName};
 use indexmap::IndexMap;
 
 use crate::core::clash::api::{
-    ClashRule, ClashVersion, DelayRes, ProvidersRulesRes, RuleProviderItem, RulesRes,
+    ClashConfig, ClashRule, ClashVersion, DelayRes, ProvidersRulesRes, RuleProviderItem, RulesRes,
 };
 
 use super::NyanpasuClient;
@@ -18,6 +18,10 @@ fn delay_query(url: Option<String>) -> Result<DelayQuery> {
 }
 
 impl NyanpasuClient {
+    pub async fn clash_configs(&self) -> Result<ClashConfig> {
+        config_item(self.inner.core_api.api_client().await?.configs().await?)
+    }
+
     pub async fn clash_rule_providers(&self) -> Result<ProvidersRulesRes> {
         let providers = self
             .inner
@@ -133,9 +137,60 @@ fn rule_provider_item(provider: clash_api::RuleProvider) -> Result<RuleProviderI
     })
 }
 
+fn config_item(config: clash_api::RuntimeConfig) -> Result<ClashConfig> {
+    Ok(ClashConfig {
+        port: config.port.map(u16::try_from).transpose()?,
+        socket_port: config.socket_port.map(u16::try_from).transpose()?,
+        socks_port: config.socks_port.map(u16::try_from).transpose()?,
+        mixed_port: config.mixed_port.map(u16::try_from).transpose()?,
+        redir_port: config.redir_port.map(u16::try_from).transpose()?,
+        tproxy_port: config.tproxy_port.map(u16::try_from).transpose()?,
+        mode: config.mode.map(|value| value.as_str().to_owned()),
+        log_level: config.log_level.map(|value| value.as_str().to_owned()),
+        allow_lan: config.allow_lan,
+        ipv6: config.ipv6,
+        external_controller: config.external_controller,
+        secret: config.secret,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::rule_provider_item;
+
+    #[test]
+    fn config_dto_preserves_absence_unknown_modes_and_valid_port_bounds() {
+        let config = serde_json::from_value(serde_json::json!({
+            "mode":"future-mode", "log-level":"trace", "mixed-port":0,
+            "port":65535, "ipv6":false, "external-controller":"127.0.0.1:9090",
+            "secret":"fixture-secret", "socket-port":100
+        }))
+        .unwrap();
+        let dto = super::config_item(config).unwrap();
+        assert_eq!(dto.mode.as_deref(), Some("future-mode"));
+        assert_eq!(dto.log_level.as_deref(), Some("trace"));
+        assert_eq!(dto.mixed_port, Some(0));
+        assert_eq!(dto.port, Some(65535));
+        assert_eq!(dto.ipv6, Some(false));
+        assert_eq!(dto.socket_port, Some(100));
+        assert_eq!(dto.secret.as_deref(), Some("fixture-secret"));
+        assert!(dto.socks_port.is_none());
+        assert!(dto.allow_lan.is_none());
+        for field in [
+            "port",
+            "socket-port",
+            "socks-port",
+            "mixed-port",
+            "redir-port",
+            "tproxy-port",
+        ] {
+            for port in [-1, 65536] {
+                let mut value = serde_json::json!({});
+                value[field] = port.into();
+                assert!(super::config_item(serde_json::from_value(value).unwrap()).is_err());
+            }
+        }
+    }
 
     #[test]
     fn provider_dto_preserves_unknown_values_and_absence() {

--- a/backend/tauri/src/core/actor_v2/api.rs
+++ b/backend/tauri/src/core/actor_v2/api.rs
@@ -104,6 +104,10 @@ impl ApiClient {
         }
     }
 
+    pub async fn configs(&self) -> Result<clash_api::RuntimeConfig, ApiError> {
+        self.execute(self.client.configs()).await
+    }
+
     pub async fn rule_providers(
         &self,
     ) -> Result<indexmap::IndexMap<clash_api::RuleProviderName, clash_api::RuleProvider>, ApiError>
@@ -320,6 +324,25 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), api.revoked.cancelled())
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn config_reads_accept_partial_responses_and_reject_retired_instances() {
+        let (url, server) = server(Router::new().route(
+            "/configs",
+            get(|| async { Json(serde_json::json!({"mixed-port":7890,"mode":"rule"})) }),
+        ))
+        .await;
+        let endpoint = endpoint(url);
+        let core = CoreClient::spawn(endpoint.clone()).await.unwrap();
+        let api = core.api_client().await.unwrap();
+        let config = api.configs().await.unwrap();
+        assert_eq!(config.mixed_port, Some(7890));
+        assert_eq!(config.allow_lan, None);
+        endpoint.binding.send_replace(None);
+        assert!(matches!(api.configs().await, Err(ApiError::Stale)));
+        core.actor.stop(None);
+        server.abort();
     }
 
     #[tokio::test]

--- a/backend/tauri/src/core/clash/api.rs
+++ b/backend/tauri/src/core/clash/api.rs
@@ -74,14 +74,6 @@ pub struct ProvidersRulesRes {
     pub providers: IndexMap<String, RuleProviderItem>,
 }
 
-/// GET /configs
-#[instrument]
-pub async fn get_configs() -> Result<ClashConfig> {
-    let path = "/configs";
-    let resp: ClashConfig = perform_request((Method::GET, path)).await?.json().await?;
-    Ok(resp)
-}
-
 /// PUT /configs
 /// path 是绝对路径
 #[instrument]

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -677,8 +677,10 @@ pub async fn clash_api_get_proxy_delay(
 
 #[tauri::command]
 #[specta::specta]
-pub async fn clash_api_get_configs() -> Result<clash::api::ClashConfig> {
-    Ok(clash::api::get_configs().await?)
+pub async fn clash_api_get_configs(
+    client: State<'_, NyanpasuClient>,
+) -> Result<clash::api::ClashConfig> {
+    Ok(client.clash_configs().await?)
 }
 
 #[tauri::command]

--- a/docs/plan/2026-09-07-clash-config-read-migration.md
+++ b/docs/plan/2026-09-07-clash-config-read-migration.md
@@ -1,0 +1,57 @@
+# Config read migration
+
+## Scope and verification
+
+1. Make RuntimeConfig top-level fields optional so partial core responses retain
+   absence. Cover known/unknown response enums, malformed values and zero/false.
+2. Keep mutation/subscription enums closed. Check core-manager runtime projection
+   against missing fields so absence cannot confirm a successful hot patch.
+3. Migrate GET /configs through NyanpasuClient and the bound ApiClient, deleting
+   the old request function. Verify revocation, port bounds and stable IPC types.
+4. Run affected runtime suites, application regression tests, Clippy, frontend
+   types, architecture ledger and formatting; deliver linked PRs.
+
+## Response contract and capabilities
+
+RuntimeConfig previously required the complete Mihomo top-level response. All
+its top-level fields now preserve absence with Option and omit absent fields
+when serialized. Present nested structures retain their existing models/defaults;
+this does not claim that every field inside a returned TUN object is observed.
+Present known fields remain validated, including extensions the old application
+DTO ignored. A malformed extension can therefore reject a response previously
+accepted by the smaller DTO. Unknown unmodeled JSON fields remain ignored.
+
+ConfigEnum<T> is a response-only string fallback around TunnelMode and LogLevel.
+Known strings stay typed, unknown strings round-trip; ConfigPatch and LogQuery
+keep their existing closed enums. FeatureSupport currently describes transports,
+so it cannot guarantee response field presence. Future API-specific feature gates
+must remain bound to the applied instance and cannot replace wire validation.
+
+The facade preserves the existing ClashConfig JSON shape, including optional
+socket-port, external-controller and secret when the core actually returns them.
+It does not fill these from the private capability binding or configuration.
+All six port fields are range-checked against the existing u16 DTO contract.
+No new Service IPC or minimum version is required.
+
+## Remaining migration
+
+Config writes remain in existing state/apply workflows; moving them needs to
+preserve state commits and post-commit side-effect semantics. Proxy/cache ownership,
+policy-triggered actions and guarded subscriptions remain in the migration queue.
+
+## Delivery and validation
+
+Runtime dependency: [nyanpasu-runtime #404](https://github.com/libnyanpasu/nyanpasu-runtime/pull/404), pinned at `44a8c54`. Merge it before the application PR.
+
+Validation on macOS:
+
+- clash-api: 20 unit, 7 REST, 2 stream and 5 traffic tests passed; the existing
+  real-Mihomo test remains ignored.
+- core-manager: 10 configuration projection tests and 17 graceful-switch tests
+  passed. Clippy across both affected runtime crates and all targets passed.
+- Application full-workspace/all-feature tests passed; application library:
+  470 passed, 1 existing ignored. Tests cover the partial read path, revocation,
+  absence, unknown strings and all six port bounds.
+- Generated IPC bindings have no diff. Frontend type checks, Oxlint, formatting
+  and the architecture ledger passed.
+- Windows transport behavior was not executed locally.

--- a/docs/plan/2026-09-07-rule-provider-api-migration.md
+++ b/docs/plan/2026-09-07-rule-provider-api-migration.md
@@ -40,7 +40,7 @@ response decoding cannot infer complete metadata from those capabilities.
 ## Remaining migration
 
 This completes the rule-provider listing path after rule reads and provider
-refresh were migrated in the previous PR. Config responses/writes, proxy cache
+refresh were migrated in the previous PR. Config reads are covered by [the next migration](2026-09-07-clash-config-read-migration.md). Config writes, proxy cache
 ownership and workflows, policy-triggered actions, and guarded streams remain.
 
 ## Delivery and validation


### PR DESCRIPTION
Config reads still reconstruct controller URLs and credentials from legacy configuration. Route GET /configs through NyanpasuClient and the existing instance-bound ApiClient, and delete the legacy read function. Stale handles reject the operation through the existing authority checks and revocation.

Depends on https://github.com/libnyanpasu/nyanpasu-runtime/pull/404 (pinned `44a8c54`); merge that PR first. It preserves missing top-level config fields and unknown mode/log-level strings without widening mutation or subscription enums. Core-manager regression coverage ensures missing fields cannot confirm an expected false/zero value. No Service IPC change is needed; rc.3 remains sufficient.

The facade keeps the existing frontend DTO and checks all six port fields against u16 bounds. Optional external-controller/secret values come only from the actual response; they are never synthesized from the capability binding. Present known extension fields are now validated by the runtime model, so malformed extensions previously ignored by the smaller application DTO can reject a response. Nested config defaults remain unchanged. Current transport FeatureSupport flags cannot establish response-field presence.

Validation on macOS:

- Application full-workspace/all-feature tests passed; application library 470 passed, 1 existing ignored. New tests cover partial reads, retired instances, absent values, unknown response enums and port bounds.
- Runtime: 20 clash-api unit, 7 REST, 2 stream, 5 traffic; 10 core-manager projection and 17 graceful-switch tests passed.
- Application/runtime Clippy, frontend TypeScript checks, Oxlint, formatting and the architecture ledger passed. Specta export produced no binding diff.

The existing real-Mihomo integration test remains ignored; Windows transports were not executed locally. The plan is in `docs/plan/2026-09-07-clash-config-read-migration.md`. Config writes remain in state/apply workflows; proxy ownership, policy actions and guarded streams remain for subsequent migration.
