### PR TITLE
chore(renovate): clone submodules so cargo lockfile updates succeed

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,5 +62,6 @@
       "matchPackageNames": ["/vitest/", "/cypress/", "/wdio/"]
     }
   ],
-  "prConcurrentLimit": 30
+  "prConcurrentLimit": 30,
+  "cloneSubmodules": true
 }


### PR DESCRIPTION
## 问题

所有 cargo 依赖更新 PR（如 #5198、#5196、#5188、#5164、#4756、#5184）的 thread 里都有 renovate 报告的 `⚠️ Artifact update problem`：`backend/Cargo.lock` 未能重新生成。

根因：workspace 的 path 依赖 `clash-api` 位于 git submodule `backend/nyanpasu-runtime`（`backend/Cargo.toml:46`），而 renovate 默认不初始化 submodule，`cargo update` 读不到 `backend/nyanpasu-runtime/crates/clash-api/Cargo.toml`：

```
error: failed to get `clash-api` as a dependency of package `clash-nyanpasu`
Caused by: failed to read `.../backend/nyanpasu-runtime/crates/clash-api/Cargo.toml`
Caused by: No such file or directory (os error 2)
```

## 修复

在 `renovate.json` 中设置 [`cloneSubmodules: true`](https://docs.renovatebot.com/configuration-options/#clonesubmodules)，让 renovate 在 clone 仓库时初始化 submodule（submodule 为公开仓库，无需额外认证）。

注意：本 PR 刻意**不**启用 `git-submodules` manager，因此 renovate 不会发起自动 bump submodule 指针的 PR。

## 验证方式

合并后，在任一带 artifact 错误的 renovate PR 上勾选 rebase/retry 复选框（或将标题改为 `rebase!` 开头），观察 renovate 下次运行是否能正常生成 `backend/Cargo.lock` 且不再出现 artifact 错误评论。