### PR TITLE
refactor(core): migrate proxy callers to an injected actor

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -147,12 +147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,7 +1853,6 @@ dependencies = [
 name = "clash-nyanpasu"
 version = "0.1.0"
 dependencies = [
- "adler",
  "ambassador",
  "ansi-str",
  "anyhow",

--- a/backend/tauri/Cargo.toml
+++ b/backend/tauri/Cargo.toml
@@ -124,7 +124,6 @@ flate2 = "1.0"
 zip = "8.0.0"
 zip-extensions = "0.14.0"
 base64 = "0.23"
-adler = "1.0.2"
 hex = "0.4"
 percent-encoding = "2.3.1"
 

--- a/backend/tauri/src/client/clash_api.rs
+++ b/backend/tauri/src/client/clash_api.rs
@@ -18,6 +18,40 @@ fn delay_query(url: Option<String>) -> Result<DelayQuery> {
 }
 
 impl NyanpasuClient {
+    pub async fn get_proxies(&self) -> Result<crate::core::clash::proxies::Proxies> {
+        self.inner.proxies.get(false).await
+    }
+    pub async fn refresh_proxies(&self) -> Result<crate::core::clash::proxies::Proxies> {
+        self.inner.proxies.get(true).await
+    }
+    pub async fn proxy_providers(&self) -> Result<crate::core::clash::api::ProvidersProxiesRes> {
+        self.inner.proxies.providers().await
+    }
+    pub async fn select_proxy(&self, group: String, name: String) -> Result<()> {
+        use nyanpasu_config::clash::config::clash_strategy::ProxyChangeBreakMode;
+        let strategy = self
+            .get_clash_config()
+            .await?
+            .break_connection
+            .on_proxy_change;
+        // FIXME(actor-migration): ProxyGroup retains the legacy close-all fallback.
+        // New code must use chain-aware interruption. Remove after connection tracking supplies group membership.
+        let interrupt = !matches!(strategy, ProxyChangeBreakMode::Off);
+        self.inner.proxies.select(group, name, interrupt).await
+    }
+    pub async fn update_proxy_provider(&self, name: String) -> Result<()> {
+        self.inner.proxies.update_provider(name).await
+    }
+    pub fn request_proxy_refresh(&self) {
+        self.inner.proxies.request_refresh();
+    }
+    pub fn proxies_snapshot(&self) -> crate::core::clash::proxies::Proxies {
+        self.inner.proxies.snapshot()
+    }
+    pub fn subscribe_proxy_changes(&self) -> tokio::sync::watch::Receiver<()> {
+        self.inner.proxies.subscribe()
+    }
+
     pub async fn clash_configs(&self) -> Result<ClashConfig> {
         config_item(self.inner.core_api.api_client().await?.configs().await?)
     }

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -259,6 +259,7 @@ struct NyanpasuClientInner {
     ui_sink: Arc<dyn UiEventSink>,
     core_lifecycle: core_lifecycle::CoreLifecycleClient,
     core_api: CoreClientV2,
+    proxies: crate::core::proxies::ProxiesClient,
     system_dns: Arc<dyn SystemDnsCache>,
 }
 
@@ -370,6 +371,7 @@ impl NyanpasuClient {
                 dirty: dirty_rx,
             })
             .await?;
+        let proxies = crate::core::proxies::ProxiesClient::spawn(core_v2.clone()).await?;
         Ok(Self {
             inner: Arc::new(NyanpasuClientInner {
                 application,
@@ -383,6 +385,7 @@ impl NyanpasuClient {
                 ui_sink,
                 core_lifecycle,
                 core_api: core_v2,
+                proxies,
                 system_dns,
             }),
         })

--- a/backend/tauri/src/core/actor_v2/api.rs
+++ b/backend/tauri/src/core/actor_v2/api.rs
@@ -104,6 +104,49 @@ impl ApiClient {
         }
     }
 
+    pub(crate) fn is_revoked(&self) -> bool {
+        self.revoked.is_cancelled()
+    }
+
+    pub(crate) fn same_instance(&self, other: &Self) -> bool {
+        !self.is_revoked() && !other.is_revoked() && self.binding == other.binding
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        self.revoked.cancelled().await;
+    }
+
+    pub async fn proxy_snapshot(
+        &self,
+    ) -> Result<
+        (
+            indexmap::IndexMap<clash_api::ProxyName, clash_api::Proxy>,
+            indexmap::IndexMap<clash_api::ProviderName, clash_api::ProxyProvider>,
+        ),
+        ApiError,
+    > {
+        self.execute(async {
+            tokio::try_join!(self.client.proxies(), self.client.proxy_providers())
+        })
+        .await
+    }
+
+    pub async fn select_proxy(
+        &self,
+        group: &ProxyName,
+        target: &ProxyName,
+    ) -> Result<(), ApiError> {
+        self.execute(
+            self.client
+                .select_proxy(clash_api::ProxySelection { group, target }),
+        )
+        .await
+    }
+
+    pub async fn update_proxy_provider(&self, name: &ProviderName) -> Result<(), ApiError> {
+        self.execute(self.client.update_proxy_provider(name)).await
+    }
+
     pub async fn configs(&self) -> Result<clash_api::RuntimeConfig, ApiError> {
         self.execute(self.client.configs()).await
     }
@@ -216,7 +259,7 @@ impl Drop for ApiLease {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::sync::Arc;
 
     use axum::{Json, Router, body::Body, response::Response, routing::get};
@@ -235,9 +278,9 @@ mod tests {
         },
     };
 
-    struct Endpoint {
+    pub(crate) struct Endpoint {
         host: ExecutionHost,
-        binding: watch::Sender<Option<CoreApiConnection>>,
+        pub(crate) binding: watch::Sender<Option<CoreApiConnection>>,
     }
 
     #[async_trait::async_trait]
@@ -299,7 +342,7 @@ mod tests {
         }
     }
 
-    fn endpoint(url: String) -> Arc<Endpoint> {
+    pub(crate) fn endpoint(url: String) -> Arc<Endpoint> {
         let (binding, _) = watch::channel(Some(CoreApiConnection {
             instance_id: "first-process".into(),
             controller: CoreControllerInfo::Http(url),
@@ -311,7 +354,7 @@ mod tests {
         })
     }
 
-    async fn server(router: Router) -> (String, tokio::task::JoinHandle<()>) {
+    pub(crate) async fn server(router: Router) -> (String, tokio::task::JoinHandle<()>) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let url = format!("http://{}/", listener.local_addr().unwrap());
         let task = tokio::spawn(async move {

--- a/backend/tauri/src/core/clash/api.rs
+++ b/backend/tauri/src/core/clash/api.rs
@@ -170,60 +170,23 @@ impl From<ProxyProviderItem> for ProxyItem {
     }
 }
 
-/// GET /proxies
-/// 获取代理列表
-#[instrument]
-pub async fn get_proxies() -> Result<ProxiesRes> {
-    let path = "/proxies";
-    let resp: ProxiesRes = perform_request((Method::GET, path)).await?.json().await?;
-    Ok(resp)
-}
-
-/// GET /proxies/{name}
-/// 获取单个代理
-/// name: 代理名称
-/// 返回代理的配置
-///
-#[allow(dead_code)]
-#[instrument]
-pub async fn get_proxy(name: String) -> Result<ProxyItem> {
-    let path = format!("/proxies/{name}");
-    let resp: ProxyItem = perform_request((Method::GET, path.as_str()))
-        .await?
-        .json()
-        .await?;
-    Ok(resp)
-}
-
-/// PUT /proxies/{group}
-/// 选择代理
-/// group: 代理分组名称
-/// name: 代理名称
-#[instrument]
-pub async fn update_proxy(group: &str, name: &str) -> Result<()> {
-    let path = format!("/proxies/{group}");
-
-    let mut data = HashMap::new();
-    data.insert("name", name);
-
-    let _ = perform_request((Method::PUT, path.as_str(), Data(data))).await?;
-    Ok(())
-}
-
 #[derive(Debug, Clone, Deserialize, Serialize, Type)]
 pub enum VehicleType {
     File,
     #[serde(rename = "HTTP")]
     Http,
     Compatible,
-    Unknown,
+    Inline,
+    #[serde(untagged)]
+    Unknown(String),
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, specta::Type)]
 pub enum ProviderType {
     Proxy,
     Rule,
-    Unknown,
+    #[serde(untagged)]
+    Unknown(String),
 }
 
 impl Display for ProviderType {
@@ -231,7 +194,7 @@ impl Display for ProviderType {
         match self {
             ProviderType::Proxy => write!(f, "Proxy"),
             ProviderType::Rule => write!(f, "Rule"),
-            ProviderType::Unknown => write!(f, "Unknown"),
+            ProviderType::Unknown(value) => write!(f, "{value}"),
         }
     }
 }
@@ -277,53 +240,6 @@ pub struct ProvidersProxiesRes {
     pub providers: IndexMap<String, ProxyProviderItem>,
 }
 
-/// GET /providers/proxies
-/// 获取所有代理集合的所有代理信息
-#[instrument]
-pub async fn get_providers_proxies() -> Result<ProvidersProxiesRes> {
-    let path = "/providers/proxies";
-    let resp: ProvidersProxiesRes = perform_request((Method::GET, path)).await?.json().await?;
-    Ok(resp)
-}
-
-/// GET /providers/proxies/:name
-/// 获取单个代理集合的所有代理信息
-/// group: 代理集合名称
-#[allow(dead_code)]
-#[instrument]
-pub async fn get_providers_proxies_group(group: String) -> Result<ProxyProviderItem> {
-    let path = format!("/providers/proxies/{group}");
-    let resp: ProxyProviderItem = perform_request((Method::GET, path.as_str()))
-        .await?
-        .json()
-        .await?;
-    Ok(resp)
-}
-
-/// PUT /providers/proxies/:name
-/// 更新代理集合
-/// name: 代理集合名称
-#[instrument]
-pub async fn update_providers_proxies_group(name: &str) -> Result<()> {
-    let path = format!("/providers/proxies/{name}");
-    let _ = perform_request((Method::PUT, path.as_str())).await?;
-    Ok(())
-}
-
-/// GET /providers/proxies/:name/healthcheck
-/// 获取代理集合的健康检查
-/// name: 代理集合名称
-#[allow(dead_code)]
-#[instrument]
-pub async fn get_providers_proxies_healthcheck(name: String) -> Result<Mapping> {
-    let path = format!("/providers/proxies/{name}/healthcheck");
-    let resp: Mapping = perform_request((Method::GET, path.as_str()))
-        .await?
-        .json()
-        .await?;
-    Ok(resp)
-}
-
 #[derive(Default, Debug, Clone, Deserialize, Serialize, Type)]
 pub struct DelayRes {
     pub delay: u64,
@@ -333,8 +249,8 @@ pub struct DelayRes {
 #[instrument]
 fn clash_client_info() -> Result<(String, HeaderMap)> {
     // TODO(actor-migration): temporary bridge to legacy controller configuration.
-    // Reason: remaining config/proxy/rule and policy callers require the actor
-    // and cross-core response migrations in docs/plan/2026-09-06-clash-api-migration.md.
+    // Reason: config writes and connection-interruption policies still need
+    // lifecycle/config reconciliation migration before using the bound API.
     // Remove when: those callers use the injected instance-bound ApiClient.
     let client = { Config::clash().data().get_client_info() };
 

--- a/backend/tauri/src/core/clash/mod.rs
+++ b/backend/tauri/src/core/clash/mod.rs
@@ -1,5 +1,3 @@
-use backon::ExponentialBuilder;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 use tauri_specta::Event;
@@ -7,13 +5,6 @@ use tauri_specta::Event;
 pub mod api;
 pub mod proxies;
 pub mod ws;
-
-pub static CLASH_API_DEFAULT_BACKOFF_STRATEGY: Lazy<ExponentialBuilder> = Lazy::new(|| {
-    ExponentialBuilder::default()
-        .with_min_delay(std::time::Duration::from_millis(50))
-        .with_max_delay(std::time::Duration::from_secs(5))
-        .with_max_times(5)
-});
 
 // TODO: support system path search via a config or flag
 // FIXME: move this fn to nyanpasu-utils

--- a/backend/tauri/src/core/clash/proxies.rs
+++ b/backend/tauri/src/core/clash/proxies.rs
@@ -1,18 +1,11 @@
 /// This module is used to manage the proxies for the Tauri application.
 /// It is used to provide the unite interface between tray and frontend.
 /// TODO: add a diff algorithm to reduce the data transfer, and the rerendering of the tray menu.
-use super::{CLASH_API_DEFAULT_BACKOFF_STRATEGY, api};
-use adler::adler32;
+use super::api;
 use anyhow::Result;
-use backon::Retryable;
 use indexmap::IndexMap;
-use log::warn;
-use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use specta::Type;
-use std::sync::{Arc, OnceLock};
-use tokio::{sync::broadcast, try_join};
-use tracing_attributes::instrument;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, Type)]
 #[serde(rename_all = "camelCase")]
@@ -66,10 +59,6 @@ pub struct Proxies {
     pub proxies: Vec<api::ProxyItem>,
 }
 
-async fn fetch_proxies() -> Result<(api::ProxiesRes, api::ProvidersProxiesRes)> {
-    try_join!(api::get_proxies(), api::get_providers_proxies())
-}
-
 fn provider_proxy_map(
     providers: &IndexMap<String, api::ProxyProviderItem>,
 ) -> IndexMap<String, api::ProxyItem> {
@@ -103,11 +92,10 @@ fn resolve_proxy(
 }
 
 impl Proxies {
-    #[instrument]
-    pub async fn fetch() -> Result<Self> {
-        let (inner_proxies, providers_proxies) = fetch_proxies
-            .retry(*CLASH_API_DEFAULT_BACKOFF_STRATEGY)
-            .await?;
+    pub fn from_responses(
+        inner_proxies: api::ProxiesRes,
+        providers_proxies: api::ProvidersProxiesRes,
+    ) -> Result<Self> {
         let inner_proxies = inner_proxies.proxies;
         // 1. filter out the Http or File type provider proxies
         let providers_proxies: IndexMap<String, api::ProxyProviderItem> = {
@@ -204,94 +192,6 @@ impl Proxies {
             records: inner_proxies,
             proxies,
         })
-    }
-}
-
-pub struct ProxiesGuard {
-    inner: Proxies,
-    checksum: Option<u32>,
-    updated_at: u64,
-    sender: broadcast::Sender<()>,
-}
-
-impl ProxiesGuard {
-    pub fn global() -> &'static Arc<RwLock<ProxiesGuard>> {
-        static PROXIES: OnceLock<Arc<RwLock<ProxiesGuard>>> = OnceLock::new();
-        PROXIES.get_or_init(|| {
-            let (tx, _) = broadcast::channel(5); // 默认提供 5 个消费位置，提供一定的缓冲
-            Arc::new(RwLock::new(ProxiesGuard {
-                checksum: None,
-                sender: tx,
-                inner: Proxies::default(),
-                updated_at: 0,
-            }))
-        })
-    }
-
-    pub fn get_receiver(&self) -> broadcast::Receiver<()> {
-        self.sender.subscribe()
-    }
-
-    pub fn replace(&mut self, proxies: Proxies, checksum: u32) {
-        let now = chrono::Utc::now().timestamp() as u64;
-        self.inner = proxies;
-        self.checksum = Some(checksum);
-        self.updated_at = now;
-
-        if let Err(e) = self.sender.send(()) {
-            warn!(
-                target: "clash::proxies",
-                "send update signal failed: {e:?}"
-            );
-        }
-    }
-
-    // pub async fn select_proxy(&mut self, group: &str, name: &str) -> Result<()> {
-    //     api::update_proxy(group, name).await?;
-    //     self.update().await?;
-    //     Ok(())
-    // }
-
-    pub fn inner(&self) -> &Proxies {
-        &self.inner
-    }
-
-    pub fn updated_at(&self) -> u64 {
-        self.updated_at
-    }
-
-    pub fn is_updated(&self) -> bool {
-        let now = chrono::Utc::now().timestamp() as u64;
-        now - self.updated_at <= 3
-    }
-}
-
-pub trait ProxiesGuardExt {
-    async fn update(&self) -> Result<()>;
-    async fn select_proxy(&self, group: &str, name: &str) -> Result<()>;
-}
-
-type ProxiesGuardSingleton = &'static Arc<RwLock<ProxiesGuard>>;
-impl ProxiesGuardExt for ProxiesGuardSingleton {
-    async fn update(&self) -> Result<()> {
-        let proxies = Proxies::fetch().await?;
-        let buf = serde_json::to_string(&proxies)?;
-        let checksum = adler32(buf.as_bytes())?;
-        {
-            let reader = self.read();
-            if reader.checksum == Some(checksum) {
-                return Ok(());
-            }
-        }
-        let mut writer = self.write();
-        writer.replace(proxies, checksum);
-        Ok(())
-    }
-
-    async fn select_proxy(&self, group: &str, name: &str) -> Result<()> {
-        api::update_proxy(group, name).await?;
-        self.update().await?;
-        Ok(())
     }
 }
 

--- a/backend/tauri/src/core/connection_interruption.rs
+++ b/backend/tauri/src/core/connection_interruption.rs
@@ -14,28 +14,6 @@ pub struct ConnectionInfo {
 pub struct ConnectionInterruptionService;
 
 impl ConnectionInterruptionService {
-    /// Interrupt connections when proxy changes
-    pub async fn on_proxy_change() -> Result<()> {
-        let config = Config::verge().data().clone();
-        let break_when = config.break_when_proxy_change.unwrap_or_default();
-
-        match break_when {
-            crate::config::nyanpasu::BreakWhenProxyChange::None => {
-                // Do nothing
-                Ok(())
-            }
-            crate::config::nyanpasu::BreakWhenProxyChange::Chain => {
-                // TODO: Implement chain-based connection interruption
-                // This would require tracking which connections use which proxy chains
-                // For now, we'll fall back to closing all connections
-                api::delete_connections(None).await
-            }
-            crate::config::nyanpasu::BreakWhenProxyChange::All => {
-                api::delete_connections(None).await
-            }
-        }
-    }
-
     /// Interrupt connections when profile changes
     pub async fn on_profile_change() -> Result<()> {
         let config = Config::verge().data().clone();

--- a/backend/tauri/src/core/handle.rs
+++ b/backend/tauri/src/core/handle.rs
@@ -26,7 +26,7 @@ pub enum Message {
     SetConfig(Result<(), String>),
 }
 
-const STATE_CHANGED_URI: &str = "nyanpasu://mutation";
+pub(crate) const STATE_CHANGED_URI: &str = "nyanpasu://mutation";
 const NOTIFY_MESSAGE_URI: &str = "nyanpasu://notice-message";
 
 impl Handle {
@@ -65,12 +65,6 @@ impl Handle {
     pub fn refresh_profiles() {
         if let Some(window) = Self::global().get_window() {
             log_err!(window.emit(STATE_CHANGED_URI, StateChanged::Profiles));
-        }
-    }
-
-    pub fn mutate_proxies() {
-        if let Some(window) = Self::global().get_window() {
-            log_err!(window.emit(STATE_CHANGED_URI, StateChanged::Proxies));
         }
     }
 

--- a/backend/tauri/src/core/hotkey.rs
+++ b/backend/tauri/src/core/hotkey.rs
@@ -100,13 +100,13 @@ impl HotkeyFunc {
     }
 
     /// Execute the hotkey action
-    fn execute(&self) {
+    fn execute(&self, app_handle: &tauri::AppHandle) {
         match self {
             HotkeyFunc::OpenOrCloseDashboard => feat::toggle_dashboard(),
-            HotkeyFunc::ClashModeRule => feat::change_clash_mode("rule".into()),
-            HotkeyFunc::ClashModeGlobal => feat::change_clash_mode("global".into()),
-            HotkeyFunc::ClashModeDirect => feat::change_clash_mode("direct".into()),
-            HotkeyFunc::ClashModeScript => feat::change_clash_mode("script".into()),
+            HotkeyFunc::ClashModeRule => feat::change_clash_mode(app_handle, "rule".into()),
+            HotkeyFunc::ClashModeGlobal => feat::change_clash_mode(app_handle, "global".into()),
+            HotkeyFunc::ClashModeDirect => feat::change_clash_mode(app_handle, "direct".into()),
+            HotkeyFunc::ClashModeScript => feat::change_clash_mode(app_handle, "script".into()),
             HotkeyFunc::ToggleSystemProxy => feat::toggle_system_proxy(),
             HotkeyFunc::EnableSystemProxy => feat::enable_system_proxy(),
             HotkeyFunc::DisableSystemProxy => feat::disable_system_proxy(),
@@ -261,10 +261,10 @@ impl Hotkey {
 
         let hotkey_func: HotkeyFunc = func.trim().parse()?;
 
-        manager.on_shortcut(hotkey, move |_app_handle, hotkey, ev| {
+        manager.on_shortcut(hotkey, move |app_handle, hotkey, ev| {
             if let ShortcutState::Pressed = ev.state {
                 tracing::info!("hotkey pressed: {}", hotkey);
-                hotkey_func.execute();
+                hotkey_func.execute(app_handle);
             }
         })?;
 

--- a/backend/tauri/src/core/mod.rs
+++ b/backend/tauri/src/core/mod.rs
@@ -18,3 +18,5 @@ pub mod win_uwp;
 pub use self::clash::find_binary_path;
 pub mod migration;
 pub mod state;
+
+pub(crate) mod proxies;

--- a/backend/tauri/src/core/proxies.rs
+++ b/backend/tauri/src/core/proxies.rs
@@ -1,0 +1,735 @@
+//! Actor-owned proxy cache shared by IPC and tray adapters.
+use std::{sync::Arc, time::Duration};
+
+use anyhow::{Context, Result};
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+use tokio::{sync::watch, time::Instant};
+
+use super::{
+    actor_v2::{CoreClient, api::ApiClient},
+    clash::{api, proxies::Proxies},
+};
+
+struct Snapshot {
+    api: ApiClient,
+    proxies: Proxies,
+    providers: api::ProvidersProxiesRes,
+    fetched: Instant,
+    fingerprint: Vec<u8>,
+}
+
+enum Message {
+    Read {
+        force: bool,
+        reply: RpcReplyPort<Result<Arc<Snapshot>>>,
+    },
+    Select {
+        group: String,
+        name: String,
+        interrupt: bool,
+        reply: RpcReplyPort<Result<()>>,
+    },
+    UpdateProvider {
+        name: String,
+        reply: RpcReplyPort<Result<()>>,
+    },
+    Refresh,
+    Invalidated(u64),
+}
+
+struct ProxiesActor;
+struct Args {
+    core: CoreClient,
+    snapshots: watch::Sender<Option<Arc<Snapshot>>>,
+    changes: watch::Sender<()>,
+}
+struct State {
+    core: CoreClient,
+    snapshots: watch::Sender<Option<Arc<Snapshot>>>,
+    changes: watch::Sender<()>,
+    cache: Option<Arc<Snapshot>>,
+    generation: u64,
+    monitor: Option<tokio::task::JoinHandle<()>>,
+    timer: Option<tokio::task::JoinHandle<()>>,
+}
+impl Drop for State {
+    fn drop(&mut self) {
+        if let Some(task) = self.monitor.take() {
+            task.abort();
+        }
+        if let Some(task) = self.timer.take() {
+            task.abort();
+        }
+    }
+}
+impl State {
+    fn clear(&mut self) {
+        if let Some(task) = self.monitor.take() {
+            task.abort();
+        }
+        if self.cache.take().is_some() {
+            self.snapshots.send_replace(None);
+            self.changes.send_replace(());
+        }
+    }
+
+    async fn read(&mut self, actor: &ActorRef<Message>, force: bool) -> Result<Arc<Snapshot>> {
+        let api = match self.core.api_client().await {
+            Ok(api) => api,
+            Err(error) => {
+                self.clear();
+                return Err(error.into());
+            }
+        };
+        if let Some(cache) = &self.cache {
+            if cache.api.same_instance(&api) {
+                if !force && cache.fetched.elapsed() < Duration::from_secs(3) {
+                    return Ok(cache.clone());
+                }
+            } else {
+                self.clear();
+            }
+        }
+        self.refresh(actor, api).await
+    }
+
+    async fn refresh(
+        &mut self,
+        actor: &ActorRef<Message>,
+        api: ApiClient,
+    ) -> Result<Arc<Snapshot>> {
+        let result = async {
+            let (proxies, providers) = api.proxy_snapshot().await?;
+            let proxies = api::ProxiesRes {
+                proxies: proxies
+                    .into_iter()
+                    .map(|(name, proxy)| (name.as_str().to_owned(), proxy_item(proxy)))
+                    .collect(),
+            };
+            let providers = api::ProvidersProxiesRes {
+                providers: providers
+                    .into_iter()
+                    .map(|(name, provider)| {
+                        Ok((name.as_str().to_owned(), provider_item(provider)?))
+                    })
+                    .collect::<Result<_>>()?,
+            };
+            let proxies = Proxies::from_responses(proxies, providers.clone())?;
+            let fingerprint = serde_json::to_vec(&(&proxies, &providers))?;
+            anyhow::ensure!(
+                !api.is_revoked(),
+                "core instance retired during proxy assembly"
+            );
+            Ok::<_, anyhow::Error>(Arc::new(Snapshot {
+                api: api.clone(),
+                proxies,
+                providers,
+                fetched: Instant::now(),
+                fingerprint,
+            }))
+        }
+        .await;
+        match result {
+            Ok(snapshot) => {
+                let changed = self
+                    .cache
+                    .as_ref()
+                    .is_none_or(|old| old.fingerprint != snapshot.fingerprint);
+                self.cache = Some(snapshot.clone());
+                self.snapshots.send_replace(Some(snapshot.clone()));
+                if changed {
+                    self.changes.send_replace(());
+                }
+                if let Some(task) = self.monitor.take() {
+                    task.abort();
+                }
+                self.generation += 1;
+                let generation = self.generation;
+                let actor = actor.clone();
+                self.monitor = Some(tokio::spawn(async move {
+                    api.cancelled().await;
+                    let _ = actor.cast(Message::Invalidated(generation));
+                }));
+                Ok(snapshot)
+            }
+            Err(error) => {
+                self.clear();
+                Err(error)
+            }
+        }
+    }
+
+    async fn select(
+        &mut self,
+        actor: &ActorRef<Message>,
+        group: String,
+        name: String,
+        interrupt: bool,
+    ) -> Result<()> {
+        self.clear();
+        let api = self.core.api_client().await?;
+        api.select_proxy(&group.into(), &name.into()).await?;
+        let interruption = if interrupt {
+            api.close_all_connections()
+                .await
+                .map_err(anyhow::Error::from)
+        } else {
+            Ok(())
+        };
+        let refresh = self.refresh(actor, api).await;
+        match (interruption, refresh) {
+            (Ok(()), Ok(_)) => Ok(()),
+            (interrupt, refresh) => anyhow::bail!(
+                "proxy selection succeeded; connection interruption error: {:?}; cache refresh error: {:?}",
+                interrupt.err(),
+                refresh.err()
+            ),
+        }
+    }
+}
+
+impl Actor for ProxiesActor {
+    type Msg = Message;
+    type State = State;
+    type Arguments = Args;
+    async fn pre_start(
+        &self,
+        _: ActorRef<Message>,
+        args: Args,
+    ) -> Result<State, ActorProcessingErr> {
+        Ok(State {
+            core: args.core,
+            snapshots: args.snapshots,
+            changes: args.changes,
+            cache: None,
+            generation: 0,
+            monitor: None,
+            timer: None,
+        })
+    }
+    async fn post_start(
+        &self,
+        actor: ActorRef<Message>,
+        state: &mut State,
+    ) -> Result<(), ActorProcessingErr> {
+        state.timer = Some(tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                if actor
+                    .call(
+                        |reply| Message::Read { force: true, reply },
+                        Some(Duration::from_secs(120)),
+                    )
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }));
+        Ok(())
+    }
+    async fn handle(
+        &self,
+        actor: ActorRef<Message>,
+        message: Message,
+        state: &mut State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            Message::Read { force, reply } => {
+                if reply.is_closed() {
+                    return Ok(());
+                }
+                let _ = reply.send(state.read(&actor, force).await);
+            }
+            Message::Select {
+                group,
+                name,
+                interrupt,
+                reply,
+            } => {
+                if reply.is_closed() {
+                    return Ok(());
+                }
+                let _ = reply.send(state.select(&actor, group, name, interrupt).await);
+            }
+            Message::UpdateProvider { name, reply } => {
+                if reply.is_closed() {
+                    return Ok(());
+                }
+                let result = async {
+                    state.clear();
+                    let api = state.core.api_client().await?;
+                    api.update_proxy_provider(&name.into()).await?;
+                    state
+                        .refresh(&actor, api)
+                        .await
+                        .context("provider update succeeded but cache refresh failed")?;
+                    Ok(())
+                }
+                .await;
+                let _ = reply.send(result);
+            }
+            Message::Refresh => {
+                if let Err(error) = state.read(&actor, true).await {
+                    tracing::debug!(%error, "proxy cache refresh failed");
+                }
+            }
+            Message::Invalidated(generation) if generation == state.generation => state.clear(),
+            Message::Invalidated(_) => {}
+        }
+        Ok(())
+    }
+}
+
+struct ClientInner {
+    actor: ActorRef<Message>,
+    snapshots: watch::Receiver<Option<Arc<Snapshot>>>,
+    changes: watch::Receiver<()>,
+}
+impl Drop for ClientInner {
+    fn drop(&mut self) {
+        self.actor.stop(None);
+    }
+}
+#[derive(Clone)]
+pub(crate) struct ProxiesClient(Arc<ClientInner>);
+impl ProxiesClient {
+    pub async fn spawn(core: CoreClient) -> Result<Self> {
+        let (snapshots, snapshot_rx) = watch::channel(None);
+        let (changes, changes_rx) = watch::channel(());
+        let (actor, _) = Actor::spawn(
+            None,
+            ProxiesActor,
+            Args {
+                core,
+                snapshots,
+                changes,
+            },
+        )
+        .await?;
+        Ok(Self(Arc::new(ClientInner {
+            actor,
+            snapshots: snapshot_rx,
+            changes: changes_rx,
+        })))
+    }
+    async fn call<T: Send + 'static>(
+        &self,
+        message: impl FnOnce(RpcReplyPort<Result<T>>) -> Message,
+    ) -> Result<T> {
+        match self
+            .0
+            .actor
+            .call(message, Some(Duration::from_secs(120)))
+            .await
+        {
+            Ok(ractor::rpc::CallResult::Success(result)) => result,
+            Ok(ractor::rpc::CallResult::Timeout) => anyhow::bail!(
+                "proxy actor timed out; an operation may still be running, do not replay mutations automatically"
+            ),
+            _ => anyhow::bail!("proxy actor is unavailable"),
+        }
+    }
+    pub async fn get(&self, force: bool) -> Result<Proxies> {
+        let snapshot = self.call(|reply| Message::Read { force, reply }).await?;
+        anyhow::ensure!(
+            !snapshot.api.is_revoked(),
+            "proxy snapshot belongs to a retired instance"
+        );
+        Ok(snapshot.proxies.clone())
+    }
+    pub async fn providers(&self) -> Result<api::ProvidersProxiesRes> {
+        let snapshot = self
+            .call(|reply| Message::Read {
+                force: false,
+                reply,
+            })
+            .await?;
+        anyhow::ensure!(
+            !snapshot.api.is_revoked(),
+            "provider snapshot belongs to a retired instance"
+        );
+        Ok(snapshot.providers.clone())
+    }
+    pub async fn select(&self, group: String, name: String, interrupt: bool) -> Result<()> {
+        self.call(|reply| Message::Select {
+            group,
+            name,
+            interrupt,
+            reply,
+        })
+        .await
+    }
+    pub async fn update_provider(&self, name: String) -> Result<()> {
+        self.call(|reply| Message::UpdateProvider { name, reply })
+            .await
+    }
+    pub fn request_refresh(&self) {
+        let _ = self.0.actor.cast(Message::Refresh);
+    }
+    pub fn snapshot(&self) -> Proxies {
+        self.0
+            .snapshots
+            .borrow()
+            .as_ref()
+            .filter(|snapshot| !snapshot.api.is_revoked())
+            .map(|snapshot| snapshot.proxies.clone())
+            .unwrap_or_default()
+    }
+    pub fn subscribe(&self) -> watch::Receiver<()> {
+        self.0.changes.clone()
+    }
+}
+
+fn proxy_item(proxy: clash_api::Proxy) -> api::ProxyItem {
+    api::ProxyItem {
+        name: proxy.name.as_str().to_owned(),
+        r#type: proxy.proxy_type,
+        udp: proxy.udp,
+        history: proxy
+            .history
+            .into_iter()
+            .map(|item| api::ProxyItemHistory {
+                time: item.time.to_rfc3339(),
+                delay: item.delay,
+            })
+            .collect(),
+        all: proxy.all.map(|items| {
+            items
+                .into_iter()
+                .map(|name| name.as_str().to_owned())
+                .collect()
+        }),
+        now: proxy.now.map(|name| name.as_str().to_owned()),
+        provider: proxy
+            .provider
+            .filter(|name| !name.is_empty())
+            .or_else(|| proxy.provider_name.filter(|name| !name.is_empty())),
+        alive: proxy.alive,
+        xudp: proxy.xudp,
+        tfo: proxy.tfo,
+        icon: proxy.icon,
+        hidden: proxy.hidden.unwrap_or(false),
+    }
+}
+fn provider_item(provider: clash_api::ProxyProvider) -> Result<api::ProxyProviderItem> {
+    Ok(api::ProxyProviderItem {
+        name: provider.name.as_str().to_owned(),
+        r#type: match provider.provider_type {
+            clash_api::ProviderType::Proxy => api::ProviderType::Proxy,
+            clash_api::ProviderType::Rule => api::ProviderType::Rule,
+            clash_api::ProviderType::Unknown(value) => api::ProviderType::Unknown(value),
+        },
+        vehicle_type: match provider.vehicle_type {
+            clash_api::VehicleType::Http => api::VehicleType::Http,
+            clash_api::VehicleType::File => api::VehicleType::File,
+            clash_api::VehicleType::Compatible => api::VehicleType::Compatible,
+            clash_api::VehicleType::Inline => api::VehicleType::Inline,
+            clash_api::VehicleType::Unknown(value) => api::VehicleType::Unknown(value),
+        },
+        proxies: provider.proxies.into_iter().map(proxy_item).collect(),
+        updated_at: provider.updated_at.map(|date| date.to_rfc3339()),
+        test_url: provider.test_url,
+        expected_status: provider.expected_status,
+        subscription_info: provider
+            .subscription_info
+            .map(|info| -> Result<_> {
+                Ok(api::SubscriptionInfo {
+                    upload: info.upload.try_into()?,
+                    download: info.download.try_into()?,
+                    total: info.total.try_into()?,
+                    expire: info.expire.try_into()?,
+                })
+            })
+            .transpose()?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::actor_v2::api::tests::{endpoint, server};
+    use axum::{
+        Json, Router,
+        extract::{Path, State as HttpState},
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        routing::{delete, get, put},
+    };
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+    use tokio::sync::Notify;
+
+    const GROUP: &str = "group/日本 ?#";
+    const NODE: &str = "node/日本";
+    const PROVIDER: &str = "provider/日本 ?#";
+    #[derive(Default)]
+    struct Fixture {
+        reads: AtomicUsize,
+        fail_reads: AtomicBool,
+        fail_mutation: AtomicBool,
+        hold_read: AtomicBool,
+        hold_select: AtomicBool,
+        entered: Notify,
+        release: Notify,
+        calls: Mutex<Vec<&'static str>>,
+        selected: Mutex<String>,
+    }
+    async fn proxies(HttpState(f): HttpState<Arc<Fixture>>) -> Response {
+        f.reads.fetch_add(1, Ordering::SeqCst);
+        f.calls.lock().unwrap().push("read");
+        if f.hold_read.load(Ordering::SeqCst) {
+            f.entered.notify_one();
+            f.release.notified().await;
+        }
+        if f.fail_reads.load(Ordering::SeqCst) {
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+        let mut proxies = serde_json::json!({});
+        for (name, kind) in [
+            ("DIRECT", "Direct"),
+            ("REJECT", "Reject"),
+            ("GLOBAL", "Selector"),
+            (GROUP, "Selector"),
+        ] {
+            proxies[name] = serde_json::json!({"name":name,"type":kind,"udp":true,"history":[]});
+        }
+        proxies["GLOBAL"]["all"] = serde_json::json!([GROUP]);
+        proxies[GROUP]["all"] = serde_json::json!([NODE, "DIRECT"]);
+        proxies[GROUP]["now"] = serde_json::json!(f.selected.lock().unwrap().clone());
+        Json(serde_json::json!({"proxies":proxies})).into_response()
+    }
+    async fn providers() -> Json<serde_json::Value> {
+        Json(
+            serde_json::json!({"providers":{PROVIDER:{"name":PROVIDER,"type":"Proxy","vehicleType":"HTTP", "proxies":[{"name":NODE,"type":"Vless","udp":true,"history":[]}], "subscriptionInfo":{"Expire":42}}}}),
+        )
+    }
+    async fn select(
+        HttpState(f): HttpState<Arc<Fixture>>,
+        Path(group): Path<String>,
+        Json(body): Json<serde_json::Value>,
+    ) -> StatusCode {
+        assert_eq!(group, GROUP);
+        assert_eq!(body["name"], NODE);
+        f.calls.lock().unwrap().push("select");
+        if f.hold_select.load(Ordering::SeqCst) {
+            f.entered.notify_one();
+            f.release.notified().await;
+        }
+        if f.fail_mutation.load(Ordering::SeqCst) {
+            return StatusCode::SERVICE_UNAVAILABLE;
+        }
+        *f.selected.lock().unwrap() = NODE.into();
+        StatusCode::NO_CONTENT
+    }
+    async fn update(HttpState(f): HttpState<Arc<Fixture>>, Path(name): Path<String>) -> StatusCode {
+        assert_eq!(name, PROVIDER);
+        f.calls.lock().unwrap().push("update");
+        if f.fail_mutation.load(Ordering::SeqCst) {
+            StatusCode::SERVICE_UNAVAILABLE
+        } else {
+            StatusCode::NO_CONTENT
+        }
+    }
+    async fn close(HttpState(f): HttpState<Arc<Fixture>>) -> StatusCode {
+        f.calls.lock().unwrap().push("close");
+        StatusCode::NO_CONTENT
+    }
+    async fn setup() -> (
+        ProxiesClient,
+        CoreClient,
+        Arc<crate::core::actor_v2::api::tests::Endpoint>,
+        Arc<Fixture>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let fixture = Arc::new(Fixture::default());
+        let router = Router::new()
+            .route("/proxies/", get(proxies))
+            .route("/providers/proxies/", get(providers))
+            .route("/proxies/{group}/", put(select))
+            .route("/providers/proxies/{name}/", put(update))
+            .route("/connections", delete(close))
+            .with_state(fixture.clone());
+        let (url, server) = server(router).await;
+        let endpoint = endpoint(url);
+        let core = CoreClient::spawn(endpoint.clone()).await.unwrap();
+        let client = ProxiesClient::spawn(core.clone()).await.unwrap();
+        (client, core, endpoint, fixture, server)
+    }
+    #[tokio::test]
+    async fn cache_ttl_and_provider_metadata_are_shared() {
+        let (client, _core, _, fixture, server) = setup().await;
+        let proxies = client.get(false).await.unwrap();
+        assert_eq!(proxies.groups[0].all[0].name, NODE);
+        assert_eq!(proxies.groups[0].all[0].provider.as_deref(), Some(PROVIDER));
+        assert_eq!(
+            client.providers().await.unwrap().providers[PROVIDER]
+                .subscription_info
+                .unwrap()
+                .expire,
+            42
+        );
+        client.get(false).await.unwrap();
+        assert_eq!(fixture.reads.load(Ordering::SeqCst), 1);
+        tokio::time::pause();
+        tokio::time::advance(Duration::from_secs(4)).await;
+        tokio::time::resume();
+        client.get(false).await.unwrap();
+        assert_eq!(fixture.reads.load(Ordering::SeqCst), 2);
+        client.get(false).await.unwrap();
+        assert_eq!(
+            fixture.reads.load(Ordering::SeqCst),
+            2,
+            "unchanged refresh must renew freshness"
+        );
+        server.abort();
+    }
+    #[tokio::test]
+    async fn select_closes_then_refreshes_without_replaying() {
+        let (client, _core, _, fixture, server) = setup().await;
+        client.get(false).await.unwrap();
+        fixture.calls.lock().unwrap().clear();
+        client
+            .select(GROUP.into(), NODE.into(), true)
+            .await
+            .unwrap();
+        assert_eq!(*fixture.calls.lock().unwrap(), ["select", "close", "read"]);
+        assert_eq!(client.snapshot().groups[0].now.as_deref(), Some(NODE));
+        fixture.calls.lock().unwrap().clear();
+        client
+            .select(GROUP.into(), NODE.into(), false)
+            .await
+            .unwrap();
+        assert_eq!(*fixture.calls.lock().unwrap(), ["select", "read"]);
+        fixture.calls.lock().unwrap().clear();
+        client.update_provider(PROVIDER.into()).await.unwrap();
+        assert_eq!(*fixture.calls.lock().unwrap(), ["update", "read"]);
+        server.abort();
+    }
+    #[tokio::test]
+    async fn successful_mutation_with_failed_refresh_is_explicit_and_clears_cache() {
+        let (client, _core, _, fixture, server) = setup().await;
+        client.get(false).await.unwrap();
+        fixture.fail_reads.store(true, Ordering::SeqCst);
+        let error = client
+            .select(GROUP.into(), NODE.into(), true)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("selection succeeded"));
+        assert!(client.snapshot().records.is_empty());
+        assert_eq!(
+            fixture
+                .calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|&&call| call == "select")
+                .count(),
+            1
+        );
+        fixture.calls.lock().unwrap().clear();
+        let error = client.update_provider(PROVIDER.into()).await.unwrap_err();
+        assert!(error.to_string().contains("provider update succeeded"));
+        assert!(client.snapshot().records.is_empty());
+        assert_eq!(*fixture.calls.lock().unwrap(), ["update", "read"]);
+        fixture.calls.lock().unwrap().clear();
+        fixture.fail_mutation.store(true, Ordering::SeqCst);
+        assert!(
+            client
+                .select(GROUP.into(), NODE.into(), true)
+                .await
+                .is_err()
+        );
+        assert_eq!(*fixture.calls.lock().unwrap(), ["select"]);
+        server.abort();
+    }
+    #[tokio::test]
+    async fn idle_cache_is_cleared_when_its_capability_is_revoked() {
+        let (client, core, endpoint, _, server) = setup().await;
+        client.get(false).await.unwrap();
+        let mut changes = client.subscribe();
+        changes.borrow_and_update();
+        endpoint.binding.send_modify(|binding| {
+            binding.as_mut().unwrap().instance_id = "replacement".into();
+        });
+        core.api_client().await.unwrap();
+        assert!(client.snapshot().records.is_empty());
+        tokio::time::timeout(Duration::from_secs(3), changes.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(client.snapshot().records.is_empty());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn replacement_during_read_never_publishes_the_old_response() {
+        let (client, core, endpoint, fixture, server) = setup().await;
+        client.get(false).await.unwrap();
+        fixture.hold_read.store(true, Ordering::SeqCst);
+        let waiting = {
+            let client = client.clone();
+            tokio::spawn(async move { client.get(true).await })
+        };
+        fixture.entered.notified().await;
+        endpoint
+            .binding
+            .send_modify(|binding| binding.as_mut().unwrap().instance_id = "replacement".into());
+        core.api_client().await.unwrap();
+        assert!(waiting.await.unwrap().is_err());
+        assert!(client.snapshot().records.is_empty());
+        fixture.hold_read.store(false, Ordering::SeqCst);
+        fixture.release.notify_one();
+        client.get(false).await.unwrap();
+        assert!(!client.snapshot().records.is_empty());
+        server.abort();
+    }
+    #[tokio::test]
+    async fn queued_cancelled_mutation_is_not_executed_and_shutdown_closes_subscriptions() {
+        let (client, _core, _, fixture, server) = setup().await;
+        fixture.hold_select.store(true, Ordering::SeqCst);
+        let first = {
+            let client = client.clone();
+            tokio::spawn(async move { client.select(GROUP.into(), NODE.into(), false).await })
+        };
+        fixture.entered.notified().await;
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        client
+            .0
+            .actor
+            .cast(Message::Select {
+                group: GROUP.into(),
+                name: NODE.into(),
+                interrupt: true,
+                reply: tx.into(),
+            })
+            .unwrap();
+        drop(rx);
+        fixture.release.notify_one();
+        first.await.unwrap().unwrap();
+        client.get(false).await.unwrap(); // Acknowledges the queued message was processed.
+        assert_eq!(
+            fixture
+                .calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|&&call| call == "select")
+                .count(),
+            1
+        );
+        let mut changes = client.subscribe();
+        changes.borrow_and_update();
+        drop(client);
+        assert!(
+            tokio::time::timeout(Duration::from_secs(3), changes.changed())
+                .await
+                .unwrap()
+                .is_err()
+        );
+        server.abort();
+    }
+}

--- a/backend/tauri/src/core/tray/mod.rs
+++ b/backend/tauri/src/core/tray/mod.rs
@@ -434,7 +434,7 @@ impl Tray {
         match id {
             mode @ ("rule_mode" | "global_mode" | "direct_mode" | "script_mode") => {
                 let mode = &mode[0..mode.len() - 5];
-                feat::change_clash_mode(mode.into());
+                feat::change_clash_mode(app_handle, mode.into());
             }
 
             "open_window" => resolve::create_window(app_handle),
@@ -455,7 +455,7 @@ impl Tray {
                 help::quit_application(app_handle);
             }
             _ => {
-                proxies::on_system_tray_event(id);
+                proxies::on_system_tray_event(app_handle, id);
             }
         }
     }

--- a/backend/tauri/src/core/tray/proxies.rs
+++ b/backend/tauri/src/core/tray/proxies.rs
@@ -1,43 +1,14 @@
+// TODO(actor-migration): compatibility bridge for legacy tray settings snapshots.
+// Reason: synchronous menu construction still reads the legacy settings mirror.
+// Remove when: tray settings snapshots are injected into menu construction.
 use crate::{
     config::{Config, nyanpasu::ProxiesSelectorMode},
-    core::{
-        clash::proxies::{Proxies, ProxiesGuard, ProxiesGuardExt},
-        handle::Handle,
-    },
+    core::clash::proxies::Proxies,
 };
-use anyhow::Context;
 use indexmap::IndexMap;
-use tauri::{AppHandle, Manager, Runtime, menu::MenuBuilder};
+use tauri::{AppHandle, Emitter, Manager, Runtime, menu::MenuBuilder};
 use tracing::{debug, error, warn};
 use tracing_attributes::instrument;
-
-#[instrument]
-async fn loop_task() {
-    loop {
-        match ProxiesGuard::global().update().await {
-            Ok(_) => {
-                debug!("update proxies success");
-            }
-            Err(e) => {
-                warn!("update proxies failed: {:?}", e);
-            }
-        }
-        {
-            let guard = ProxiesGuard::global().read();
-            if guard.updated_at() == 0 {
-                error!("proxies not updated yet!!!!");
-                // TODO: add a error dialog or notification, and panic?
-            }
-
-            // else {
-            //     let proxies = guard.inner();
-            //     let str = simd_json::to_string_pretty(proxies).unwrap();
-            //     debug!(target: "tray", "proxies info: {:?}", str);
-            // }
-        }
-        tokio::time::sleep(tokio::time::Duration::from_secs(10)).await; // TODO: add a config to control the interval
-    }
-}
 
 type GroupName = String;
 type ProxyName = String;
@@ -140,83 +111,52 @@ fn diff_proxies(old_proxies: &TrayProxies, new_proxies: &TrayProxies) -> TrayUpd
     }
 }
 
-#[instrument]
-pub async fn proxies_updated_receiver() {
-    let (mut rx, mut tray_proxies_holder) = {
-        let guard = ProxiesGuard::global().read();
-        let proxies = guard.inner().to_owned();
-        let mode = crate::utils::config::get_current_clash_mode();
-        (
-            guard.get_receiver(),
-            to_tray_proxies(mode.as_str(), &proxies),
-        )
-    };
-
-    loop {
-        match rx.recv().await {
-            Ok(_) => {
-                debug!("proxies updated");
-                if Handle::global().app_handle.lock().is_none() {
-                    warn!("app handle not found");
-                    continue;
-                }
-                Handle::mutate_proxies();
-                {
-                    let is_tray_selector_enabled = Config::verge()
-                        .latest()
-                        .clash_tray_selector
-                        .unwrap_or_default()
-                        != ProxiesSelectorMode::Hidden;
-                    if !is_tray_selector_enabled {
-                        continue;
-                    }
-                }
-                // Do diff check
-                let mode = crate::utils::config::get_current_clash_mode();
-                let current_tray_proxies =
-                    to_tray_proxies(mode.as_str(), ProxiesGuard::global().read().inner());
-
-                match diff_proxies(&tray_proxies_holder, &current_tray_proxies) {
-                    TrayUpdateType::Full => {
-                        debug!("should do full update");
-
-                        tray_proxies_holder = current_tray_proxies;
-                        match Handle::emit("update_systray", ()) {
-                            Ok(_) => {
-                                debug!("update systray success");
-                            }
-                            Err(e) => {
-                                warn!("update systray failed: {:?}", e);
-                            }
-                        }
-                    }
-                    TrayUpdateType::Part(action_list) => {
-                        debug!("should do partial update, op list: {:?}", action_list);
-                        tray_proxies_holder = current_tray_proxies;
-                        platform_impl::update_selected_proxies(&action_list);
-                        debug!("update selected proxies success");
-                    }
-                    _ => {}
-                }
-            }
-            Err(e) => {
-                warn!("proxies updated receiver failed: {:?}", e);
-            }
+#[instrument(skip(app_handle, client))]
+pub async fn proxies_updated_receiver(
+    app_handle: AppHandle,
+    client: crate::client::NyanpasuClient,
+) {
+    let mut rx = client.subscribe_proxy_changes();
+    let mode = crate::utils::config::get_current_clash_mode();
+    let mut tray_proxies_holder = to_tray_proxies(mode.as_str(), &client.proxies_snapshot());
+    while rx.changed().await.is_ok() {
+        let _ = app_handle.emit(
+            crate::core::handle::STATE_CHANGED_URI,
+            crate::core::handle::StateChanged::Proxies,
+        );
+        let is_tray_selector_enabled = Config::verge()
+            .latest()
+            .clash_tray_selector
+            .unwrap_or_default()
+            != ProxiesSelectorMode::Hidden;
+        if !is_tray_selector_enabled {
+            continue;
         }
+        let mode = crate::utils::config::get_current_clash_mode();
+        let current = to_tray_proxies(mode.as_str(), &client.proxies_snapshot());
+        match diff_proxies(&tray_proxies_holder, &current) {
+            TrayUpdateType::Full => {
+                let _ = app_handle.emit("update_systray", ());
+            }
+            TrayUpdateType::Part(actions) => platform_impl::update_selected_proxies(&actions),
+            TrayUpdateType::None => {}
+        }
+        tray_proxies_holder = current;
     }
 }
 
-pub fn setup_proxies() {
-    tauri::async_runtime::spawn(loop_task());
-    tauri::async_runtime::spawn(proxies_updated_receiver());
+pub fn setup_proxies(app_handle: &AppHandle) {
+    let client = app_handle
+        .state::<crate::client::NyanpasuClient>()
+        .inner()
+        .clone();
+    client.request_proxy_refresh();
+    tauri::async_runtime::spawn(proxies_updated_receiver(app_handle.clone(), client));
 }
 
 mod platform_impl {
     use super::{GroupName, ProxyName, ProxySelectAction, TrayProxyItem};
-    use crate::{
-        config::nyanpasu::ProxiesSelectorMode,
-        core::{clash::proxies::ProxiesGuard, handle::Handle},
-    };
+    use crate::{config::nyanpasu::ProxiesSelectorMode, core::handle::Handle};
     use bimap::BiMap;
     use once_cell::sync::Lazy;
     use parking_lot::Mutex;
@@ -311,7 +251,9 @@ mod platform_impl {
             ProxiesSelectorMode::Normal => menu.separator(),
             ProxiesSelectorMode::Submenu => menu,
         };
-        let proxies = ProxiesGuard::global().read().inner().to_owned();
+        let proxies = app_handle
+            .state::<crate::client::NyanpasuClient>()
+            .proxies_snapshot();
         let mode = crate::utils::config::get_current_clash_mode();
         let tray_proxies = super::to_tray_proxies(mode.as_str(), &proxies);
         let items = generate_selectors::<R>(app_handle, &tray_proxies)?;
@@ -489,7 +431,7 @@ impl<R: Runtime, M: Manager<R>> SystemTrayMenuProxiesExt<R> for MenuBuilder<'_, 
 }
 
 #[instrument]
-pub fn on_system_tray_event(event: &str) {
+pub fn on_system_tray_event(app_handle: &AppHandle, event: &str) {
     if !event.starts_with("proxy_node_") {
         return; // bypass non-select event
     }
@@ -514,22 +456,15 @@ pub fn on_system_tray_event(event: &str) {
         }
     };
 
-    let wrapper = move || -> anyhow::Result<()> {
-        tracing::debug!("received select proxy event: {} {}", group, name);
-        tauri::async_runtime::block_on(async move {
-            ProxiesGuard::global()
-                .select_proxy(&group, &name)
-                .await
-                .with_context(|| format!("select proxy failed, {group} {name}, cause: "))?;
-
-            debug!("select proxy success: {} {}", group, name);
-            Ok::<(), anyhow::Error>(())
-        })?;
-        Ok(())
-    };
-
-    if let Err(e) = wrapper() {
-        // TODO: add a error dialog or notification
-        error!("on_system_tray_event failed: {:?}", e);
-    }
+    let client = app_handle
+        .state::<crate::client::NyanpasuClient>()
+        .inner()
+        .clone();
+    tauri::async_runtime::spawn(async move {
+        debug!("received select proxy event: {} {}", group, name);
+        match client.select_proxy(group.clone(), name.clone()).await {
+            Ok(()) => debug!("select proxy success: {} {}", group, name),
+            Err(error) => error!("select proxy failed, {} {}: {:#}", group, name, error),
+        }
+    });
 }

--- a/backend/tauri/src/feat.rs
+++ b/backend/tauri/src/feat.rs
@@ -80,10 +80,13 @@ pub fn restart_clash_core(app_handle: &AppHandle) {
 }
 
 // 切换模式 rule/global/direct/script mode
-pub fn change_clash_mode(mode: String) {
+pub fn change_clash_mode(app_handle: &AppHandle, mode: String) {
+    let client = app_handle
+        .state::<crate::client::NyanpasuClient>()
+        .inner()
+        .clone();
     let mut mapping = Mapping::new();
     mapping.insert(Value::from("mode"), mode.clone().into());
-    let (tx, rx) = tokio::sync::oneshot::channel();
     tauri::async_runtime::spawn(async move {
         log::debug!(target: "app", "change clash mode to {mode}");
 
@@ -99,13 +102,8 @@ pub fn change_clash_mode(mode: String) {
             }
             Err(err) => log::error!(target: "app", "{err:?}"),
         }
-        if tx.send(()).is_err() {
-            log::error!(target: "app::change_clash_mode", "failed to send tx");
-        }
+        client.request_proxy_refresh();
     });
-
-    // refresh proxies
-    update_proxies_buff(Some(rx));
 
     // Interrupt connections based on configuration
     tauri::async_runtime::spawn(async move {
@@ -513,26 +511,6 @@ pub fn copy_clash_env(app_handle: &AppHandle, option: &CopyEnvOption) {
             }
         }
     }
-}
-
-pub fn update_proxies_buff(rx: Option<tokio::sync::oneshot::Receiver<()>>) {
-    use crate::core::clash::proxies::{ProxiesGuard, ProxiesGuardExt};
-
-    tauri::async_runtime::spawn(async move {
-        if let Some(rx) = rx
-            && let Err(e) = rx.await
-        {
-            log::error!(target: "app::clash::proxies", "update proxies buff by rx failed: {e}");
-        }
-        match ProxiesGuard::global().update().await {
-            Ok(_) => {
-                log::debug!(target: "app::clash::proxies", "update proxies buff success");
-            }
-            Err(e) => {
-                log::error!(target: "app::clash::proxies", "update proxies buff failed: {e}");
-            }
-        }
-    });
 }
 
 #[cfg(test)]

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -457,8 +457,8 @@ pub async fn patch_clash_config(
     client.reconcile_core().await?;
     // A mode change rewrites the proxy groups; warm the cache the same way the
     // pre-facade patch path did, or the next read serves the old groups until
-    // the guard's freshness window lapses.
-    crate::feat::update_proxies_buff(None);
+    // the actor cache's freshness window lapses.
+    client.request_proxy_refresh();
     Ok(())
 }
 
@@ -737,60 +737,42 @@ pub async fn clash_api_get_group_delay(
 
 #[tauri::command]
 #[specta::specta]
-pub async fn clash_api_get_providers_proxies() -> Result<clash::api::ProvidersProxiesRes> {
-    Ok(clash::api::get_providers_proxies().await?)
+pub async fn clash_api_get_providers_proxies(
+    client: State<'_, NyanpasuClient>,
+) -> Result<clash::api::ProvidersProxiesRes> {
+    Ok(client.proxy_providers().await?)
 }
 
 #[tauri::command]
 #[specta::specta]
-pub async fn get_proxies() -> Result<crate::core::clash::proxies::Proxies> {
-    use crate::core::clash::proxies::{ProxiesGuard, ProxiesGuardExt};
-    {
-        let guard = ProxiesGuard::global().read();
-        if guard.is_updated() {
-            return Ok(guard.inner().clone());
-        }
-    }
-    match ProxiesGuard::global().update().await {
-        Ok(_) => {
-            let proxies = ProxiesGuard::global().read().inner().clone();
-            Ok(proxies)
-        }
-        Err(err) => Err(err.into()),
-    }
+pub async fn get_proxies(
+    client: State<'_, NyanpasuClient>,
+) -> Result<crate::core::clash::proxies::Proxies> {
+    Ok(client.get_proxies().await?)
 }
 
 #[tauri::command]
 #[specta::specta]
-pub async fn mutate_proxies() -> Result<crate::core::clash::proxies::Proxies> {
-    use crate::core::clash::proxies::{ProxiesGuard, ProxiesGuardExt};
-    (ProxiesGuard::global().update().await)?;
-    Ok(ProxiesGuard::global().read().inner().clone())
+pub async fn mutate_proxies(
+    client: State<'_, NyanpasuClient>,
+) -> Result<crate::core::clash::proxies::Proxies> {
+    Ok(client.refresh_proxies().await?)
 }
 
 #[tauri::command]
 #[specta::specta]
-pub async fn select_proxy(group: String, name: String) -> Result<()> {
-    use crate::core::clash::proxies::{ProxiesGuard, ProxiesGuardExt};
-    (ProxiesGuard::global().select_proxy(&group, &name).await)?;
-
-    // Interrupt connections based on configuration
-    let _ = crate::core::connection_interruption::ConnectionInterruptionService::on_proxy_change()
-        .await;
-
-    Ok(())
+pub async fn select_proxy(
+    client: State<'_, NyanpasuClient>,
+    group: String,
+    name: String,
+) -> Result<()> {
+    Ok(client.select_proxy(group, name).await?)
 }
 
 #[tauri::command]
 #[specta::specta]
-pub async fn update_proxy_provider(name: String) -> Result<()> {
-    use crate::core::clash::{
-        api,
-        proxies::{ProxiesGuard, ProxiesGuardExt},
-    };
-    (api::update_providers_proxies_group(&name).await)?;
-    (ProxiesGuard::global().update().await)?;
-    Ok(())
+pub async fn update_proxy_provider(client: State<'_, NyanpasuClient>, name: String) -> Result<()> {
+    Ok(client.update_proxy_provider(name).await?)
 }
 
 #[tauri::command]

--- a/backend/tauri/src/utils/resolve.rs
+++ b/backend/tauri/src/utils/resolve.rs
@@ -239,7 +239,7 @@ pub fn resolve_setup(app: &mut App) {
     }
 
     // test job
-    proxies::setup_proxies();
+    proxies::setup_proxies(app.app_handle());
     crate::core::storage::register_web_storage_listener(app.app_handle());
 }
 

--- a/docs/plan/2026-09-07-proxies-actor-migration.md
+++ b/docs/plan/2026-09-07-proxies-actor-migration.md
@@ -1,0 +1,82 @@
+# ProxiesActor migration
+
+## Scope and acceptance
+
+1. Make the runtime proxy/provider response model accept missing extensions and
+   partial subscription usage without losing unknown enum strings. Test wire
+   decoding, port-independent paths and signed history delays.
+2. Keep proxy/group assembly a pure service. Replace ProxiesGuard with an injected
+   ProxiesActor owning the cache, freshness, refresh timer and subscriptions.
+3. Move list/read/refresh/select/provider-update calls to NyanpasuClient. Retire
+   legacy proxy REST functions and update frontend IPC, tray and cache warming.
+4. Verify same-instance paired reads, cache expiry, invalidation, write ordering,
+   post-write errors, shutdown and tray/IPC type checks. Deliver linked PRs.
+
+## Ownership and lifecycle
+
+CoreActor owns the revocable ApiClient. ProxiesActor owns an immutable published
+snapshot and a three-second cache age; only its mailbox changes cache state.
+The ten-second refresh loop waits for each refresh before scheduling the next,
+so slow requests cannot accumulate timer messages. Actor teardown aborts its
+background tasks. Typed clients use finite RPC timeouts.
+
+A cache hit still checks the active CoreClient capability. Paired proxies/provider
+reads run under one capability with a single postflight check, preventing mixed
+process snapshots. Revocation clears the cache and notifies consumers; synchronous
+tray projections also reject snapshots whose capability has been revoked.
+Subscribers see immutable snapshots, not actor-owned state behind shared locks.
+
+Selection and provider refresh execute once on a bound capability, invalidate
+old cache, and refresh using that same capability. Errors after a successful
+mutation explicitly report that it applied; no replay or rollback is attempted.
+
+## Boundaries and policy
+
+NyanpasuClient remains a facade. Its composition code injects CoreClient into
+ProxiesActor. DTO conversion/group assembly are pure functions. Network I/O stays
+inside the typed clash-api adapter; Tauri events and menu updates stay at the UI
+boundary. The frontend's command names remain stable.
+
+Proxy-change interruption reads the typed ClashConfig strategy, not a global.
+Off skips closure; All closes all connections. The existing ProxyGroup fallback
+to closing all is retained and documented, since chain-filtered closure is a
+separate policy feature. Selection, closure and refresh share the same ApiClient.
+Mode-change and other legacy policy paths remain outside this migration, except
+that their proxy-cache warming is routed to the injected facade.
+
+## Response compatibility
+
+Keep name/type/history/udp required. Core-specific proxy extensions and provider
+test metadata may be absent. Preserve unknown provider/vehicle strings. Validate
+numeric conversions for the existing frontend DTO. Subscription usage retains
+legacy PascalCase/lowercase aliases and default-zero missing counters. Configured
+core kind/transport FeatureSupport cannot establish these response fields.
+
+## Implementation and validation
+
+- Added the injected ProxiesActor and retired ProxiesGuard plus legacy proxy REST
+  functions. Removed the obsolete backoff/checksum and cache-warming helpers.
+- IPC commands retain their names. Proxy selection now unwraps command errors in
+  the frontend; actor change events refresh both proxy and provider queries.
+  Tray selection runs asynchronously through the same facade and policy.
+- Six actor tests cover shared cache/expiry, encoded mutation names, ordering,
+  post-mutation refresh failures, idle and in-flight instance replacement,
+  cancellation of queued mutations, and subscription shutdown.
+- Application library tests: 476 passed, one ignored. Runtime clash-api tests:
+  36 passed, one ignored. Runtime Clippy with warnings denied and application
+  workspace Clippy/all targets/all features passed (existing application warnings).
+- Generated IPC bindings preserve unknown provider/vehicle values as strings.
+  Interface build, TypeScript checks and architecture ledger gate passed. No live GUI/core smoke test has been performed.
+
+Runtime dependency: [nyanpasu-runtime #405](https://github.com/libnyanpasu/nyanpasu-runtime/pull/405),
+pinned at `82092b0`. Merge that PR before the application migration.
+
+## Remaining migration batches
+
+1. Configuration PUT/PATCH and their reconciliation/lifecycle callers.
+2. Remaining connection-interruption policy callers (including mode/profile
+   changes and chain-aware ProxyGroup closure).
+3. WebSocket stream ownership and transport through the typed runtime API.
+
+Proxy/Provider REST callers are complete in this batch. Frontend REST hooks use
+IPC; remaining stream work is in the backend connector, not frontend URL assembly.

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -1892,7 +1892,7 @@ export type ProfileValidationError =
       UnsupportedRemoteUrlScheme?: never
     })
 
-export type ProviderType = 'Proxy' | 'Rule' | 'Unknown'
+export type ProviderType = 'Proxy' | 'Rule' | string
 
 export type ProvidersProxiesRes =
   | ProvidersProxiesRes_Serialize
@@ -2381,7 +2381,7 @@ export type UpdaterSummary = {
   downloader: DownloadStatus
 }
 
-export type VehicleType = 'File' | 'HTTP' | 'Compatible' | 'Unknown'
+export type VehicleType = 'File' | 'HTTP' | 'Compatible' | 'Inline' | string
 
 /**  Message for inter-window communication */
 export type WindowMessageEvent = {

--- a/frontend/interface/src/ipc/use-clash-proxies.ts
+++ b/frontend/interface/src/ipc/use-clash-proxies.ts
@@ -74,7 +74,7 @@ export const useClashProxies = () => {
           ])
         },
         mutateSelect: async () => {
-          await commands.selectProxy(groupName, proxy.name)
+          unwrapResult(await commands.selectProxy(groupName, proxy.name))
           await proxies.refetch()
         },
       })

--- a/frontend/interface/src/provider/mutation-provider.tsx
+++ b/frontend/interface/src/provider/mutation-provider.tsx
@@ -4,6 +4,8 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import {
   CLASH_CONFIG_QUERY_KEY,
   CLASH_INFO_QUERY_KEY,
+  CLASH_PROXIES_PROVIDER_QUERY_KEY,
+  CLASH_PROXIES_QUERY_KEY,
   CLASH_VERSION_QUERY_KEY,
   NYANPASU_BACKEND_EVENT_NAME,
   NYANPASU_SETTING_QUERY_KEY,
@@ -45,7 +47,8 @@ const PROFILES_MUTATION_KEYS = [
 ]
 
 const PROXIES_MUTATION_KEYS = [
-  // TODO: key.includes('getProxies')
+  CLASH_PROXIES_QUERY_KEY,
+  CLASH_PROXIES_PROVIDER_QUERY_KEY,
 ] as const
 
 export const MutationProvider = ({ children }: PropsWithChildren) => {

--- a/scripts/architecture-ledger.snapshot.json
+++ b/scripts/architecture-ledger.snapshot.json
@@ -4,18 +4,17 @@
   ],
   "metrics": {
     "config_calls": {
-      "total": 107,
+      "total": 106,
       "byKey": {
-        "Config::verge()": 81,
+        "Config::verge()": 80,
         "Config::clash()": 26
       }
     },
     "service_globals": {
-      "total": 57,
+      "total": 41,
       "byKey": {
-        "ProxiesGuard::global()": 14,
-        "Handle::global()": 11,
-        "Self::global()": 9,
+        "Handle::global()": 10,
+        "Self::global()": 8,
         "Sysopt::global()": 8,
         "WindowManager::global()": 8,
         "Hotkey::global()": 3,
@@ -24,10 +23,10 @@
       }
     },
     "migration_markers": {
-      "total": 11,
+      "total": 13,
       "byKey": {
-        "TODO(actor-migration)": 9,
-        "FIXME(actor-migration)": 2
+        "TODO(actor-migration)": 10,
+        "FIXME(actor-migration)": 3
       }
     },
     "legacy_dto_refs": {


### PR DESCRIPTION
Proxy and provider calls still used legacy HTTP helpers and a global ProxiesGuard cache. A core replacement could leave consumers using old cached data, and concurrent proxy mutations could race with refreshes. This change routes the complete call path through an injected ProxiesActor and the revocable CoreActor ApiClient.

- The actor owns the three-second cache, ten-second refresh loop and cancellation subscriptions. Paired proxy/provider reads share one capability; retired snapshots are rejected and cleared.
- Selection and provider refresh run once, then refresh on the same capability. Failures after a successful mutation explicitly report that it applied. Proxy-change interruption uses typed configuration; the existing ProxyGroup close-all fallback is documented.
- IPC, asynchronous tray selection and startup/mode-change cache warming use NyanpasuClient. Frontend selection unwraps command errors, and change events refresh both proxy and provider queries. Legacy ProxiesGuard and proxy REST helpers are removed.

Depends on https://github.com/libnyanpasu/nyanpasu-runtime/pull/405 (pinned `82092b0`); merge runtime first. Optional response metadata is not inferred from transport FeatureSupport. The implementation plan and remaining migration batches are in `docs/plan/2026-09-07-proxies-actor-migration.md`.

Validation: 476 application library tests passed, 1 ignored, including six actor lifecycle/cache/mutation tests; workspace Clippy with all targets/features passed with existing warnings; interface build, all three TypeScript checks, frontend lint, rustfmt and architecture ledger gate passed. The runtime dependency has 36 passing tests and Clippy with warnings denied. No live GUI/core smoke test was performed.

Remaining: configuration PUT/PATCH, other connection-interruption policies, and WebSocket stream migration.
