### PR TITLE
feat(core): configure channels and recover applied snapshot inspection

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1874,7 +1874,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clash-api"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "backon",
  "chrono",
@@ -6561,7 +6561,7 @@ dependencies = [
 
 [[package]]
 name = "nyanpasu-core-manager"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "camino",
  "chrono",
@@ -6585,7 +6585,7 @@ dependencies = [
 
 [[package]]
 name = "nyanpasu-core-metadata"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "constcat",
  "enumset",
@@ -6628,7 +6628,7 @@ dependencies = [
 
 [[package]]
 name = "nyanpasu-ipc"
-version = "2.0.0-rc.3"
+version = "2.0.0-rc.4"
 dependencies = [
  "anyhow",
  "derive_builder",

--- a/backend/nyanpasu-config/src/application/mod.rs
+++ b/backend/nyanpasu-config/src/application/mod.rs
@@ -4,6 +4,14 @@ use specta::Type;
 use struct_patch::Patch;
 use url::Url;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum ClashControlChannel {
+    #[default]
+    PreferIpc,
+    HttpOnly,
+}
+
 mod clash_core;
 mod i18n;
 mod logging;
@@ -117,6 +125,10 @@ pub struct NyanpasuAppConfig {
     /// clash core path
     #[patch(attribute(serde(alias = "clash_core")))]
     pub core: ClashCore,
+    #[serde(default)]
+    pub clash_control_channel: ClashControlChannel,
+    #[serde(default)]
+    pub clash_ipc_disable_http_controller: bool,
 
     /// hotkey map
     /// format: {func},{key}
@@ -199,6 +211,8 @@ impl Default for NyanpasuAppConfig {
             proxy_guard_interval: 30,
             theme_color: CssColor::from_rgba8(24, 103, 192, 255),
             core: ClashCore::default(),
+            clash_control_channel: ClashControlChannel::default(),
+            clash_ipc_disable_http_controller: false,
             hotkeys: Vec::new(),
             default_latency_test: "http://www.gstatic.com/generate_204".into(),
             enable_builtin_enhanced: true,

--- a/backend/nyanpasu-config/src/application/mod.rs
+++ b/backend/nyanpasu-config/src/application/mod.rs
@@ -4,14 +4,6 @@ use specta::Type;
 use struct_patch::Patch;
 use url::Url;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default, Type)]
-#[serde(rename_all = "snake_case")]
-pub enum ClashControlChannel {
-    #[default]
-    PreferIpc,
-    HttpOnly,
-}
-
 mod clash_core;
 mod i18n;
 mod logging;
@@ -125,10 +117,6 @@ pub struct NyanpasuAppConfig {
     /// clash core path
     #[patch(attribute(serde(alias = "clash_core")))]
     pub core: ClashCore,
-    #[serde(default)]
-    pub clash_control_channel: ClashControlChannel,
-    #[serde(default)]
-    pub clash_ipc_disable_http_controller: bool,
 
     /// hotkey map
     /// format: {func},{key}
@@ -211,8 +199,6 @@ impl Default for NyanpasuAppConfig {
             proxy_guard_interval: 30,
             theme_color: CssColor::from_rgba8(24, 103, 192, 255),
             core: ClashCore::default(),
-            clash_control_channel: ClashControlChannel::default(),
-            clash_ipc_disable_http_controller: false,
             hotkeys: Vec::new(),
             default_latency_test: "http://www.gstatic.com/generate_204".into(),
             enable_builtin_enhanced: true,

--- a/backend/nyanpasu-config/src/clash/config/mod.rs
+++ b/backend/nyanpasu-config/src/clash/config/mod.rs
@@ -18,6 +18,14 @@ pub const DEFAULT_EXTERNAL_CONTROLLER_PORT: u16 = 9872;
 #[cfg(not(debug_assertions))]
 pub const DEFAULT_EXTERNAL_CONTROLLER_PORT: u16 = 17650;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum ClashControlChannel {
+    #[default]
+    PreferIpc,
+    HttpOnly,
+}
+
 /// Clash Related Config
 #[derive(Default, Debug, Clone, Deserialize, Serialize, Type, Patch)]
 #[patch(attribute(serde_with::skip_serializing_none))]
@@ -39,6 +47,11 @@ pub struct ClashConfig {
 
     /// 外部控制器端口策略
     pub external_controller: ExternalControllerStrategy,
+
+    #[serde(default)]
+    pub clash_control_channel: ClashControlChannel,
+    #[serde(default)]
+    pub clash_ipc_disable_http_controller: bool,
 
     /// Mixed Proxy(Socks5, HTTP) Port Strategy
     pub mixed_port: PortStrategy,
@@ -62,6 +75,21 @@ pub struct ClashConfig {
 mod patch_tests {
     use super::*;
     use struct_patch::Patch;
+
+    #[test]
+    fn old_clash_config_defaults_control_channel_without_application_fields() {
+        let mut yaml = serde_yaml_ng::to_value(ClashConfig::default()).unwrap();
+        let mapping = yaml.as_mapping_mut().unwrap();
+        mapping.remove("clash_control_channel");
+        mapping.remove("clash_ipc_disable_http_controller");
+        let config: ClashConfig = serde_yaml_ng::from_value(yaml).unwrap();
+        assert_eq!(config.clash_control_channel, ClashControlChannel::PreferIpc);
+        assert!(!config.clash_ipc_disable_http_controller);
+        let app =
+            serde_yaml_ng::to_value(crate::application::NyanpasuAppConfig::default()).unwrap();
+        assert!(app.get("clash_control_channel").is_none());
+        assert!(app.get("clash_ipc_disable_http_controller").is_none());
+    }
 
     /// `socks_port`/`http_port` are `Option<PortStrategy>` originals under the
     /// struct-level `skip_serializing_none` + field-level `double_option` combo:

--- a/backend/nyanpasu-config/src/runtime/snapshot.rs
+++ b/backend/nyanpasu-config/src/runtime/snapshot.rs
@@ -76,6 +76,7 @@ pub enum BuiltinStepKind {
     GuardOverrides,
     WhitelistFieldFilter,
     Finalizing,
+    CoreController,
 }
 
 /// The pipeline operator that produced a snapshot node.
@@ -268,6 +269,48 @@ pub struct ConfigSnapshotsGraph {
 }
 
 impl ConfigSnapshotsGraph {
+    /// Append one materialized transition using the same patch semantics as the
+    /// recorder. Validate a candidate before replacing the graph: errors are atomic.
+    pub fn append_transition(
+        &mut self,
+        parent: Idx,
+        tag: OperatorTag,
+        config: serde_json::Value,
+    ) -> Result<Idx, SnapshotBuildError> {
+        let previous = self
+            .nodes
+            .get(parent as usize)
+            .ok_or(SnapshotBuildError::MissingChild {
+                parent_id: parent as usize,
+                child_id: parent as usize,
+            })?;
+        let fields =
+            changed_fields_from_patch(&json_patch::diff(&previous.snapshot.config, &config));
+        let id = Idx::try_from(self.nodes.len()).map_err(|_| SnapshotBuildError::IdOverflow {
+            node_id: self.nodes.len(),
+        })?;
+        let mut candidate = self.clone();
+        candidate.nodes[parent as usize]
+            .next
+            .get_or_insert_default()
+            .push(id);
+        candidate.nodes.push(ConfigSnapshotState::new(
+            ConfigSnapshot::new(config, fields),
+            tag,
+            SnapshotBaseline::Parent,
+            None,
+        ));
+        validate_tree_links(
+            candidate.root_id,
+            candidate
+                .nodes
+                .iter()
+                .map(|node| (node.baseline, node.next.as_deref().unwrap_or(&[]))),
+        )?;
+        *self = candidate;
+        Ok(id)
+    }
+
     /// The comparison parent, excluding an independent branch's attachment point.
     pub fn comparison_parent(&self, node_id: Idx) -> Option<Idx> {
         let node = self.nodes.get(node_id as usize)?;
@@ -865,15 +908,6 @@ impl StoredConfigSnapshotsGraph {
     /// reachable from the root, depth within [`MAX_MATERIALIZE_DEPTH`], an
     /// independent root, and no independent node carrying a delta payload.
     pub(crate) fn validate_tree_shape(&self) -> Result<(), SnapshotBuildError> {
-        let root = self.root_id as usize;
-        if root >= self.nodes.len() {
-            return Err(SnapshotBuildError::MissingRoot { root_id: root });
-        }
-
-        if self.nodes[root].baseline != SnapshotBaseline::Independent {
-            return Err(SnapshotBuildError::RootNotIndependent { root_id: root });
-        }
-
         for (node_id, node) in self.nodes.iter().enumerate() {
             if node.baseline == SnapshotBaseline::Independent
                 && matches!(node.snapshot.payload, SnapshotPayload::Delta(_))
@@ -881,63 +915,12 @@ impl StoredConfigSnapshotsGraph {
                 return Err(SnapshotBuildError::IndependentDelta { node_id });
             }
         }
-
-        let mut indegree = vec![0usize; self.nodes.len()];
-        for (parent_id, node) in self.nodes.iter().enumerate() {
-            for child in node.next.as_deref().unwrap_or(&[]) {
-                let child_id = *child as usize;
-                if child_id >= self.nodes.len() {
-                    return Err(SnapshotBuildError::MissingChild {
-                        parent_id,
-                        child_id,
-                    });
-                }
-                if child_id == parent_id {
-                    return Err(SnapshotBuildError::Cycle { node_id: parent_id });
-                }
-
-                indegree[child_id] += 1;
-                if indegree[child_id] > 1 {
-                    return Err(SnapshotBuildError::MultipleParents { node_id: child_id });
-                }
-            }
-        }
-
-        if indegree[root] != 0 {
-            return Err(SnapshotBuildError::MissingRoot { root_id: root });
-        }
-
-        let mut reachable = vec![false; self.nodes.len()];
-        let mut queue = VecDeque::from_iter([(root, 0usize)]);
-        while let Some((node_id, depth)) = queue.pop_front() {
-            if depth > MAX_MATERIALIZE_DEPTH {
-                return Err(SnapshotBuildError::DepthLimitExceeded {
-                    depth,
-                    max: MAX_MATERIALIZE_DEPTH,
-                });
-            }
-            if reachable[node_id] {
-                continue;
-            }
-            reachable[node_id] = true;
-
-            for child in self.nodes[node_id].next.as_deref().unwrap_or(&[]) {
-                queue.push_back((*child as usize, depth + 1));
-            }
-        }
-
-        let unreachable = reachable
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, seen)| (!*seen).then_some(idx))
-            .collect::<Vec<_>>();
-        if !unreachable.is_empty() {
-            return Err(SnapshotBuildError::Unreachable {
-                node_ids: unreachable,
-            });
-        }
-
-        Ok(())
+        validate_tree_links(
+            self.root_id,
+            self.nodes
+                .iter()
+                .map(|node| (node.baseline, node.next.as_deref().unwrap_or(&[]))),
+        )
     }
 }
 
@@ -1109,6 +1092,76 @@ pub mod persistence {
     }
 }
 
+fn validate_tree_links<'a>(
+    root_id: Idx,
+    links: impl IntoIterator<Item = (SnapshotBaseline, &'a [Idx])>,
+) -> Result<(), SnapshotBuildError> {
+    let nodes: Vec<_> = links.into_iter().collect();
+    let root = root_id as usize;
+    if root >= nodes.len() {
+        return Err(SnapshotBuildError::MissingRoot { root_id: root });
+    }
+    if nodes[root].0 != SnapshotBaseline::Independent {
+        return Err(SnapshotBuildError::RootNotIndependent { root_id: root });
+    }
+    let mut indegree = vec![0usize; nodes.len()];
+    for (parent_id, node) in nodes.iter().enumerate() {
+        for child in node.1 {
+            let child_id = *child as usize;
+            if child_id >= nodes.len() {
+                return Err(SnapshotBuildError::MissingChild {
+                    parent_id,
+                    child_id,
+                });
+            }
+            if child_id == parent_id {
+                return Err(SnapshotBuildError::Cycle { node_id: parent_id });
+            }
+
+            indegree[child_id] += 1;
+            if indegree[child_id] > 1 {
+                return Err(SnapshotBuildError::MultipleParents { node_id: child_id });
+            }
+        }
+    }
+
+    if indegree[root] != 0 {
+        return Err(SnapshotBuildError::MissingRoot { root_id: root });
+    }
+
+    let mut reachable = vec![false; nodes.len()];
+    let mut queue = VecDeque::from_iter([(root, 0usize)]);
+    while let Some((node_id, depth)) = queue.pop_front() {
+        if depth > MAX_MATERIALIZE_DEPTH {
+            return Err(SnapshotBuildError::DepthLimitExceeded {
+                depth,
+                max: MAX_MATERIALIZE_DEPTH,
+            });
+        }
+        if reachable[node_id] {
+            continue;
+        }
+        reachable[node_id] = true;
+
+        for child in nodes[node_id].1 {
+            queue.push_back((*child as usize, depth + 1));
+        }
+    }
+
+    let unreachable = reachable
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, seen)| (!*seen).then_some(idx))
+        .collect::<Vec<_>>();
+    if !unreachable.is_empty() {
+        return Err(SnapshotBuildError::Unreachable {
+            node_ids: unreachable,
+        });
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -1120,6 +1173,63 @@ mod tests {
         profile::ScriptRuntime,
         runtime::value::{ConfigValue, PathSegment},
     };
+
+    #[test]
+    fn appended_transitions_match_recorder_diff_semantics() {
+        let before = json!({"tun": {"enable": false}, "items": [1, 2]});
+        for after in [
+            before.clone(),
+            json!({"tun": {"enable": true}, "items": [1, 3, 4]}),
+        ] {
+            let tag = OperatorTag::BuiltinStep {
+                selected_profile_id: None,
+                step: BuiltinStepKind::CoreController,
+            };
+            let mut builder =
+                ConfigSnapshotsBuilder::new_root(value(before.clone()), OperatorTag::BareRoot);
+            let mut graph =
+                ConfigSnapshotsBuilder::new_root(value(before.clone()), OperatorTag::BareRoot)
+                    .build()
+                    .unwrap();
+            builder.push(tag.clone(), value(after.clone())).unwrap();
+            let expected = builder.build().unwrap();
+            let id = graph.append_transition(graph.root_id, tag, after).unwrap();
+            assert_eq!(graph, expected);
+            if graph.nodes[id as usize].snapshot.config == before {
+                assert!(graph.nodes[id as usize].snapshot.changed_fields.is_none());
+            } else {
+                let fields = graph.nodes[id as usize]
+                    .snapshot
+                    .changed_fields
+                    .as_ref()
+                    .unwrap();
+                assert!(fields.contains("tun.enable"));
+                assert!(fields.iter().any(|field| field.starts_with("items.")));
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_transition_leaves_the_graph_unchanged() {
+        let mut graph = ConfigSnapshotsBuilder::new_root(value(json!({})), OperatorTag::BareRoot)
+            .build()
+            .unwrap();
+        let original = graph.clone();
+        assert!(
+            graph
+                .append_transition(99, OperatorTag::BareRoot, json!({"x": 1}))
+                .is_err()
+        );
+        assert_eq!(graph, original);
+        graph.nodes[0].next = Some(vec![0]);
+        let invalid = graph.clone();
+        assert!(
+            graph
+                .append_transition(0, OperatorTag::BareRoot, json!({"x": 1}))
+                .is_err()
+        );
+        assert_eq!(graph, invalid);
+    }
 
     fn value(value: serde_json::Value) -> Arc<ConfigValue> {
         Arc::new(ConfigValue::try_from(value).unwrap())

--- a/backend/tauri/src/bridge/clash.rs
+++ b/backend/tauri/src/bridge/clash.rs
@@ -98,6 +98,12 @@ pub(crate) fn clash_config_from_legacy(
         ..ClashConfig::default()
     };
 
+    if let Some(value) = legacy_verge.clash_control_channel {
+        next.clash_control_channel = value;
+    }
+    if let Some(value) = legacy_verge.clash_ipc_disable_http_controller {
+        next.clash_ipc_disable_http_controller = value;
+    }
     if let Some(value) = legacy_verge.enable_tun_mode {
         next.enable_tun_mode = value;
     }
@@ -170,6 +176,8 @@ fn prepare_clash_overrides(projected: &mut IClashTemp, snap: &ClashConfig) -> an
 }
 
 pub(crate) fn apply_prepared_clash_verge_projection(target: &mut IVerge, projected: &IVerge) {
+    target.clash_control_channel = projected.clash_control_channel;
+    target.clash_ipc_disable_http_controller = projected.clash_ipc_disable_http_controller;
     target.enable_tun_mode = projected.enable_tun_mode;
     target.web_ui_list = projected.web_ui_list.clone();
     target.enable_clash_fields = projected.enable_clash_fields;
@@ -186,6 +194,8 @@ pub(crate) fn apply_clash_config_to_legacy_verge(
     draft: &mut IVerge,
     snap: &ClashConfig,
 ) -> anyhow::Result<()> {
+    draft.clash_control_channel = Some(snap.clash_control_channel);
+    draft.clash_ipc_disable_http_controller = Some(snap.clash_ipc_disable_http_controller);
     draft.enable_tun_mode = Some(snap.enable_tun_mode);
     draft.web_ui_list = Some(snap.web_ui_list.clone());
     draft.enable_clash_fields = Some(snap.enable_clash_fields);

--- a/backend/tauri/src/bridge/mapping.rs
+++ b/backend/tauri/src/bridge/mapping.rs
@@ -105,6 +105,16 @@ pub const IVERGE_FIELD_MAPPING: &[IVergeFieldMapping] = &[
         target: "nyanpasu_config::clash::config::ClashConfig.web_ui_list",
     },
     IVergeFieldMapping {
+        legacy: "clash_control_channel",
+        owner: LegacyFieldOwner::Application,
+        target: "NyanpasuAppConfig.clash_control_channel",
+    },
+    IVergeFieldMapping {
+        legacy: "clash_ipc_disable_http_controller",
+        owner: LegacyFieldOwner::Application,
+        target: "NyanpasuAppConfig.clash_ipc_disable_http_controller",
+    },
+    IVergeFieldMapping {
         legacy: "clash_core",
         owner: LegacyFieldOwner::Application,
         target: "NyanpasuAppConfig.core",
@@ -265,6 +275,8 @@ mod tests {
         "theme_color",
         "web_ui_list",
         "clash_core",
+        "clash_control_channel",
+        "clash_ipc_disable_http_controller",
         "hotkeys",
         "auto_close_connection",
         "break_when_proxy_change",

--- a/backend/tauri/src/bridge/mapping.rs
+++ b/backend/tauri/src/bridge/mapping.rs
@@ -106,13 +106,13 @@ pub const IVERGE_FIELD_MAPPING: &[IVergeFieldMapping] = &[
     },
     IVergeFieldMapping {
         legacy: "clash_control_channel",
-        owner: LegacyFieldOwner::Application,
-        target: "NyanpasuAppConfig.clash_control_channel",
+        owner: LegacyFieldOwner::Clash,
+        target: "nyanpasu_config::clash::config::ClashConfig.clash_control_channel",
     },
     IVergeFieldMapping {
         legacy: "clash_ipc_disable_http_controller",
-        owner: LegacyFieldOwner::Application,
-        target: "NyanpasuAppConfig.clash_ipc_disable_http_controller",
+        owner: LegacyFieldOwner::Clash,
+        target: "nyanpasu_config::clash::config::ClashConfig.clash_ipc_disable_http_controller",
     },
     IVergeFieldMapping {
         legacy: "clash_core",

--- a/backend/tauri/src/bridge/mod.rs
+++ b/backend/tauri/src/bridge/mod.rs
@@ -136,6 +136,14 @@ fn clash_patch_from_legacy_patch(patch: &IVerge, next: ClashConfig) -> Option<Cl
     let mut clash = ClashConfig::new_empty_patch();
     let mut touched = false;
 
+    if patch.clash_control_channel.is_some() {
+        clash.clash_control_channel = Some(next.clash_control_channel);
+        touched = true;
+    }
+    if patch.clash_ipc_disable_http_controller.is_some() {
+        clash.clash_ipc_disable_http_controller = Some(next.clash_ipc_disable_http_controller);
+        touched = true;
+    }
     if patch.enable_tun_mode.is_some() {
         clash.enable_tun_mode = Some(next.enable_tun_mode);
         touched = true;
@@ -182,4 +190,55 @@ where
 {
     let value = serde_yaml::to_value(value)?;
     Ok(serde_yaml::from_value(value)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nyanpasu_config::clash::config::ClashControlChannel;
+
+    #[test]
+    fn control_channel_patch_is_clash_owned_and_round_trips() {
+        let legacy = IVerge {
+            clash_control_channel: Some(ClashControlChannel::HttpOnly),
+            clash_ipc_disable_http_controller: Some(true),
+            ..IVerge::default()
+        };
+        let plan = typed_patches_from_legacy_patch(
+            IVerge::default(),
+            &legacy,
+            &serde_yaml::Mapping::new(),
+        )
+        .unwrap();
+        assert!(plan.application.is_none());
+        assert!(plan.session_state.is_none());
+        let mut clash = ClashConfig::default();
+        clash.apply(plan.clash_config.unwrap());
+        assert_eq!(clash.clash_control_channel, ClashControlChannel::HttpOnly);
+        assert!(clash.clash_ipc_disable_http_controller);
+
+        let projected = legacy_iverge_from_typed(
+            IVerge::default(),
+            &NyanpasuAppConfig::default(),
+            &PersistentState::default(),
+            &clash,
+        )
+        .unwrap();
+        assert_eq!(
+            projected.clash_control_channel,
+            legacy.clash_control_channel
+        );
+        assert_eq!(projected.clash_ipc_disable_http_controller, Some(true));
+
+        let patch = IVerge {
+            clash_ipc_disable_http_controller: Some(false),
+            ..IVerge::default()
+        };
+        let plan = typed_patches_from_legacy_patch(projected, &patch, &serde_yaml::Mapping::new())
+            .unwrap();
+        assert!(plan.application.is_none());
+        clash.apply(plan.clash_config.unwrap());
+        assert_eq!(clash.clash_control_channel, ClashControlChannel::HttpOnly);
+        assert!(!clash.clash_ipc_disable_http_controller);
+    }
 }

--- a/backend/tauri/src/bridge/verge.rs
+++ b/backend/tauri/src/bridge/verge.rs
@@ -604,12 +604,6 @@ pub(crate) fn application_from_legacy(legacy: &IVerge) -> anyhow::Result<Nyanpas
     {
         next.theme_color = value;
     }
-    if let Some(value) = legacy.clash_control_channel {
-        next.clash_control_channel = value;
-    }
-    if let Some(value) = legacy.clash_ipc_disable_http_controller {
-        next.clash_ipc_disable_http_controller = value;
-    }
     if let Some(value) = &legacy.clash_core
         && let Ok(value) = super::yaml_convert(value)
     {
@@ -686,8 +680,6 @@ fn apply_prepared_app_projection(target: &mut IVerge, projected: &IVerge) {
     target.proxy_guard_interval = projected.proxy_guard_interval;
     target.theme_color = projected.theme_color.clone();
     target.clash_core = projected.clash_core;
-    target.clash_control_channel = projected.clash_control_channel;
-    target.clash_ipc_disable_http_controller = projected.clash_ipc_disable_http_controller;
     target.hotkeys = projected.hotkeys.clone();
     target.default_latency_test = projected.default_latency_test.clone();
     target.enable_builtin_enhanced = projected.enable_builtin_enhanced;
@@ -728,8 +720,6 @@ pub(crate) fn apply_app_config_to_legacy_verge(
     draft.proxy_guard_interval = Some(snap.proxy_guard_interval);
     draft.theme_color = Some(super::yaml_convert(&snap.theme_color)?);
     draft.clash_core = Some(super::yaml_convert(snap.core)?);
-    draft.clash_control_channel = Some(snap.clash_control_channel);
-    draft.clash_ipc_disable_http_controller = Some(snap.clash_ipc_disable_http_controller);
     draft.hotkeys = Some(snap.hotkeys.clone());
     draft.default_latency_test = Some(snap.default_latency_test.clone());
     draft.enable_builtin_enhanced = Some(snap.enable_builtin_enhanced);

--- a/backend/tauri/src/bridge/verge.rs
+++ b/backend/tauri/src/bridge/verge.rs
@@ -226,6 +226,12 @@ impl LegacyVergeBridge {
                 let clash = managed.client.get_clash_config().await?;
                 let legacy_clash = super::yaml_convert(&clash.overrides)?;
                 let plan = Self::typed_patch_plan(base.clone(), &payload, &legacy_clash)?;
+                let channel_changed = payload
+                    .clash_control_channel
+                    .is_some_and(|v| Some(v) != base.clash_control_channel)
+                    || payload
+                        .clash_ipc_disable_http_controller
+                        .is_some_and(|v| Some(v) != base.clash_ipc_disable_http_controller);
                 let mut desired = base;
                 desired.patch_config(payload.clone());
                 let prepared = self
@@ -233,6 +239,15 @@ impl LegacyVergeBridge {
                     .prepare_commit(&managed.legacy_verge_path, desired)?;
                 self.apply_typed_config_patch_plan(plan, move || prepared.commit())
                     .await?;
+                if channel_changed {
+                    managed
+                        .client
+                        .apply_control_channel()
+                        .await
+                        .map_err(|error| {
+                            Self::legacy_mutation_partial(anyhow::anyhow!("{error:#}"), Some(error))
+                        })?;
+                }
             }
             LegacyVergePatchRoute::LegacySideEffects => {
                 let client = self.managed()?.client.clone();
@@ -277,7 +292,9 @@ impl LegacyVergeBridge {
         // below: the post-commit reconcile must build the runtime config from
         // the just-committed typed state, never from the pre-commit draft
         // (AGENTS.md section 10: commit first, then side effects).
-        let reconcile_tun = patch.enable_tun_mode.is_some();
+        let channel_changed = patch.clash_control_channel.is_some()
+            || patch.clash_ipc_disable_http_controller.is_some();
+        let reconcile_tun = patch.enable_tun_mode.is_some() || channel_changed;
         let restore = self
             .legacy_store
             .prepare_restore(&managed.legacy_verge_path, previous)
@@ -316,16 +333,17 @@ impl LegacyVergeBridge {
                     // before this commit ran. A reconcile failure here must
                     // not undo the successful commit: report it the same way
                     // the commit-phase failures above already do.
-                    managed
-                        .client
-                        .rebuild_running_config()
-                        .await
-                        .map_err(|error| {
-                            Self::legacy_mutation_partial(
-                                anyhow::anyhow!(format!("{error:#}")),
-                                Some(error),
-                            )
-                        })?;
+                    let result = if channel_changed {
+                        managed.client.apply_control_channel().await
+                    } else {
+                        managed.client.rebuild_running_config().await
+                    };
+                    result.map_err(|error| {
+                        Self::legacy_mutation_partial(
+                            anyhow::anyhow!(format!("{error:#}")),
+                            Some(error),
+                        )
+                    })?;
                 }
                 Ok(())
             }
@@ -586,6 +604,12 @@ pub(crate) fn application_from_legacy(legacy: &IVerge) -> anyhow::Result<Nyanpas
     {
         next.theme_color = value;
     }
+    if let Some(value) = legacy.clash_control_channel {
+        next.clash_control_channel = value;
+    }
+    if let Some(value) = legacy.clash_ipc_disable_http_controller {
+        next.clash_ipc_disable_http_controller = value;
+    }
     if let Some(value) = &legacy.clash_core
         && let Ok(value) = super::yaml_convert(value)
     {
@@ -662,6 +686,8 @@ fn apply_prepared_app_projection(target: &mut IVerge, projected: &IVerge) {
     target.proxy_guard_interval = projected.proxy_guard_interval;
     target.theme_color = projected.theme_color.clone();
     target.clash_core = projected.clash_core;
+    target.clash_control_channel = projected.clash_control_channel;
+    target.clash_ipc_disable_http_controller = projected.clash_ipc_disable_http_controller;
     target.hotkeys = projected.hotkeys.clone();
     target.default_latency_test = projected.default_latency_test.clone();
     target.enable_builtin_enhanced = projected.enable_builtin_enhanced;
@@ -702,6 +728,8 @@ pub(crate) fn apply_app_config_to_legacy_verge(
     draft.proxy_guard_interval = Some(snap.proxy_guard_interval);
     draft.theme_color = Some(super::yaml_convert(&snap.theme_color)?);
     draft.clash_core = Some(super::yaml_convert(snap.core)?);
+    draft.clash_control_channel = Some(snap.clash_control_channel);
+    draft.clash_ipc_disable_http_controller = Some(snap.clash_ipc_disable_http_controller);
     draft.hotkeys = Some(snap.hotkeys.clone());
     draft.default_latency_test = Some(snap.default_latency_test.clone());
     draft.enable_builtin_enhanced = Some(snap.enable_builtin_enhanced);
@@ -2333,6 +2361,7 @@ mod tests {
             nyanpasu_core_manager::CoreError,
         > {
             Ok(crate::core::actor_v2::endpoint::CoreStatusSnapshot {
+                controller: None,
                 state: Some(nyanpasu_ipc::api::status::CoreStateDetail::Stopped { reason: None }),
                 state_changed_at: 0,
                 revision: None,

--- a/backend/tauri/src/client/core_lifecycle/mod.rs
+++ b/backend/tauri/src/client/core_lifecycle/mod.rs
@@ -66,6 +66,7 @@ pub struct CoreLifecycleOperationResult {
 
 pub(super) enum Command {
     Reconcile,
+    ApplyControlChannel,
     PatchRuntimeOverrides(nyanpasu_config::clash::config::overrides::ClashGuardOverridesPatch),
     SelectCore(ClashCore),
     ChangeHost(ExecutionHost),
@@ -141,6 +142,7 @@ struct CoreLifecycleState {
 }
 
 pub(super) struct CoreLifecycleArgs {
+    pub snapshots: runtime::RuntimeSnapshotStore,
     pub application: super::application::ApplicationClient,
     pub clash: super::clash_config::ClashConfigClient,
     pub profiles: super::profiles::ProfilesClient,
@@ -447,7 +449,7 @@ impl Actor for CoreLifecycleActor {
 
 struct ClientInner {
     actor: ActorRef<Message>,
-    runtime: watch::Receiver<runtime::RuntimeLifecycleState>,
+    runtime: runtime::RuntimeSnapshotStore,
     status: watch::Receiver<CoreLifecycleStatus>,
     core: crate::core::actor_v2::CoreObserver,
     service_status: watch::Receiver<ServiceHostStatus>,
@@ -483,7 +485,7 @@ impl CoreLifecycleClient {
         args: CoreLifecycleArgs,
         schedule_dirty_ticks: bool,
     ) -> anyhow::Result<Self> {
-        let (runtime_tx, runtime) = watch::channel(runtime::RuntimeLifecycleState::default());
+        let runtime = args.snapshots;
         let (status_tx, status) = watch::channel(CoreLifecycleStatus::default());
         let service_status = args.service.subscribe();
         let core = args.core.observer();
@@ -495,7 +497,7 @@ impl CoreLifecycleClient {
             builder: args.builder,
             installer: args.installer,
             ui: args.ui,
-            runtime: runtime_tx,
+            runtime: runtime.clone(),
             revisions: runtime::RuntimeRevisionAllocator::new(),
             uncertain: false,
         };
@@ -540,8 +542,16 @@ impl CoreLifecycleClient {
     pub fn status(&self) -> CoreLifecycleStatus {
         self.0.status.borrow().clone()
     }
+    pub async fn apply_control_channel(&self) -> Result<(), CoreError> {
+        self.call(Command::ApplyControlChannel).await.map(|_| ())
+    }
+
+    pub(super) fn snapshot_store(&self) -> &runtime::RuntimeSnapshotStore {
+        &self.0.runtime
+    }
+
     pub fn runtime(&self) -> runtime::RuntimeLifecycleState {
-        self.0.runtime.borrow().clone()
+        self.0.runtime.read()
     }
     pub fn core_status(&self) -> CoreStatusProjection {
         self.0.core.status()

--- a/backend/tauri/src/client/core_lifecycle/tests.rs
+++ b/backend/tauri/src/client/core_lifecycle/tests.rs
@@ -49,6 +49,42 @@ async fn dirty_graph(
     super::super::application::ApplicationClient,
     super::super::clash_config::ClashConfigClient,
 ) {
+    dirty_graph_with_store(dir, runtime::RuntimeSnapshotStore::default()).await
+}
+
+#[tokio::test]
+async fn injected_snapshot_store_is_shared_by_workflow_and_reader() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = runtime::RuntimeSnapshotStore::default();
+    let (client, notifier, builder, _, _) = dirty_graph_with_store(&dir, store.clone()).await;
+    notifier.request_rebuild();
+    tick(&client).await;
+    builder.entered.notified().await;
+    builder.release.notify_one();
+    let mut status = client.0.status.clone();
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        status.wait_for(|s| !s.completed.is_empty() && s.active.is_none()),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let written = store.read().promoted.unwrap();
+    let observed = client.runtime().promoted.unwrap();
+    assert!(Arc::ptr_eq(&written, &observed));
+    client.shutdown().await.unwrap();
+}
+
+async fn dirty_graph_with_store(
+    dir: &tempfile::TempDir,
+    snapshots: runtime::RuntimeSnapshotStore,
+) -> (
+    CoreLifecycleClient,
+    DirtyNotifier,
+    Arc<BlockingBuilder>,
+    super::super::application::ApplicationClient,
+    super::super::clash_config::ClashConfigClient,
+) {
     use super::super::tests::{
         IdleServiceAdapter, test_materialization_port, test_typed_config_clients,
     };
@@ -87,6 +123,7 @@ async fn dirty_graph(
     });
     let client = CoreLifecycleClient::spawn_with_ticks(
         CoreLifecycleArgs {
+            snapshots,
             application: application.clone(),
             clash: clash.clone(),
             profiles,
@@ -871,5 +908,24 @@ fn config_ui_failure_is_degraded_after_successful_reconcile() {
                 .as_str(),
             Some("global")
         );
+    });
+}
+
+#[test]
+fn control_channel_application_does_not_start_a_stopped_core() {
+    let f = Fixture::new(false, false, false);
+    tauri::async_runtime::block_on(async {
+        f.endpoint.set_status(
+            Some(nyanpasu_ipc::api::status::CoreStateDetail::Stopped { reason: None }),
+            None,
+        );
+        f.client.apply_control_channel().await.unwrap();
+        assert_eq!(f.endpoint.submissions(), 0);
+        f.endpoint.set_status(
+            Some(nyanpasu_ipc::api::status::CoreStateDetail::Running { epoch: 1, pid: 7 }),
+            Some(nyanpasu_core_manager::CoreKind::Mihomo),
+        );
+        f.client.apply_control_channel().await.unwrap();
+        assert_eq!(f.endpoint.submissions(), 1);
     });
 }

--- a/backend/tauri/src/client/core_lifecycle/tests.rs
+++ b/backend/tauri/src/client/core_lifecycle/tests.rs
@@ -912,6 +912,33 @@ fn config_ui_failure_is_degraded_after_successful_reconcile() {
 }
 
 #[test]
+fn control_channel_reconcile_reads_committed_clash_config() {
+    use nyanpasu_config::clash::config::{ClashConfig, ClashControlChannel};
+    use nyanpasu_core_manager::LocalIpcPolicy;
+
+    let f = Fixture::new(false, false, false);
+    tauri::async_runtime::block_on(async {
+        for (channel, disable_http, policy) in [
+            (ClashControlChannel::HttpOnly, true, LocalIpcPolicy::Disable),
+            (
+                ClashControlChannel::PreferIpc,
+                false,
+                LocalIpcPolicy::Prefer,
+            ),
+        ] {
+            let mut patch = ClashConfig::new_empty_patch();
+            patch.clash_control_channel = Some(channel);
+            patch.clash_ipc_disable_http_controller = Some(disable_http);
+            f.client.patch_clash_config(patch).await.unwrap();
+            f.client.apply_control_channel().await.unwrap();
+            let settings = f.endpoint.local_ipc.lock().unwrap().unwrap();
+            assert_eq!(settings.policy, policy);
+            assert_eq!(settings.keep_http_controller, !disable_http);
+        }
+    });
+}
+
+#[test]
 fn control_channel_application_does_not_start_a_stopped_core() {
     let f = Fixture::new(false, false, false);
     tauri::async_runtime::block_on(async {

--- a/backend/tauri/src/client/core_lifecycle/workflow.rs
+++ b/backend/tauri/src/client/core_lifecycle/workflow.rs
@@ -240,15 +240,15 @@ impl CoreLifecycleWorkflow {
         let clash = self.clash.get().await.map_err(domain_error)?.state;
         let app = self.application.get().await.map_err(domain_error)?.state;
         let local_ipc = nyanpasu_core_manager::LocalIpcSettings {
-            policy: match app.clash_control_channel {
-                nyanpasu_config::application::ClashControlChannel::PreferIpc => {
+            policy: match clash.clash_control_channel {
+                nyanpasu_config::clash::config::ClashControlChannel::PreferIpc => {
                     nyanpasu_core_manager::LocalIpcPolicy::Prefer
                 }
-                nyanpasu_config::application::ClashControlChannel::HttpOnly => {
+                nyanpasu_config::clash::config::ClashControlChannel::HttpOnly => {
                     nyanpasu_core_manager::LocalIpcPolicy::Disable
                 }
             },
-            keep_http_controller: !app.clash_ipc_disable_http_controller,
+            keep_http_controller: !clash.clash_ipc_disable_http_controller,
         };
         let snapshot = self
             .builder

--- a/backend/tauri/src/client/core_lifecycle/workflow.rs
+++ b/backend/tauri/src/client/core_lifecycle/workflow.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use nyanpasu_config::application::NyanpasuAppConfig;
 use nyanpasu_core_manager::{CoreError, CoreErrorKind};
 use struct_patch::Patch;
-use tokio::sync::watch;
 
 use super::{
     super::{
@@ -28,7 +27,7 @@ pub(super) struct CoreLifecycleWorkflow {
     pub builder: Arc<dyn RuntimeBuildPort>,
     pub installer: Arc<dyn BinaryInstaller>,
     pub ui: Arc<dyn UiEventSink>,
-    pub runtime: watch::Sender<runtime::RuntimeLifecycleState>,
+    pub runtime: runtime::RuntimeSnapshotStore,
     pub revisions: runtime::RuntimeRevisionAllocator,
     // A lost lower-level reply is not evidence its side effects have finished.
     pub uncertain: bool,
@@ -47,6 +46,16 @@ impl CoreLifecycleWorkflow {
 
     async fn execute_inner(&mut self, command: Command) -> Result<Output, CoreError> {
         match command {
+            Command::ApplyControlChannel => {
+                let status = self.core.refresh_status().await?;
+                if !matches!(
+                    status.snapshot.and_then(|s| s.state),
+                    Some(nyanpasu_ipc::api::status::CoreStateDetail::Stopped { .. })
+                ) {
+                    self.reconcile().await?;
+                }
+                Ok(Output::Unit)
+            }
             Command::Reconcile => Ok(Output::Reconcile(self.reconcile().await?)),
             Command::PatchRuntimeOverrides(patch) => {
                 let policy = self
@@ -230,6 +239,17 @@ impl CoreLifecycleWorkflow {
         let profiles = self.profiles.get().await.map_err(domain_error)?;
         let clash = self.clash.get().await.map_err(domain_error)?.state;
         let app = self.application.get().await.map_err(domain_error)?.state;
+        let local_ipc = nyanpasu_core_manager::LocalIpcSettings {
+            policy: match app.clash_control_channel {
+                nyanpasu_config::application::ClashControlChannel::PreferIpc => {
+                    nyanpasu_core_manager::LocalIpcPolicy::Prefer
+                }
+                nyanpasu_config::application::ClashControlChannel::HttpOnly => {
+                    nyanpasu_core_manager::LocalIpcPolicy::Disable
+                }
+            },
+            keep_http_controller: !app.clash_ipc_disable_http_controller,
+        };
         let snapshot = self
             .builder
             .build(revision, profiles, clash, app)
@@ -240,18 +260,34 @@ impl CoreLifecycleWorkflow {
             .await
             .map_err(domain_error)?;
         // Promoted means the product was published, not that the host applied it.
-        self.runtime.send_replace(runtime::RuntimeLifecycleState {
-            promoted: Some(snapshot.clone()),
-        });
+        self.runtime.generated(snapshot.clone());
         let spec = self
             .builder
             .core_spec(&snapshot.target_core)
             .map_err(|error| {
                 CoreError::new(CoreErrorKind::BinaryNotFound, error.to_string(), false)
             })?;
-        self.core
-            .reconcile(snapshot.target_core, &snapshot.config, spec)
-            .await
+        let report = self
+            .core
+            .reconcile(snapshot.target_core, &snapshot.config, spec, local_ipc)
+            .await?;
+        let mut bound = snapshot.as_ref().clone();
+        bound.applied_binding = Some(report.applied.clone());
+        let snapshot = Arc::new(bound);
+        self.runtime.bind_applied(snapshot.clone());
+        if let Some(effective) = report.effective_config.clone() {
+            match snapshot.with_effective_config(
+                effective,
+                report.applied.host,
+                report.applied.generation,
+            ) {
+                Ok(applied) => self
+                    .runtime
+                    .applied(&snapshot.inspection_id, Arc::new(applied)),
+                Err(error) => tracing::warn!("effective config inspection unavailable: {error}"),
+            }
+        }
+        Ok(report)
     }
 
     async fn replace_binary(&mut self, artifact: PreparedCoreBinary) -> Result<(), CoreError> {

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -359,6 +359,7 @@ impl NyanpasuClient {
     ) -> anyhow::Result<Self> {
         let core_lifecycle =
             core_lifecycle::CoreLifecycleClient::spawn(core_lifecycle::CoreLifecycleArgs {
+                snapshots: runtime::RuntimeSnapshotStore::default(),
                 application: application.clone(),
                 clash: clash_config.clone(),
                 profiles: profiles.clone(),
@@ -1319,6 +1320,16 @@ impl NyanpasuClient {
             .map_err(client_error_from_core)
     }
 
+    pub async fn apply_control_channel(&self) -> Result<()> {
+        self.inner
+            .core_lifecycle
+            .apply_control_channel()
+            .await
+            .map_err(client_error_from_core)?;
+        self.inner.ui_sink.refresh_clash();
+        Ok(())
+    }
+
     pub async fn rebuild_running_config(&self) -> Result<()> {
         self.reconcile_core()
             .await
@@ -1399,6 +1410,7 @@ pub(crate) mod tests {
             nyanpasu_core_manager::CoreError,
         > {
             Ok(crate::core::actor_v2::endpoint::CoreStatusSnapshot {
+                controller: None,
                 state: Some(nyanpasu_ipc::api::status::CoreStateDetail::Stopped { reason: None }),
                 state_changed_at: 0,
                 revision: None,
@@ -1410,6 +1422,8 @@ pub(crate) mod tests {
 
     pub(crate) struct TestControlEndpoint {
         fail: bool,
+        effective_enabled: std::sync::atomic::AtomicBool,
+        effective_queries: std::sync::atomic::AtomicUsize,
         submissions: std::sync::atomic::AtomicUsize,
         /// The endpoint's current applied revision (finding 2's CAS
         /// enforcement). Starts non-`None` so the router's very first pump
@@ -1448,6 +1462,8 @@ pub(crate) mod tests {
         pub(crate) fn succeeding() -> Arc<Self> {
             Arc::new(Self {
                 fail: false,
+                effective_enabled: std::sync::atomic::AtomicBool::new(false),
+                effective_queries: std::sync::atomic::AtomicUsize::new(0),
                 submissions: std::sync::atomic::AtomicUsize::new(0),
                 revision: StdMutex::new(Self::initial_revision()),
                 operations: StdMutex::new(std::collections::HashMap::new()),
@@ -1460,6 +1476,8 @@ pub(crate) mod tests {
         pub(crate) fn failing() -> Arc<Self> {
             Arc::new(Self {
                 fail: true,
+                effective_enabled: std::sync::atomic::AtomicBool::new(false),
+                effective_queries: std::sync::atomic::AtomicUsize::new(0),
                 submissions: std::sync::atomic::AtomicUsize::new(0),
                 revision: StdMutex::new(Self::initial_revision()),
                 operations: StdMutex::new(std::collections::HashMap::new()),
@@ -1667,6 +1685,36 @@ pub(crate) mod tests {
                 .cloned()
         }
 
+        async fn effective_config(
+            &self,
+        ) -> std::result::Result<
+            Option<nyanpasu_ipc::api::core::v2::CoreEffectiveConfig>,
+            nyanpasu_core_manager::CoreError,
+        > {
+            use std::sync::atomic::Ordering;
+            if !self.effective_enabled.load(Ordering::SeqCst) {
+                return Ok(None);
+            }
+            if self.effective_queries.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(nyanpasu_core_manager::CoreError::new(
+                    nyanpasu_core_manager::CoreErrorKind::BackendUnavailable,
+                    "snapshot temporarily unavailable",
+                    true,
+                ));
+            }
+            let current = self.revision.lock().unwrap().clone();
+            Ok(Some(nyanpasu_ipc::api::core::v2::CoreEffectiveConfig {
+                instance_id: "test-instance".into(),
+                revision: nyanpasu_ipc::api::status::ConfigRevisionInfo {
+                    epoch: current.epoch,
+                    generation: current.generation,
+                    source_hash: "source".into(),
+                    effective_hash: current.effective_hash,
+                },
+                config: "mode: rule\nexternal-controller-unix: /tmp/recovered.sock\n".into(),
+            }))
+        }
+
         async fn status(
             &self,
         ) -> std::result::Result<
@@ -1675,6 +1723,7 @@ pub(crate) mod tests {
         > {
             let (state, applied_kind) = self.status_override.lock().unwrap().clone();
             Ok(crate::core::actor_v2::endpoint::CoreStatusSnapshot {
+                controller: None,
                 state,
                 state_changed_at: 0,
                 revision: Some(self.revision.lock().unwrap().clone()),
@@ -1769,6 +1818,7 @@ pub(crate) mod tests {
             nyanpasu_core_manager::CoreError,
         > {
             Ok(crate::core::actor_v2::endpoint::CoreStatusSnapshot {
+                controller: None,
                 state: Some(nyanpasu_ipc::api::status::CoreStateDetail::Running {
                     epoch: 1,
                     pid: 7,
@@ -2647,7 +2697,13 @@ pub(crate) mod tests {
             .await
             .unwrap();
         let config: serde_yaml::Mapping = serde_yaml::from_str(&content.yaml).unwrap();
-        assert_eq!(config, client.promoted_runtime().await.unwrap().config);
+        let mut expected = client.promoted_runtime().await.unwrap().config.clone();
+        assert_ne!(
+            expected.get("secret").and_then(serde_yaml::Value::as_str),
+            Some("<redacted>")
+        );
+        expected.insert("secret".into(), "<redacted>".into());
+        assert_eq!(config, expected);
         client.reconcile_core().await.unwrap();
         let second = client.inspect_runtime().await.unwrap();
         assert_ne!(first.snapshot_id, second.snapshot_id);
@@ -2887,6 +2943,48 @@ pub(crate) mod tests {
             result.is_err(),
             "legacy callers rely on Err to discard their drafts"
         );
+    }
+
+    #[test]
+    fn inspection_recovers_a_successful_apply_without_reconciling_again() {
+        use std::sync::atomic::Ordering;
+        let dir = tempdir().unwrap();
+        let endpoint = TestControlEndpoint::succeeding();
+        let client = NyanpasuClient::try_new_with_args(test_client_args_with_endpoint(
+            &dir,
+            endpoint.clone(),
+        ))
+        .unwrap();
+        tauri::async_runtime::block_on(async {
+            let uid = client
+                .add_profile(
+                    minimal_file_profile_request(),
+                    Some("proxies: []\nmode: rule\n".into()),
+                )
+                .await
+                .unwrap()
+                .into_value();
+            client.activate_profile(Some(uid)).await.unwrap();
+            endpoint.effective_enabled.store(true, Ordering::SeqCst);
+            client.rebuild_running_config().await.unwrap();
+            let state = client.inner.core_lifecycle.runtime();
+            assert!(state.pending.is_some());
+            assert!(state.promoted.as_ref().unwrap().effective.is_none());
+            let submitted = endpoint.submissions();
+            let inspection = client.inspect_runtime().await.unwrap();
+            assert!(inspection.applied);
+            assert!(!inspection.effective_pending);
+            assert!(inspection.nodes.iter().any(|node| matches!(
+                node.tag,
+                nyanpasu_config::runtime::snapshot::OperatorTag::BuiltinStep {
+                    step: nyanpasu_config::runtime::snapshot::BuiltinStepKind::CoreController,
+                    ..
+                }
+            )));
+            assert_eq!(endpoint.submissions(), submitted);
+            assert!(client.inner.core_lifecycle.runtime().pending.is_none());
+            assert!(client.inspect_applied_runtime().await.unwrap().applied);
+        });
     }
 
     #[test]

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -1425,6 +1425,7 @@ pub(crate) mod tests {
         effective_enabled: std::sync::atomic::AtomicBool,
         effective_queries: std::sync::atomic::AtomicUsize,
         submissions: std::sync::atomic::AtomicUsize,
+        pub(crate) local_ipc: StdMutex<Option<nyanpasu_core_manager::LocalIpcSettings>>,
         /// The endpoint's current applied revision (finding 2's CAS
         /// enforcement). Starts non-`None` so the router's very first pump
         /// read seeds the projection with a real baseline, and advances on
@@ -1465,6 +1466,7 @@ pub(crate) mod tests {
                 effective_enabled: std::sync::atomic::AtomicBool::new(false),
                 effective_queries: std::sync::atomic::AtomicUsize::new(0),
                 submissions: std::sync::atomic::AtomicUsize::new(0),
+                local_ipc: StdMutex::new(None),
                 revision: StdMutex::new(Self::initial_revision()),
                 operations: StdMutex::new(std::collections::HashMap::new()),
                 status_override: StdMutex::new((None, None)),
@@ -1479,6 +1481,7 @@ pub(crate) mod tests {
                 effective_enabled: std::sync::atomic::AtomicBool::new(false),
                 effective_queries: std::sync::atomic::AtomicUsize::new(0),
                 submissions: std::sync::atomic::AtomicUsize::new(0),
+                local_ipc: StdMutex::new(None),
                 revision: StdMutex::new(Self::initial_revision()),
                 operations: StdMutex::new(std::collections::HashMap::new()),
                 status_override: StdMutex::new((None, None)),
@@ -1591,6 +1594,7 @@ pub(crate) mod tests {
             else {
                 return successful_reconcile(submission.envelope.operation_id);
             };
+            *self.local_ipc.lock().unwrap() = request.options.local_ipc;
             let mut current = self.revision.lock().unwrap();
             if let Some(expected) = &request.expected_applied {
                 let stale = expected.epoch.get() != current.epoch

--- a/backend/tauri/src/client/runtime.rs
+++ b/backend/tauri/src/client/runtime.rs
@@ -57,6 +57,9 @@ pub(crate) struct RuntimeSnapshotData {
 #[derive(Debug, Clone)]
 pub struct RuntimeSnapshot {
     pub(crate) inspection_id: String,
+    pub(crate) applied_binding: Option<crate::core::actor_v2::facade::AppliedConfigBinding>,
+    pub(crate) effective_host: Option<(crate::core::actor_v2::endpoint::ExecutionHost, u64)>,
+    pub(crate) effective: Option<nyanpasu_ipc::api::core::v2::CoreEffectiveConfig>,
     pub revision: RuntimeRevision,
     pub target_core: ClashCore,
     pub product_sha256: [u8; 32],
@@ -77,6 +80,9 @@ impl RuntimeSnapshot {
         let product_sha256 = Sha256::digest(&product_bytes).into();
         Self {
             inspection_id: nanoid::nanoid!(),
+            applied_binding: None,
+            effective: None,
+            effective_host: None,
             revision,
             target_core,
             product_sha256,
@@ -102,6 +108,62 @@ impl RuntimeSnapshot {
 #[derive(Debug, Clone, Default)]
 pub struct RuntimeLifecycleState {
     pub promoted: Option<Arc<RuntimeSnapshot>>,
+    pub applied: Option<Arc<RuntimeSnapshot>>,
+    /// A successful application whose effective inspection is not yet available.
+    pub(crate) pending: Option<Arc<RuntimeSnapshot>>,
+}
+
+/// One shared read/write boundary; watch is a private implementation detail.
+#[derive(Clone)]
+pub(crate) struct RuntimeSnapshotStore(tokio::sync::watch::Sender<RuntimeLifecycleState>);
+
+impl Default for RuntimeSnapshotStore {
+    fn default() -> Self {
+        Self(tokio::sync::watch::Sender::new(
+            RuntimeLifecycleState::default(),
+        ))
+    }
+}
+
+impl RuntimeSnapshotStore {
+    pub(crate) fn read(&self) -> RuntimeLifecycleState {
+        self.0.borrow().clone()
+    }
+    pub(crate) fn generated(&self, snapshot: Arc<RuntimeSnapshot>) {
+        self.0.send_modify(|state| state.promoted = Some(snapshot));
+    }
+    pub(crate) fn bind_applied(&self, snapshot: Arc<RuntimeSnapshot>) {
+        self.0.send_modify(|state| {
+            if snapshot.applied_binding.is_some()
+                && state
+                    .promoted
+                    .as_ref()
+                    .is_some_and(|source| source.inspection_id == snapshot.inspection_id)
+            {
+                state.promoted = Some(snapshot.clone());
+                state.pending = Some(snapshot);
+            }
+        });
+    }
+    pub(crate) fn applied(&self, source_id: &str, snapshot: Arc<RuntimeSnapshot>) {
+        self.0.send_modify(|state| {
+            if !state.pending.as_ref().is_some_and(|pending| {
+                pending.inspection_id == source_id
+                    && pending.applied_binding == snapshot.applied_binding
+            }) {
+                return;
+            }
+            if state
+                .promoted
+                .as_ref()
+                .is_some_and(|source| source.inspection_id == source_id)
+            {
+                state.promoted = Some(snapshot.clone());
+            }
+            state.applied = Some(snapshot);
+            state.pending = None;
+        });
+    }
 }
 
 pub(crate) async fn write_product(product: &Path, bytes: &[u8]) -> anyhow::Result<()> {

--- a/backend/tauri/src/client/runtime_inspection.rs
+++ b/backend/tauri/src/client/runtime_inspection.rs
@@ -16,6 +16,9 @@ pub(crate) struct RuntimeInspectionData {
 #[derive(Debug, Clone, Serialize, specta::Type)]
 pub struct RuntimeInspection {
     pub snapshot_id: String,
+    pub applied: bool,
+    pub effective_pending: bool,
+    pub effective_revision: Option<nyanpasu_ipc::api::status::ConfigRevisionInfo>,
     pub revision: String,
     pub target_core: String,
     pub root_id: u32,
@@ -46,9 +49,76 @@ pub struct RuntimeInspectionDiff {
 }
 
 impl RuntimeSnapshot {
+    pub(crate) fn with_effective_config(
+        &self,
+        effective: nyanpasu_ipc::api::core::v2::CoreEffectiveConfig,
+        host: crate::core::actor_v2::endpoint::ExecutionHost,
+        generation: u64,
+    ) -> anyhow::Result<Self> {
+        use nyanpasu_config::runtime::snapshot::BuiltinStepKind;
+        let binding = self
+            .applied_binding
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("effective snapshot has no successful apply binding"))?;
+        anyhow::ensure!(
+            binding.revision == effective.revision
+                && (binding.host, binding.generation) == (host, generation),
+            "effective snapshot does not match the applied build"
+        );
+        let mut inspection = self.inspection.as_ref().clone();
+        let parent = inspection
+            .graph
+            .nodes
+            .iter()
+            .position(|node| {
+                matches!(
+                    node.tag,
+                    OperatorTag::BuiltinStep {
+                        step: BuiltinStepKind::Finalizing,
+                        ..
+                    }
+                )
+            })
+            .ok_or_else(|| anyhow::anyhow!("runtime graph has no finalizing node"))?;
+        let selected_profile_id = match &inspection.graph.nodes[parent].tag {
+            OperatorTag::BuiltinStep {
+                selected_profile_id,
+                ..
+            } => selected_profile_id.clone(),
+            _ => unreachable!(),
+        };
+        let value: serde_yaml::Value = serde_yaml::from_str(&effective.config)?;
+        let config = serde_json::to_value(value)?;
+        inspection.graph.append_transition(
+            parent as u32,
+            OperatorTag::BuiltinStep {
+                selected_profile_id,
+                step: BuiltinStepKind::CoreController,
+            },
+            config,
+        )?;
+        let mut snapshot = self.clone();
+        snapshot.inspection_id = nanoid::nanoid!();
+        snapshot.inspection = std::sync::Arc::new(inspection);
+        snapshot.effective = Some(effective);
+        snapshot.effective_host = Some((host, generation));
+        Ok(snapshot)
+    }
+
     fn inspection_summary(&self) -> RuntimeInspection {
         RuntimeInspection {
             snapshot_id: self.inspection_id.clone(),
+            applied: false,
+            effective_pending: self.applied_binding.is_some() && self.effective.is_none(),
+            effective_revision: self
+                .effective
+                .as_ref()
+                .map(|effective| effective.revision.clone())
+                .or_else(|| {
+                    self.applied_binding
+                        .as_ref()
+                        .map(|binding| binding.revision.clone())
+                }),
             revision: self.revision.get().to_string(),
             target_core: self.target_core.to_string(),
             root_id: self.inspection.graph.root_id,
@@ -92,7 +162,7 @@ impl RuntimeSnapshot {
             .nodes
             .get(node_id as usize)
             .ok_or_else(|| anyhow::anyhow!("runtime snapshot node does not exist"))?;
-        let yaml = serde_yaml::to_string(&node.snapshot.config)?;
+        let yaml = serde_yaml::to_string(&redact_config(node.snapshot.config.clone()))?;
         Ok(RuntimeInspectionContent {
             diff: self
                 .inspection
@@ -101,9 +171,15 @@ impl RuntimeSnapshot {
                 .map(|parent_id| -> anyhow::Result<_> {
                     Ok(RuntimeInspectionDiff {
                         parent_id,
-                        hunks: self.inspection.graph.nodes[parent_id as usize]
-                            .snapshot
-                            .diff_yaml_to(&yaml)?,
+                        hunks: nyanpasu_config::runtime::snapshot::ConfigSnapshot::new_unchanged(
+                            redact_config(
+                                self.inspection.graph.nodes[parent_id as usize]
+                                    .snapshot
+                                    .config
+                                    .clone(),
+                            ),
+                        )
+                        .diff_yaml_to(&yaml)?,
                     })
                 })
                 .transpose()?,
@@ -121,9 +197,57 @@ impl RuntimeSnapshot {
 
 impl NyanpasuClient {
     pub async fn inspect_runtime(&self) -> Option<RuntimeInspection> {
-        self.promoted_runtime()
-            .await
-            .map(|snapshot| snapshot.inspection_summary())
+        self.recover_effective_snapshot().await;
+        let snapshot = self.promoted_runtime().await?;
+        Some(self.inspect_snapshot(&snapshot).await)
+    }
+
+    pub async fn inspect_applied_runtime(&self) -> Option<RuntimeInspection> {
+        self.recover_effective_snapshot().await;
+        let snapshot = self.inner.core_lifecycle.runtime().applied?;
+        Some(self.inspect_snapshot(&snapshot).await)
+    }
+
+    /// Inspection recovery is read-only with respect to the core. A newer
+    /// successful bind wins even if this query completes after another build.
+    async fn recover_effective_snapshot(&self) {
+        let store = self.inner.core_lifecycle.snapshot_store();
+        let Some(pending) = store.read().pending else {
+            return;
+        };
+        let Some(binding) = &pending.applied_binding else {
+            return;
+        };
+        let before = self.inner.core_api.status();
+        if (before.host, before.generation) != (binding.host, binding.generation) {
+            return;
+        }
+        let Ok(Some(effective)) = self.inner.core_api.effective_config().await else {
+            return;
+        };
+        let after = self.inner.core_api.status();
+        if (after.host, after.generation) != (binding.host, binding.generation)
+            || effective.revision != binding.revision
+        {
+            return;
+        }
+        match pending.with_effective_config(effective, binding.host, binding.generation) {
+            Ok(snapshot) => store.applied(&pending.inspection_id, std::sync::Arc::new(snapshot)),
+            Err(error) => tracing::warn!(%error, "effective inspection recovery failed"),
+        }
+    }
+
+    async fn inspect_snapshot(&self, snapshot: &RuntimeSnapshot) -> RuntimeInspection {
+        let mut summary = snapshot.inspection_summary();
+        if let Some(effective) = &snapshot.effective {
+            let before = self.inner.core_api.status();
+            let current = self.inner.core_api.effective_config().await.ok().flatten();
+            let after = self.inner.core_api.status();
+            summary.applied = snapshot.effective_host == Some((before.host, before.generation))
+                && (before.host, before.generation) == (after.host, after.generation)
+                && current.is_some_and(|current| current.revision == effective.revision);
+        }
+        summary
     }
 
     pub async fn inspect_runtime_node(
@@ -131,13 +255,49 @@ impl NyanpasuClient {
         snapshot_id: &str,
         node_id: u32,
     ) -> anyhow::Result<RuntimeInspectionContent> {
-        let snapshot = self.promoted_runtime().await.ok_or_else(|| {
-            anyhow::anyhow!("no promoted runtime snapshot; refresh the inspection")
-        })?;
+        let state = self.inner.core_lifecycle.runtime();
+        let snapshot = [state.promoted, state.applied]
+            .into_iter()
+            .flatten()
+            .find(|snapshot| snapshot.inspection_id == snapshot_id)
+            .ok_or_else(|| anyhow::anyhow!("runtime snapshot changed; refresh the inspection"))?;
         let snapshot_id = snapshot_id.to_owned();
         tokio::task::spawn_blocking(move || snapshot.inspection_content(&snapshot_id, node_id))
             .await?
     }
+}
+
+fn redact_config(mut value: serde_json::Value) -> serde_json::Value {
+    match &mut value {
+        serde_json::Value::Object(fields) => {
+            for (key, value) in fields {
+                if matches!(
+                    key.as_str(),
+                    "secret" | "password" | "token" | "private-key" | "auth-str" | "authentication"
+                ) {
+                    *value = serde_json::Value::String("<redacted>".into());
+                } else if matches!(
+                    key.as_str(),
+                    "external-controller" | "external-controller-tls"
+                ) {
+                    if let Some(address) = value.as_str()
+                        && let Some((_, authority)) = address.rsplit_once('@')
+                    {
+                        *value = serde_json::Value::String(format!("<redacted>@{authority}"));
+                    }
+                } else {
+                    *value = redact_config(std::mem::take(value));
+                }
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                *value = redact_config(std::mem::take(value));
+            }
+        }
+        _ => {}
+    }
+    value
 }
 
 #[cfg(test)]
@@ -184,6 +344,129 @@ pub(crate) mod tests {
                 inspection: Arc::new(inspection_data()),
             },
         )
+    }
+
+    #[test]
+    fn effective_config_is_a_separate_node_and_store_rejects_stale_reports() {
+        use crate::client::runtime::RuntimeSnapshotStore;
+        use nyanpasu_config::runtime::snapshot::BuiltinStepKind;
+        let input =
+            serde_json::json!({"external-controller": "127.0.0.1:9090", "secret": "private"});
+        let value = Arc::new(serde_json::from_value::<ConfigValue>(input.clone()).unwrap());
+        let mut graph = ConfigSnapshotsBuilder::new_root(value.clone(), OperatorTag::BareRoot);
+        graph
+            .push(
+                OperatorTag::BuiltinStep {
+                    selected_profile_id: None,
+                    step: BuiltinStepKind::Finalizing,
+                },
+                value,
+            )
+            .unwrap();
+        let mut generated = snapshot();
+        generated.config =
+            serde_yaml::from_str("external-controller: 127.0.0.1:9090\nsecret: private\n").unwrap();
+        generated.inspection = Arc::new(RuntimeInspectionData {
+            graph: graph.build().unwrap(),
+            step_logs: vec![],
+        });
+        let effective = nyanpasu_ipc::api::core::v2::CoreEffectiveConfig {
+            instance_id: "instance-1".into(),
+            revision: nyanpasu_ipc::api::status::ConfigRevisionInfo {
+                epoch: 1,
+                generation: 1,
+                source_hash: "source".into(),
+                effective_hash: "effective".into(),
+            },
+            config: "external-controller-unix: /tmp/managed.sock\nsecret: private\n".into(),
+        };
+        generated.applied_binding = Some(crate::core::actor_v2::facade::AppliedConfigBinding {
+            revision: effective.revision.clone(),
+            host: crate::core::actor_v2::endpoint::ExecutionHost::Local,
+            generation: 1,
+        });
+        let applied = generated
+            .with_effective_config(
+                effective,
+                crate::core::actor_v2::endpoint::ExecutionHost::Local,
+                1,
+            )
+            .unwrap();
+        assert_eq!(
+            generated.config, applied.config,
+            "next rebuild must use the original source"
+        );
+        assert_eq!(generated.inspection.graph.nodes.len(), 2);
+        assert_eq!(applied.inspection.graph.nodes.len(), 3);
+        let node = applied
+            .inspection_content(&applied.inspection_id, 2)
+            .unwrap();
+        assert!(node.yaml.contains("/tmp/managed.sock"));
+        assert!(!node.yaml.contains("private"));
+        assert!(node.diff.is_some());
+        assert!(!format!("{:?}", node.diff).contains("private"));
+        let store = RuntimeSnapshotStore::default();
+        store.generated(Arc::new(generated.clone()));
+        store.bind_applied(Arc::new(generated.clone()));
+        store.applied("stale-build", Arc::new(applied.clone()));
+        assert!(store.read().applied.is_none());
+        store.applied(&generated.inspection_id, Arc::new(applied.clone()));
+        assert!(store.read().applied.is_some());
+        store.generated(Arc::new(generated.clone()));
+        assert!(
+            store.read().applied.is_some(),
+            "a rejected candidate must retain the last applied view"
+        );
+        let mut next = generated.clone();
+        next.inspection_id = "new-success".into();
+        next.applied_binding.as_mut().unwrap().revision.generation += 1;
+        let next = Arc::new(next);
+        store.generated(next.clone());
+        store.bind_applied(next.clone());
+        store.applied(&generated.inspection_id, Arc::new(applied.clone()));
+        assert_eq!(
+            store.read().pending.as_ref().unwrap().inspection_id,
+            "new-success"
+        );
+        let mut candidate = generated.clone();
+        candidate.inspection_id = "new-failed-build".into();
+        candidate.applied_binding = None;
+        store.generated(Arc::new(candidate));
+        let mut effective = applied.effective.clone().unwrap();
+        assert!(
+            next.with_effective_config(
+                effective.clone(),
+                crate::core::actor_v2::endpoint::ExecutionHost::Local,
+                1
+            )
+            .is_err()
+        );
+        effective.revision = next.applied_binding.as_ref().unwrap().revision.clone();
+        assert!(
+            next.with_effective_config(
+                effective.clone(),
+                crate::core::actor_v2::endpoint::ExecutionHost::Local,
+                2
+            )
+            .is_err()
+        );
+        let recovered = next
+            .with_effective_config(
+                effective,
+                crate::core::actor_v2::endpoint::ExecutionHost::Local,
+                1,
+            )
+            .unwrap();
+        store.applied(&next.inspection_id, Arc::new(recovered));
+        assert!(store.read().pending.is_none());
+        assert_eq!(
+            store.read().promoted.unwrap().inspection_id,
+            "new-failed-build"
+        );
+        assert_eq!(
+            store.read().applied.unwrap().applied_binding,
+            next.applied_binding
+        );
     }
 
     #[test]

--- a/backend/tauri/src/config/nyanpasu/mod.rs
+++ b/backend/tauri/src/config/nyanpasu/mod.rs
@@ -265,7 +265,7 @@ pub struct IVerge {
     /// clash core path
     #[serde(skip_serializing_if = "Option::is_none")]
     pub clash_core: Option<ClashCore>,
-    pub clash_control_channel: Option<nyanpasu_config::application::ClashControlChannel>,
+    pub clash_control_channel: Option<nyanpasu_config::clash::config::ClashControlChannel>,
     pub clash_ipc_disable_http_controller: Option<bool>,
 
     /// hotkey map
@@ -469,7 +469,7 @@ impl IVerge {
         Self {
             clash_core: Some(ClashCore::default()),
             clash_control_channel: Some(
-                nyanpasu_config::application::ClashControlChannel::default(),
+                nyanpasu_config::clash::config::ClashControlChannel::default(),
             ),
             clash_ipc_disable_http_controller: Some(false),
             language: Some(crate::utils::help::detect_system_i18n_key().into()),

--- a/backend/tauri/src/config/nyanpasu/mod.rs
+++ b/backend/tauri/src/config/nyanpasu/mod.rs
@@ -265,6 +265,8 @@ pub struct IVerge {
     /// clash core path
     #[serde(skip_serializing_if = "Option::is_none")]
     pub clash_core: Option<ClashCore>,
+    pub clash_control_channel: Option<nyanpasu_config::application::ClashControlChannel>,
+    pub clash_ipc_disable_http_controller: Option<bool>,
 
     /// hotkey map
     /// format: {func},{key}
@@ -466,6 +468,10 @@ impl IVerge {
     pub fn template() -> Self {
         Self {
             clash_core: Some(ClashCore::default()),
+            clash_control_channel: Some(
+                nyanpasu_config::application::ClashControlChannel::default(),
+            ),
+            clash_ipc_disable_http_controller: Some(false),
             language: {
                 let locale = crate::utils::help::get_system_locale();
                 Some(crate::utils::help::mapping_to_i18n_key(&locale).into())

--- a/backend/tauri/src/core/actor_v2/api.rs
+++ b/backend/tauri/src/core/actor_v2/api.rs
@@ -367,6 +367,7 @@ pub(crate) mod tests {
 
         async fn status(&self) -> Result<CoreStatusSnapshot, CoreError> {
             Ok(CoreStatusSnapshot {
+                controller: None,
                 state: Some(if self.binding.borrow().is_some() {
                     CoreStateDetail::Running { epoch: 1, pid: 7 }
                 } else {

--- a/backend/tauri/src/core/actor_v2/endpoint.rs
+++ b/backend/tauri/src/core/actor_v2/endpoint.rs
@@ -40,6 +40,7 @@ pub enum ExecutionHost {
 /// No field here is ever derived by the router itself.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CoreStatusSnapshot {
+    pub controller: Option<nyanpasu_ipc::api::status::CoreControllerInfo>,
     /// `None` means the host published no state this router can trust — an
     /// unmapped future variant, or a daemon that answered without a detail.
     /// No consumer may read it as `Stopped`: "we do not know" is the one
@@ -72,6 +73,12 @@ pub struct CoreSubmission {
 /// read and deliberately not routed through the actor mailbox.
 #[async_trait::async_trait]
 pub trait ControlEndpoint: Send + Sync {
+    async fn effective_config(
+        &self,
+    ) -> Result<Option<nyanpasu_ipc::api::core::v2::CoreEffectiveConfig>, CoreError> {
+        Ok(None)
+    }
+
     /// The applied process binding; absent means no usable API. Old hosts must
     /// fail explicitly rather than reconstructing credentials from globals.
     async fn api_connection(
@@ -121,6 +128,33 @@ impl LocalEndpoint {
 
 #[async_trait::async_trait]
 impl ControlEndpoint for LocalEndpoint {
+    async fn effective_config(
+        &self,
+    ) -> Result<Option<nyanpasu_ipc::api::core::v2::CoreEffectiveConfig>, CoreError> {
+        self.control
+            .effective_config()
+            .await
+            .map(|snapshot| {
+                Ok(nyanpasu_ipc::api::core::v2::CoreEffectiveConfig {
+                    instance_id: snapshot.instance_id.to_string(),
+                    revision: nyanpasu_ipc::api::status::ConfigRevisionInfo {
+                        epoch: snapshot.revision.epoch.get(),
+                        generation: snapshot.revision.generation,
+                        source_hash: snapshot.revision.source_hash.clone(),
+                        effective_hash: snapshot.revision.effective_hash.clone(),
+                    },
+                    config: serde_yaml::to_string(snapshot.config.as_ref()).map_err(|_| {
+                        CoreError::new(
+                            CoreErrorKind::Internal,
+                            "failed to serialize effective config",
+                            false,
+                        )
+                    })?,
+                })
+            })
+            .transpose()
+    }
+
     async fn api_connection(
         &self,
     ) -> Result<Option<nyanpasu_ipc::api::core::v2::CoreApiConnection>, CoreError> {
@@ -288,6 +322,7 @@ fn map_local_status(status: &nyanpasu_core_manager::CoreStatus) -> CoreStatusSna
         }
     };
     CoreStatusSnapshot {
+        controller: status.controller.as_ref().and_then(map_controller),
         state,
         state_changed_at: status.changed_at,
         revision: status.revision.as_ref().map(|revision| {
@@ -345,6 +380,16 @@ fn map_client_error(error: nyanpasu_ipc::client::ClientError) -> CoreError {
 
 #[async_trait::async_trait]
 impl ControlEndpoint for ServiceEndpoint {
+    async fn effective_config(
+        &self,
+    ) -> Result<Option<nyanpasu_ipc::api::core::v2::CoreEffectiveConfig>, CoreError> {
+        self.client
+            .call::<nyanpasu_ipc::api::contract::CoreV2EffectiveConfig>(None)
+            .await
+            .map(|response| response.data.flatten())
+            .map_err(map_client_error)
+    }
+
     async fn api_connection(
         &self,
     ) -> Result<Option<nyanpasu_ipc::api::core::v2::CoreApiConnection>, CoreError> {
@@ -432,6 +477,20 @@ pub(super) fn wire_submit_request(
                 )
             })?;
             CoreCommandInfo::Reconcile {
+                local_ipc: request.options.local_ipc.map(|settings| {
+                    nyanpasu_ipc::api::core::v2::LocalIpcSettingsInfo {
+                        policy: match settings.policy {
+                            nyanpasu_core_manager::LocalIpcPolicy::Force => {
+                                nyanpasu_ipc::api::core::v2::LocalIpcPolicyInfo::Force
+                            }
+                            nyanpasu_core_manager::LocalIpcPolicy::Prefer => {
+                                nyanpasu_ipc::api::core::v2::LocalIpcPolicyInfo::Prefer
+                            }
+                            _ => nyanpasu_ipc::api::core::v2::LocalIpcPolicyInfo::Disable,
+                        },
+                        keep_http_controller: settings.keep_http_controller,
+                    }
+                }),
                 core_type: Cow::Owned(match &submission.core_type {
                     Some(core_type) => core_type.clone(),
                     None => app_core_kind_to_type(request.core.kind)?,
@@ -513,6 +572,7 @@ pub(crate) fn wire_core_type_to_kind(
 
 fn map_service_status(infos: &CoreInfos) -> CoreStatusSnapshot {
     CoreStatusSnapshot {
+        controller: infos.controller.clone(),
         // A daemon too old to publish `detail` leaves this unknown. The coarse
         // `CoreInfos::state` cannot stand in: it collapses Starting and
         // Restarting into a Stopped shape, which would read as a stop proof.
@@ -625,5 +685,23 @@ mod tests {
         });
         assert_eq!(error.kind, Some(CoreErrorKind::BackendUnavailable));
         assert!(error.retryable);
+    }
+}
+
+fn map_controller(
+    host: &nyanpasu_core_manager::Host,
+) -> Option<nyanpasu_ipc::api::status::CoreControllerInfo> {
+    use nyanpasu_core_manager::Host;
+    use nyanpasu_ipc::api::status::CoreControllerInfo;
+    match host {
+        Host::Http(url) => {
+            let mut url = url.clone();
+            let _ = url.set_username("");
+            let _ = url.set_password(None);
+            Some(CoreControllerInfo::Http(url.to_string()))
+        }
+        Host::UnixSocket(path) => Some(CoreControllerInfo::UnixSocket(path.clone())),
+        Host::NamedPipe(path) => Some(CoreControllerInfo::NamedPipe(path.clone())),
+        _ => None,
     }
 }

--- a/backend/tauri/src/core/actor_v2/facade.rs
+++ b/backend/tauri/src/core/actor_v2/facade.rs
@@ -23,7 +23,16 @@ use super::{
 const OPERATION_WAIT: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct AppliedConfigBinding {
+    pub revision: nyanpasu_ipc::api::status::ConfigRevisionInfo,
+    pub host: ExecutionHost,
+    pub generation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct ReconcileReport {
+    pub applied: AppliedConfigBinding,
+    pub effective_config: Option<nyanpasu_ipc::api::core::v2::CoreEffectiveConfig>,
     pub output: OperationOutputInfo,
     pub status: CoreStatusProjection,
 }
@@ -101,6 +110,7 @@ impl CoreFacade {
         core: ClashCore,
         document: &serde_yaml::Mapping,
         core_spec: CoreSpec,
+        local_ipc: nyanpasu_core_manager::LocalIpcSettings,
     ) -> Result<ReconcileReport, CoreError> {
         // Admission-time authoritative read (F2), not the router's cached
         // projection: the cache is refreshed only by the 2s pump, so a
@@ -114,8 +124,9 @@ impl CoreFacade {
             .snapshot
             .and_then(|snapshot| snapshot.revision);
         let core_type: nyanpasu_utils::core::CoreType = (&core).into();
-        let intent = RuntimeIntentBuilder::build(core_type.clone(), document, expected_applied)
-            .map_err(|error| {
+        let intent =
+            RuntimeIntentBuilder::build(core_type.clone(), document, expected_applied, local_ipc)
+                .map_err(|error| {
                 CoreError::new(
                     CoreErrorKind::InvalidConfig,
                     format!("failed to serialize runtime config: {error}"),
@@ -154,12 +165,16 @@ impl CoreFacade {
                         bytes: intent.config_text.into_bytes(),
                         expected_digest: Some(intent.digest),
                     },
-                    options: InstanceOptions::default(),
+                    options: InstanceOptions {
+                        local_ipc: Some(intent.local_ipc),
+                        ..InstanceOptions::default()
+                    },
                     expected_applied,
                 })),
             },
             core_type: Some(core_type),
         };
+        let applied_owner = self.core.status();
         let output = self.submit_and_wait(submission).await?;
         let outcome = match &output {
             OperationOutputInfo::Reconciled(outcome) => outcome,
@@ -184,9 +199,29 @@ impl CoreFacade {
                 false,
             ));
         }
+        let owner = applied_owner;
+        let effective_config = self
+            .core
+            .effective_config()
+            .await
+            .ok()
+            .flatten()
+            .filter(|snapshot| snapshot.revision == outcome.revision);
+        let status = self.core.status();
+        let effective_config = effective_config
+            .filter(|_| (owner.host, owner.generation) == (status.host, status.generation));
+        if effective_config.is_none() {
+            tracing::warn!("core applied configuration, but its effective snapshot is unavailable");
+        }
         Ok(ReconcileReport {
+            applied: AppliedConfigBinding {
+                revision: outcome.revision.clone(),
+                host: owner.host,
+                generation: owner.generation,
+            },
+            effective_config,
             output,
-            status: self.core.status(),
+            status,
         })
     }
 
@@ -424,6 +459,7 @@ mod tests {
             Arc::new(Self {
                 host,
                 status: CoreStatusSnapshot {
+                    controller: None,
                     state: Some(CoreStateDetail::Running { pid: 7, epoch: 1 }),
                     state_changed_at: 1,
                     revision,
@@ -608,7 +644,15 @@ mod tests {
         };
 
         facade
-            .reconcile(ClashCore::Mihomo, &document, spec)
+            .reconcile(
+                ClashCore::Mihomo,
+                &document,
+                spec,
+                nyanpasu_core_manager::LocalIpcSettings {
+                    policy: nyanpasu_core_manager::LocalIpcPolicy::Disable,
+                    keep_http_controller: true,
+                },
+            )
             .await
             .unwrap();
 
@@ -658,7 +702,15 @@ mod tests {
         };
 
         let error = facade
-            .reconcile(ClashCore::Mihomo, &document, spec)
+            .reconcile(
+                ClashCore::Mihomo,
+                &document,
+                spec,
+                nyanpasu_core_manager::LocalIpcSettings {
+                    policy: nyanpasu_core_manager::LocalIpcPolicy::Disable,
+                    keep_http_controller: true,
+                },
+            )
             .await
             .unwrap_err();
 
@@ -692,7 +744,15 @@ mod tests {
         };
 
         facade
-            .reconcile(ClashCore::Mihomo, &document, spec)
+            .reconcile(
+                ClashCore::Mihomo,
+                &document,
+                spec,
+                nyanpasu_core_manager::LocalIpcSettings {
+                    policy: nyanpasu_core_manager::LocalIpcPolicy::Disable,
+                    keep_http_controller: true,
+                },
+            )
             .await
             .unwrap();
     }
@@ -716,7 +776,15 @@ mod tests {
         };
 
         let error = facade
-            .reconcile(ClashCore::Mihomo, &document, spec)
+            .reconcile(
+                ClashCore::Mihomo,
+                &document,
+                spec,
+                nyanpasu_core_manager::LocalIpcSettings {
+                    policy: nyanpasu_core_manager::LocalIpcPolicy::Disable,
+                    keep_http_controller: true,
+                },
+            )
             .await
             .unwrap_err();
 

--- a/backend/tauri/src/core/actor_v2/intent.rs
+++ b/backend/tauri/src/core/actor_v2/intent.rs
@@ -15,6 +15,7 @@ use nyanpasu_utils::core::CoreType;
 /// that is not host-resolved (binary paths stay host-side).
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeIntent {
+    pub local_ipc: nyanpasu_core_manager::LocalIpcSettings,
     pub core_type: CoreType,
     /// The full runtime config document, serialized.
     pub config_text: String,
@@ -34,10 +35,12 @@ impl RuntimeIntentBuilder {
         core_type: CoreType,
         document: &serde_yaml::Mapping,
         expected_applied: Option<RevisionIdInfo>,
+        local_ipc: nyanpasu_core_manager::LocalIpcSettings,
     ) -> Result<RuntimeIntent, serde_yaml::Error> {
         let config_text = serde_yaml::to_string(document)?;
         let digest = payload_digest(config_text.as_bytes());
         Ok(RuntimeIntent {
+            local_ipc,
             core_type,
             config_text,
             digest,
@@ -51,6 +54,12 @@ mod tests {
     use super::*;
     use nyanpasu_utils::core::ClashCoreType;
 
+    fn test_settings() -> nyanpasu_core_manager::LocalIpcSettings {
+        nyanpasu_core_manager::LocalIpcSettings {
+            policy: nyanpasu_core_manager::LocalIpcPolicy::Prefer,
+            keep_http_controller: true,
+        }
+    }
     fn document() -> serde_yaml::Mapping {
         let mut document = serde_yaml::Mapping::new();
         document.insert(
@@ -63,8 +72,11 @@ mod tests {
     #[test]
     fn the_same_inputs_produce_the_same_intent() {
         let core_type = CoreType::Clash(ClashCoreType::Mihomo);
-        let first = RuntimeIntentBuilder::build(core_type.clone(), &document(), None).unwrap();
-        let second = RuntimeIntentBuilder::build(core_type, &document(), None).unwrap();
+        let first =
+            RuntimeIntentBuilder::build(core_type.clone(), &document(), None, test_settings())
+                .unwrap();
+        let second =
+            RuntimeIntentBuilder::build(core_type, &document(), None, test_settings()).unwrap();
         assert_eq!(first, second);
         assert_eq!(first.digest, payload_digest(first.config_text.as_bytes()));
     }
@@ -72,13 +84,15 @@ mod tests {
     #[test]
     fn a_document_change_changes_the_digest() {
         let core_type = CoreType::Clash(ClashCoreType::Mihomo);
-        let base = RuntimeIntentBuilder::build(core_type.clone(), &document(), None).unwrap();
+        let base =
+            RuntimeIntentBuilder::build(core_type.clone(), &document(), None, test_settings())
+                .unwrap();
         let mut changed = document();
         changed.insert(
             serde_yaml::Value::String("mixed-port".into()),
             serde_yaml::Value::Number(7890.into()),
         );
-        let next = RuntimeIntentBuilder::build(core_type, &changed, None).unwrap();
+        let next = RuntimeIntentBuilder::build(core_type, &changed, None, test_settings()).unwrap();
         assert_ne!(base.digest, next.digest);
     }
 }

--- a/backend/tauri/src/core/actor_v2/mod.rs
+++ b/backend/tauri/src/core/actor_v2/mod.rs
@@ -152,6 +152,7 @@ pub enum EndpointConnectivity {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, specta::Type)]
 pub struct CoreStatusInfo {
+    pub controller: Option<nyanpasu_ipc::api::status::CoreControllerInfo>,
     pub host: ExecutionHost,
     pub connectivity: EndpointConnectivity,
     pub generation: u64,
@@ -165,6 +166,7 @@ impl From<CoreStatusProjection> for CoreStatusInfo {
     fn from(status: CoreStatusProjection) -> Self {
         let snapshot = status.snapshot;
         Self {
+            controller: snapshot.as_ref().and_then(|s| s.controller.clone()),
             host: status.host,
             connectivity: status.connectivity,
             generation: status.generation,
@@ -231,6 +233,11 @@ impl std::fmt::Debug for SubmitTicket {
 }
 
 pub enum CoreActorMessage {
+    EffectiveConfig {
+        reply: RpcReplyPort<
+            Result<Option<nyanpasu_ipc::api::core::v2::CoreEffectiveConfig>, CoreError>,
+        >,
+    },
     ApiClient {
         reply: RpcReplyPort<Result<api::ApiClient, api::ApiError>>,
     },
@@ -618,6 +625,29 @@ impl Actor for CoreActor {
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
         match message {
+            CoreActorMessage::EffectiveConfig { reply } => {
+                let result = match &state.slot {
+                    EndpointSlot::Connected(endpoint) => match tokio::time::timeout(
+                        state.status_timeout,
+                        endpoint.effective_config(),
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(_) => Err(CoreError::new(
+                            CoreErrorKind::BackendUnavailable,
+                            "effective config read timed out",
+                            true,
+                        )),
+                    },
+                    _ => Err(CoreError::new(
+                        CoreErrorKind::BackendUnavailable,
+                        "core endpoint is not connected",
+                        true,
+                    )),
+                };
+                let _ = reply.send(result);
+            }
             CoreActorMessage::ApiClient { reply } => {
                 let result = match &state.slot {
                     EndpointSlot::Connected(endpoint) => {
@@ -1112,6 +1142,26 @@ impl CoreObserver {
 }
 
 impl CoreClient {
+    pub async fn effective_config(
+        &self,
+    ) -> Result<Option<nyanpasu_ipc::api::core::v2::CoreEffectiveConfig>, CoreError> {
+        match self
+            .actor
+            .call(
+                |reply| CoreActorMessage::EffectiveConfig { reply },
+                Some(self.submit_budget),
+            )
+            .await
+        {
+            Ok(ractor::rpc::CallResult::Success(result)) => result,
+            _ => Err(CoreError::new(
+                CoreErrorKind::BackendUnavailable,
+                "core actor did not answer effective config query",
+                true,
+            )),
+        }
+    }
+
     pub async fn api_client(&self) -> Result<api::ApiClient, api::ApiError> {
         let reply = self
             .actor

--- a/backend/tauri/src/core/actor_v2/tests.rs
+++ b/backend/tauri/src/core/actor_v2/tests.rs
@@ -160,6 +160,7 @@ impl FakeEndpoint {
 
 fn snapshot(state: CoreStateDetail) -> CoreStatusSnapshot {
     CoreStatusSnapshot {
+        controller: None,
         state: Some(state),
         state_changed_at: 0,
         revision: None,
@@ -461,6 +462,7 @@ async fn a_lost_stop_result_with_an_unknown_status_is_not_a_stop_proof() {
     );
     local.script_stop(StopScript::Lost);
     *local.status.lock().unwrap() = Ok(CoreStatusSnapshot {
+        controller: None,
         state: None,
         state_changed_at: 0,
         revision: None,

--- a/backend/tauri/src/core/service/compat.rs
+++ b/backend/tauri/src/core/service/compat.rs
@@ -13,13 +13,13 @@ use nyanpasu_ipc::types::{ServiceStatus, StatusInfo};
 /// PR-5-pre 起，只有主版本等于此值的 daemon 允许承载核心生命周期。
 pub const REQUIRED_SERVICE_MAJOR: u64 = 2;
 
-/// 控制通道设置和实例有效配置查询需要 `2.0.0-rc.4` 协议。
-/// rc.3 即使支持实例连接，也不能应用新设置或查询有效配置。
+/// 控制通道设置和实例有效配置查询随 `2.0.0-rc.5` 服务发布。
+/// 更早版本即使支持实例连接，也不能保证应用新设置或查询有效配置。
 ///
 /// 存成字符串而非 `semver::Version` 常量：`Prerelease::new` 不是 `const fn`，
 /// 能进 const 上下文的只有不带预发布标识的版本，而那样只能写成 `2.0.0`——按
 /// semver 预发布序 `2.0.0-rc.3 < 2.0.0`，反而会把本轮发布的 rc 系列全拒掉。
-pub const REQUIRED_SERVICE_MIN: &str = "2.0.0-rc.4";
+pub const REQUIRED_SERVICE_MIN: &str = "2.0.0-rc.5";
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, specta::Type)]
 #[serde(rename_all = "snake_case", tag = "kind")]
@@ -185,6 +185,13 @@ mod tests {
     fn rc3_without_control_channel_settings_is_incompatible() {
         let mut info = parse_fixture(STATUS_V2_0_0_RC1_FIXTURE);
         info.server.as_mut().unwrap().version = Cow::Borrowed("2.0.0-rc.3");
+        assert!(!ServiceCompat::classify(&info).allows_service_backend());
+    }
+
+    #[test]
+    fn rc4_before_control_channel_release_is_incompatible() {
+        let mut info = parse_fixture(STATUS_V2_0_0_RC1_FIXTURE);
+        info.server.as_mut().unwrap().version = Cow::Borrowed("2.0.0-rc.4");
         assert!(!ServiceCompat::classify(&info).allows_service_backend());
     }
 

--- a/backend/tauri/src/core/service/compat.rs
+++ b/backend/tauri/src/core/service/compat.rs
@@ -13,13 +13,13 @@ use nyanpasu_ipc::types::{ServiceStatus, StatusInfo};
 /// PR-5-pre 起，只有主版本等于此值的 daemon 允许承载核心生命周期。
 pub const REQUIRED_SERVICE_MAJOR: u64 = 2;
 
-/// 实例绑定的 ApiClient 需要 `2.0.0-rc.3` 新增的 `/v2/core/api-connection`。
-/// 旧 rc 即使支持核心生命周期路由，也不能提供进程身份和控制器凭据。
+/// 控制通道设置和实例有效配置查询需要 `2.0.0-rc.4` 协议。
+/// rc.3 即使支持实例连接，也不能应用新设置或查询有效配置。
 ///
 /// 存成字符串而非 `semver::Version` 常量：`Prerelease::new` 不是 `const fn`，
 /// 能进 const 上下文的只有不带预发布标识的版本，而那样只能写成 `2.0.0`——按
 /// semver 预发布序 `2.0.0-rc.3 < 2.0.0`，反而会把本轮发布的 rc 系列全拒掉。
-pub const REQUIRED_SERVICE_MIN: &str = "2.0.0-rc.3";
+pub const REQUIRED_SERVICE_MIN: &str = "2.0.0-rc.4";
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, specta::Type)]
 #[serde(rename_all = "snake_case", tag = "kind")]
@@ -179,6 +179,13 @@ mod tests {
                 required_min: REQUIRED_SERVICE_MIN.to_owned(),
             }
         );
+    }
+
+    #[test]
+    fn rc3_without_control_channel_settings_is_incompatible() {
+        let mut info = parse_fixture(STATUS_V2_0_0_RC1_FIXTURE);
+        info.server.as_mut().unwrap().version = Cow::Borrowed("2.0.0-rc.3");
+        assert!(!ServiceCompat::classify(&info).allows_service_backend());
     }
 
     #[test]

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -377,6 +377,14 @@ pub async fn inspect_runtime(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn inspect_applied_runtime(
+    client: State<'_, NyanpasuClient>,
+) -> Result<Option<crate::client::runtime_inspection::RuntimeInspection>> {
+    Ok(client.inspect_applied_runtime().await)
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn inspect_runtime_node(
     client: State<'_, NyanpasuClient>,
     snapshot_id: String,

--- a/backend/tauri/src/specta_export.rs
+++ b/backend/tauri/src/specta_export.rs
@@ -28,6 +28,7 @@ pub(crate) fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             ipc::get_runtime_yaml,
             ipc::get_runtime_exists,
             ipc::inspect_runtime,
+            ipc::inspect_applied_runtime,
             ipc::inspect_runtime_node,
             ipc::get_postprocessing_output,
             ipc::clash_api_get_proxy_delay,

--- a/docs/plan/2026-09-07-core-control-channel-ipc.md
+++ b/docs/plan/2026-09-07-core-control-channel-ipc.md
@@ -1,0 +1,299 @@
+# 内核控制通道（IPC / HTTP）：审计与最终实施计划
+
+日期：2026-09-07（实施记录更新于 2026-09-08）
+
+状态：源码已实现并提交审核；服务发布和跨平台/跨用户实测待完成，详见 §10。
+
+审计基线：主仓库 `7e24d8e4`，runtime 子模块 `82092b0`
+
+## 1. 目标与范围
+
+保留原稿的产品决策：
+
+- 设置项「控制通道 / Control Channel」：`PreferIpc`（默认）与 `HttpOnly`。
+- 独立开关「IPC 可用时关闭 HTTP 外部控制器」：默认关闭，即默认保留 HTTP。
+- 首页显示实际主控制通道：`HTTP`、`IPC · Named Pipe`、`IPC · Unix Socket`。
+- Local 与 Service 使用相同应用设置；修改设置不要求重装 daemon。
+- UI 不暴露 `Force`。保留 HTTP 指保留源配置中的 HTTP 地址及 secret，不额外创造监听地址。
+
+本次仅审计和修改计划，不执行功能开发、服务安装或版本发布。以下设计以现有 actor/DI 规则为约束；平台相关行为作为实施验收项，不把代码阅读等同于实机验证。
+
+## 2. 审计结论
+
+原稿不能直接执行，主要问题如下。路径均相对仓库根目录。
+
+| 级别 | 原稿问题                                                                                            | 当前实现依据                                                                                                                                           | 最终处理                                                                                  |
+| ---- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| P0   | 队列外 setter 与下一次 restart 分离，策略可能在 prepare 中途变化，操作身份也不包含策略              | `backend/nyanpasu-runtime/crates/nyanpasu-core-manager/src/control/mod.rs` 的 `ReconcileRequest`、`CoreCommand::payload_digest`；`control/executor.rs` | 设置随同一个 Reconcile 不可变请求传递，进入现有队列、幂等注册和事务；删除独立 setter 方案 |
+| P0   | 保留 HTTP 破坏原先“每个 epoch 只有独立 IPC controller”的切换前提                                    | core-manager `config/clash.rs::rewrite_managed_controller`；`manager/switching.rs::graceful_degrade_reason` 目前只检查主通道是否 IPC 等条件            | 有 HTTP controller 监听的切换保守使用 hard switch；不能凭主通道是 IPC 就允许重叠启动      |
+| P0   | 服务 runtime 目录是私有目录，只 chmod socket 不解决父目录不可遍历；放宽整个目录会暴露配置等私有文件 | core-manager `config/mod.rs::managed_unix_endpoint` 强制 socket 位于 runtime 内；IPC `api/status.rs::ConfigRevisionInfo` 说明 runtime 为 `0700`        | 独立控制端点目录和窄权限适配器；保留私有 runtime 的权限与验证器                           |
+| P0   | daemon 的管道 ACL 工具并不能直接控制第三方核心创建的管道                                            | `backend/nyanpasu-runtime/nyanpasu_ipc/src/server/mod.rs::create_server` 把安全描述符传给自己创建的 listener                                           | Windows 单独验证核心管道及重建权限；不把“生成 SDDL”当作已解决访问问题                     |
+| P1   | 新动词不在现有单一 Reconcile 协议内，新增一套操作路径；仅捕获未知方法不足以保证旧服务兼容           | IPC `api/core/v2.rs`；`backend/tauri/src/core/service/compat.rs` 已有显式最低版本门                                                                    | 扩展现有 Reconcile DTO，复用版本门；禁止旧 daemon 静默忽略新设置                          |
+| P1   | 安装参数不是持续生效的应用设置来源；daemon 重启、宿主切换和后续普通 reconcile 都可能丢设置          | service-runtime `cmds/install.rs`、`server/manager_bridge.rs`；tauri `client/core_lifecycle/workflow.rs::reconcile`                                    | 每次应用 Reconcile 都携带完整设置；daemon 不另存应用偏好                                  |
+| P1   | 只检查 manager 自身探针不能证明普通 GUI 可连接 root/SYSTEM 创建的端点                               | tauri `core/actor_v2/api.rs` 和 `endpoint.rs::api_connection`：GUI 后端直接访问核心 API                                                                | 服务验收必须包含非提权 GUI 的 REST 和 WebSocket；区分核心能力与宿主可达性                 |
+| P1   | 未覆盖子模块、服务版本和实际 sidecar 的发布一致性                                                   | `.gitmodules`；`backend/Cargo.toml` 关于发布 tag 与服务下载版本的约束                                                                                  | runtime 先完整实现及发布，主仓库更新 gitlink、兼容门和打包版本                            |
+| P2   | Local 状态不必另取 credential-bearing API binding，否则可能拼出跨实例快照                           | core-manager `state.rs`、`manager/publish.rs` 已发布无 secret 的 controller                                                                            | 从同一 `CoreStatus` 映射 controller；Service 从 `CoreInfos` 映射                          |
+| P2   | “仅 HTTP”可能仅改变客户端选择，源配置残留 pipe/unix 仍被核心监听                                    | core-manager `config/mod.rs::prepare` 在不改写 IPC 时只用 `inspect_http`，没有删除源 IPC 字段                                                          | 显式应用通道设置时统一规范化三个 controller 键                                            |
+
+能力探测及 HTTP/UnixSocket/NamedPipe 客户端抽象可以复用。版本下限以 `nyanpasu-core-metadata/src/feature/clash.rs` 的实现与测试为准；它证明声明的核心能力，不证明双监听、GUI 权限或实际二进制行为。
+
+## 3. 服务分类与依赖方向
+
+```text
+Tauri command / UI
+  -> NyanpasuClient
+    -> CoreLifecycleActor（串行工作流，读取已提交状态）
+      -> RuntimeIntentBuilder（纯服务）
+      -> CoreFacade / CoreClient（现有路由与宿主交接）
+        -> LocalEndpoint -> CoreControl
+        -> ServiceEndpoint -> daemon IPC Reconcile -> CoreControl
+          -> 现有 core-manager 执行器 / manager 生命周期
+            -> 注入的控制端点权限适配器
+```
+
+| 组件                                   | 分类与职责                                                                                    |
+| -------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 应用状态 actor                         | 持久化期望设置；schema、默认值、patch 使用纯类型与函数                                        |
+| CoreLifecycleActor                     | actor service；串行构建并提交运行意图，协调提交后的副作用                                     |
+| CoreClient / 路由 actor                | actor service 的 typed client；沿用宿主交接与操作归属，不在此读取 globals                     |
+| ServiceHostActor                       | actor service；仅负责 daemon 安装、启动、退出、兼容探测与 endpoint 供给，不持有另一份通道偏好 |
+| RuntimeIntentBuilder / controller 改写 | pure service；显式输入设置、能力与配置，输出意图或有效配置                                    |
+| CoreManagerService / ServiceEndpoint   | adapter；做 wire/domain 转换并调用现有控制执行器，不另开策略锁或后台循环                      |
+| 控制端点权限适配器                     | adapter/port；宿主注入授权身份、端点根目录、命名空间与 OS 操作，生命周期由现有 manager 管理   |
+
+本功能不新增 `ControlChannelActor`，也不顺带重写成熟的 CoreControl 执行器为 ractor。复用已有状态所有者，新增依赖由 Local composition root 和 daemon `server::run` 显式构造。核心域和 manager 不引入 Tauri 类型。
+
+## 4. 设置模型及运行语义
+
+### 4.1 持久化与不可变请求
+
+应用 schema 新增：
+
+- `clash_control_channel: ClashControlChannel`，serde `prefer_ipc` / `http_only`，缺失默认 `prefer_ipc`。
+- `clash_ipc_disable_http_controller: bool`，缺失默认 `false`。
+- `IVerge` 按既有双 schema bridge 使用对应 `Option<T>`，补全正反映射与默认投影。
+
+core-manager 定义值类型 `LocalIpcSettings { policy, keep_http_controller }`。应用到 domain 的映射为纯函数：`PreferIpc -> Prefer`，`HttpOnly -> Disable`，`keep_http_controller = !disable_http`。HTTP only 下开关保留用户值但不生效。
+
+将设置放入 `RuntimeIntent`、`ReconcileRequest`，并传入 `InstanceSpec` / epoch plan；请求进入队列后不再读取可变偏好。`ManagerOptions` 的现有策略仅作为旧调用者/CLI 的构造默认，不增加运行期 setter；无显式设置的调用在入队前解析默认值。新的应用调用始终显式传完整设置。
+
+设置必须参与 `CoreCommand::payload_digest`，不要仅塞入当前不参与摘要的 `InstanceOptions`。配置文本摘要仍只校验配置字节，不能与操作身份摘要混淆。源 YAML 不变但设置变了仍要经过有效配置比较，不能被 source hash 提前判为 Noop。
+
+### 4.2 行为矩阵
+
+| 期望设置             | 核心及宿主具备可用 IPC | 有效配置与主控制通道                                     |
+| -------------------- | ---------------------- | -------------------------------------------------------- |
+| PreferIpc，保留 HTTP | 是                     | 写受管 IPC，保留源 HTTP，主通道 IPC                      |
+| PreferIpc，关闭 HTTP | 是                     | 写受管 IPC，移除 HTTP，主通道 IPC                        |
+| PreferIpc，任意开关  | 否                     | 清理源 pipe/unix，保留源 HTTP，主通道 HTTP，返回回退原因 |
+| HttpOnly，任意开关   | 任意                   | 清理源 pipe/unix，保留源 HTTP，主通道 HTTP               |
+
+需要 HTTP 时若源配置没有合法 HTTP controller，则显式报错，不猜端口或 secret。开关只管理本计划所列三个 controller 键；实现前核对所支持核心是否还有其他 HTTP/TLS 控制监听，若有则一并定义关闭规则，不能对仍可访问的 HTTP 入口声称“已关闭”。
+
+停止状态修改设置只持久化，不启动核心、不启动 daemon。运行中修改后提交一次包含配置与设置的 Reconcile，由 manager 决定 Noop/Restarted/Switched 等结果，不在 UI 或 endpoint 再叠加一次 restart。
+
+已提交配置不因运行失败回滚；按现有部分提交/降级结果报告“已保存但未应用”。旧运行实例保留或事务回退时，状态展示其真实通道。快速连续修改最终收敛到最新已提交快照；TUN 与通道一起修改合并为一次提交后的重建。
+
+### 4.3 核心改写必须反映到配置 snapshot（2026-09-08 补充）
+
+这里的 snapshot 包含配置检查页使用的运行配置快照图，不仅是 `CoreStatusSnapshot.controller`。当前 `client/core_lifecycle/workflow.rs::reconcile` 在 host 应用前发布 `RuntimeSnapshot`；`client/runtime_inspection.rs` 只读取 promoted pipeline graph。manager 的 `EpochPlan` 已保留 `source_document` 与 `effective_document`，但尚未接回应用快照。因此只扩展状态 controller 不能满足“核心改写在 snapshot 中可见”。
+
+审计发现的 manager 配置转换：
+
+| 转换                      | 当前行为                                                                                                                                                        | snapshot 语义                                                                                |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| 控制通道改写              | 删除/重写 `external-controller`、`external-controller-pipe`、`external-controller-unix`；本计划增加保留 HTTP 与 fallback 规范化                                 | 稳态有效配置的一部分，必须反映真实 endpoint、HTTP 保留/移除及 diff                           |
+| Mihomo bootstrap 入站处理 | `config/mihomo.rs::zero_inbounds` 将已存在且非零的 `port`、`socks-port`、`redir-port`、`tproxy-port`、`mixed-port` 置零；将原本为 true 的 `tun.enable` 置 false | 仅 graceful switch 过渡配置；不得当作最终已应用配置。诊断中展示时明确标记 bootstrap/候选实例 |
+| canonicalize / serialize  | 映射键排序及 YAML 序列化规范化                                                                                                                                  | 不视为业务字段改写；diff 按配置值比较，避免排序噪声                                          |
+
+当前检查的 manager prepare/apply/switch 调用链中，未发现除此之外自主修改稳态业务配置的逻辑。PATCH 字段筛选是提交核心 API 的请求构造，DNS adapter 是 OS 副作用，均不应伪装成额外的最终 YAML 改写；应用 enhance pipeline 的其他转换已有自己的上游 snapshot 节点。
+
+实施要求：
+
+1. 保留不可变的生成产物 `promoted`，增加与之关联的 host 有效配置视图；配置检查图追加“核心有效配置”节点及 source → effective 的 diff。不能覆盖原生成节点，也不能将受管 socket 路径回写成下一次 Reconcile 的源配置。
+2. manager 提供原子读取的有效配置快照，携带 host 侧实例 ID、revision（含 source/effective hash）、配置及应用阶段。读取由现有状态所有者串行完成，不让应用直接读取服务私有配置路径或跨锁拼接 controller 与文档。语义是 manager 已确认的有效配置，不承诺包含核心自身未上报的默认值或第三方修改。
+3. Local 通过 typed endpoint 读取；Service 增加受现有 IPC 授权保护的只读 effective-config 查询与对应 DTO。该查询纳入本轮服务版本门和发布闭环；不会引入第二条变更通道。完整配置按需查询，状态事件只承载实例/revision 等失效标识。
+4. CoreLifecycleActor 将操作 ID、构建 snapshot ID 与返回 revision 关联，并校验查询结果的实例/revision。源码 hash 相同不代表同一次构建；迟到结果、宿主变化或查询时实例已替换，必须丢弃或重新获取，不能把 A 实例的 effective 节点挂到 B 构建上。
+5. `Started/Patched/Reloaded/Restarted/Switched/Noop` 的成功终态均关联真实有效快照；失败或 `RolledBack` 保留旧实例的 applied 视图，并把新生成产物标为未应用。有效配置查询失败时显示未知/待刷新，不用 promoted 配置冒充已应用结果。自动重启、恢复及宿主交接通过现有状态订阅重新校验绑定。
+6. bootstrap 不是最终节点：只有 full config 提交并确认成功后才能标记 applied。过渡期保留旧已应用视图并标记切换中；如展示候选配置，明确区分实例与 bootstrap 阶段。本轮不扩展为通用的全生命周期快照历史系统。
+7. 完整配置只经受控的配置检查 API 按需提供，不加入通用状态、日志或广播事件。公开检查内容中的 secret 等凭据作脱敏投影；revision/hash 仍取原始有效配置的结果，不对脱敏 YAML 重新计算后冒充运行 revision。
+
+验收补充：IPC endpoint 和 HTTP 字段变化可在最终 snapshot/diff 中看到；HTTP fallback 与实际配置一致；bootstrap 置零/关闭 TUN 不污染最终 applied 节点；回退保留旧配置；Noop 可正确关联新生成产物；过期查询和重复 source hash 不发生串线；Local/Service 的有效配置视图语义一致，且不泄漏凭据。
+
+## 5. core-manager 事务与切换
+
+1. 设置沿 prepare、check、apply、switch、bootstrap/full config 全链路显式传递。同一事务内能力解析和改写使用同一份设置。
+2. 自动 respawn、手动重启及失败回退使用对应实例/epoch 保存的设置，不能使用后来到达请求的设置。
+3. 统一 controller 改写函数支持保留 HTTP，并保证 HTTP fallback/HTTP only 不遗留非受管 IPC。旧无显式设置入口确需保留旧语义时，按仓库要求标注迁移原因和移除条件，不让新应用经过该兼容入口。
+4. 判断 graceful switch 时检查旧、新有效配置的 HTTP controller 监听面。任一侧存在 HTTP controller 监听时保守退化为 hard switch，并给出明确原因；本轮不实现临时随机 HTTP 端口或控制器端口迁移。
+5. IPC-only 的原有 graceful switch 继续沿用现有入站/DNS/核心能力门槛。关闭 HTTP 并不意味着其他监听没有冲突。
+6. 有效配置校验在破坏旧实例前完成；事务失败沿用既有 rollback/quarantine/stop proof，不能通过改全局策略规避。
+
+验证：纯配置矩阵、设置改变但 source hash 不变、重复提交幂等、同 ID 不同设置冲突、并发请求隔离、CAS 失败无副作用、带 HTTP 的切换不并行占端口、失败回退保留旧设置、respawn 重建端点。
+
+## 6. 服务模式设计（关键路径）
+
+### 6.1 协议与生命周期
+
+扩展 `nyanpasu_ipc/src/api/core/v2.rs::CoreCommandInfo::Reconcile` 的结构化通道设置 DTO，复用 `CoreV2Submit` / operation query；不新增 `CoreV2SetLocalIpc` 路由。
+
+- wire DTO 与 manager 类型显式转换；不把 manager 内部对象、调用者路径或授权身份透传为服务端输入。
+- 兼容旧客户端时，缺失字段解析为 daemon 构造默认；在服务端 admission 时固定下来，并纳入最终入队操作身份。增加所需的 `TODO(actor-migration)`，移除条件是停止支持缺字段的客户端。
+- 新应用通过 `core/service/compat.rs` 的最低版本门确认 daemon 支持此语义后才进入 Service endpoint；版本解析失败或过旧不得试着提交再凭结果猜测。旧 daemon 可能静默忽略未知字段。
+- bump 到包含本协议的实际服务发布版本，并同步最低版本；不在计划中编造尚未发布的版本号。复用现有不兼容提示和服务管理流程，不新增自动卸载/重装。
+- 保留现有 `--local-ipc-policy` 作为独立 CLI/旧调用者默认，应用不再通过安装参数同步日常偏好，也无需为本功能再加一套安装配置持久化。
+- 每次首次启动、普通重建、核心切换、Local↔Service 交接后的目标 Reconcile 都带设置。daemon 重连不应无条件启动已停止核心；复用现有恢复工作流，在下一次需要 Reconcile 时携带最新设置。
+- 交接前先验证目标兼容性；旧服务不兼容时不停止 Local 核心。不因为应用设置已保存就停止旧服务或自动换宿主。
+- 请求超时属于结果未知：保留原 operation ID 查询结果，不自动换 ID 重做，更不能退回另一条非事务 setter 路径。
+
+验证：现有 `server/routing/tests.rs` harness 覆盖 DTO 与映射、终态查询、幂等冲突、默认兼容；actor fake endpoint 覆盖宿主交接、断连重连与旧版本门。
+
+### 6.2 明确两个 IPC 边界
+
+1. **GUI → daemon**：现有 nyanpasu-ipc socket/pipe，用于生命周期请求及读取 API binding。
+2. **GUI 后端与 daemon → 核心**：核心自己创建的 socket/pipe，承担 Clash REST / WebSocket。首页“控制通道”展示的是这一条。
+
+daemon 以 root/SYSTEM 探测成功不能证明 GUI 可达；`CoreApiConnection.secret` 只留在私有后端 binding，不进入首页、状态事件或日志。HTTP 关闭时，GUI 的代理查询、选择、连接管理及订阅仍须能工作。
+
+### 6.3 Unix：独立端点目录，保留私有 runtime
+
+- 增加受注入的控制端点根目录，默认 Local 可沿用自身私有目录；Service 使用私有 runtime 之外的独立目录，只存 socket。
+- manager 的 `managed_unix_endpoint` 改为校验注入的端点根目录，而非简单删除现有路径限制。根目录由宿主创建并规范化，禁止调用者请求指定绝对路径。
+- 服务目录 owner 为服务账户，授权范围复用安装时建立的 `nyanpasu` 用户组；目标模式为目录 `0750`、socket `0660`，父目录也须可遍历。组不能写目录，私有配置/日志/runtime 不扩大权限。
+- 权限 adapter 在每次核心创建/重建 socket 后、对外宣告控制端点就绪前执行授权与验证；启动、自动 respawn、切换和失败清理共用同一生命周期钩子。
+- adapter 验证路径属于受管根、对象确为预期 socket、owner 合法且不是符号链接替换；仅清理本 manager/epoch 拥有的端点。
+- 命名包含宿主/安装实例命名空间与 epoch，避免多个 manager 都从 epoch 1 开始导致碰撞；覆盖 Unix 路径长度限制。
+
+实测必须用属于授权组的非 root GUI 进程完成连接；另验证未授权用户不能访问。安装后组成员身份尚未进入当前 GUI 会话时，明确报告访问问题，不能仅凭磁盘上的组成员表宣称就绪。
+
+### 6.4 Windows：核心 pipe 的创建与重建独立验证
+
+- pipe 名称使用宿主/安装实例命名空间与 epoch，避免 Local 与 Service 冲突。
+- 授权目标沿用服务安装的明确 SID 集合及 SYSTEM/管理员；不默认放宽到所有 Authenticated Users。
+- daemon listener 的 `generate_windows_security_descriptor` 只能复用描述符构造部分。核心管道能否在创建时设 ACL、是否允许受控修改、每个 pipe instance 重建是否保留授权，必须针对实际 mihomo/clash-rs 二进制验证。
+- 权限处理封装在 Windows adapter，由 manager 生命周期调用；没有可靠的创建/重建保证时，该核心/宿主组合标记为不具备可用 IPC。
+- 本轮不新增通用 API relay/proxy。如果直接连接方案不可行，PreferIpc 在该组合使用 HTTP 并报告原因；不能交付一个仅 SYSTEM 探针可达的 IPC 状态。
+
+### 6.5 回退边界与发布门槛
+
+分开记录“核心实现了 IPC”与“当前宿主能提供符合权限约束的 IPC”。前者来自 metadata，后者来自注入 adapter 的平台支持及检查结果。
+
+- 启动前已知不支持时，Prefer 回退 HTTP，Force 报错。回退不修改已保存偏好；关闭 HTTP 开关在 IPC 不可用时不执行。
+- 本轮不把任意启动失败、探针超时或 GUI 断连解释为 IPC 不支持。实际授权失败走有限超时和原事务失败/回退旧实例；输出具体原因，不无限启动重试、不盲目打开 HTTP。
+- GUI 对已发布 binding 的真实访问失败不能显示为“已验证连接正常”；通道名称与健康/可达性分开呈现。
+- 每个平台的服务 IPC 只有通过授权 GUI 的 REST、WebSocket、核心自动重启和并发实例测试后才能宣称支持；未验证组合按宿主不支持处理，并列入发布限制。
+
+## 7. 应用接线与状态展示
+
+1. 修改 `nyanpasu-config/src/application/mod.rs`、tauri `config/nyanpasu/mod.rs`、`bridge/mapping.rs`、`bridge/verge.rs` 及实际 schema/patch 派生所需调用点。验证旧配置、序列化回写、两个方向映射和默认值一致。
+2. `client/core_lifecycle/workflow.rs::reconcile` 使用本轮已读取的 application snapshot 构建通道设置；让 runtime 构建产物与 RuntimeIntent 显式携带该值，避免第二次独立读配置。
+3. 更新 `core/actor_v2/intent.rs`、`facade.rs`、`endpoint.rs` 和 Local/Service 提交映射。继续通过 `NyanpasuClient` 的普通 async 应用 API 调用，无需向上暴露设置 setter 或 ActorRef。
+4. `bridge/verge.rs` 的提交后重建条件合并 TUN 与两个通道字段；检查实际值变化，停止时只保存。保留现有提交失败与部分成功的区别，前端收到部分成功后重新读取已持久化值，避免乐观回滚显示错误设置。
+5. `CoreStatusSnapshot` 与 `CoreStatusInfo` 增加 `controller: Option<CoreControllerInfo>`。Local 从同一份 manager `CoreStatus.controller` 映射，Service 从同一份 `CoreInfos.controller` 映射，HTTP 映射沿用服务端去除凭据的规则。
+6. 从 `CoreStatusInfo` 到 `useCoreStatus` 保持状态失效/刷新链路；停机、交接、断连时清除或明确标记过期 controller，不能残留前一宿主的通道。
+7. 重新生成 Specta bindings，更新所有相关 mock/status 构造点。Secret 不加入任何公开 DTO。
+8. 设置页 PortSettings 后新增选择器和开关；HTTP only 时禁用开关但保留保存值。首页只显示通道种类，不展示内部路径。`None` 显示未知/未运行，不能推断成 HTTP。
+9. 补齐 en、zh-cn、zh-tw、ko、ru；开关说明明确 Web UI/第三方 HTTP 客户端将不可用。主通道显示 IPC 不代表 HTTP 已关闭。
+
+保留 `get_clash_info` 的旧返回形状，但审查其调用者：应用内部核心操作必须走现有实例绑定 API，不能继续依赖该 HTTP 地址。纯 Web UI/外部访问链接保留 HTTP 语义，不用它来判断首页主通道。
+
+## 8. 实施顺序与验收
+
+### 阶段 0：隔离环境与服务可达性验证
+
+功能实施在仓库外独立 worktree；本次文档审计不创建功能 worktree。初始化 `backend/nyanpasu-runtime` 子模块并核对版本。按 AGENTS.md §17 仅复用 `sidecar/`、`resources/`，独立安装 node_modules，独立 target 与 dist。Rust-only 可用 frontendDist 占位，UI 验收必须真实构建。
+
+先验证三个平台上目标核心的双监听、非提权服务 IPC、管道重建和端点命名，记录核心版本/运行账户/结果。此阶段决定平台 adapter 的支持范围；不把 macOS 实测替代 Windows/Linux 验收。
+
+→ 出口：端点权限方案及支持矩阵有证据；构建前置条件完整。
+
+### 阶段 1：runtime 内完成完整事务与服务实现
+
+完成 §4–6：不可变设置、幂等身份、配置改写、有效配置快照读取、hard switch 判定、权限 adapter、wire 转换与服务默认兼容。同步 runtime workspace 内所有调用者及测试，不能提交无法构建的 DTO 半迁移。
+
+→ 验证：
+
+```bash
+cargo test --manifest-path backend/nyanpasu-runtime/Cargo.toml -p nyanpasu-core-manager
+cargo test --manifest-path backend/nyanpasu-runtime/Cargo.toml -p nyanpasu-ipc --all-features
+cargo test --manifest-path backend/nyanpasu-runtime/Cargo.toml -p nyanpasu-service-runtime
+cargo fmt --manifest-path backend/nyanpasu-runtime/Cargo.toml --all -- --check
+```
+
+上述命令不能替代权限实测。测试用 fake adapter/typed request/显式事件同步，不用 sleep 猜 readiness。
+
+### 阶段 2：应用全链路及 UI
+
+完成 §4.3 与 §7 的应用接线，补充 snapshot 图及已应用视图、停止修改、并发修改、部分成功、宿主切换、旧 daemon 拒绝以及状态无 secret 的测试。把设置始终随构建快照传递作为集成验收重点。
+
+→ 验证：
+
+```bash
+cargo test --manifest-path backend/Cargo.toml export_typescript_bindings --all-features
+cargo test --manifest-path backend/Cargo.toml --all-features
+cargo clippy --manifest-path backend/Cargo.toml --all-targets --all-features
+cargo fmt --manifest-path backend/Cargo.toml --all -- --check
+pnpm -F interface build
+pnpm typecheck
+pnpm lint:oxlint
+pnpm lint:architecture-ledger
+pnpm web:build
+```
+
+对本次文档、TS/TSX/i18n 运行定向 Prettier 检查。根 package.json 没有 `pnpm check`，不使用原稿的占位命令。环境缺失或既有失败单独记录，不能声称验证通过。
+
+### 阶段 3：端到端与发布闭环
+
+| 场景                                 | 必须验证                                                            |
+| ------------------------------------ | ------------------------------------------------------------------- |
+| Local 与 Service，Prefer + 保留 HTTP | GUI 实际走 IPC；REST/WS 均通；HTTP 同时可用                         |
+| Prefer + 关闭 HTTP                   | GUI 功能保持；HTTP 实际不再监听；外部客户端行为符合说明             |
+| Premium/低版本/宿主不支持 IPC        | HTTP fallback、可见原因、期望设置不变                               |
+| HttpOnly，源 YAML 带自定义 pipe/unix | 实际只保留受管规则允许的 HTTP 控制通道                              |
+| 保留 HTTP 时重启/切核心              | 无新旧实例 HTTP 端口争用；正确 hard switch 与失败恢复               |
+| Service 核心自动重启                 | 新 socket/pipe 权限有效，旧绑定失效，WS 能重新订阅                  |
+| Local↔Service、daemon 重启、应用重启 | 每次所需 Reconcile 设置一致；无停止意图被意外启动；无跨宿主状态残留 |
+| 旧 daemon、RPC 超时、权限失败        | 不静默忽略、不重复执行、不误报应用成功                              |
+| 多实例、未授权账户                   | 命名不冲突，清理不越界，未授权访问失败                              |
+
+runtime 是独立仓库：先完成源码、版本 bump、测试和对应服务制品发布；主仓库正式 gitlink 指向含该功能的已发布 tag。同步 `REQUIRED_SERVICE_MIN` 并验证 `scripts/check.ts` 获取的服务版本就是协议实现版本，不能只对照本机旧 sidecar。
+
+开发调试使用新构建的 daemon 时明确实际路径；不要覆盖 symlink 指向主 checkout 的共享 sidecar。发布、安装实机服务是后续实施动作，本次审计不执行。
+
+## 9. 提交边界与完成标准
+
+- runtime 子模块：按可独立构建的依赖边界拆分；不可变请求与所有受影响调用者在同一原子提交完成，配置语义/权限实现可在不留半成品的前提下独立提交。协议服务能力与发布版本必须一致。
+- 主仓库：gitlink、必要的 Rust 调用者迁移、schema、兼容门及 bindings 放在一个可构建提交；UI 与 i18n 可独立提交。
+- 不采用原稿“core-manager setter → 新路由 → app setter”的提交顺序；那会保留第二条生命周期变更路径。
+- 提交前只显式 stage 相关文件，检查 status 与 cached diff；不处理现有无关文件。
+
+完成标准：设置保存、事务应用、实例恢复、Service 普通用户访问、状态展示和实际发布二进制六者一致。未完成某个平台实测时，交付说明必须列明其 HTTP 回退限制，不能笼统声称服务 IPC 已全面支持。
+
+## 10. 实施记录（2026-09-08）
+
+实现位于独立 worktree `/private/tmp/clash-nyanpasu-control-channel`，分支 `feat/core-control-channel`；runtime 子模块的源码修改也在该 worktree 内。范围为控制通道、服务权限和对应有效配置 snapshot，不扩展其他服务迁移。
+
+- 请求级 `LocalIpcSettings` 随 Reconcile 冻结，纳入 payload digest；未提供设置的旧调用者在提交入口解析一次默认值。应用始终显式传入同一次构建所用设置，没有独立 setter。
+- `ConfigSnapshotSink` 是 core-manager 的可注入上报 port；`RuntimeSnapshotSink` 是应用生成/应用快照存储 port。有效配置查询携带实例身份和完整 revision，应用通过宿主 generation 与 revision 校验关联。新增 `CoreController` 节点，以及最近成功应用快照视图；生成产物不被覆盖，bootstrap 不作为最终 applied 节点。
+- HTTP 控制字段还包含 `external-controller-tls`，已纳入关闭 HTTP 和 hard switch 判断。除此以外，manager 的 bootstrap 入站端口置零与临时关闭 TUN 仍仅是过渡配置，不改变本轮范围。
+- Unix Service 使用独立 `/var/run/nyanpasu-core`，目录 `0750`、socket `0660`，授权给既有 nyanpasu 组；每次 readiness（包含自动重启）重新授权。路径/文件类型/所有者检查失败则报告错误。宿主无法建立授权目录时 Prefer 回退 HTTP；Windows Service 暂不声明 pipe 支持，明确回退 HTTP。
+- 独立 socket 目录按 epoch 清理；崩溃恢复仅清理有 runtime 记录、且进程已确认退出的 endpoint。socket 名称的目录哈希采用 16 位十六进制，避免 macOS 路径长度限制；同时校验实际 socket 路径长度。
+- daemon 源码版本与应用最低兼容版本同步为 `2.0.0-rc.4`。该版本尚未发布，主仓库 gitlink 暂指向 runtime PR 的审核提交，合并前需更新到正式发布版本；现有 rc.3 服务将被兼容门拒绝。未覆盖共享 sidecar、未安装或发布 daemon。
+
+验证记录：应用后端 workspace library 回归通过（应用 500 项通过、1 项忽略），随后新增 rc.3 拒绝用例单独通过；bindings 导出、interface 构建、前端构建、TypeScript、Oxlint、架构门禁和 Clippy 通过（保留既有警告）。本机四类真实核心原有 20 项测试通过；新增 mihomo/clash-rs 三种通道设置切换的 2 项实机测试通过，包含 HTTP 监听和有效 snapshot 一致性断言。
+
+runtime 最终定向回归：core-manager library 106 项通过、1 项忽略，控制通道集成 2 项通过（另 2 项真实核心用例已显式运行通过），service-runtime 87 项通过。完整 runtime workspace 回归仍有未改动的 `version_probe_is_cached_by_path_and_mtime_and_supplied_versions_skip_it` 失败：macOS 临时复制二进制在修改 mtime 后版本探测以 `process exited with code None` 退出。服务测试此前发现的 socket 长度误拦截已修复并全部复验通过；不将完整 workspace 标记为全绿。相关日志在 `/private/tmp/control-runtime-complete.log`、`/private/tmp/control-service-final.log` 和 `/private/tmp/control-manager-final.log`。
+
+发布前仍需：Linux/Windows 平台验证、Unix root daemon → 普通 GUI 用户的 REST/WS 与拒绝未授权用户实测、正式服务制品发布及 gitlink 更新。这些不能由本机同用户 socket 权限测试或 Local 实机测试替代。
+
+## 11. Snapshot 审计修补（2026-09-09）
+
+后续架构安排见 [配置追踪与 Snapshot Store Roadmap](../roadmap/2026-09-09-tracked-config-and-snapshot-store.md)。本节更新 §10 中的接口状态，原测试记录保留为当时结果。
+
+- 删除 manager 锁内执行的 `ConfigSnapshotSink` 回调，改为 `subscribe_config_commits()` 返回 owned snapshot 的合并式订阅。不会将慢消费者、panic 或存储失败传播到核心事务；订阅只表示配置提交，当前运行状态仍需查询。
+- 应用 `RuntimeSnapshotSink` 写侧 trait 收敛为具体 `RuntimeSnapshotStore`，通过生命周期启动参数注入，同一个实例承担读写。完整 reader/writer 能力拆分在后续 P1。
+- 成功 reconcile 先记录 revision 与宿主 generation 绑定；effective 内容暂不可用时保留 pending。重新打开 inspection 只读补齐，不重跑 reconcile；较新绑定排除过期结果，失败候选不覆盖历史。
+- CoreController 通过统一 `append_transition` 追加，复用 JSON Patch、changed fields 和图校验；空 diff 为 `None`。
+- 进程差异改用显式字段比较；IPC 偏好解析后没有运行差异时返回 Noop，同时保留最新策略供 restart 使用。utils 的 Backoff 增加值相等比较。
+
+本轮不实现完整 ConfigWorkspace 或配置批次 ChangeSet；也不改变已有服务发布与跨用户验证门槛。

--- a/docs/roadmap/2026-09-09-tracked-config-and-snapshot-store.md
+++ b/docs/roadmap/2026-09-09-tracked-config-and-snapshot-store.md
@@ -1,0 +1,204 @@
+# 配置追踪与 Snapshot Store Roadmap
+
+日期：2026-09-09
+
+状态：P0 为当前审计修补；P1–P3 为后续交付，不能据此声称已经完成统一配置 wrapper。
+
+审计来源：[Snapshot Store 架构审计](https://chatgpt.com/share/6aa03799-76a0-83ea-8de6-3c3168e55ebf)。审计基线为应用 PR [#5227](https://github.com/libnyanpasu/clash-nyanpasu/pull/5227) 的 `cb3b161`、runtime PR [#414](https://github.com/libnyanpasu/nyanpasu-runtime/pull/414) 的 `3a003e0`。以下安排结合代码核对结果；外部审计的测试描述不作为本地测试证据。
+
+关联：[控制通道实施计划](../plan/2026-09-07-core-control-channel-ipc.md)。本 roadmap 接续该计划的快照部分；服务发布门槛继续有效。
+
+## 1. 目标与责任边界
+
+最终目标是让派生配置的修改、记录和冻结不可分离，同时让应用配置的持久化提交与副作用具有清楚的边界。
+
+| 组件                                      | 权威内容                                                 | 类型与边界                                      |
+| ----------------------------------------- | -------------------------------------------------------- | ----------------------------------------------- |
+| Application / Profiles / Clash 配置 actor | 已提交的期望配置及版本                                   | Actor service；持久化由注入的 port 完成         |
+| ConfigWorkspace（待实现）                 | 一次 pipeline 执行的当前值及转换记录                     | Pure service；不拥有文件、网络或后台任务        |
+| core-manager / EpochPlan                  | 已提交给受管核心的有效配置、revision、实例及事务状态     | 生命周期服务；实际通道决策仍在这里              |
+| RuntimeSnapshotStore                      | 应用观察视图、成功应用关联、尚未获取的内容、最近成功快照 | 有界的具体读写 wrapper；本轮内部使用私有 watch  |
+| ConfigCommitSubscription                  | 最近一次配置提交通知                                     | 观察 port；不是完整状态存储，也不是可靠事件日志 |
+| Tauri / UI                                | inspection DTO 和交互                                    | Adapter；不直接改写上述权威状态                 |
+
+IPC 职责保持不变：应用冻结用户偏好；宿主 adapter 提供目录和授权能力；manager 结合核心能力、epoch 与当前实例选择实际通道及切换路径。GUI → daemon 的控制协议兼容性由服务层处理。应用 pipeline 不提前分配受管 socket 路径。
+
+不在此路线中引入全局 store、通用 service locator、持久化 actor → core-manager 的同步调用环，或两仓库共享的庞大 graph 框架。
+
+## 2. 必须保持的不变量
+
+1. 期望配置先提交，再规划副作用；副作用失败报告降级，不静默撤销成功提交。
+2. generated、成功应用关联、effective 内容、当前运行实例是不同事实，不用单个 `applied` 布尔替代所有状态。
+3. 应用成功但 effective 查询失败，只改变 inspection 可用性；恢复过程只能读核心，不能再次 reconcile。
+4. 内容必须与成功应用的完整 revision、宿主及宿主 generation 匹配。相同 source hash 不能证明属于同一运行请求。
+5. 新生成失败候选不清除最近成功应用历史；旧查询完成不能覆盖较新的成功关联。
+6. manager 的提交通知不能执行注入代码或向消费者泄漏锁 guard；消费者阻塞或 panic 不影响核心事务。
+7. runtime 改写通过统一 transition API 附加到 inspection；不把受管端点回写为下一次生成的源配置。
+8. 空变化、嵌套字段、数组、独立分支的 diff 语义只有一套实现。
+9. bootstrap 仅是过渡配置；rollback 保留旧提交；stop 后历史记录不代表当前仍在运行。
+10. 原始配置可能含凭据。日志和普通状态事件不携带配置正文；inspection 在生成 YAML 与 diff 前脱敏。持久化 raw snapshot 必须先另行设计访问权限及保留策略。
+
+## 3. 审计问题与阶段映射
+
+| 审计问题                                         | 当前处理                                                                          | 后续责任                                                         |
+| ------------------------------------------------ | --------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| 首次 effective 查询失败后无法恢复                | P0 保存成功绑定与 pending 内容；打开 inspection 时只读重试，身份校验后补齐        | P1 完善 unavailable / superseded / 当前实例的 UI 状态            |
+| sink 在 manager 事务锁内执行                     | P0 删除回调式 `ConfigSnapshotSink`，改为私有提交槽和返回 owned snapshot 的订阅    | 只有确有落盘需求时才增加外部持久化消费者及其生命周期             |
+| 应用只有写侧 trait，读仍固定在另一通道           | P0 使用具体 `RuntimeSnapshotStore`，由 `CoreLifecycleArgs` 注入，读写来自同一实例 | P1 分离 reader / writer 能力；存在第二种真实实现时才抽完整 trait |
+| CoreController 手工改图、顶层 diff、空集合不一致 | P0 `append_transition` 复用 JSON Patch、changed-fields 与图校验                   | P2 将 pipeline 当前值和 recorder 合为 owner                      |
+| 策略变化导致相同 HTTP 配置也 Switch              | P0 显式比较进程选项；策略由 effective 配置差异判定；Noop 保存新期望策略           | P2 抽纯 ControllerPlan，继续覆盖 bootstrap / rollback / restart  |
+| 同一 YAML 没有冻结对应控制策略                   | 当前构建仍从同次 app 读取传递策略；未声称类型已完全封闭                           | P1 将策略收进冻结请求身份                                        |
+| actor 提交没有统一 ChangeSet                     | 维持现有提交协调，避免改变批量提交语义                                            | P3 在批次提交边界统一生成变更集与副作用计划                      |
+
+## 4. P0：本阶段修补
+
+### P0.1 成功应用关联与只读恢复
+
+`ReconcileReport` 保留已应用 revision 和提交时宿主归属，即使后续内容查询失败也不丢失事实。workflow 将带绑定的构建写入 pending；有效内容到达后才追加 `CoreController` 节点并更新最近成功视图。
+
+恢复入口是现有 generated / last-applied inspection 查询。每次读取至多尝试一次 pending 内容查询，沿用 CoreClient 的有限超时；不新增周期任务或无限重试。返回前校验宿主 generation、完整 revision，写回时再次校验 pending 构建身份。
+
+当新候选 C 已生成但未成功应用时，允许补齐之前成功的 B；只更新 B 的 applied 视图，不覆盖 C 的 generated 视图。较新的成功应用 D 则使 B 的晚到结果失效。持续不可用时保留 pending 与上次可读历史。
+
+### P0.2 提交通知隔离
+
+manager 内部保存最近提交的完整配置。`subscribe_config_commits()` 返回专用 reader，仅提供 owned 值与异步变更等待，不暴露 watch guard。消费者自行拥有执行与存储生命周期；manager 不调用消费者，不等待消费确认。
+
+慢消费允许合并中间提交；新订阅者可读取最近值；manager drop 关闭通知。stop 后最近提交仍是历史值。需要判断当前是否运行时必须调用 `effective_config()`，不能凭通知中的最后一条推断。此通知不是 respawn / stop 的完整事件流。
+
+本阶段删除尚未发布的回调式 API，并迁移当前全部调用者，不保留假装等价的 compatibility sink。应用侧具体 store 的注入不因此取消。
+
+### P0.3 图追加统一
+
+`ConfigSnapshotsGraph::append_transition(parent, tag, value)` 负责生成 JSON Patch、推导 changed fields、连接节点和验证候选图；错误不修改原图。materialized 与 stored graph 复用拓扑验证，原 archive 语义保持。
+
+测试必须覆盖与 builder 产生的图一致、空变化为 `None`、嵌套与数组路径、无效 parent / 图结构的原子失败。已有 archive、独立分支及深度限制测试继续执行。
+
+### P0.4 策略与进程差异分离
+
+显式比较核心类型、二进制、版本、features、工作目录及 startup / health / restart / backoff 等进程选项；`local_ipc` 不再因为出现在整个 options 的 Debug 文本中而触发 Switch。Backoff 需要上游 utils 提供值相等比较，这是一项最小基础类型变更，不增加运行时依赖。
+
+实际端点或监听面变化仍由最终配置分类决定。Noop 保持 live revision 与实例，更新 `source_spec` 和 `last_spec`，保证未来手动 restart 使用新策略。自动 respawn 继续使用当前 epoch 的已解析配置，不在后台重新协商出另一通道。
+
+### P0 出口
+
+- 上述四项的回归测试通过；记录完整 workspace 的失败与忽略项，不用定向通过冒充全绿。
+- 原 IPC 三种组合、HTTP fallback、服务授权测试无回归。
+- DTO / bindings / UI 文案同步，pending 不被展示为已确认当前运行。
+- 原始配置继续通过现有脱敏投影，不扩大一般状态事件载荷。
+- 代码可在隔离 worktree 审核；发布和跨用户验证不由本阶段自动豁免。
+
+## 5. P1：封闭观察 store 与冻结请求身份
+
+依赖：P0 完成。交付单位以应用仓库为主，避免同时改动所有 pipeline 步骤。
+
+1. 从同一 `RuntimeSnapshotStore` 派生 writer 和 reader 能力。workflow 只获得 generated / bind / resolve 写权限；inspection 获得 read 和窄化的恢复协调入口。禁止替换 writer 后仍读取旧 store。
+2. 定义 generated、pending、available、unavailable、superseded 的合法转换及展示规则。unavailable 记录安全的分类错误与最近尝试信息；不保存凭据或无界错误日志。失去宿主联系时不假装已经 stop。
+3. 明确两种判断：完整 revision 相同表示配置一致；instance_id 相同才表示同一进程。respawn 可以维持配置关联，但 UI 不得把新进程说成旧实例。stop 后保留历史，当前状态由核心查询决定。
+4. 引入冻结构建/请求类型，将生成配置身份、LocalIpcSettings 和必要的输入版本关联。序列化 bytes/hash 与完整请求 digest 分开命名，不能只凭 YAML hash 重放另一套策略。
+5. 仅在需求明确后选择自动恢复机制：复用已有状态刷新触发一次有界只读查询并合并并发请求。不要新增无主定时器；定义关闭、宿主切换和 superseded 时的取消行为。
+
+验收：注入两个独立 store 无串线；clone 的 reader/writer 共享同一状态；查询超时不触发 mutation；较新绑定排除旧结果；相同 YAML 不同策略的请求身份不同；stop、respawn、host-generation 变化各有明确断言。保留对没有第二种存储实现时使用具体类型的选择，不为测试引入生产 service locator。
+
+## 6. P2：配置修改与记录合为一个 owner
+
+依赖：P1 冻结身份；P0 统一 transition API。分为可独立评审的应用 pipeline 和 runtime 两步。
+
+### P2-A 应用 ConfigWorkspace
+
+- workspace 拥有当前不可变 ConfigValue 和 recorder，取消 executor 外部的另一份 `working`。
+- `step(tag, transform)` 内部完成读取当前 view、计算候选、校验、记录及推进当前位置。不得要求调用方再补一次 `record()`。
+- 对既有异步脚本，可采用带父节点身份的候选结果再原子提交；不能把可变权威引用交给脚本。日志与失败 passthrough 的现有策略保持不变。
+- 独立 composition 分支携带自己的 baseline，并通过明确的分支 API 接入；不破坏已有节点 key 与 inspection 选择稳定性。
+- `finish()` 消费 workspace，从同一最终节点导出 config、bytes、hash 和最终节点引用；外部不能分别填写不一致的 artifact 字段。若序列化失败，不产生部分可发布产物。
+- read view 带版本/节点身份且只读；纯函数可自由读取，导出 YAML 或脚本输入是合法边界，但不能由导出副本绕过 workspace 回写权威状态。
+
+迁移顺序：内建确定性步骤 → profile merge / composition → 脚本边界 → finalizing 和 artifact 生成。每条迁移调用链同时移除旧的双变量写法，不留下默认兼容旁路。若公开 API 暂时无法迁移，必须注明 blocker 和删除条件。
+
+验收：transform 返回错误后当前位置、值、图和产物均保持一致；失败脚本按原语义记录而不污染配置；空变化、删除、数组、嵌套和独立分支可回放；最终节点导出的内容与提交 bytes/hash 一致；外部无法取得可写当前值。
+
+### P2-B Runtime 的纯 ControllerPlan / PreparedEffectiveConfig
+
+- 在 manager 内部把策略、已解析能力、宿主目录、epoch 转为纯 ControllerPlan；没有应用的 ProfileId 或 OperatorTag 依赖。
+- 用受控入口构造 PreparedEffectiveConfig，区分 full 和 bootstrap；校验、hash、staging 读取同一冻结结果。
+- manager 输出通用的输入/输出身份与有效内容；应用 adapter 通过统一 transition API 映射到 CoreController。
+- runtime 文件存储、授权和进程仍在 adapters；pure plan 不隐式访问文件系统或分配进程。
+
+验收：真实通道切换、保持 HTTP 的 hard switch、fallback、bootstrap 端口/TUN 恢复、失败 rollback、自动 respawn、人工 restart 均不产生身份错配。任何共用库抽取须由已证明重复的算法驱动，不能让 runtime 反向依赖应用 inspection graph。
+
+## 7. P3：期望配置 ChangeSet 与副作用规划
+
+依赖：P1/P2 的清晰配置身份。涉及 Application / Profiles / Clash 配置 actor 和现有 bridge 提交协调；不合并成一个生命周期巨型 actor。
+
+1. 在统一 mutation 入口根据 before / after 计算类型化 ChangeSet；同值 patch 不触发副作用。
+2. 持久化完成后生成 CommittedChange，绑定配置版本及批次身份；提交失败不发布成功通知。
+3. 多配置域提交由已有 coordinator 形成完整批次结果。禁止每个底层 actor 提交一部分就分别触发 rebuild，从而读到半批次状态。
+4. 应用工作流将一批变更合并为副作用计划。TUN 与控制通道同时变化只安排一次 reconcile；系统代理、热键等仍调用相应 typed clients。
+5. 先落地已触及的控制通道/TUN 路径，再逐条迁移 legacy bridge；不借此清理无关服务。需要临时桥接时写明原因及删除条件。
+6. 决定 side-effect 失败的重试粒度与幂等键；仅重试未完成效果，不重复提交配置或重跑已成功 mutation。
+
+验收：混合配置批次只观察最终版本；持久化失败无核心调用；提交成功后的副作用失败保留状态并返回降级；相同 patch 为零效果；并发批次结果不会串版本；持久化 actor 不依赖 Tauri 或 core-manager。
+
+## 8. 验证矩阵与执行入口
+
+| 场景                                                           | 观察点                                          | 所属阶段 |
+| -------------------------------------------------------------- | ----------------------------------------------- | -------- |
+| 应用成功、第一次内容查询失败、再次打开恢复                     | 提交计数不变；pending 清除；CoreController 出现 | P0       |
+| B 已成功但内容待取，C 生成失败                                 | C 仍为 generated，恢复 B 成为 last-applied      | P0       |
+| B 查询晚到而 D 已成功；不同宿主 generation / revision          | 拒绝旧结果，不覆盖 D                            | P0/P1    |
+| 消费者不读、持有 owned snapshot、消费者 panic                  | mutation 仍完成；最新提交可读取；无用户锁 guard | P0       |
+| IPC 不可用时 Prefer → Disable，然后宿主恢复 IPC 能力再 restart | 首次切换 Noop，restart 使用 Disable             | P0       |
+| 相同内容、嵌套修改、数组修改、非法图                           | diff 与 recorder 一致，失败无半状态             | P0/P2    |
+| 注入 store 与独立应用图                                        | workflow 与 inspection 共用实例，两个图互不污染 | P0/P1    |
+| stop / rollback / respawn / host handoff                       | full、历史、当前配置、当前进程身份不混淆        | P1/P2    |
+| 脚本失败与 finalizing 序列化失败                               | 配置记录原子，容错不变，产物与最终节点绑定      | P2       |
+| 跨域 patch、提交失败、后置效果失败                             | 批次与 ChangeSet 语义成立                       | P3       |
+
+本地验证命令（从主仓库 worktree 执行）：
+
+```sh
+cargo test --manifest-path backend/Cargo.toml --workspace --all-features --lib
+cargo test --manifest-path backend/Cargo.toml export_typescript_bindings --all-features
+cargo clippy --manifest-path backend/Cargo.toml --all-targets --all-features
+cargo test --manifest-path backend/nyanpasu-runtime/Cargo.toml -p nyanpasu-core-manager --lib --test control_channel
+cargo test --manifest-path backend/nyanpasu-runtime/Cargo.toml -p nyanpasu-service-runtime --all-features
+cargo fmt --manifest-path backend/Cargo.toml --all -- --check
+cargo fmt --manifest-path backend/nyanpasu-runtime/Cargo.toml --all -- --check
+pnpm -F interface build
+pnpm web:build
+pnpm typecheck
+pnpm lint:oxlint
+pnpm lint:architecture-ledger
+```
+
+对修改的 TS/TSX/JSON/Markdown 定向运行 Prettier。actor 测试用 acknowledgement、watch 条件或 typed RPC 同步，不用 sleep 推测完成。真实核心测试通过 `MIHOMO_BIN` / `CLASH_RS_BIN` 指向现有二进制并显式运行 ignored 用例，不覆盖共享 sidecar。
+
+## 9. 合并、发布和完成标准
+
+代码依赖顺序：utils 的 Backoff 值相等能力 → runtime 分类器及通知 API → 应用关联恢复与图追加。每层先审核并提供可获取提交；正式 gitlink 必须对应已发布的协议实现。P0 不修改既有远端提交历史，不自动发布服务或安装系统 daemon。
+
+服务发布仍需：
+
+- `rc.4` 制品、版本检测、下载脚本获取的二进制与新协议一致，rc.3 被明确拒绝。
+- Unix root daemon 到普通 GUI 用户的 REST、WS、重启后 socket 授权、未授权用户拒绝与孤儿清理实测。
+- Linux/macOS/Windows 的实际权限和路径矩阵；Windows 未证明跨用户 pipe ACL 前维持 HTTP fallback。
+- 应用、daemon、核心重启和 Local↔Service 切换后的关联恢复；不由同用户 Local 实测替代。
+
+P0 完成只表示修复当前行为与隔离风险。整个 roadmap 的完成要求是：派生配置不存在独立可变 working/recorder 双入口，artifact 只能由同一最终节点冻结，期望配置变更经提交结果统一规划效果，snapshot 观察故障不影响核心事务，并且上述服务发布矩阵有实际证据。
+
+## 10. 本轮验证记录（2026-09-09）
+
+| 验证                                                        | 结果                                                                          |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| 应用 workspace library 回归                                 | 应用 503 项通过、1 项忽略；配置库 143 项通过，其余 workspace library 测试通过 |
+| core-manager library / 通道集成                             | 107 项通过、1 项忽略；通道集成 2 项通过                                       |
+| 新增真实通道切换                                            | mihomo、clash-rs 共 2 项通过，实际运行 ignored 用例                           |
+| service-runtime                                             | 87 项通过                                                                     |
+| bindings / interface / web / TypeScript                     | 通过                                                                          |
+| Oxlint / Clippy / architecture ledger / fmt / 定向 Prettier | 通过；保留既有警告                                                            |
+
+完整 core-manager 回归首次在 `dropping_live_manager_releases_runtime_ownership` 出现 `No such file or directory`，对应 manager_orchestration 目标 19 通过、1 失败；该目标串行复跑 20 项全部通过。首次整套运行不能标记为全绿，也未将这个未改动测试的失败诊断为确定根因。本轮旧的 macOS version-probe 测试通过。
+
+新增回归已证明：首次 effective 查询失败可由 inspection 恢复且提交数不增加；晚到结果不覆盖较新绑定；失败候选保留 generated 视图；统一图追加与 recorder 一致；注入 store 被 workflow 和 reader 共用；无实际通道变化时 Noop，restart 保留新策略；消费 owned snapshot 或消费者 panic 不改变核心事务结果。
+
+本轮源码和文档通过应用 PR #5227、runtime PR #414 与 [utils PR #185](https://github.com/libnyanpasu/nyanpasu-utils/pull/185) 关联审核。gitlink 引用相应审核提交；发布前仍需按 §9 完成依赖合并和已发布版本接线，不能只提交父仓库而遗漏嵌套子模块修改。

--- a/frontend/interface/src/hooks/use-core-status.ts
+++ b/frontend/interface/src/hooks/use-core-status.ts
@@ -22,6 +22,10 @@ export function useCoreStatus() {
         status,
         startAt: result.state_changed_at,
         type: result.host,
+        controller:
+          status === 'Running' && result.connectivity.kind === 'connected'
+            ? result.controller
+            : null,
       }
     },
   })

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -61,6 +61,9 @@ export const commands = {
     typedError<
       {
         snapshot_id: string
+        applied: boolean
+        effective_pending: boolean
+        effective_revision: ConfigRevisionInfo | null
         revision: string
         target_core: string
         root_id: number
@@ -68,6 +71,20 @@ export const commands = {
       } | null,
       string
     >(__TAURI_INVOKE('inspect_runtime')),
+  inspectAppliedRuntime: () =>
+    typedError<
+      {
+        snapshot_id: string
+        applied: boolean
+        effective_pending: boolean
+        effective_revision: ConfigRevisionInfo | null
+        revision: string
+        target_core: string
+        root_id: number
+        nodes: RuntimeInspectionNode[]
+      } | null,
+      string
+    >(__TAURI_INVOKE('inspect_applied_runtime')),
   inspectRuntimeNode: (snapshotId: string, nodeId: number) =>
     typedError<RuntimeInspectionContent, string>(
       __TAURI_INVOKE('inspect_runtime_node', { snapshotId, nodeId }),
@@ -400,7 +417,10 @@ export type BuildInfo = {
 
 /**  Built-in post-processing steps applied to the selected config. */
 export type BuiltinStepKind =
-  'guard_overrides' | 'whitelist_field_filter' | 'finalizing'
+  | 'guard_overrides'
+  | 'whitelist_field_filter'
+  | 'finalizing'
+  | 'core_controller'
 
 export type ClashConfig = {
   port: number | null
@@ -432,6 +452,8 @@ export type ClashConnectionsInfo = {
   downloadSpeed: number
   uploadSpeed: number
 }
+
+export type ClashControlChannel = 'prefer_ipc' | 'http_only'
 
 export type ClashCore = ClashCore_Serialize | ClashCore_Deserialize
 
@@ -797,6 +819,7 @@ export type CoreStateDetail =
 export type CoreStatusChangedEvent = CoreStatusInfo
 
 export type CoreStatusInfo = {
+  controller: CoreControllerInfo | null
   host: ExecutionHost
   connectivity: EndpointConnectivity
   generation: number
@@ -971,6 +994,8 @@ export type IVerge_Deserialize =
       web_ui_list: string[] | null
       /**  clash core path */
       clash_core: ClashCore_Deserialize | null
+      clash_control_channel: ClashControlChannel | null
+      clash_ipc_disable_http_controller: boolean | null
       /**
        *  hotkey map
        *  format: {func},{key}
@@ -1117,6 +1142,8 @@ export type IVerge_Serialize = {
   web_ui_list: string[] | null
   /**  clash core path */
   clash_core?: ClashCore_Serialize | null
+  clash_control_channel: ClashControlChannel | null
+  clash_ipc_disable_http_controller: boolean | null
   /**
    *  hotkey map
    *  format: {func},{key}
@@ -2157,6 +2184,9 @@ export type RuntimeInfos = {
 
 export type RuntimeInspection = {
   snapshot_id: string
+  applied: boolean
+  effective_pending: boolean
+  effective_revision: ConfigRevisionInfo | null
   revision: string
   target_core: string
   root_id: number

--- a/frontend/nyanpasu/messages/en.json
+++ b/frontend/nyanpasu/messages/en.json
@@ -423,5 +423,14 @@
   "inspect_filtered_empty": "No steps changed the configuration or produced logs. Turn on the full process chain to inspect all steps.",
   "inspect_old_line": "Old line",
   "inspect_new_line": "New line",
-  "inspect_change": "Change"
+  "inspect_change": "Change",
+  "settings_clash_control_channel_label": "Control Channel",
+  "settings_clash_control_channel_prefer_ipc": "Prefer IPC (HTTP fallback)",
+  "settings_clash_control_channel_http_only": "HTTP only",
+  "settings_clash_ipc_disable_http_label": "Disable HTTP external controller when IPC is available",
+  "settings_clash_ipc_disable_http_description": "Only applies when IPC is selected and available. Disables HTTP access for Web UI and third-party tools.",
+  "inspect_core_controller": "Core effective configuration",
+  "inspect_effective_pending": "Effective snapshot content pending",
+  "inspect_applied": "Applied",
+  "inspect_last_applied": "Last applied snapshot"
 }

--- a/frontend/nyanpasu/messages/ko.json
+++ b/frontend/nyanpasu/messages/ko.json
@@ -381,5 +381,14 @@
   "common_off": "꺼짐",
   "common_enabled": "사용",
   "common_disabled": "사용 안 함",
-  "common_clear": "지우기"
+  "common_clear": "지우기",
+  "settings_clash_control_channel_label": "제어 채널",
+  "settings_clash_control_channel_prefer_ipc": "IPC 우선 (사용할 수 없으면 HTTP)",
+  "settings_clash_control_channel_http_only": "HTTP만 사용",
+  "settings_clash_ipc_disable_http_label": "IPC 사용 시 HTTP 외부 컨트롤러 비활성화",
+  "settings_clash_ipc_disable_http_description": "IPC를 선택하고 사용할 수 있을 때만 적용됩니다. Web UI와 타사 도구의 HTTP 접근이 비활성화됩니다.",
+  "inspect_core_controller": "코어에 적용된 설정",
+  "inspect_effective_pending": "유효한 스냅샷 내용을 기다리는 중",
+  "inspect_applied": "적용됨",
+  "inspect_last_applied": "마지막으로 적용한 스냅샷"
 }

--- a/frontend/nyanpasu/messages/ru.json
+++ b/frontend/nyanpasu/messages/ru.json
@@ -385,5 +385,14 @@
   "deep_link_import_title": "Импорт профиля",
   "deep_link_import_success_message": "Профиль «{name}» успешно импортирован",
   "deep_link_import_failed_message": "Не удалось импортировать профиль по ссылке",
-  "deep_link_import_invalid_message": "Ссылка не является корректной ссылкой для импорта профиля"
+  "deep_link_import_invalid_message": "Ссылка не является корректной ссылкой для импорта профиля",
+  "settings_clash_control_channel_label": "Канал управления",
+  "settings_clash_control_channel_prefer_ipc": "Приоритет IPC (иначе HTTP)",
+  "settings_clash_control_channel_http_only": "Только HTTP",
+  "settings_clash_ipc_disable_http_label": "Отключать внешний HTTP-контроллер при доступном IPC",
+  "settings_clash_ipc_disable_http_description": "Действует, когда выбран и доступен IPC. Отключает HTTP-доступ для Web UI и сторонних инструментов.",
+  "inspect_core_controller": "Применённая конфигурация ядра",
+  "inspect_effective_pending": "Ожидание содержимого эффективного снимка",
+  "inspect_applied": "Применено",
+  "inspect_last_applied": "Последний применённый снимок"
 }

--- a/frontend/nyanpasu/messages/zh-cn.json
+++ b/frontend/nyanpasu/messages/zh-cn.json
@@ -423,5 +423,14 @@
   "inspect_filtered_empty": "没有步骤修改配置或产生日志。开启完整处理链可查看所有步骤。",
   "inspect_old_line": "原行号",
   "inspect_new_line": "新行号",
-  "inspect_change": "变更"
+  "inspect_change": "变更",
+  "settings_clash_control_channel_label": "控制通道",
+  "settings_clash_control_channel_prefer_ipc": "IPC 优先（不可用时回退 HTTP）",
+  "settings_clash_control_channel_http_only": "仅 HTTP",
+  "settings_clash_ipc_disable_http_label": "IPC 可用时关闭 HTTP 外部控制器",
+  "settings_clash_ipc_disable_http_description": "仅在选择 IPC 且可用时生效。关闭后 Web UI 和第三方工具无法通过 HTTP 访问。",
+  "inspect_core_controller": "核心有效配置",
+  "inspect_effective_pending": "等待获取有效快照内容",
+  "inspect_applied": "已应用",
+  "inspect_last_applied": "上次应用的快照"
 }

--- a/frontend/nyanpasu/messages/zh-tw.json
+++ b/frontend/nyanpasu/messages/zh-tw.json
@@ -423,5 +423,14 @@
   "inspect_filtered_empty": "沒有步驟修改設定或產生日誌。開啟完整處理鏈可查看所有步驟。",
   "inspect_old_line": "原行號",
   "inspect_new_line": "新行號",
-  "inspect_change": "變更"
+  "inspect_change": "變更",
+  "settings_clash_control_channel_label": "控制通道",
+  "settings_clash_control_channel_prefer_ipc": "IPC 優先（不可用時退回 HTTP）",
+  "settings_clash_control_channel_http_only": "僅 HTTP",
+  "settings_clash_ipc_disable_http_label": "IPC 可用時關閉 HTTP 外部控制器",
+  "settings_clash_ipc_disable_http_description": "僅在選擇 IPC 且可用時生效。關閉後 Web UI 和第三方工具無法透過 HTTP 存取。",
+  "inspect_core_controller": "核心有效設定",
+  "inspect_effective_pending": "等待取得有效快照內容",
+  "inspect_applied": "已套用",
+  "inspect_last_applied": "上次套用的快照"
 }

--- a/frontend/nyanpasu/src/pages/(main)/main/dashboard/_modules/widget-shortcut.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/dashboard/_modules/widget-shortcut.tsx
@@ -1,3 +1,4 @@
+import ChevronRightRounded from '~icons/material-symbols/chevron-right-rounded'
 import { useMemo } from 'react'
 import {
   SystemProxyButton,
@@ -190,8 +191,8 @@ const CoreStatusBadge = () => {
   return (
     <div
       className={cn(
-        'flex h-6 min-w-0 items-center rounded-full text-sm',
-        'bg-surface-variant/50',
+        'flex h-6 max-w-full min-w-0 items-center rounded-full text-xs font-medium',
+        'bg-secondary-container/50 text-on-secondary-container',
       )}
       data-slot="core-status-badge"
     >
@@ -215,81 +216,89 @@ const CurrentCoreCard = () => {
 
   const isRunning = coreStatus?.status === 'Running'
 
+  const channel = coreStatus?.controller
+    ? 'Http' in coreStatus.controller
+      ? 'HTTP'
+      : 'NamedPipe' in coreStatus.controller
+        ? 'IPC · Named Pipe'
+        : 'IPC · Unix Socket'
+    : '—'
+
   return (
     <Button
       variant="raised"
       className={cn(
-        'group flex flex-1 items-center gap-4 rounded-2xl pr-3 pl-4',
-        'bg-surface-variant/30 hover:bg-surface-variant',
+        'group grid h-auto min-w-0 flex-1 grid-rows-[minmax(3.5rem,1fr)_minmax(2rem,0.6fr)] rounded-[20px] px-2.5 py-0 text-left',
+        'bg-surface-variant/30 text-on-surface hover:bg-surface-variant/50 shadow-none hover:shadow-none focus:shadow-none',
+        'focus-visible:outline-primary focus-visible:outline-2 focus-visible:-outline-offset-2',
       )}
       data-running={String(isRunning)}
       data-slot="current-core-card"
       asChild
     >
       <Link to="/main/settings/clash">
-        <img
-          src={currentCoreIcon}
-          alt={currentCore?.name}
-          className="size-12 shrink-0"
-          data-slot="core-icon"
-        />
-
-        <div
-          className="flex flex-1 flex-col items-start gap-1 truncate"
-          data-slot="core-info"
-        >
-          <div className="font-semibold" data-slot="core-name">
-            {currentCore?.name}
+        <div className="flex w-full min-w-0 shrink-0 items-center gap-3">
+          <div className="bg-surface/60 grid size-10 shrink-0 place-items-center rounded-xl">
+            <img
+              src={currentCoreIcon}
+              alt=""
+              className="size-8 object-contain"
+              data-slot="core-icon"
+            />
           </div>
 
-          <div
-            className="text-zinc-700 dark:text-zinc-300"
-            data-slot="core-version"
-          >
-            {currentCore?.currentVersion}
+          <div className="min-w-0 flex-1" data-slot="core-info">
+            <div
+              className="truncate text-base leading-5 font-semibold"
+              title={currentCore?.name}
+              data-slot="core-name"
+            >
+              {currentCore?.name ?? '—'}
+            </div>
+            <div
+              className="text-on-surface-variant truncate text-xs leading-4 font-normal"
+              title={currentCore?.currentVersion}
+              data-slot="core-version"
+            >
+              {currentCore?.currentVersion ?? '—'}
+            </div>
           </div>
-          <div className="text-xs" data-slot="core-control-channel">
-            {m.settings_clash_control_channel_label()}:{' '}
-            {coreStatus?.controller
-              ? 'Http' in coreStatus.controller
-                ? 'HTTP'
-                : 'NamedPipe' in coreStatus.controller
-                  ? 'IPC · Named Pipe'
-                  : 'IPC · Unix Socket'
-              : '—'}
-          </div>
+
+          {coreStatus && (
+            <div
+              className={cn(
+                'flex shrink-0 items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium',
+                isRunning
+                  ? 'bg-primary-container text-on-primary-container'
+                  : 'bg-surface-variant text-on-surface-variant',
+              )}
+              data-slot="core-status"
+            >
+              <span
+                className="size-1.5 shrink-0 rounded-full bg-current"
+                aria-hidden="true"
+                data-slot="core-status-indicator"
+              />
+              <span data-slot="core-status-text">
+                {isRunning
+                  ? m.dashboard_widget_core_status_running()
+                  : m.dashboard_widget_core_status_stopped()}
+              </span>
+            </div>
+          )}
         </div>
 
         <div
-          className="flex items-center gap-2 truncate pr-2"
-          data-slot="core-status"
+          className="border-outline-variant/40 text-on-surface-variant flex w-full min-w-0 items-center gap-2 border-t text-xs leading-4 font-normal"
+          data-slot="core-control-channel"
         >
-          <div className="truncate" data-slot="core-status-text">
-            {isRunning
-              ? m.dashboard_widget_core_status_running()
-              : m.dashboard_widget_core_status_stopped()}
-          </div>
-
-          <div
-            className="relative flex size-3 shrink-0"
-            data-slot="core-status-indicator"
-          >
-            <span
-              className={cn(
-                'absolute inline-flex size-full animate-ping rounded-full opacity-75',
-                'group-data-[running=true]:bg-green-500',
-                'group-data-[running=false]:opacity-0',
-              )}
-            />
-
-            <span
-              className={cn(
-                'relative inline-flex size-full rounded-full',
-                'group-data-[running=true]:bg-green-500',
-                'group-data-[running=false]:bg-gray-400',
-              )}
-            />
-          </div>
+          <span className="min-w-0 truncate">
+            {m.settings_clash_control_channel_label()}
+          </span>
+          <span className="text-on-surface ml-auto shrink-0 font-medium">
+            {channel}
+          </span>
+          <ChevronRightRounded className="size-4 shrink-0" aria-hidden="true" />
         </div>
       </Link>
     </Button>
@@ -303,15 +312,15 @@ export function CoreShortcutsWidget({
   return (
     <WidgetItem id={id} minW={4} minH={2} onCloseClick={onCloseClick}>
       <Card className="flex size-full flex-col justify-between">
-        <CardHeader>
-          <span className="shrink-0 font-bold">
+        <CardHeader className="shrink-0 gap-3 pt-3">
+          <span className="shrink-0 text-base font-medium">
             {m.dashboard_widget_core_status()}
           </span>
 
           <CoreStatusBadge />
         </CardHeader>
 
-        <CardContent className="flex-1">
+        <CardContent className="min-h-0 flex-1 pt-2 pb-3">
           <CurrentCoreCard />
         </CardContent>
       </Card>

--- a/frontend/nyanpasu/src/pages/(main)/main/dashboard/_modules/widget-shortcut.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/dashboard/_modules/widget-shortcut.tsx
@@ -248,6 +248,16 @@ const CurrentCoreCard = () => {
           >
             {currentCore?.currentVersion}
           </div>
+          <div className="text-xs" data-slot="core-control-channel">
+            {m.settings_clash_control_channel_label()}:{' '}
+            {coreStatus?.controller
+              ? 'Http' in coreStatus.controller
+                ? 'HTTP'
+                : 'NamedPipe' in coreStatus.controller
+                  ? 'IPC · Named Pipe'
+                  : 'IPC · Unix Socket'
+              : '—'}
+          </div>
         </div>
 
         <div

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/inspect/route.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/inspect/route.tsx
@@ -55,6 +55,8 @@ function stepLabel(tag: OperatorTag): string {
           return m.inspect_overrides()
         case 'whitelist_field_filter':
           return m.inspect_filter()
+        case 'core_controller':
+          return m.inspect_core_controller()
         case 'finalizing':
           return m.inspect_finalizing()
       }
@@ -62,9 +64,15 @@ function stepLabel(tag: OperatorTag): string {
 }
 
 function RouteComponent() {
+  const [appliedView, setAppliedView] = useState(false)
   const inspection = useQuery({
-    queryKey: ['runtime-inspection'],
-    queryFn: async () => unwrapResult(await commands.inspectRuntime()),
+    queryKey: ['runtime-inspection', appliedView],
+    queryFn: async () =>
+      unwrapResult(
+        await (appliedView
+          ? commands.inspectAppliedRuntime()
+          : commands.inspectRuntime()),
+      ),
     refetchOnWindowFocus: false,
     retry: false,
   })
@@ -86,6 +94,10 @@ function RouteComponent() {
           {m.inspect_refresh()}
         </Button>
       </header>
+      <label className="flex items-center gap-2 text-sm">
+        <Switch checked={appliedView} onCheckedChange={setAppliedView} />
+        {m.inspect_last_applied()}
+      </label>
       {inspection.isPending && <p role="status">{m.inspect_loading()}</p>}
       {inspection.isError && (
         <p role="alert">
@@ -134,8 +146,12 @@ function SnapshotBrowser({ snapshot }: { snapshot: RuntimeInspection }) {
   return (
     <>
       <p className="text-on-surface-variant text-sm">
-        {m.inspect_generated()} · {snapshot.target_core} ·{' '}
-        {m.inspect_revision()} {snapshot.revision}
+        {snapshot.effective_pending
+          ? m.inspect_effective_pending()
+          : snapshot.applied
+            ? m.inspect_applied()
+            : m.inspect_generated()}{' '}
+        · {snapshot.target_core} · {m.inspect_revision()} {snapshot.revision}
       </p>
       <div className="grid min-w-0 gap-4 @[40rem]:grid-cols-[minmax(12rem,1fr)_minmax(0,3fr)]">
         <div className="flex min-w-0 flex-col gap-3">

--- a/frontend/nyanpasu/src/pages/(main)/main/settings/clash/_modules/control-channel-settings.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/settings/clash/_modules/control-channel-settings.tsx
@@ -1,0 +1,107 @@
+import ArrowForwardIosRounded from '~icons/material-symbols/arrow-forward-ios-rounded'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Switch } from '@/components/ui/switch'
+import { m } from '@/paraglide/messages'
+import { formatError } from '@/utils'
+import { message } from '@/utils/notification'
+import { useSetting } from '@nyanpasu/interface'
+import {
+  ItemContainer,
+  ItemLabel,
+  ItemLabelDescription,
+  ItemLabelText,
+  SettingsCard,
+  SettingsCardContent,
+  SettingsGroup,
+  SettingsLabel,
+} from '../../_modules/settings-card'
+
+export default function ControlChannelSettings() {
+  const channel = useSetting('clash_control_channel')
+  const disableHttp = useSetting('clash_ipc_disable_http_controller')
+  const current = channel.value ?? 'prefer_ipc'
+  const options = {
+    prefer_ipc: m.settings_clash_control_channel_prefer_ipc(),
+    http_only: m.settings_clash_control_channel_http_only(),
+  }
+  const reportError = (error: unknown) =>
+    message(formatError(error), { title: 'Error', kind: 'error' })
+  return (
+    <div>
+      <SettingsLabel>{m.settings_clash_control_channel_label()}</SettingsLabel>
+      <SettingsGroup>
+        <SettingsCard>
+          <DropdownMenu align="end">
+            <DropdownMenuTrigger asChild>
+              <SettingsCardContent asChild>
+                <Button
+                  disabled={channel.isPending}
+                  className="text-on-surface! h-auto w-full rounded-none px-5 text-left text-base"
+                >
+                  <ItemContainer>
+                    <ItemLabel>
+                      <ItemLabelText>
+                        {m.settings_clash_control_channel_label()}
+                      </ItemLabelText>
+                      <ItemLabelDescription>
+                        {options[current]}
+                      </ItemLabelDescription>
+                    </ItemLabel>
+                    <ArrowForwardIosRounded />
+                  </ItemContainer>
+                </Button>
+              </SettingsCardContent>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent sideOffset={-16} alignOffset={16}>
+              {(['prefer_ipc', 'http_only'] as const).map((value) => (
+                <DropdownMenuCheckboxItem
+                  key={value}
+                  checked={value === current}
+                  onSelect={() => {
+                    channel
+                      .upsert(value)
+                      .catch(reportError)
+                      .finally(() => channel.refetch())
+                  }}
+                >
+                  {options[value]}
+                </DropdownMenuCheckboxItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </SettingsCard>
+        <SettingsCard>
+          <SettingsCardContent>
+            <ItemContainer>
+              <ItemLabel>
+                <ItemLabelText>
+                  {m.settings_clash_ipc_disable_http_label()}
+                </ItemLabelText>
+                <ItemLabelDescription>
+                  {m.settings_clash_ipc_disable_http_description()}
+                </ItemLabelDescription>
+              </ItemLabel>
+              <Switch
+                checked={disableHttp.value ?? false}
+                disabled={current === 'http_only'}
+                loading={disableHttp.isPending}
+                onCheckedChange={(value) => {
+                  disableHttp
+                    .upsert(value)
+                    .catch(reportError)
+                    .finally(() => disableHttp.refetch())
+                }}
+              />
+            </ItemContainer>
+          </SettingsCardContent>
+        </SettingsCard>
+      </SettingsGroup>
+    </div>
+  )
+}

--- a/frontend/nyanpasu/src/pages/(main)/main/settings/clash/route.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/settings/clash/route.tsx
@@ -8,6 +8,7 @@ import {
 } from '../_modules/settings-card'
 import { SettingsTitle } from '../_modules/settings-title'
 import AllowLanSwitch from './_modules/allow-lan-switch'
+import ControlChannelSettings from './_modules/control-channel-settings'
 import CoreManagerCard from './_modules/core-manager-card'
 import FieldFilterCard from './_modules/field-filter-card'
 import FieldFilterSwitch from './_modules/field-filter-switch'
@@ -108,6 +109,8 @@ function RouteComponent() {
         <PatchSettings />
 
         <PortSettings />
+
+        <ControlChannelSettings />
 
         <CoreManagerSettings />
 

--- a/scripts/architecture-ledger.snapshot.json
+++ b/scripts/architecture-ledger.snapshot.json
@@ -30,9 +30,9 @@
       }
     },
     "legacy_dto_refs": {
-      "total": 312,
+      "total": 321,
       "byKey": {
-        "IVerge": 180,
+        "IVerge": 186,
         "IClashTemp": 31,
         "LegacyVergeBridge": 31,
         "ClashLegacyBridge": 19,
@@ -40,8 +40,8 @@
         "LegacyClashBridge": 10,
         "LegacyVergePatchRoute": 9,
         "LegacyWindowBridge": 7,
-        "legacy_iverge_from_typed": 3,
-        "typed_patches_from_legacy_patch": 2,
+        "legacy_iverge_from_typed": 4,
+        "typed_patches_from_legacy_patch": 4,
         "IClash": 1
       }
     },


### PR DESCRIPTION
Users can select Prefer IPC or HTTP-only and whether to retain the HTTP controller. Preferences are persisted before reconciliation, remain attached to the build request, and do not start a stopped core. Post-commit failures retain saved configuration and return a degraded result.

Runtime inspection preserves generated and applied views separately. A successful apply records its revision and execution host even if the first effective-config query fails; reopening inspection can recover the content without another reconcile. A single injected RuntimeSnapshotStore serves workflow writes and inspection reads. The CoreController transition uses the shared graph/diff implementation, with stale-result checks and redacted content.

Depends on https://github.com/libnyanpasu/nyanpasu-runtime/pull/414 and its utils dependency. The gitlink pins the runtime review commit; merge requires a corresponding service release and released runtime revision. Minimum daemon version is rc.4, so existing rc.3 daemons are rejected.

Validation:
- Application workspace library regression passed: application 503 passed / 1 ignored, configuration library 143 passed, remaining library targets passed.
- Read-only recovery, stale results, shared injected store, nested/array/no-op graph transitions and atomic invalid-graph rejection are covered.
- Bindings export, interface/web build, TypeScript, Oxlint, architecture ledger, formatting and Clippy passed with existing warnings retained.
- Companion runtime: 107 library tests and 87 service tests passed; two real channel-switch tests passed. One directory-ownership test failed in the initial full core-manager run; its 20-test target passed on serial rerun. See runtime PR for details.

The roadmap at `docs/roadmap/2026-09-09-tracked-config-and-snapshot-store.md` separates current fixes from frozen request identities, ConfigWorkspace ownership, ChangeSet orchestration and release gates.

Draft release gates: rc.4 artifacts are unpublished. Platform and privileged Unix daemon → ordinary GUI user REST/WS and unauthorized-user validation remain pending. Windows service IPC intentionally falls back to HTTP. No daemon installation or release is included.
