### PR TITLE
feat(i18n): select UI language from the system locale

### DIFF
--- a/backend/nyanpasu-config/src/application/i18n.rs
+++ b/backend/nyanpasu-config/src/application/i18n.rs
@@ -2,18 +2,38 @@ use language_tags::LanguageTag;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
+/// UI language of the application.
+///
+/// The serialized form is the canonical i18n key shared by every layer that
+/// names a language: the `rust_i18n` bundles under `backend/tauri/locales`, the
+/// paraglide runtime under `frontend/nyanpasu/src/paraglide`, and the dayjs
+/// locale imports. All of those are lowercase, so this enum is too. Legacy
+/// mixed-case spellings are still accepted on read through `serde(alias)`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Type)]
 pub enum I18nLanguage {
-    #[serde(rename = "en-US")]
+    #[serde(rename = "en", alias = "en-US")]
     English,
     #[serde(rename = "ko")]
     Korean,
     #[serde(rename = "ru")]
     Russian,
-    #[serde(rename = "zh-CN")]
+    #[serde(rename = "zh-cn", alias = "zh-CN")]
     SimplifiedChinese,
-    #[serde(rename = "zh-TW")]
+    #[serde(rename = "zh-tw", alias = "zh-TW")]
     TraditionalChinese,
+}
+
+impl I18nLanguage {
+    /// The canonical i18n key. Identical to the serialized representation.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::English => "en",
+            Self::Korean => "ko",
+            Self::Russian => "ru",
+            Self::SimplifiedChinese => "zh-cn",
+            Self::TraditionalChinese => "zh-tw",
+        }
+    }
 }
 
 pub fn default_i18n_language() -> I18nLanguage {
@@ -114,6 +134,39 @@ mod tests {
         assert!(!is_simplified_chinese(&tag("zh-MO")));
         assert!(!is_simplified_chinese(&tag("zh-Hant")));
         assert!(!is_simplified_chinese(&tag("zh-Hant-TW")));
+    }
+
+    const ALL: [I18nLanguage; 5] = [
+        I18nLanguage::English,
+        I18nLanguage::Korean,
+        I18nLanguage::Russian,
+        I18nLanguage::SimplifiedChinese,
+        I18nLanguage::TraditionalChinese,
+    ];
+
+    #[test]
+    fn as_str_matches_serialized_form() {
+        for lang in ALL {
+            let serialized = serde_json::to_string(&lang).unwrap();
+            assert_eq!(serialized, format!("\"{}\"", lang.as_str()));
+        }
+    }
+
+    #[test]
+    fn canonical_keys_are_lowercase() {
+        // The keys must stay byte-identical to `backend/tauri/locales/<key>.json`
+        // and to the paraglide locale list, both of which are lowercase.
+        for lang in ALL {
+            assert_eq!(lang.as_str(), lang.as_str().to_ascii_lowercase());
+        }
+    }
+
+    #[test]
+    fn legacy_mixed_case_spellings_still_deserialize() {
+        let parse = |s: &str| serde_json::from_str::<I18nLanguage>(&format!("\"{s}\"")).unwrap();
+        assert_eq!(parse("en-US"), I18nLanguage::English);
+        assert_eq!(parse("zh-CN"), I18nLanguage::SimplifiedChinese);
+        assert_eq!(parse("zh-TW"), I18nLanguage::TraditionalChinese);
     }
 
     #[test]

--- a/backend/tauri/src/config/nyanpasu/mod.rs
+++ b/backend/tauri/src/config/nyanpasu/mod.rs
@@ -466,10 +466,7 @@ impl IVerge {
     pub fn template() -> Self {
         Self {
             clash_core: Some(ClashCore::default()),
-            language: {
-                let locale = crate::utils::help::get_system_locale();
-                Some(crate::utils::help::mapping_to_i18n_key(&locale).into())
-            },
+            language: Some(crate::utils::help::detect_system_i18n_key().into()),
             app_log_level: Some(logging::LoggingLevel::default()),
             theme_mode: Some("system".into()),
             traffic_graph: Some(true),

--- a/backend/tauri/src/core/migration/fixtures/v2_0_expected/nyanpasu-config.yaml
+++ b/backend/tauri/src/core/migration/fixtures/v2_0_expected/nyanpasu-config.yaml
@@ -1,4 +1,4 @@
-language: zh-CN
+language: zh-cn
 theme_color: '#1867c0'
 network_statistic_widget: large
 clash_core: mihomo

--- a/backend/tauri/src/core/migration/modules/app_config.rs
+++ b/backend/tauri/src/core/migration/modules/app_config.rs
@@ -10,8 +10,15 @@ static LANGUAGE_OPTION: MigrateLanguageOption = MigrateLanguageOption;
 static THEME_SETTING: MigrateThemeSetting = MigrateThemeSetting;
 static NET_STAT_WIDGET_FLATTEN: MigrateNetworkStatisticWidgetFlatten =
     MigrateNetworkStatisticWidgetFlatten;
-static STEPS: [&dyn MigrationStep; 3] =
-    [&LANGUAGE_OPTION, &THEME_SETTING, &NET_STAT_WIDGET_FLATTEN];
+static LANGUAGE_CASE: MigrateLanguageCase = MigrateLanguageCase;
+// `LANGUAGE_CASE` must stay after `LANGUAGE_OPTION`: the latter rewrites `zh`
+// into the mixed-case `zh-CN` that the former then canonicalizes.
+static STEPS: [&dyn MigrationStep; 4] = [
+    &LANGUAGE_OPTION,
+    &THEME_SETTING,
+    &NET_STAT_WIDGET_FLATTEN,
+    &LANGUAGE_CASE,
+];
 
 const NETWORK_STATISTIC_WIDGET_KEY: &str = "network_statistic_widget";
 
@@ -34,6 +41,7 @@ impl ModuleMigrator for AppConfigMigrator {
         if needs_language_option_migration(&config)
             || needs_theme_setting_migration(&config)
             || needs_network_statistic_widget_migration(&config)
+            || needs_language_case_migration(&config)
         {
             Ok(0)
         } else {
@@ -229,12 +237,79 @@ impl MigrationStep for MigrateNetworkStatisticWidgetFlatten {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct MigrateLanguageCase;
+
+impl MigrationStep for MigrateLanguageCase {
+    fn id(&self) -> &'static str {
+        "app_config/language_case"
+    }
+
+    fn module(&self) -> &'static str {
+        "app_config"
+    }
+
+    fn revision(&self) -> u64 {
+        4
+    }
+
+    fn introduced_in(&self) -> &'static Version {
+        &VERSION_2_0_0
+    }
+
+    fn name(&self) -> &'static str {
+        "MigrateLanguageCase"
+    }
+
+    fn run(&self, ctx: &mut Ctx) -> anyhow::Result<()> {
+        let config_path = ctx.nyanpasu_config_path();
+        if !config_path.exists() {
+            return Ok(());
+        }
+        let raw = std::fs::read_to_string(&config_path)?;
+        let mut config: Mapping = serde_yaml::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("failed to parse config: {e}"))?;
+        let Some(canonical) = config.get("language").and_then(canonical_language) else {
+            return Ok(());
+        };
+        config.insert("language".into(), Value::String(canonical.to_string()));
+        let new_config = serde_yaml::to_string(&config)?;
+        crate::core::migration::fs::atomic_write(&config_path, new_config.as_bytes())?;
+        Ok(())
+    }
+}
+
 fn current_revision() -> u64 {
     STEPS.last().map(|step| step.revision()).unwrap_or_default()
 }
 
 fn needs_language_option_migration(config: &Mapping) -> bool {
     config.get("language").is_some_and(|lang| lang == "zh")
+}
+
+fn needs_language_case_migration(config: &Mapping) -> bool {
+    config
+        .get("language")
+        .and_then(canonical_language)
+        .is_some()
+}
+
+/// Canonical spelling for a persisted `language` value, or `None` when the
+/// value is already canonical (or is not a language this build knows).
+///
+/// Older builds wrote mixed-case tags such as `zh-CN`, which no longer match the
+/// lowercase keys used by `rust_i18n`, the paraglide runtime, and dayjs.
+fn canonical_language(value: &Value) -> Option<&'static str> {
+    let raw = value.as_str()?;
+    let canonical = match raw.to_ascii_lowercase().as_str() {
+        "en" | "en-us" => "en",
+        "ko" => "ko",
+        "ru" => "ru",
+        "zh-cn" => "zh-cn",
+        "zh-tw" => "zh-tw",
+        _ => return None,
+    };
+    (canonical != raw).then_some(canonical)
 }
 
 fn needs_theme_setting_migration(config: &Mapping) -> bool {
@@ -349,5 +424,60 @@ mod tests {
     fn expand_mapping_is_noop() {
         let before = yaml("{ kind: enabled, value: large }");
         assert!(expand_value(&before).is_none());
+    }
+
+    #[test]
+    fn canonicalizes_mixed_case_language() {
+        let canonical = |raw: &str| canonical_language(&Value::String(raw.to_string()));
+        assert_eq!(canonical("zh-CN"), Some("zh-cn"));
+        assert_eq!(canonical("zh-TW"), Some("zh-tw"));
+        assert_eq!(canonical("en-US"), Some("en"));
+        assert_eq!(canonical("EN"), Some("en"));
+    }
+
+    #[test]
+    fn already_canonical_language_is_noop() {
+        for raw in ["en", "ko", "ru", "zh-cn", "zh-tw"] {
+            assert_eq!(canonical_language(&Value::String(raw.to_string())), None);
+        }
+    }
+
+    #[test]
+    fn unknown_language_is_noop() {
+        assert_eq!(canonical_language(&Value::String("fr".to_string())), None);
+        assert_eq!(canonical_language(&Value::Bool(true)), None);
+    }
+
+    #[test]
+    fn language_case_migration_is_detected() {
+        assert!(needs_language_case_migration(
+            yaml("language: zh-CN").as_mapping().unwrap()
+        ));
+        assert!(!needs_language_case_migration(
+            yaml("language: zh-cn").as_mapping().unwrap()
+        ));
+        assert!(!needs_language_case_migration(
+            yaml("theme_mode: dark").as_mapping().unwrap()
+        ));
+    }
+
+    #[test]
+    fn language_option_output_is_canonicalized_by_the_case_step() {
+        // `MigrateLanguageOption` rewrites `zh` into `zh-CN`; the case step has
+        // to run after it, or the chain leaves a non-canonical value behind.
+        let produced_by_language_option = Value::String("zh-CN".to_string());
+        assert_eq!(
+            canonical_language(&produced_by_language_option),
+            Some("zh-cn")
+        );
+        let case_step_position = STEPS
+            .iter()
+            .position(|step| step.id() == "app_config/language_case")
+            .unwrap();
+        let option_step_position = STEPS
+            .iter()
+            .position(|step| step.id() == "app_config/language_option")
+            .unwrap();
+        assert!(option_step_position < case_step_position);
     }
 }

--- a/backend/tauri/src/core/migration/runner.rs
+++ b/backend/tauri/src/core/migration/runner.rs
@@ -416,7 +416,7 @@ mod tests {
 
         // Each module advanced to the head of its step list.
         assert_eq!(runner.store.module_state("profiles").applied_revision, 3);
-        assert_eq!(runner.store.module_state("app_config").applied_revision, 3);
+        assert_eq!(runner.store.module_state("app_config").applied_revision, 4);
         assert_eq!(runner.store.module_state("storage").applied_revision, 1);
         assert_eq!(
             runner.store.module_state("typed_config").applied_revision,

--- a/backend/tauri/src/lib.rs
+++ b/backend/tauri/src/lib.rs
@@ -108,11 +108,7 @@ pub fn run() -> std::io::Result<()> {
         }
     }
     // Use system locale as default
-    let locale = {
-        let locale = utils::help::get_system_locale();
-        utils::help::mapping_to_i18n_key(&locale)
-    };
-    rust_i18n::set_locale(locale.to_lowercase().as_str());
+    rust_i18n::set_locale(utils::help::detect_system_i18n_key());
 
     if single_instance_result
         .as_ref()

--- a/backend/tauri/src/utils/help.rs
+++ b/backend/tauri/src/utils/help.rs
@@ -146,18 +146,12 @@ pub fn open_file(app: tauri::AppHandle, path: PathBuf) -> Result<()> {
     Ok(())
 }
 
-pub fn get_system_locale() -> String {
-    tauri_plugin_os::locale().unwrap_or("en-US".to_string())
-}
-
-pub fn mapping_to_i18n_key(locale_key: &str) -> &'static str {
-    if locale_key.starts_with("zh-TW") {
-        "zh-TW"
-    } else if locale_key.starts_with("zh-") {
-        "zh-CN"
-    } else {
-        "en"
-    }
+/// Resolve the UI language from the OS locale, as the canonical i18n key.
+///
+/// The key names a `rust_i18n` bundle in `backend/tauri/locales` and a paraglide
+/// locale in the frontend; both use the same lowercase spelling.
+pub fn detect_system_i18n_key() -> &'static str {
+    nyanpasu_config::application::default_i18n_language().as_str()
 }
 
 pub fn get_clash_external_port(

--- a/frontend/nyanpasu/src/components/providers/language-provider.tsx
+++ b/frontend/nyanpasu/src/components/providers/language-provider.tsx
@@ -1,8 +1,15 @@
 import { locale } from 'dayjs'
-import { createContext, PropsWithChildren, useContext, useEffect } from 'react'
+import {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useState,
+} from 'react'
 import { useLockFn } from '@/hooks/use-lock-fn'
 import { getLocale, Locale, setLocale } from '@/paraglide/runtime'
-import { useSetting } from '@nyanpasu/interface'
+import { getCachedLanguage, normalizeLanguage } from '@/utils/language'
+import { useSettings } from '@nyanpasu/interface'
 
 const LanguageContext = createContext<{
   language?: Locale
@@ -19,20 +26,71 @@ export const useLanguage = () => {
   return context
 }
 
+/**
+ * Applies the language the backend persisted, which is derived from the system
+ * locale on a first run and from the user's choice afterwards.
+ *
+ * The locale cached in `localStorage` is only a fast path that lets the tree
+ * mount before the settings query resolves; the backend stays authoritative and
+ * corrects the cache whenever the two disagree.
+ */
 export const LanguageProvider = ({ children }: PropsWithChildren) => {
-  const language = useSetting('language')
+  const { query, upsert } = useSettings()
+
+  const persisted = normalizeLanguage(query.data?.language)
+  const settled = query.isSuccess || query.isError
+
+  // Deliberately compares against the cache rather than `getLocale()`: the
+  // first `getLocale()` call writes whatever it resolved back into the cache,
+  // so calling it here would mask a first launch (no cache at all) as a
+  // deliberate choice of `baseLocale`.
+  const [cached] = useState(getCachedLanguage)
+  const [applied, setApplied] = useState(cached !== null)
+
+  useEffect(() => {
+    if (applied || !settled) {
+      return
+    }
+
+    if (persisted && persisted !== cached) {
+      setLocale(persisted, { reload: false })
+    }
+
+    // Released even when the query failed or named a language this build has no
+    // messages for: `baseLocale` is then the honest answer, and the window must
+    // not stay hidden waiting for a better one.
+    setApplied(true)
+  }, [applied, settled, persisted, cached])
+
+  // A cache that disagrees with the backend means the cache is stale — a locale
+  // paraglide auto-persisted before the backend answered on an earlier run, or
+  // a change made in another window. Paraglide reads messages at call time, so
+  // a reload is what makes an already-mounted tree switch language.
+  useEffect(() => {
+    if (!applied || !persisted || persisted === getLocale()) {
+      return
+    }
+
+    setLocale(persisted)
+  }, [applied, persisted])
 
   const setLanguage = useLockFn(async (value: Locale) => {
-    await language.upsert(value)
+    await upsert.mutateAsync({ language: value })
     setLocale(value)
   })
 
   // sync dayjs locale
   useEffect(() => {
-    if (language) {
-      locale(language.value || 'en')
+    if (!applied) {
+      return
     }
-  }, [language])
+
+    locale(persisted ?? getLocale())
+  }, [applied, persisted])
+
+  if (!applied) {
+    return null
+  }
 
   return (
     <LanguageContext.Provider

--- a/frontend/nyanpasu/src/utils/language.ts
+++ b/frontend/nyanpasu/src/utils/language.ts
@@ -4,26 +4,56 @@ export type Language = (typeof locales)[number]
 
 export const LANGUAGE_STORAGE_KEY = 'paraglide-language-cache'
 
-export const DEFAULT_LANGUAGE = 'en'
-
 // encode the language storage key to avoid special characters
 const CACHED_LANGUAGE_STORAGE_KEY = btoa(LANGUAGE_STORAGE_KEY)
+
+/**
+ * Spellings that older builds persisted for a language, mapped to the paraglide
+ * locale. The backend now writes the canonical lowercase key and migrates
+ * existing configs, but a config that has not been migrated yet — or a stale
+ * localStorage cache — can still carry these.
+ */
+const LEGACY_LANGUAGE_ALIASES: Record<string, Language> = {
+  'en-us': 'en',
+}
+
+/**
+ * Resolve an arbitrary persisted language value to a paraglide locale, or
+ * `null` when this build has no messages for it.
+ */
+export const normalizeLanguage = (value: unknown): Language | null => {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const lowered = value.toLowerCase()
+
+  return (
+    locales.find((locale) => locale === lowered) ??
+    LEGACY_LANGUAGE_ALIASES[lowered] ??
+    null
+  )
+}
 
 export const setCachedLanguage = (locale: Language) => {
   localStorage.setItem(CACHED_LANGUAGE_STORAGE_KEY, locale)
 }
 
-export const getCachedLanguage = () => {
-  const value = localStorage.getItem(CACHED_LANGUAGE_STORAGE_KEY)
-
-  return value && locales.includes(value as Language)
-    ? (value as Language)
-    : DEFAULT_LANGUAGE
-}
+/**
+ * The locale chosen on a previous run, or `null` on a first launch.
+ *
+ * Returning `null` is deliberate: it lets the paraglide strategy chain fall
+ * through to `baseLocale` for the very first render, after which the
+ * `LanguageProvider` applies the system-derived language the backend resolved.
+ * Reporting a cached `en` here would be indistinguishable from a user who
+ * actually picked English.
+ */
+export const getCachedLanguage = (): Language | null =>
+  normalizeLanguage(localStorage.getItem(CACHED_LANGUAGE_STORAGE_KEY))
 
 defineCustomClientStrategy('custom-extension', {
   getLocale: () => {
-    return getCachedLanguage()
+    return getCachedLanguage() ?? undefined
   },
   setLocale: (locale) => {
     setCachedLanguage(locale as Language)

--- a/frontend/nyanpasu/vite.config.ts
+++ b/frontend/nyanpasu/vite.config.ts
@@ -101,7 +101,11 @@ export default defineConfig(({ command, mode }) => {
       paraglideVitePlugin({
         project: './project.inlang',
         outdir: './src/paraglide',
-        strategy: ['custom-extension'],
+        // `custom-extension` reports the locale cached from a previous run and
+        // returns undefined on a first launch, so `baseLocale` has to terminate
+        // the chain. `LanguageProvider` then applies the system-derived
+        // language the backend resolved.
+        strategy: ['custom-extension', 'baseLocale'],
       }),
     ],
     resolve: {


### PR DESCRIPTION
## Problem

The app opened in English for everyone on a first launch, regardless of system language. Two independent defects kept the detection that already existed from reaching the UI.

**The backend only recognized Chinese.** `mapping_to_i18n_key` mapped `zh-TW*` → `zh-TW`, any other `zh-*` → `zh-CN`, and everything else → `en`. Korean and Russian system locales fell through to English even though both ship complete message bundles. `nyanpasu-config::default_i18n_language()` already had richer detection covering all five languages — including `zh-Hans`/`zh-Hant` script subtags and the `TW`/`HK`/`MO` region split — but nothing on the legacy config path used it.

**The frontend never consulted the backend.** `getCachedLanguage()` returned `en` whenever `localStorage` held no locale, and `custom-extension` was the only strategy paraglide was configured with. So on exactly the launch where detection matters, the detected language was discarded before it could be read.

## The spelling mismatch

Both halves depend on the two sides naming a language identically, and they did not. The backend wrote `zh-CN`; paraglide locales, the dayjs locale imports in `__root.tsx`, and the `rust_i18n` bundles in `backend/tauri/locales/` all use `zh-cn`. This was already load-bearing beyond the first-launch bug:

- `application_from_legacy` converts `legacy.language` into `I18nLanguage` inside `if let Ok(..)`. The settings UI writes the paraglide locale `zh-cn`, which did not match the `zh-CN` rename, so the conversion failed silently and **a language change never reached the typed config**.
- `LanguageProvider` passed the raw setting to dayjs, so `dayjs.locale('zh-CN')` found no such locale and **dates stayed English for Chinese users**.

Lowercase wins because three of the four consumers already used it. `serde(alias)` keeps reading the old spellings, and a migration step canonicalizes configs on disk.

## Changes

| Area | Change |
| --- | --- |
| `nyanpasu-config` | `I18nLanguage` serializes lowercase (`en`, `zh-cn`, `zh-tw`), with `serde(alias)` for the legacy mixed-case forms; adds `as_str()` as the single source for the canonical key |
| `utils/help.rs` | `mapping_to_i18n_key` + `get_system_locale` replaced by `detect_system_i18n_key()`, delegating to the shared detection. Also drops a `tauri_plugin_os` dependency from this path (AGENTS.md §7) |
| `lib.rs`, `IVerge::template()` | Both startup paths route through the shared detection |
| `migration/modules/app_config.rs` | New `MigrateLanguageCase` step (rev 4) canonicalizing persisted values. Ordered after `MigrateLanguageOption`, which emits `zh-CN` |
| `utils/language.ts` | `normalizeLanguage()` for case/alias folding; `getCachedLanguage()` returns `null` instead of a fabricated `en` |
| `vite.config.ts` | `baseLocale` terminates the strategy chain, now that `custom-extension` can return undefined |
| `language-provider.tsx` | Applies the language the backend persisted; dayjs gets the normalized locale |

## Behaviour

**First launch:** no cache, so the tree waits (the window is already hidden until the settings query settles, so this is not user-visible), the backend's system-derived language is applied via `setLocale(.., { reload: false })`, and children mount already translated — no English flash, no reload.

**Later launches:** the cache resolves synchronously and the tree mounts immediately; no added startup latency.

**Stale cache:** if the cache and the backend disagree, the backend wins and a reload applies it. This self-heals users whose cache holds an `en` that paraglide auto-persisted on an earlier run — worth knowing that `getLocale()` writes its resolved value back into the cache on first call, which is why the provider compares against the cache rather than `getLocale()`.

## Review notes

- **`setLanguage` now surfaces failures.** It previously called `useSetting('language').upsert`, which silently no-ops when settings failed to load — yet still called `setLocale`, reloading into a language that was never persisted. It now calls `upsert.mutateAsync` directly, so that case rejects instead. Behaviour change in the touched path; flagging deliberately.
- **`MigrateLanguageOption` still emits `zh-CN`.** Left as-is rather than rewriting a shipped migration's output; the new step canonicalizes it, and a test pins the ordering the chain depends on.
- **Existing users keep their choice.** Their cache already matches the migrated backend value, so nothing is re-detected for them.

## Verification

- `cargo test -p nyanpasu-config` — 7/7 in the i18n module, covering `as_str()` ≡ the serialized form, the lowercase invariant, and legacy-alias parsing
- `cargo test -p clash-nyanpasu --lib` — 503 passed, 0 failed. Two assertions in the 1.6.1 → 2.0 fixture test were updated to the intended new output (`language: zh-cn`, `app_config` head revision 4)
- `pnpm typecheck`, `pnpm web:build`, `prettier`, `oxlint` clean; `pnpm lint:architecture-ledger` gate passed
- Pre-commit hooks ran `cargo clippy --all-targets --all-features` and `cargo fmt` — green

Not exercised: a real end-to-end launch under a non-English system locale. The detection logic itself is unit-tested, but the assembled startup path is not.

https://claude.ai/code/session_01CUTYVpXHNpzAgqtAeJkBPL
