### PR TITLE
refactor(core): unify configuration writes through lifecycle actors

### DIFF
--- a/backend/nyanpasu-config/src/clash/config/overrides/mod.rs
+++ b/backend/nyanpasu-config/src/clash/config/overrides/mod.rs
@@ -47,6 +47,7 @@ pub enum Mode {
     Rule,
     Global,
     Direct,
+    Script,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, specta::Type, Patch)]

--- a/backend/tauri/src/client/clash_config.rs
+++ b/backend/tauri/src/client/clash_config.rs
@@ -2,7 +2,9 @@ use std::{sync::Arc, time::Duration};
 
 use anyhow::Context as _;
 use camino::Utf8PathBuf;
-use nyanpasu_config::clash::config::{ClashConfig, ClashConfigPatch};
+use nyanpasu_config::clash::config::{
+    ClashConfig, ClashConfigPatch, overrides::ClashGuardOverridesPatch,
+};
 use nyanpasu_core::state::PersistentStateManagerSetup;
 use ractor::{Actor, ActorRef, RpcReplyPort, rpc::CallResult};
 
@@ -73,6 +75,17 @@ impl ClashConfigClient {
     pub async fn patch(&self, patch: ClashConfigPatch) -> anyhow::Result<ClashConfigSnapshot> {
         self.call(
             |reply| ClashConfigActorMessage::Patch { patch, reply },
+            None,
+        )
+        .await
+    }
+
+    pub async fn patch_overrides(
+        &self,
+        patch: ClashGuardOverridesPatch,
+    ) -> anyhow::Result<ClashConfigSnapshot> {
+        self.call(
+            |reply| ClashConfigActorMessage::PatchOverrides { patch, reply },
             None,
         )
         .await
@@ -236,5 +249,21 @@ mod tests {
                 panic!("unexpected conflict at version {actual_version}")
             }
         }
+    }
+    #[tokio::test]
+    async fn concurrent_override_patches_preserve_unrelated_fields() {
+        let (client, _dir) = test_client().await;
+        let before = serde_json::to_value(client.get().await.unwrap().state.overrides).unwrap();
+        let left = serde_json::from_value(serde_json::json!({"mode":"script"})).unwrap();
+        let right = serde_json::from_value(serde_json::json!({"allow-lan":true})).unwrap();
+        let (left, right) =
+            tokio::join!(client.patch_overrides(left), client.patch_overrides(right));
+        left.unwrap();
+        right.unwrap();
+        let after = serde_json::to_value(client.get().await.unwrap().state.overrides).unwrap();
+        assert_eq!(after["mode"], "script");
+        assert_eq!(after["allow-lan"], true);
+        assert_eq!(after["secret"], before["secret"]);
+        assert_eq!(after["ipv6"], before["ipv6"]);
     }
 }

