### PR TITLE
feat(proxies): show recent latency history in node cards

### DIFF
--- a/frontend/interface/src/ipc/use-clash-proxies.ts
+++ b/frontend/interface/src/ipc/use-clash-proxies.ts
@@ -2,10 +2,10 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { unwrapResult } from '../utils'
 import {
   commands,
-  ProxyItemHistory,
   type Proxies_Serialize,
   type ProxyGroupItem_Serialize,
   type ProxyItem_Serialize,
+  type ProxyItemHistory,
 } from './bindings'
 import { CLASH_PROXIES_QUERY_KEY } from './consts'
 
@@ -200,10 +200,7 @@ export const useClashProxies = () => {
                   name: proxy.name,
                   delay: data[proxy.name],
                 })
-              : {
-                  ...proxy,
-                  history: [],
-                },
+              : proxy,
           ),
         },
         groups: oldData.groups.map((group) => ({
@@ -214,10 +211,7 @@ export const useClashProxies = () => {
                   name: proxy.name,
                   delay: data[proxy.name],
                 })
-              : {
-                  ...proxy,
-                  history: [],
-                },
+              : proxy,
           ),
         })),
       } satisfies ClashProxiesQuery

--- a/frontend/nyanpasu/messages/en.json
+++ b/frontend/nyanpasu/messages/en.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "proxies_delay_history_title": "Latency history",
+  "proxies_delay_history_empty": "No latency history yet",
+  "proxies_delay_history_recent": "Latest {count} tests · newest first",
+  "proxies_delay_history_failed": "Failed",
   "language": "English",
   "navbar_label_dashboard": "Dashboard",
   "navbar_label_proxies": "Proxies",

--- a/frontend/nyanpasu/messages/ko.json
+++ b/frontend/nyanpasu/messages/ko.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "proxies_delay_history_title": "지연 시간 기록",
+  "proxies_delay_history_empty": "지연 시간 기록이 없습니다",
+  "proxies_delay_history_recent": "최근 {count}회 테스트 · 최신순",
+  "proxies_delay_history_failed": "실패",
   "language": "한국어",
   "navbar_label_dashboard": "대시보드",
   "navbar_label_proxies": "프록시",

--- a/frontend/nyanpasu/messages/ru.json
+++ b/frontend/nyanpasu/messages/ru.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "proxies_delay_history_title": "История задержки",
+  "proxies_delay_history_empty": "История задержки пока пуста",
+  "proxies_delay_history_recent": "Последние тесты: {count} · сначала новые",
+  "proxies_delay_history_failed": "Ошибка",
   "language": "Русский",
   "navbar_label_dashboard": "Панель управления",
   "navbar_label_proxies": "Прокси",

--- a/frontend/nyanpasu/messages/zh-cn.json
+++ b/frontend/nyanpasu/messages/zh-cn.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "proxies_delay_history_title": "延迟历史",
+  "proxies_delay_history_empty": "暂无延迟历史",
+  "proxies_delay_history_recent": "最近 {count} 次测速 · 最新在前",
+  "proxies_delay_history_failed": "失败",
   "language": "简体中文",
   "navbar_label_dashboard": "概览",
   "navbar_label_proxies": "代理",

--- a/frontend/nyanpasu/messages/zh-tw.json
+++ b/frontend/nyanpasu/messages/zh-tw.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "proxies_delay_history_title": "延遲歷史",
+  "proxies_delay_history_empty": "暫無延遲歷史",
+  "proxies_delay_history_recent": "最近 {count} 次測速 · 最新在前",
+  "proxies_delay_history_failed": "失敗",
   "language": "繁體中文",
   "navbar_label_dashboard": "概覽",
   "navbar_label_proxies": "代理組",