--- a/backend/tauri/src/client/core_lifecycle/mod.rs
+++ b/backend/tauri/src/client/core_lifecycle/mod.rs
@@ -66,6 +66,7 @@ pub struct CoreLifecycleOperationResult {
 
 pub(super) enum Command {
     Reconcile,
+    PatchRuntimeOverrides(nyanpasu_config::clash::config::overrides::ClashGuardOverridesPatch),
     SelectCore(ClashCore),
     ChangeHost(ExecutionHost),
     SetExecutionHost(bool),
@@ -565,6 +566,16 @@ impl CoreLifecycleClient {
         }
     }
     method!(shutdown, Command::Shutdown, Shutdown, ShutdownReport);
+
+    pub async fn patch_runtime_overrides(
+        &self,
+        patch: nyanpasu_config::clash::config::overrides::ClashGuardOverridesPatch,
+    ) -> Result<runtime::MutationOutcome<()>, CoreError> {
+        match self.call(Command::PatchRuntimeOverrides(patch)).await? {
+            Output::Mutation(result) => Ok(result),
+            _ => unreachable!(),
+        }
+    }
 
     pub async fn select_core(&self, core: ClashCore) -> Result<ReconcileReport, CoreError> {
         match self.call(Command::SelectCore(core)).await? {

--- a/backend/tauri/src/client/core_lifecycle/tests.rs
+++ b/backend/tauri/src/client/core_lifecycle/tests.rs
@@ -47,6 +47,7 @@ async fn dirty_graph(
     DirtyNotifier,
     Arc<BlockingBuilder>,
     super::super::application::ApplicationClient,
+    super::super::clash_config::ClashConfigClient,
 ) {
     use super::super::tests::{
         IdleServiceAdapter, test_materialization_port, test_typed_config_clients,
@@ -87,7 +88,7 @@ async fn dirty_graph(
     let client = CoreLifecycleClient::spawn_with_ticks(
         CoreLifecycleArgs {
             application: application.clone(),
-            clash,
+            clash: clash.clone(),
             profiles,
             core,
             service,
@@ -100,7 +101,7 @@ async fn dirty_graph(
     )
     .await
     .unwrap();
-    (client, notifier, builder, application)
+    (client, notifier, builder, application, clash)
 }
 
 async fn tick(client: &CoreLifecycleClient) {
@@ -111,7 +112,7 @@ async fn tick(client: &CoreLifecycleClient) {
 #[tokio::test]
 async fn dirty_during_build_coalesces_and_eventually_applies_the_new_snapshot() {
     let dir = tempfile::tempdir().unwrap();
-    let (client, notifier, builder, application) = dirty_graph(&dir).await;
+    let (client, notifier, builder, application, _) = dirty_graph(&dir).await;
     for _ in 0..8 {
         notifier.request_rebuild();
     }
@@ -145,7 +146,7 @@ async fn dirty_during_build_coalesces_and_eventually_applies_the_new_snapshot() 
 async fn shutdown_discards_dirty_before_start_and_after_an_active_build() {
     for active in [false, true] {
         let dir = tempfile::tempdir().unwrap();
-        let (client, notifier, builder, _) = dirty_graph(&dir).await;
+        let (client, notifier, builder, _, _) = dirty_graph(&dir).await;
         if active {
             notifier.request_rebuild();
             tick(&client).await;
@@ -620,8 +621,8 @@ fn lost_backend_result_blocks_new_mutations_without_hiding_the_promoted_product(
 async fn dirty_notifications_and_shutdown_are_isolated_between_graphs() {
     let dir_a = tempfile::tempdir().unwrap();
     let dir_b = tempfile::tempdir().unwrap();
-    let (a, notify_a, build_a, _) = dirty_graph(&dir_a).await;
-    let (b, notify_b, build_b, _) = dirty_graph(&dir_b).await;
+    let (a, notify_a, build_a, _, _) = dirty_graph(&dir_a).await;
+    let (b, notify_b, build_b, _, _) = dirty_graph(&dir_b).await;
     notify_a.request_rebuild();
     tick(&a).await;
     tick(&b).await;
@@ -636,4 +637,225 @@ async fn dirty_notifications_and_shutdown_are_isolated_between_graphs() {
     b.shutdown().await.unwrap();
     assert_eq!(build_a.calls.load(Ordering::SeqCst), 1);
     assert_eq!(build_b.calls.load(Ordering::SeqCst), 1);
+}
+
+fn override_patch(
+    value: serde_json::Value,
+) -> nyanpasu_config::clash::config::overrides::ClashGuardOverridesPatch {
+    serde_json::from_value(value).unwrap()
+}
+
+#[test]
+fn config_writes_preserve_both_fields_and_reconcile_each_committed_patch() {
+    let dir = tempfile::tempdir().unwrap();
+    let endpoint = TestControlEndpoint::succeeding();
+    let client =
+        NyanpasuClient::try_new_with_args(test_client_args_with_endpoint(&dir, endpoint.clone()))
+            .unwrap();
+    tauri::async_runtime::block_on(async {
+        let (left, right) = tokio::join!(
+            client.patch_runtime_overrides(override_patch(serde_json::json!({"mode":"global"}))),
+            client.patch_runtime_overrides(override_patch(serde_json::json!({"ipv6":true})))
+        );
+        assert!(left.unwrap().degradations().is_empty());
+        assert!(right.unwrap().degradations().is_empty());
+        let saved =
+            serde_json::to_value(client.get_clash_config().await.unwrap().overrides).unwrap();
+        assert_eq!(saved["mode"], "global");
+        assert_eq!(saved["ipv6"], true);
+        let applied = client.runtime_lifecycle_state().await.promoted.unwrap();
+        assert_eq!(applied.config["mode"].as_str(), Some("global"));
+        assert_eq!(applied.config["ipv6"].as_bool(), Some(true));
+        assert_eq!(applied.revision.get(), 2);
+        assert_eq!(endpoint.submissions(), 2);
+    });
+}
+
+#[test]
+fn config_reconcile_failure_reports_committed_state_without_replaying() {
+    let dir = tempfile::tempdir().unwrap();
+    let endpoint = TestControlEndpoint::failing();
+    let args = test_client_args_with_endpoint(&dir, endpoint.clone());
+    let config_path = args.paths.clash_config_path();
+    let client = NyanpasuClient::try_new_with_args(args).unwrap();
+    tauri::async_runtime::block_on(async {
+        let outcome = client
+            .patch_runtime_overrides(override_patch(serde_json::json!({"mode":"direct"})))
+            .await
+            .unwrap();
+        assert_eq!(outcome.degradations().len(), 1);
+        assert_eq!(outcome.degradations()[0].code, "config_reconcile_failed");
+        assert!(
+            outcome.degradations()[0]
+                .message
+                .contains("configuration saved")
+        );
+        assert_eq!(endpoint.submissions(), 1);
+        let persisted: nyanpasu_config::clash::config::ClashConfig =
+            serde_yaml::from_slice(&std::fs::read(config_path).unwrap()).unwrap();
+        assert_eq!(
+            serde_json::to_value(persisted.overrides).unwrap()["mode"],
+            "direct"
+        );
+        assert_eq!(
+            serde_json::to_value(client.get_clash_config().await.unwrap().overrides).unwrap()["mode"],
+            "direct"
+        );
+    });
+}
+
+struct RejectConfigMirror(AtomicBool);
+impl crate::state::mirror::ClashLegacyBridge for RejectConfigMirror {
+    fn prepare(
+        &self,
+        _: &nyanpasu_config::clash::config::ClashConfig,
+    ) -> anyhow::Result<Box<dyn crate::state::mirror::PreparedLegacyMirror>> {
+        anyhow::ensure!(
+            !self.0.load(Ordering::SeqCst),
+            "config preparation rejected"
+        );
+        Ok(Box::new(crate::state::mirror::NoopPreparedLegacyMirror))
+    }
+    fn snapshot_legacy(&self) -> anyhow::Result<nyanpasu_config::clash::config::ClashConfig> {
+        Ok(Default::default())
+    }
+}
+
+#[test]
+fn config_commit_failure_never_reconciles_or_changes_the_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    let endpoint = TestControlEndpoint::succeeding();
+    let bridge = Arc::new(RejectConfigMirror(AtomicBool::new(false)));
+    let mut args = test_client_args_with_endpoint(&dir, endpoint.clone());
+    args.bridges.clash = bridge.clone();
+    let client = NyanpasuClient::try_new_with_args(args).unwrap();
+    tauri::async_runtime::block_on(async {
+        let before = client.inner.clash_config.get().await.unwrap();
+        bridge.0.store(true, Ordering::SeqCst);
+        assert!(
+            client
+                .patch_runtime_overrides(override_patch(serde_json::json!({"mode":"global"})))
+                .await
+                .is_err()
+        );
+        let after = client.inner.clash_config.get().await.unwrap();
+        assert_eq!(after.version, before.version);
+        assert_eq!(
+            serde_json::to_value(after.state).unwrap(),
+            serde_json::to_value(before.state).unwrap()
+        );
+        assert_eq!(endpoint.submissions(), 0);
+        assert!(client.runtime_lifecycle_state().await.promoted.is_none());
+    });
+}
+
+#[tokio::test]
+async fn config_write_waits_for_active_lifecycle_work_before_committing() {
+    let dir = tempfile::tempdir().unwrap();
+    let (client, _, builder, _, clash) = dirty_graph(&dir).await;
+    let active = {
+        let client = client.clone();
+        tokio::spawn(async move { client.reconcile().await })
+    };
+    builder.entered.notified().await;
+    let mut patch = Box::pin(
+        client.patch_runtime_overrides(override_patch(serde_json::json!({"mode":"global"}))),
+    );
+    assert!(patch.as_mut().now_or_never().is_none());
+    barrier(&client).await;
+    assert_eq!(client.status().queued.len(), 1);
+    assert_eq!(
+        serde_json::to_value(clash.get().await.unwrap().state.overrides).unwrap()["mode"],
+        "rule",
+        "queued writes must not commit ahead of lifecycle admission"
+    );
+    assert_eq!(builder.calls.load(Ordering::SeqCst), 1);
+    builder.release.notify_one();
+    active.await.unwrap().unwrap();
+    assert!(patch.await.unwrap().degradations().is_empty());
+    let config = &client.runtime().promoted.unwrap().config;
+    assert_eq!(config["mode"].as_str(), Some("global"));
+    assert_eq!(builder.calls.load(Ordering::SeqCst), 2);
+    client.shutdown().await.unwrap();
+}
+
+#[test]
+fn config_persistence_failure_leaves_state_unchanged_and_never_reconciles() {
+    let dir = tempfile::tempdir().unwrap();
+    let endpoint = TestControlEndpoint::succeeding();
+    let args = test_client_args_with_endpoint(&dir, endpoint.clone());
+    let path = args.paths.clash_config_path();
+    let client = NyanpasuClient::try_new_with_args(args).unwrap();
+    tauri::async_runtime::block_on(async {
+        let before = client.inner.clash_config.get().await.unwrap();
+        if path.exists() {
+            std::fs::remove_file(&path).unwrap();
+        }
+        std::fs::create_dir_all(&path).unwrap();
+        assert!(
+            client
+                .patch_runtime_overrides(override_patch(serde_json::json!({"mode":"global"})))
+                .await
+                .is_err()
+        );
+        let after = client.inner.clash_config.get().await.unwrap();
+        assert_eq!(after.version, before.version);
+        assert_eq!(
+            serde_json::to_value(after.state).unwrap(),
+            serde_json::to_value(before.state).unwrap()
+        );
+        assert_eq!(endpoint.submissions(), 0);
+    });
+}
+
+struct FailingConfigTray {
+    refreshed: AtomicUsize,
+}
+impl UiEventSink for FailingConfigTray {
+    fn state_changed(&self, _: crate::core::handle::StateChanged) {
+        self.refreshed.fetch_add(1, Ordering::SeqCst);
+    }
+    fn notice_message(&self, _: &crate::core::handle::Message) {}
+    fn update_systray(&self) -> crate::client::Result<()> {
+        Ok(())
+    }
+    fn update_systray_part(&self) -> crate::client::Result<()> {
+        Err(anyhow::anyhow!("tray refresh rejected").into())
+    }
+}
+
+#[test]
+fn config_ui_failure_is_degraded_after_successful_reconcile() {
+    let dir = tempfile::tempdir().unwrap();
+    let endpoint = TestControlEndpoint::succeeding();
+    let ui = Arc::new(FailingConfigTray {
+        refreshed: AtomicUsize::new(0),
+    });
+    let mut args = test_client_args_with_endpoint(&dir, endpoint.clone());
+    args.ui_sink = ui.clone();
+    let client = NyanpasuClient::try_new_with_args(args).unwrap();
+    tauri::async_runtime::block_on(async {
+        let outcome = client
+            .patch_runtime_overrides(override_patch(serde_json::json!({"mode":"global"})))
+            .await
+            .unwrap();
+        assert_eq!(endpoint.submissions(), 1);
+        assert_eq!(ui.refreshed.load(Ordering::SeqCst), 1);
+        assert_eq!(outcome.degradations().len(), 1);
+        assert_eq!(outcome.degradations()[0].code, "config_tray_refresh_failed");
+        assert_eq!(
+            outcome.degradations()[0].phase,
+            runtime::DegradationPhase::UiEffect
+        );
+        assert_eq!(
+            client
+                .runtime_lifecycle_state()
+                .await
+                .promoted
+                .unwrap()
+                .config["mode"]
+                .as_str(),
+            Some("global")
+        );
+    });
 }

--- a/backend/tauri/src/client/core_lifecycle/workflow.rs
+++ b/backend/tauri/src/client/core_lifecycle/workflow.rs
@@ -48,6 +48,36 @@ impl CoreLifecycleWorkflow {
     async fn execute_inner(&mut self, command: Command) -> Result<Output, CoreError> {
         match command {
             Command::Reconcile => Ok(Output::Reconcile(self.reconcile().await?)),
+            Command::PatchRuntimeOverrides(patch) => {
+                self.clash
+                    .patch_overrides(patch)
+                    .await
+                    .map_err(domain_error)?;
+                let mut degradations = Vec::new();
+                if let Err(error) = self.reconcile().await {
+                    degradations.push(runtime::Degradation {
+                        phase: runtime::DegradationPhase::RuntimeApply,
+                        code: "config_reconcile_failed".into(),
+                        message: format!(
+                            "configuration saved, but core reconciliation failed: {error}"
+                        ),
+                        retryable: error.retryable,
+                    });
+                }
+                self.ui.refresh_clash();
+                if let Err(error) = self.ui.update_systray_part() {
+                    degradations.push(runtime::Degradation {
+                        phase: runtime::DegradationPhase::UiEffect,
+                        code: "config_tray_refresh_failed".into(),
+                        message: error.to_string(),
+                        retryable: true,
+                    });
+                }
+                Ok(Output::Mutation(runtime::MutationOutcome::from_parts(
+                    (),
+                    degradations,
+                )))
+            }
             Command::RuntimeDirty => {
                 self.reconcile().await?;
                 self.ui.refresh_clash();

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -558,6 +558,20 @@ impl NyanpasuClient {
         Ok(client.get().await?.state)
     }
 
+    pub async fn patch_runtime_overrides(
+        &self,
+        patch: nyanpasu_config::clash::config::overrides::ClashGuardOverridesPatch,
+    ) -> Result<runtime::MutationOutcome<()>> {
+        let outcome = self
+            .inner
+            .core_lifecycle
+            .patch_runtime_overrides(patch)
+            .await
+            .map_err(client_error_from_core)?;
+        self.request_proxy_refresh();
+        Ok(outcome)
+    }
+
     pub async fn patch_clash_config(&self, patch: ClashConfigPatch) -> Result<()> {
         let client = self.inner.clash_config.clone();
         client.patch(patch).await?;

--- a/backend/tauri/src/core/clash/api.rs
+++ b/backend/tauri/src/core/clash/api.rs
@@ -3,12 +3,8 @@ use anyhow::{Context, Result};
 use indexmap::IndexMap;
 use reqwest::{Method, StatusCode, header::HeaderMap};
 use serde::{Deserialize, Serialize};
-use serde_yaml::Mapping;
 use specta::Type;
-use std::{
-    collections::HashMap,
-    fmt::{self, Display, Formatter},
-};
+use std::fmt::{self, Display, Formatter};
 use tracing_attributes::instrument;
 use url::Url;
 
@@ -72,28 +68,6 @@ pub struct RuleProviderItem {
 #[derive(Debug, Clone, Deserialize, Serialize, Type)]
 pub struct ProvidersRulesRes {
     pub providers: IndexMap<String, RuleProviderItem>,
-}
-
-/// PUT /configs
-/// path 是绝对路径
-#[instrument]
-pub async fn put_configs(config_path: &str) -> Result<()> {
-    let path = "/configs";
-
-    let mut data = HashMap::new();
-    data.insert("path", config_path);
-
-    let _ = perform_request((Method::PUT, path, Data(data))).await?;
-
-    Ok(())
-}
-
-/// PATCH /configs
-#[instrument]
-pub async fn patch_configs(config: &Mapping) -> Result<()> {
-    let path = "/configs";
-    let _ = perform_request((Method::PATCH, path, Data(config))).await?;
-    Ok(())
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Type)]
@@ -249,8 +223,8 @@ pub struct DelayRes {
 #[instrument]
 fn clash_client_info() -> Result<(String, HeaderMap)> {
     // TODO(actor-migration): temporary bridge to legacy controller configuration.
-    // Reason: config writes and connection-interruption policies still need
-    // lifecycle/config reconciliation migration before using the bound API.
+    // Reason: remaining connection-interruption policies still need
+    // lifecycle migration before using the bound API.
     // Remove when: those callers use the injected instance-bound ApiClient.
     let client = { Config::clash().data().get_client_info() };
 
@@ -267,65 +241,23 @@ fn clash_client_info() -> Result<(String, HeaderMap)> {
     Ok((server, headers))
 }
 
-/// The Request Parameters
-struct PerformRequest<D = ()> {
-    method: reqwest::Method,
-    path: String,
-    data: Option<D>,
-}
-/// A newtype wrapper for request body
-struct Data<T>(T);
-
-impl From<(reqwest::Method, &str)> for PerformRequest<()> {
-    fn from((method, path): (reqwest::Method, &str)) -> Self {
-        Self {
-            method,
-            path: path.to_string(),
-            data: None,
-        }
-    }
-}
-
-impl<T> From<(reqwest::Method, &str, Data<T>)> for PerformRequest<T>
-where
-    T: Serialize,
-{
-    fn from((method, path, Data(data)): (reqwest::Method, &str, Data<T>)) -> Self {
-        Self {
-            method,
-            path: path.to_string(),
-            data: Some(data),
-        }
-    }
-}
-
 #[instrument(skip_all, fields(
     method = tracing::field::Empty,
     url = tracing::field::Empty,
-    data = tracing::field::Empty,
 ))]
-async fn perform_request<D>(param: impl Into<PerformRequest<D>>) -> Result<reqwest::Response>
-where
-    D: Serialize + core::fmt::Debug,
-{
-    let PerformRequest { method, path, data } = param.into();
+async fn perform_request((method, path): (Method, &str)) -> Result<reqwest::Response> {
     let (host, headers) = clash_client_info().context("failed to get clash client info")?;
     let base_url = Url::parse(&host).context("failed to parse host")?;
     let opts = url::Url::options().base_url(Some(&base_url));
-    let url = opts.parse(&path).context("failed to parse path")?;
+    let url = opts.parse(path).context("failed to parse path")?;
 
     let span = tracing::Span::current();
     span.record("method", tracing::field::display(&method));
     span.record("url", tracing::field::display(&url));
-    span.record("data", tracing::field::debug(&data));
 
     async {
         let client = reqwest::ClientBuilder::new().no_proxy().build()?;
-        let mut builder = client.request(method.clone(), url.clone()).headers(headers);
-
-        if let Some(data) = &data {
-            builder = builder.json(data);
-        }
+        let builder = client.request(method.clone(), url.clone()).headers(headers);
 
         let resp = builder.send().await?;
 
@@ -353,7 +285,9 @@ where
         Ok(resp)
     }
     .await
-    .inspect_err(|e| tracing::error!(method = %method, url = %url, data = ?data, "failed to perform request: {:?}", e))
+    .inspect_err(
+        |e| tracing::error!(method = %method, url = %url, "failed to perform request: {:?}", e),
+    )
 }
 
 /// 缩短clash的日志

--- a/backend/tauri/src/feat.rs
+++ b/backend/tauri/src/feat.rs
@@ -14,7 +14,7 @@ use anyhow::{Result, bail};
 use handle::Message;
 use nyanpasu_ipc::api::status::CoreStateDetail;
 use serde::{Deserialize, Serialize};
-use serde_yaml::{Mapping, Value};
+use serde_yaml::Mapping;
 use std::future::Future;
 use strum::EnumString;
 use tauri::{AppHandle, Manager};
@@ -85,31 +85,39 @@ pub fn change_clash_mode(app_handle: &AppHandle, mode: String) {
         .state::<crate::client::NyanpasuClient>()
         .inner()
         .clone();
-    let mut mapping = Mapping::new();
-    mapping.insert(Value::from("mode"), mode.clone().into());
     tauri::async_runtime::spawn(async move {
-        log::debug!(target: "app", "change clash mode to {mode}");
-
-        match clash::api::patch_configs(&mapping).await {
-            Ok(_) => {
-                // 更新配置
-                Config::clash().data().patch_config(mapping);
-
-                if Config::clash().data().save_config().is_ok() {
-                    handle::Handle::refresh_clash();
-                    log_err!(handle::Handle::update_systray_part());
+        let mode = match mode.parse::<nyanpasu_config::clash::config::overrides::Mode>() {
+            Ok(mode) => mode,
+            Err(error) => {
+                log::error!("invalid clash mode: {error}");
+                return;
+            }
+        };
+        let patch = nyanpasu_config::clash::config::overrides::ClashGuardOverridesPatch {
+            mode: Some(mode),
+            ..Default::default()
+        };
+        match client.patch_runtime_overrides(patch).await {
+            Ok(outcome) => {
+                for degradation in outcome.degradations() {
+                    log::warn!("{}: {}", degradation.code, degradation.message);
+                }
+                if outcome
+                    .degradations()
+                    .iter()
+                    .any(|d| d.code == "config_reconcile_failed")
+                {
+                    return;
+                }
+                // TODO(actor-migration): compatibility bridge for mode interruption policy.
+                // Reason: connection-interruption policies migrate separately from config writes.
+                // Remove when: the typed lifecycle workflow owns mode interruption.
+                if let Err(error) = crate::core::connection_interruption::ConnectionInterruptionService::on_mode_change().await {
+                    log::warn!("mode changed, but connection interruption failed: {error}");
                 }
             }
-            Err(err) => log::error!(target: "app", "{err:?}"),
+            Err(error) => log::error!("mode change failed: {error:#}"),
         }
-        client.request_proxy_refresh();
-    });
-
-    // Interrupt connections based on configuration
-    tauri::async_runtime::spawn(async move {
-        let _ =
-            crate::core::connection_interruption::ConnectionInterruptionService::on_mode_change()
-                .await;
     });
 }
 

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -14,7 +14,6 @@ use log::debug;
 use serde::{Deserialize, Serialize};
 use std::{collections::VecDeque, path::PathBuf, result::Result as StdResult};
 use storage::{StorageOperationError, WebStorage};
-use struct_patch::Patch as _;
 use sysproxy::Sysproxy;
 use tauri::{AppHandle, Manager, State};
 use tray::icon::TrayIcon;
@@ -436,7 +435,7 @@ pub struct PatchRuntimeConfig {
 pub async fn patch_clash_config(
     client: State<'_, NyanpasuClient>,
     payload: PatchRuntimeConfig,
-) -> Result {
+) -> Result<crate::client::runtime::MutationOutcome<()>> {
     // Explicit-field whitelist so future DTO fields never auto-leak into logs.
     tracing::debug!(
         allow_lan = ?payload.allow_lan,
@@ -449,17 +448,7 @@ pub async fn patch_clash_config(
     let overrides = serde_yaml::from_value::<
         nyanpasu_config::clash::config::overrides::ClashGuardOverridesPatch,
     >(serde_yaml::to_value(payload)?)?;
-    let mut clash = client.get_clash_config().await?;
-    clash.overrides.apply(overrides);
-    let mut patch = nyanpasu_config::clash::config::ClashConfig::new_empty_patch();
-    patch.overrides = Some(clash.overrides);
-    client.patch_clash_config(patch).await?;
-    client.reconcile_core().await?;
-    // A mode change rewrites the proxy groups; warm the cache the same way the
-    // pre-facade patch path did, or the next read serves the old groups until
-    // the actor cache's freshness window lapses.
-    client.request_proxy_refresh();
-    Ok(())
+    Ok(client.patch_runtime_overrides(overrides).await?)
 }
 
 #[tauri::command]

--- a/backend/tauri/src/state/clash_config.rs
+++ b/backend/tauri/src/state/clash_config.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use nyanpasu_config::clash::config::{ClashConfig, ClashConfigPatch};
+use nyanpasu_config::clash::config::{
+    ClashConfig, ClashConfigPatch, overrides::ClashGuardOverridesPatch,
+};
 use nyanpasu_core::state::{PersistentStateManager, ReplaceIfVersionResult, Version};
 use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
 use struct_patch::Patch;
@@ -34,6 +36,10 @@ pub enum ClashConfigActorMessage {
     Get(RpcReplyPort<anyhow::Result<ClashConfigSnapshot>>),
     Patch {
         patch: ClashConfigPatch,
+        reply: RpcReplyPort<anyhow::Result<ClashConfigSnapshot>>,
+    },
+    PatchOverrides {
+        patch: ClashGuardOverridesPatch,
         reply: RpcReplyPort<anyhow::Result<ClashConfigSnapshot>>,
     },
     Replace {
@@ -147,6 +153,11 @@ impl Actor for ClashConfigActor {
                 }
                 .await;
                 let _ = reply.send(result);
+            }
+            ClashConfigActorMessage::PatchOverrides { patch, reply } => {
+                let mut next = state.manager.snapshot_handle().load().state.clone();
+                next.overrides.apply(patch);
+                let _ = reply.send(Self::commit(state, next).await);
             }
             ClashConfigActorMessage::Replace { state: next, reply } => {
                 let _ = reply.send(Self::commit(state, next).await);

--- a/docs/plan/2026-09-07-config-write-migration.md
+++ b/docs/plan/2026-09-07-config-write-migration.md
@@ -1,0 +1,58 @@
+# Configuration write migration
+
+## Scope and acceptance
+
+Unify frontend config changes and tray/hotkey mode changes through
+NyanpasuClient and CoreLifecycleActor. Retire application PUT/PATCH HTTP helpers;
+runtime reconciliation already owns applying typed configuration to the core.
+
+1. Merge field-level override patches inside ClashConfigActor so concurrent
+   updates cannot overwrite unrelated fields from stale snapshots.
+2. Admit persistence and reconcile as one lifecycle command, serialized with
+   host changes, shutdown and other reconciles. Retain persisted state and return
+   MutationOutcome::CommittedDegraded if post-commit application or UI effects fail.
+3. Keep IPC a DTO adapter; route tray/hotkey mode changes through the same facade.
+   Preserve Premium script mode in the typed config enum.
+4. Verify patch isolation, serialized application, durable state after failure,
+   no core work after persistence failure, IPC exports and frontend type checks.
+
+## Boundaries
+
+No new actor or service singleton is needed. Configuration patch merging remains
+inside the existing state actor; lifecycle admission and side effects stay in the
+existing lifecycle actor. UI notifications use its injected UiEventSink.
+The frontend keeps its command request shape and receives the existing structured
+mutation outcome, already handled by the global MutationCache notifier.
+
+Proxy-cache warming runs through the injected facade after the lifecycle result.
+The tray/hotkey mode interruption policy remains a documented boundary bridge for
+its separate migration, but runs only after successful application rather than
+racing configuration changes in an independent task. The frontend retains its
+existing close-all trigger, also moved after application success. No new interruption policy is introduced in this configuration-only batch.
+
+ApiClient expiry rules remain unchanged: the runtime reconciler chooses hot patch
+or replacement, and CoreActor observes the resulting instance identity. Do not
+add a second direct PATCH path that bypasses runtime revision accounting.
+
+## Delivery and validation
+
+- Added PatchOverrides to ClashConfigActor and PatchRuntimeOverrides to the
+  lifecycle actor. Both UI entry paths use NyanpasuClient::patch_runtime_overrides.
+- Removed application PUT/PATCH helpers and their unused generic request-body
+  machinery. Only legacy connection-interruption requests remain in that helper.
+- IPC now returns MutationOutcome rather than unit. Existing frontend mutation
+  notifications handle committed_degraded; the request DTO is unchanged.
+- Seven new regression tests cover independent field patches (including script
+  mode), concurrent application, lifecycle admission, mirror preparation failure,
+  actual filesystem persistence failure, durable state after reconcile failure,
+  and UI failure after successful reconciliation.
+- Full application library suite passed (482 passed, one ignored before the final
+  UI-failure test addition); all six lifecycle config tests passed after the final
+  additions. Workspace Clippy/all targets/all features, interface build and all
+  three frontend TypeScript checks passed. Existing application warnings remain.
+- Generated bindings were formatted with the current lockfile's tools. The
+  architecture ledger records two fewer Config::clash calls; its additional
+  legacy DTO reference comes from the injected failure-test bridge.
+
+No runtime dependency change or live GUI/core smoke test is included. Remaining
+connection policy ownership and WebSocket migration stay in their separate batches.

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -32,7 +32,9 @@ export const commands = {
     typedError<string[], string>(__TAURI_INVOKE('get_clash_logs')),
   /**  patch clash runtime config */
   patchClashConfig: (payload: PatchRuntimeConfig_Deserialize) =>
-    typedError<null, string>(__TAURI_INVOKE('patch_clash_config', { payload })),
+    typedError<MutationOutcome<null>, string>(
+      __TAURI_INVOKE('patch_clash_config', { payload }),
+    ),
   changeClashCore: (
     clashCore:
       | 'clash'

--- a/frontend/interface/src/ipc/use-proxy-mode.ts
+++ b/frontend/interface/src/ipc/use-proxy-mode.ts
@@ -56,9 +56,17 @@ export const useProxyMode = () => {
       throw new Error('Script mode is only available for Clash Premium')
     }
 
-    await commands.clashApiDeleteConnections(null)
+    const outcome = await clashConfig.upsert.mutateAsync({ mode })
+    if (
+      outcome?.status === 'committed_degraded' &&
+      outcome.degradations.some(
+        (item) => item.code === 'config_reconcile_failed',
+      )
+    ) {
+      return
+    }
 
-    await clashConfig.upsert.mutateAsync({ mode })
+    await commands.clashApiDeleteConnections(null)
   }
 
   return {

--- a/scripts/architecture-ledger.snapshot.json
+++ b/scripts/architecture-ledger.snapshot.json
@@ -4,10 +4,10 @@
   ],
   "metrics": {
     "config_calls": {
-      "total": 106,
+      "total": 104,
       "byKey": {
         "Config::verge()": 80,
-        "Config::clash()": 26
+        "Config::clash()": 24
       }
     },
     "service_globals": {
@@ -23,20 +23,20 @@
       }
     },
     "migration_markers": {
-      "total": 13,
+      "total": 14,
       "byKey": {
-        "TODO(actor-migration)": 10,
+        "TODO(actor-migration)": 11,
         "FIXME(actor-migration)": 3
       }
     },
     "legacy_dto_refs": {
-      "total": 311,
+      "total": 312,
       "byKey": {
         "IVerge": 180,
         "IClashTemp": 31,
         "LegacyVergeBridge": 31,
+        "ClashLegacyBridge": 19,
         "VergeLegacyBridge": 19,
-        "ClashLegacyBridge": 18,
         "LegacyClashBridge": 10,
         "LegacyVergePatchRoute": 9,
         "LegacyWindowBridge": 7,


### PR DESCRIPTION
Frontend configuration changes merged overrides from a separately read snapshot, so concurrent updates could lose unrelated fields. Tray and hotkey mode changes used direct HTTP PATCH and persisted the legacy config separately. Both now use `NyanpasuClient::patch_runtime_overrides`.

- ClashConfigActor merges individual override fields atomically. CoreLifecycleActor serializes persistence and reconcile with other lifecycle operations.
- Post-commit reconcile or tray refresh failures return the existing `committed_degraded` mutation outcome. The frontend mutation notifier already handles it; request DTOs are unchanged.
- Tray/hotkey mode changes preserve Premium script mode. Existing mode-change connection closure now follows successful configuration application, rather than racing or preceding it. Full connection-policy migration remains separate.
- Retire application PUT/PATCH helpers and unused request-body machinery. Runtime reconciliation already owns typed configuration application, so this adds no second direct API write path or runtime dependency update.

Plan: `docs/plan/2026-09-07-config-write-migration.md`.

Validation: full application library suite passed (482 passed, 1 ignored); all six focused lifecycle config tests passed after the final test additions, alongside the config actor field-isolation test. Coverage includes concurrent writes, lifecycle admission, mirror/persistence failures, durable state after apply failure, and UI degradation. Workspace Clippy with all targets/features, interface build, all three frontend TypeScript checks, frontend lint, formatting and architecture ledger gate passed. Existing Rust warnings remain. No live GUI/core smoke test was performed.