--- a/frontend/nyanpasu/src/components/proxies/delay-history.tsx
+++ b/frontend/nyanpasu/src/components/proxies/delay-history.tsx
@@ -1,0 +1,93 @@
+import { Tooltip } from 'radix-ui'
+import { ReactElement } from 'react'
+import { m } from '@/paraglide/messages'
+import { getLocale } from '@/paraglide/runtime'
+import { ProxyItemHistory } from '@nyanpasu/interface'
+import { cn } from '@nyanpasu/utils'
+import DelayChip from './delay-chip'
+
+const HISTORY_LIMIT = 10
+
+export function DelayHistoryBar({ history }: { history: ProxyItemHistory[] }) {
+  return (
+    <span
+      className="flex h-1 w-12 shrink-0 gap-px overflow-hidden rounded-full"
+      aria-hidden="true"
+    >
+      {history.slice(-HISTORY_LIMIT).map(({ delay }, index) => (
+        <span
+          key={index}
+          className={cn(
+            'h-full flex-1 bg-green-500',
+            delay > 100 && 'bg-yellow-500',
+            delay > 300 && 'bg-orange-500',
+            (delay > 500 || delay <= 0) && 'bg-red-500',
+          )}
+        />
+      ))}
+    </span>
+  )
+}
+
+export default function DelayHistory({
+  history = [],
+  children,
+}: {
+  history?: ProxyItemHistory[]
+  children: ReactElement
+}) {
+  const recent = history.slice(-HISTORY_LIMIT).reverse()
+  const formatTime = (time: string) => {
+    const date = new Date(time)
+    return Number.isNaN(date.getTime())
+      ? time
+      : date.toLocaleString(getLocale(), { hour12: false })
+  }
+
+  return (
+    <Tooltip.Provider delayDuration={300}>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            sideOffset={8}
+            className="bg-surface text-on-surface z-50 max-w-[calc(100vw-2rem)] rounded-xl px-3 py-2 text-xs shadow-lg"
+            data-slot="proxy-delay-history"
+          >
+            <div className="space-y-2 py-1">
+              <div className="font-medium">
+                {m.proxies_delay_history_title()}
+              </div>
+              {recent.length === 0 ? (
+                <div>{m.proxies_delay_history_empty()}</div>
+              ) : (
+                <>
+                  <div className="text-on-surface-variant">
+                    {m.proxies_delay_history_recent({ count: recent.length })}
+                  </div>
+                  <ol className="space-y-1">
+                    {recent.map(({ time, delay }, index) => (
+                      <li
+                        key={`${time}-${index}`}
+                        className="flex items-center justify-between gap-4 tabular-nums"
+                      >
+                        <time dateTime={time}>{formatTime(time)}</time>
+                        {delay > 0 ? (
+                          <DelayChip delay={delay} />
+                        ) : (
+                          <span className="text-red-500">
+                            {m.proxies_delay_history_failed()}
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ol>
+                </>
+              )}
+            </div>
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  )
+}

--- a/frontend/nyanpasu/src/pages/(main)/main/proxies/group/_modules/proxy-node-button.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/proxies/group/_modules/proxy-node-button.tsx
@@ -2,6 +2,9 @@ import FlashOnRounded from '~icons/material-symbols/flash-on-rounded'
 import { ComponentProps, MouseEvent, useMemo } from 'react'
 import { useBlockTask } from '@/components/providers/block-task-provider'
 import DelayChip from '@/components/proxies/delay-chip'
+import DelayHistory, {
+  DelayHistoryBar,
+} from '@/components/proxies/delay-history'
 import { Button } from '@/components/ui/button'
 import { useLockFn } from '@/hooks/use-lock-fn'
 import { ClashProxiesQueryProxyItem } from '@nyanpasu/interface'
@@ -63,49 +66,52 @@ export default function ProxyNodeButton({
   }, [proxy.history])
 
   return (
-    <Button
-      variant="fab"
-      className={cn(
-        'flex w-full flex-col justify-center gap-1 px-2 text-left',
-        'group-data-[active=true]:bg-primary-container/75',
-        'dark:group-data-[active=true]:bg-surface-variant/50',
-        'group-data-[active=false]:bg-on-background/3',
-        'dark:group-data-[active=false]:bg-surface/30',
-        'group-data-[active=false]:shadow-none',
-        'group-data-[active=false]:hover:shadow-none',
-        'group-data-[active=false]:hover:bg-surface-variant/30',
-      )}
-      onClick={handleSelectProxy}
-      {...props}
-    >
-      <div className="flex items-center gap-2 px-2">
-        <div className="truncate text-sm font-medium">{proxy.name}</div>
-      </div>
-
-      <div className="flex w-full items-center justify-between gap-2 overflow-hidden px-2">
-        <div className="flex items-center gap-1 overflow-hidden">
-          <FeatureChip label={proxy.type} variant="type" />
-          {proxy.udp && <FeatureChip label="UDP" />}
-          {proxy.xudp && <FeatureChip label="XUDP" />}
-          {proxy.tfo && <FeatureChip label="TFO" />}
+    <DelayHistory history={proxy.history}>
+      <Button
+        variant="fab"
+        className={cn(
+          'flex w-full flex-col justify-center gap-1 px-2 text-left',
+          'group-data-[active=true]:bg-primary-container/75',
+          'dark:group-data-[active=true]:bg-surface-variant/50',
+          'group-data-[active=false]:bg-on-background/3',
+          'dark:group-data-[active=false]:bg-surface/30',
+          'group-data-[active=false]:shadow-none',
+          'group-data-[active=false]:hover:shadow-none',
+          'group-data-[active=false]:hover:bg-surface-variant/30',
+        )}
+        onClick={handleSelectProxy}
+        {...props}
+      >
+        <div className="flex w-full items-center justify-between gap-2 px-2">
+          <div className="truncate text-sm font-medium">{proxy.name}</div>
+          <DelayHistoryBar history={proxy.history ?? []} />
         </div>
 
-        <Button
-          className="grid h-4 min-w-10 shrink-0 place-content-center px-2 text-center"
-          variant="raised"
-          onClick={handleDelayClick}
-          loading={delayTask.isPending}
-          asChild
-        >
-          {currentDelay > 0 ? (
-            <DelayChip delay={currentDelay} />
-          ) : (
-            <span>
-              <FlashOnRounded className="py-1" />
-            </span>
-          )}
-        </Button>
-      </div>
-    </Button>
+        <div className="flex w-full items-center justify-between gap-2 overflow-hidden px-2">
+          <div className="flex items-center gap-1 overflow-hidden">
+            <FeatureChip label={proxy.type} variant="type" />
+            {proxy.udp && <FeatureChip label="UDP" />}
+            {proxy.xudp && <FeatureChip label="XUDP" />}
+            {proxy.tfo && <FeatureChip label="TFO" />}
+          </div>
+
+          <Button
+            className="grid h-4 min-w-10 shrink-0 place-content-center px-2 text-center"
+            variant="raised"
+            onClick={handleDelayClick}
+            loading={delayTask.isPending}
+            asChild
+          >
+            {currentDelay > 0 ? (
+              <DelayChip delay={currentDelay} />
+            ) : (
+              <span>
+                <FlashOnRounded className="py-1" />
+              </span>
+            )}
+          </Button>
+        </div>
+      </Button>
+    </DelayHistory>
   )
 }

--- a/scripts/proxy-delay-history.test.mjs
+++ b/scripts/proxy-delay-history.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { stripTypeScriptTypes } from "node:module";
+import test from "node:test";
+import { SourceTextModule, SyntheticModule } from "node:vm";
+
+const source = stripTypeScriptTypes(
+  await readFile(
+    new URL(
+      "../frontend/interface/src/ipc/use-clash-proxies.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+);
+
+async function setup() {
+  const node = (name) => ({
+    name,
+    history: [{ time: "2026-09-10T00:00:00Z", delay: 42 }],
+  });
+  const original = {
+    global: { all: [node("tested"), node("other")] },
+    groups: [{ all: [node("tested"), node("other")] }],
+  };
+  let cached = original;
+  const dependencies = {
+    "@tanstack/react-query": {
+      useQuery: () => ({}),
+      useMutation: (options) => options,
+      useQueryClient: () => ({
+        getQueryData: () => cached,
+        setQueryData: (_, data) => {
+          cached = data;
+        },
+      }),
+    },
+    "../utils": { unwrapResult: (value) => value },
+    "./bindings": { commands: {} },
+    "./consts": { CLASH_PROXIES_QUERY_KEY: "clash-proxies" },
+  };
+  const module = new SourceTextModule(source);
+  await module.link((specifier) => {
+    const exports = dependencies[specifier];
+    return new SyntheticModule(Object.keys(exports), function () {
+      for (const [name, value] of Object.entries(exports)) {
+        this.setExport(name, value);
+      }
+    });
+  });
+  await module.evaluate();
+  return {
+    hook: module.namespace.useClashProxies(),
+    original,
+    data: () => cached,
+  };
+}
+
+test("group delay preserves history of nodes absent from the response", async () => {
+  const { hook, original, data } = await setup();
+  hook.updateGroupDelay.onSuccess({ tested: 100 });
+  for (const group of [data().global, ...data().groups]) {
+    assert.deepEqual(group.all[0].history.map(({ delay }) => delay), [42, 100]);
+    assert.deepEqual(group.all[1].history, original.global.all[1].history);
+  }
+  assert.equal(original.global.all[0].history.length, 1);
+});
+
+test("empty group responses retain all existing history", async () => {
+  const { hook, original, data } = await setup();
+  hook.updateGroupDelay.onSuccess({});
+  assert.deepEqual(data(), original);
+});
+
+test("zero delay is retained as a failed sample", async () => {
+  const { hook, data } = await setup();
+  hook.updateGroupDelay.onSuccess({ tested: 0 });
+  assert.deepEqual(data().groups[0].all[0].history.map(({ delay }) => delay), [
+    42,
+    0,
+  ]);
+});


### PR DESCRIPTION
Proxy cards currently expose only the latest latency even though the API already supplies timestamped history. Show the latest ten samples as a compact color bar, with hover and keyboard-focus details listing timestamps, latency, failures, and an empty state. Includes translations for all five supported locales and preserves the existing node selection and latency-test interactions.

Group latency tests also preserve history for nodes absent from the response, instead of clearing unrelated samples from the frontend cache. The feature uses the existing history data without adding backend storage or APIs.

Validation:
- `node --experimental-vm-modules --test scripts/proxy-delay-history.test.mjs`: three regression tests pass.
- `pnpm typecheck`, targeted Oxlint and Prettier checks, and commit hooks pass.
- `pnpm web:build` passes with existing chunk-size and dynamic-import warnings.
- Browser component checks with mocked Tauri data cover the ten-sample limit, newest-first ordering, failure and empty states, updates after testing, keyboard focus/Escape/Enter, and testing without selecting a node.
- Windows Cargo dependency resolution passes; a full native application build was not run.

UI reference: [MetaCubeXD proxy cards](https://github.com/MetaCubeX/metacubexd/blob/main/packages/ui/components/ProxyNodeCard.vue).
