### PR TITLE
feat(updater): own core updates in an injected actor

### DIFF
--- a/backend/tauri/src/client/core_lifecycle/mod.rs
+++ b/backend/tauri/src/client/core_lifecycle/mod.rs
@@ -220,6 +220,22 @@ impl CoreLifecycleState {
         }
     }
 
+    fn reject(&mut self, request: Request, error: CoreError) {
+        if let Command::ReplaceCoreBinary(artifact) = &request.command {
+            // A timed-out installer may still reserve its updater task. Rejection
+            // before execution must settle that observer as well as the RPC.
+            let message = error.to_string();
+            if std::panic::catch_unwind(AssertUnwindSafe(|| {
+                artifact.progress.finished(Some(&message));
+            }))
+            .is_err()
+            {
+                tracing::error!("binary installation progress observer panicked");
+            }
+        }
+        self.settle(request.response, Err(error));
+    }
+
     fn close(&mut self) {
         self.closing = true;
         self.closing_token.cancel();
@@ -232,10 +248,7 @@ impl CoreLifecycleState {
         }
         self.dirty = false;
         while let Some(request) = self.pending.pop_front() {
-            self.settle(
-                request.response,
-                Err(conflict("core lifecycle is shutting down")),
-            );
+            self.reject(request, conflict("core lifecycle is shutting down"));
         }
     }
 
@@ -249,7 +262,7 @@ impl CoreLifecycleState {
             self.status.send_modify(|status| status.uncertain = true);
             self.dirty = false;
             while let Some(request) = self.pending.pop_front() {
-                self.settle(request.response, Err(CoreError::new(CoreErrorKind::OperationConflict, "previous core lifecycle operation has an uncertain outcome; restart the application before further mutations", false)));
+                self.reject(request, CoreError::new(CoreErrorKind::OperationConflict, "previous core lifecycle operation has an uncertain outcome; restart the application before further mutations", false));
             }
         }
         let request = if self.closing {
@@ -396,15 +409,9 @@ impl Actor for CoreLifecycleActor {
                         state.settle(request.response, Err(conflict("too many shutdown waiters")));
                     }
                 } else if state.closing {
-                    state.settle(
-                        request.response,
-                        Err(conflict("core lifecycle is shutting down")),
-                    );
+                    state.reject(request, conflict("core lifecycle is shutting down"));
                 } else if state.pending.len() >= MAX_PENDING {
-                    state.settle(
-                        request.response,
-                        Err(conflict("core lifecycle queue is full")),
-                    );
+                    state.reject(request, conflict("core lifecycle queue is full"));
                 } else {
                     state.pending.push_back(request);
                 }

--- a/backend/tauri/src/client/core_lifecycle/tests/mod.rs
+++ b/backend/tauri/src/client/core_lifecycle/tests/mod.rs
@@ -611,6 +611,13 @@ fn queue_is_bounded_and_caller_timeout_does_not_release_admission() {
             core_lifecycle.reconcile().await.unwrap_err().kind,
             Some(CoreErrorKind::OperationConflict)
         );
+        let (mut rejected, _) = f.artifact(ClashCore::ClashRs);
+        let terminal = Arc::new(TerminalProgress::default());
+        rejected.progress = terminal.clone();
+        assert!(core_lifecycle.replace_binary(rejected).await.is_err());
+        let outcomes = terminal.0.lock().unwrap().clone();
+        assert_eq!(outcomes.len(), 1);
+        assert!(outcomes[0].as_ref().unwrap().contains("queue is full"));
         assert_eq!(f.endpoint.submissions(), 2);
         let mut shutdown = Box::pin(f.client.shutdown_core());
         assert!(shutdown.as_mut().now_or_never().is_none());
@@ -978,4 +985,66 @@ fn control_channel_application_does_not_start_a_stopped_core() {
         f.client.apply_control_channel().await.unwrap();
         assert_eq!(f.endpoint.submissions(), 1);
     });
+}
+
+#[derive(Default)]
+struct TerminalProgress(std::sync::Mutex<Vec<Option<String>>>);
+impl BinaryInstallProgress for TerminalProgress {
+    fn restarting(&self) {
+        panic!("a rejected installation must not restart");
+    }
+    fn finished(&self, error: Option<&str>) {
+        self.0.lock().unwrap().push(error.map(str::to_owned));
+    }
+}
+
+#[test]
+fn queued_installation_timeout_is_settled_when_shutdown_or_uncertainty_rejects_it() {
+    for panic in [false, true] {
+        let f = Fixture::new(true, false, panic);
+        tauri::async_runtime::block_on(async {
+            let (first, _) = start_replacement(&f).await;
+            let (mut queued, _) = f.artifact(ClashCore::ClashRs);
+            let terminal = Arc::new(TerminalProgress::default());
+            queued.progress = terminal.clone();
+            let client = &f.client.inner.core_lifecycle;
+            let result = client
+                .call_with_timeout(
+                    Command::ReplaceCoreBinary(queued),
+                    Duration::from_millis(20),
+                )
+                .await;
+            assert!(
+                matches!(result, Err(error) if error.kind == Some(CoreErrorKind::BackendUnavailable))
+            );
+            assert_eq!(client.status().queued.len(), 1);
+            assert!(terminal.0.lock().unwrap().is_empty());
+            if panic {
+                f.installer.release.notify_one();
+                assert!(first.await.unwrap().is_err());
+                barrier(client).await;
+                assert!(client.status().uncertain);
+            } else {
+                let mut shutdown = Box::pin(f.client.shutdown_core());
+                assert!(shutdown.as_mut().now_or_never().is_none());
+                barrier(client).await;
+                f.installer.release.notify_one();
+                first.await.unwrap().unwrap();
+                assert!(shutdown.await.stop.is_ok());
+            }
+            let outcomes = terminal.0.lock().unwrap().clone();
+            assert_eq!(
+                outcomes.len(),
+                1,
+                "rejected request must deliver exactly one terminal notification"
+            );
+            assert!(outcomes[0].as_ref().unwrap().contains(if panic {
+                "uncertain outcome"
+            } else {
+                "shutting down"
+            }));
+            assert_eq!(f.installer.calls.load(Ordering::SeqCst), 1);
+            assert!(client.status().queued.is_empty());
+        });
+    }
 }

--- a/backend/tauri/src/client/mod.rs
+++ b/backend/tauri/src/client/mod.rs
@@ -267,6 +267,7 @@ struct NyanpasuClientInner {
     core_api: CoreClientV2,
     proxies: crate::core::proxies::ProxiesClient,
     streams: crate::core::clash::ws::StreamsClient,
+    updater: crate::core::updater::UpdaterClient,
     system_dns: Arc<dyn SystemDnsCache>,
 }
 
@@ -384,6 +385,17 @@ impl NyanpasuClient {
                 dirty: dirty_rx,
             })
             .await?;
+        let updater = crate::core::updater::UpdaterClient::spawn(
+            Arc::new(crate::core::updater::HttpUpdaterBackend::new(
+                std::env::current_exe()?
+                    .parent()
+                    .context("executable has no parent directory")?
+                    .to_path_buf(),
+                ports.clone(),
+            )),
+            Arc::new(core_lifecycle.clone()),
+        )
+        .await?;
         let proxies = crate::core::proxies::ProxiesClient::spawn(core_v2.clone()).await?;
         let streams = crate::core::clash::ws::StreamsClient::spawn(core_v2.clone()).await?;
         Ok(Self {
@@ -403,6 +415,7 @@ impl NyanpasuClient {
                 core_api: core_v2,
                 proxies,
                 streams,
+                updater,
                 system_dns,
             }),
         })
@@ -522,15 +535,37 @@ impl NyanpasuClient {
         self.inner.core_lifecycle.uninstall_service().await
     }
 
+    pub async fn fetch_latest_core_versions(
+        &self,
+    ) -> Result<crate::core::updater::ManifestVersionLatest> {
+        Ok(self.inner.updater.fetch_latest().await?)
+    }
+
+    pub async fn download_core_update(
+        &self,
+        core: crate::config::nyanpasu::ClashCore,
+    ) -> Result<usize> {
+        Ok(self.inner.updater.update(core).await?)
+    }
+
+    pub async fn inspect_updater(&self, id: usize) -> Result<crate::core::updater::UpdaterSummary> {
+        Ok(self.inner.updater.inspect(id).await?)
+    }
+
     pub async fn shutdown_core(&self) -> ShutdownReport {
-        self.inner
-            .core_lifecycle
-            .shutdown()
-            .await
-            .unwrap_or_else(|error| ShutdownReport {
-                stop: Err(error),
-                final_status: self.core_status().snapshot,
-            })
+        // Close both admission paths immediately; lifecycle shutdown waits for
+        // already admitted installations while updater cancels preparation work.
+        let (updater, shutdown) = tokio::join!(
+            self.inner.updater.shutdown(),
+            self.inner.core_lifecycle.shutdown(),
+        );
+        if let Err(error) = updater {
+            tracing::warn!(%error, "failed to shut down updater workers");
+        }
+        shutdown.unwrap_or_else(|error| ShutdownReport {
+            stop: Err(error),
+            final_status: self.core_status().snapshot,
+        })
     }
 
     pub async fn flush_system_dns_cache(&self) -> Result<()> {
@@ -1360,6 +1395,32 @@ impl NyanpasuClient {
 fn utf8_path(path: PathBuf) -> anyhow::Result<Utf8PathBuf> {
     Utf8PathBuf::from_path_buf(path)
         .map_err(|path| anyhow::anyhow!("config path is not UTF-8: {}", path.display()))
+}
+
+#[async_trait::async_trait]
+impl crate::core::updater::ports::CoreUpdateInstaller for core_lifecycle::CoreLifecycleClient {
+    async fn install(
+        &self,
+        artifact: core_lifecycle::ports::PreparedCoreBinary,
+    ) -> anyhow::Result<()> {
+        self.replace_binary(artifact).await.map_err(|error| {
+            if error.operation_id.is_some()
+                && matches!(
+                    error.kind,
+                    Some(
+                        nyanpasu_core_manager::CoreErrorKind::BackendUnavailable
+                            | nyanpasu_core_manager::CoreErrorKind::Internal
+                    )
+                )
+            {
+                anyhow::Error::new(crate::core::updater::ports::InstallPending(
+                    error.to_string(),
+                ))
+            } else {
+                anyhow::Error::from(error)
+            }
+        })
+    }
 }
 
 #[cfg(test)]

--- a/backend/tauri/src/core/updater/instance.rs
+++ b/backend/tauri/src/core/updater/instance.rs
@@ -1,16 +1,27 @@
-use super::shared::{self, CoreTypeMeta};
-use crate::{
-    client::NyanpasuClient,
-    config::nyanpasu::ClashCore,
-    core::download::{DownloadSession, DownloadStatus},
+use std::{
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, Instant},
 };
-use anyhow::anyhow;
+
+use async_trait::async_trait;
 use serde::Serialize;
 use specta::Type;
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
-use std::sync::Arc;
 use tempfile::TempDir;
+
+use super::{
+    ManifestVersion,
+    ports::{UpdaterBackend, UpdaterProgress},
+    shared::{self, CoreTypeMeta},
+};
+use crate::{
+    client::core_lifecycle::ports::PreparedCoreBinary,
+    config::nyanpasu::ClashCore,
+    core::download::{DownloadSession, DownloadStatus},
+    utils::candy::{ReqwestSpeedTestExt, parse_gh_url},
+};
 
 #[derive(Debug, Clone, Serialize, Default, specta::Type)]
 #[serde(rename_all = "snake_case")]
@@ -22,274 +33,318 @@ pub enum UpdaterState {
     Replacing,
     Restarting,
     Done,
+    Pending(String),
     Failed(String),
 }
 
-pub(super) struct Updater {
-    id: usize,
-    temp_dir: Arc<TempDir>,
-    core_type: ClashCore,
-    artifact: String,
-    inner: Arc<parking_lot::RwLock<UpdaterInner>>,
-    downloader: Arc<DownloadSession>,
-    nyanpasu: NyanpasuClient,
-}
-
-struct UpdaterInstallProgress(Arc<parking_lot::RwLock<UpdaterInner>>);
-
-impl crate::client::core_lifecycle::ports::BinaryInstallProgress for UpdaterInstallProgress {
-    fn restarting(&self) {
-        self.0.write().state = UpdaterState::Restarting;
-    }
-    fn finished(&self, error: Option<&str>) {
-        self.0.write().state = match error {
-            Some(error) => UpdaterState::Failed(error.to_owned()),
-            None => UpdaterState::Done,
-        };
-    }
-}
-
-struct UpdaterInner {
-    state: UpdaterState,
-}
-
-#[derive(Debug, Serialize, Type)]
+#[derive(Debug, Clone, Serialize, Type)]
 pub struct UpdaterSummary {
     pub id: usize,
     pub state: UpdaterState,
     pub downloader: DownloadStatus,
 }
 
-pub(super) struct UpdaterBuilder {
-    client: Option<reqwest::Client>,
-    core_type: Option<ClashCore>,
-    mirror: Option<String>,
-    artifact: Option<String>,
-    tag: Option<CoreTypeMeta>,
-    nyanpasu: Option<NyanpasuClient>,
+pub(crate) struct HttpUpdaterBackend {
+    proxy_port: Arc<dyn crate::service::profile_file::SelfProxyPortSource>,
+    destination_dir: PathBuf,
 }
 
-impl UpdaterBuilder {
-    pub fn new() -> Self {
+impl HttpUpdaterBackend {
+    pub fn new(
+        destination_dir: PathBuf,
+        proxy_port: Arc<dyn crate::service::profile_file::SelfProxyPortSource>,
+    ) -> Self {
         Self {
-            client: None,
-            core_type: None,
-            mirror: None,
-            artifact: None,
-            tag: None,
-            nyanpasu: None,
+            proxy_port,
+            destination_dir,
         }
     }
 
-    pub fn set_client(mut self, client: reqwest::Client) -> Self {
-        self.client = Some(client);
-        self
-    }
-
-    pub fn set_nyanpasu_client(mut self, client: NyanpasuClient) -> Self {
-        self.nyanpasu = Some(client);
-        self
-    }
-
-    pub fn set_core_type(mut self, core_type: ClashCore) -> Self {
-        self.core_type = Some(core_type);
-        self
-    }
-
-    pub fn set_artifact(mut self, artifact: String) -> Self {
-        self.artifact = Some(artifact);
-        self
-    }
-
-    pub fn set_tag(mut self, tag: CoreTypeMeta) -> Self {
-        self.tag = Some(tag);
-        self
-    }
-
-    pub fn set_mirror(mut self, mirror: String) -> Self {
-        self.mirror = Some(mirror);
-        self
-    }
-
-    pub async fn build(self) -> anyhow::Result<Updater> {
-        let client = self.client.ok_or(anyhow::anyhow!("client is required"))?;
-        let core_type = self
-            .core_type
-            .ok_or(anyhow::anyhow!("core_type is required"))?;
-        let artifact = self
-            .artifact
-            .ok_or(anyhow::anyhow!("artifact is required"))?;
-        let tag = self.tag.ok_or(anyhow::anyhow!("tag is required"))?;
-        let mirror = self.mirror.ok_or(anyhow::anyhow!("mirror is required"))?;
-        let nyanpasu = self
-            .nyanpasu
-            .ok_or(anyhow::anyhow!("nyanpasu client is required"))?;
-
-        let temp_dir = TempDir::new()?;
-        let inner = UpdaterInner {
-            state: UpdaterState::Idle,
-        };
-
-        // setup downloader
-        let download_path = shared::get_download_path(tag, &artifact);
-        let mut download_url = url::Url::parse("https://github.com")?;
-        download_url.set_path(&download_path);
-        let download_url = crate::utils::candy::parse_gh_url(&mirror, download_url.as_str())?;
-        let save_path = temp_dir.path().join(&artifact);
-        tracing::debug!("downloader url: {}", download_url);
-        tracing::debug!("downloader save path: {:?}", save_path);
-        let downloader = Arc::new(DownloadSession::new(client, download_url, save_path).await?);
-        Ok(Updater {
-            id: rand::random::<u32>() as usize,
-            temp_dir: Arc::new(temp_dir),
-            core_type,
-            inner: Arc::new(parking_lot::RwLock::new(inner)),
-            artifact,
-            downloader,
-            nyanpasu,
-        })
+    fn http_client(&self) -> anyhow::Result<reqwest::Client> {
+        let mut builder = reqwest::Client::builder()
+            .user_agent(concat!("clash-nyanpasu/", env!("CARGO_PKG_VERSION")))
+            .timeout(Duration::from_secs(120));
+        if let Some(port) = self.proxy_port.mixed_port() {
+            builder = builder.proxy(reqwest::Proxy::all(format!("http://127.0.0.1:{port}"))?);
+        }
+        Ok(builder.build()?)
     }
 }
 
-impl Updater {
-    fn dispatch_state(&self, state: UpdaterState) {
-        tracing::debug!("dispatching updater state: {:?}", state);
-        let mut inner = self.inner.write();
-        inner.state = state;
+// DownloadSession drives background IO internally; cancelling its owner must also
+// cancel those tasks before the worker releases its staging directory.
+struct OwnedDownload(DownloadSession);
+
+impl Drop for OwnedDownload {
+    fn drop(&mut self) {
+        self.0.cancel();
+    }
+}
+
+#[async_trait]
+impl UpdaterBackend for HttpUpdaterBackend {
+    async fn fetch_manifest(
+        &self,
+        mirror: Option<(String, Instant)>,
+    ) -> anyhow::Result<(ManifestVersion, (String, Instant))> {
+        let client = self.http_client()?;
+        let mirror = match mirror {
+            Some(cached) if cached.1.elapsed() < Duration::from_secs(3600) => cached,
+            _ => {
+                let results = client.mirror_speed_test(
+                    crate::utils::candy::INTERNAL_MIRRORS,
+                    "https://github.com/libnyanpasu/clash-nyanpasu/raw/main/manifest/version.json",
+                ).await?;
+                let (mirror, speed) = results
+                    .first()
+                    .ok_or_else(|| anyhow::anyhow!("no mirrors found"))?;
+                if speed - 1.0 < 0.0001 {
+                    anyhow::bail!("all mirrors are too slow");
+                }
+                (mirror.to_string(), Instant::now())
+            }
+        };
+        let url = parse_gh_url(
+            &mirror.0,
+            "/libnyanpasu/clash-nyanpasu/raw/main/manifest/version.json",
+        )?;
+        let manifest = client
+            .get(url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok((manifest, mirror))
     }
 
-    async fn decompress_and_set_permission(&self) -> anyhow::Result<()> {
-        self.dispatch_state(UpdaterState::Decompressing);
-        let path = self.temp_dir.path().join(&self.artifact);
-        tracing::debug!("decompressing file: {:?}", path);
-        let mut tmp_file = std::fs::File::open(path)?;
-        tracing::debug!("file size: {}", tmp_file.metadata()?.len());
-        let artifact = self.artifact.clone();
-        let buff = tokio::task::spawn_blocking(move || {
-            let mut buff = Vec::<u8>::new();
-            match artifact {
-                fname if fname.ends_with(".gz") => {
-                    tracing::debug!("decompressing gz file");
-                    let mut decoder = flate2::read::GzDecoder::new(&mut tmp_file);
-                    std::io::copy(&mut decoder, &mut buff)?;
+    async fn prepare(
+        &self,
+        core_type: ClashCore,
+        mirror: String,
+        artifact: String,
+        tag: CoreTypeMeta,
+        progress: UpdaterProgress,
+    ) -> anyhow::Result<PreparedCoreBinary> {
+        let staging = Arc::new(TempDir::new()?);
+        let mut url = url::Url::parse("https://github.com")?;
+        url.set_path(&shared::get_download_path(tag, &artifact));
+        let url = parse_gh_url(&mirror, url.as_str())?;
+        let downloader = OwnedDownload(
+            DownloadSession::new(self.http_client()?, url, staging.path().join(&artifact)).await?,
+        );
+        let download = downloader.0.start();
+        tokio::pin!(download);
+        let mut interval = tokio::time::interval(Duration::from_millis(250));
+        loop {
+            tokio::select! {
+                result = &mut download => {
+                    progress.report(UpdaterState::Downloading, Some(downloader.0.status()));
+                    result?;
+                    break;
                 }
-                fname if fname.ends_with(".zip") => {
-                    tracing::debug!("decompressing zip file");
-                    let mut archive = zip::ZipArchive::new(tmp_file)?;
-                    let len = archive.len();
-                    for i in 0..len {
-                        let mut file = archive.by_index(i)?;
-                        let file_name = file.name();
-                        tracing::debug!("Filename: {}", file.name());
-                        // TODO: 在 enum 做点魔法
-                        if file_name.contains("mihomo")
-                            || file_name.contains("clash")
-                            || file_name.contains("meow")
-                        {
-                            tracing::debug!("extract file: {}", file_name);
-                            tracing::debug!("extract file size: {}", file.size());
-                            std::io::copy(&mut file, &mut buff)?;
-                            break;
-                        }
-                        if i == len - 1 {
-                            anyhow::bail!("failed to find core file in a zip archive");
-                        }
-                    }
+                _ = interval.tick() => {
+                    progress.report(UpdaterState::Downloading, Some(downloader.0.status()));
                 }
-                _ => {
-                    tracing::debug!("directly copying file");
-                    std::io::copy(&mut tmp_file, &mut buff)?;
-                }
-            };
-            Ok::<_, anyhow::Error>(buff)
+            }
+        }
+        progress.report(UpdaterState::Decompressing, None);
+        let filename = format!("{}{}", core_type, std::env::consts::EXE_SUFFIX);
+        let prepared_dir = staging.path().join("prepared");
+        tokio::fs::create_dir(&prepared_dir).await?;
+        let source = prepared_dir.join(&filename);
+        let extraction_staging = staging.clone();
+        let extraction_source = source.clone();
+        // A blocking extraction cannot be aborted midway. It owns staging until
+        // completion, including when its async worker is cancelled during shutdown.
+        tokio::task::spawn_blocking(move || {
+            extract_core(
+                extraction_staging.path().join(&artifact),
+                &artifact,
+                extraction_source,
+            )
         })
         .await??;
-        let tmp_core = self.temp_dir.path().join(format!(
-            "{}{}",
-            self.core_type,
-            std::env::consts::EXE_SUFFIX
-        ));
-        tracing::debug!("writing core to {:?} ({} bytes)", tmp_core, buff.len());
-        let mut core_file = tokio::fs::File::create(&tmp_core).await?;
-        tokio::io::copy(&mut buff.as_slice(), &mut core_file).await?;
-        #[cfg(target_family = "unix")]
-        {
-            std::fs::set_permissions(&tmp_core, std::fs::Permissions::from_mode(0o755))?;
+        progress.report(UpdaterState::Replacing, None);
+        Ok(PreparedCoreBinary {
+            target: core_type,
+            source,
+            destination: self.destination_dir.join(filename),
+            staging,
+            progress: Arc::new(progress),
+        })
+    }
+}
+
+fn extract_core(archive_path: PathBuf, artifact: &str, destination: PathBuf) -> anyhow::Result<()> {
+    let mut source = std::fs::File::open(archive_path)?;
+    let mut output = std::fs::File::create(&destination)?;
+    if artifact.ends_with(".gz") {
+        std::io::copy(&mut flate2::read::GzDecoder::new(source), &mut output)?;
+    } else if artifact.ends_with(".zip") {
+        let mut archive = zip::ZipArchive::new(source)?;
+        let mut found = false;
+        for index in 0..archive.len() {
+            let mut file = archive.by_index(index)?;
+            if !file.is_dir()
+                && ["mihomo", "clash", "meow"]
+                    .iter()
+                    .any(|name| file.name().contains(name))
+            {
+                std::io::copy(&mut file, &mut output)?;
+                found = true;
+                break;
+            }
         }
-        Ok(())
+        anyhow::ensure!(found, "failed to find core file in a zip archive");
+    } else {
+        std::io::copy(&mut source, &mut output)?;
+    }
+    #[cfg(target_family = "unix")]
+    std::fs::set_permissions(destination, std::fs::Permissions::from_mode(0o755))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    struct ProxyPort(std::sync::atomic::AtomicU16);
+
+    impl crate::service::profile_file::SelfProxyPortSource for ProxyPort {
+        fn mixed_port(&self) -> Option<u16> {
+            Some(self.0.load(std::sync::atomic::Ordering::SeqCst))
+        }
     }
 
-    async fn replace_core(&self) -> anyhow::Result<()> {
-        self.dispatch_state(UpdaterState::Replacing);
+    async fn proxy_reply(listener: &tokio::net::TcpListener, body: &str) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        loop {
+            let mut buffer = [0; 1024];
+            let read = socket.read(&mut buffer).await.unwrap();
+            assert_ne!(read, 0);
+            request.extend_from_slice(&buffer[..read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+        assert!(
+            String::from_utf8(request)
+                .unwrap()
+                .starts_with("GET http://updater.invalid/artifact HTTP/1.1")
+        );
+        socket
+            .write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+    }
 
-        #[cfg(target_os = "windows")]
-        let target_core = format!("{}.exe", self.core_type);
-        #[cfg(not(target_os = "windows"))]
-        let target_core = self.core_type.clone().to_string();
-        let core_dir = tauri::utils::platform::current_exe()?;
-        let core_dir = core_dir.parent().ok_or(anyhow!("failed to get core dir"))?;
-        let target_core = core_dir.join(target_core);
-        let tmp_core_path = self.temp_dir.path().join(format!(
-            "{}{}",
-            self.core_type,
-            std::env::consts::EXE_SUFFIX
-        ));
-
-        self.nyanpasu
-            .replace_core_binary(crate::client::core_lifecycle::ports::PreparedCoreBinary {
-                target: self.core_type,
-                source: tmp_core_path,
-                destination: target_core,
-                staging: self.temp_dir.clone(),
-                progress: Arc::new(UpdaterInstallProgress(self.inner.clone())),
+    #[tokio::test]
+    async fn new_http_operation_uses_latest_actual_proxy_port() {
+        let first = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let second = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = Arc::new(ProxyPort(std::sync::atomic::AtomicU16::new(
+            first.local_addr().unwrap().port(),
+        )));
+        let dir = TempDir::new().unwrap();
+        let backend = HttpUpdaterBackend::new(dir.path().to_path_buf(), port.clone());
+        for (listener, expected) in [(&first, "first core"), (&second, "restarted core")] {
+            port.0.store(
+                listener.local_addr().unwrap().port(),
+                std::sync::atomic::Ordering::SeqCst,
+            );
+            let client = backend.http_client().unwrap();
+            let (response, ()) = tokio::time::timeout(Duration::from_secs(5), async {
+                tokio::join!(
+                    async {
+                        client
+                            .get("http://updater.invalid/artifact")
+                            .send()
+                            .await
+                            .unwrap()
+                            .text()
+                            .await
+                            .unwrap()
+                    },
+                    proxy_reply(listener, expected),
+                )
             })
-            .await?;
-
-        Ok(())
-    }
-
-    pub async fn start(&self) {
-        {
-            let mut inner = self.inner.write();
-            if !matches!(inner.state, UpdaterState::Idle) {
-                return;
-            }
-            inner.state = UpdaterState::Downloading;
-        }
-        // The download engine reports live progress through `downloader.status()`,
-        // which `get_report` surfaces to the frontend while this runs.
-        if let Err(e) = self.downloader.start().await {
-            tracing::error!("download failed: {}", e);
-            self.dispatch_state(UpdaterState::Failed(e.to_string()));
-            return;
-        }
-        tracing::debug!("download finished and start to incoming update logic");
-        if let Err(e) = self.decompress_and_set_permission().await {
-            tracing::error!("failed to decompress and set permission: {}", e);
-            self.dispatch_state(UpdaterState::Failed(e.to_string()));
-            return;
-        }
-        if let Err(e) = self.replace_core().await {
-            tracing::error!("failed to replace core: {}", e);
-            // The terminal notification can race the requester's timeout.
-            let mut inner = self.inner.write();
-            if !matches!(inner.state, UpdaterState::Done) {
-                inner.state = UpdaterState::Failed(e.to_string());
-            }
-            return;
-        }
-        self.dispatch_state(UpdaterState::Done);
-    }
-
-    pub fn get_report(&self) -> UpdaterSummary {
-        UpdaterSummary {
-            id: self.id,
-            state: self.inner.read().state.clone(),
-            downloader: self.downloader.status(),
+            .await
+            .unwrap();
+            assert_eq!(response, expected);
         }
     }
 
-    pub fn get_updater_id(&self) -> usize {
-        self.id
+    #[test]
+    fn raw_artifact_with_core_filename_is_preserved_during_extraction() {
+        let dir = TempDir::new().unwrap();
+        let filename = format!("mihomo{}", std::env::consts::EXE_SUFFIX);
+        let archive = dir.path().join(&filename);
+        std::fs::write(&archive, b"raw core binary").unwrap();
+        let prepared_dir = dir.path().join("prepared");
+        std::fs::create_dir(&prepared_dir).unwrap();
+        let destination = prepared_dir.join(&filename);
+        extract_core(archive.clone(), &filename, destination.clone()).unwrap();
+        assert_eq!(std::fs::read(archive).unwrap(), b"raw core binary");
+        assert_eq!(std::fs::read(destination).unwrap(), b"raw core binary");
+    }
+
+    #[test]
+    fn extracts_gzip_and_sets_executable_permission() {
+        let dir = TempDir::new().unwrap();
+        let archive = dir.path().join("core.gz");
+        let mut encoder = flate2::write::GzEncoder::new(
+            std::fs::File::create(&archive).unwrap(),
+            flate2::Compression::default(),
+        );
+        encoder.write_all(b"core binary").unwrap();
+        encoder.finish().unwrap();
+        let destination = dir.path().join("core");
+        extract_core(archive, "core.gz", destination.clone()).unwrap();
+        assert_eq!(std::fs::read(&destination).unwrap(), b"core binary");
+        #[cfg(target_family = "unix")]
+        assert_eq!(
+            std::fs::metadata(destination).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+    }
+
+    #[test]
+    fn zip_ignores_directories_and_rejects_missing_core() {
+        let dir = TempDir::new().unwrap();
+        let archive = dir.path().join("core.zip");
+        let mut writer = zip::ZipWriter::new(std::fs::File::create(&archive).unwrap());
+        writer
+            .add_directory("mihomo/", zip::write::SimpleFileOptions::default())
+            .unwrap();
+        writer.finish().unwrap();
+        let error = extract_core(archive, "core.zip", dir.path().join("core")).unwrap_err();
+        assert!(error.to_string().contains("failed to find core file"));
+    }
+
+    #[test]
+    fn zip_extracts_core_without_using_archive_paths() {
+        let dir = TempDir::new().unwrap();
+        let archive = dir.path().join("core.zip");
+        let mut writer = zip::ZipWriter::new(std::fs::File::create(&archive).unwrap());
+        writer
+            .start_file("nested/mihomo", zip::write::SimpleFileOptions::default())
+            .unwrap();
+        writer.write_all(b"core binary").unwrap();
+        writer.finish().unwrap();
+        let destination = dir.path().join("core");
+        extract_core(archive, "core.zip", destination.clone()).unwrap();
+        assert_eq!(std::fs::read(destination).unwrap(), b"core binary");
+        assert!(!dir.path().join("nested").exists());
     }
 }

--- a/backend/tauri/src/core/updater/mod.rs
+++ b/backend/tauri/src/core/updater/mod.rs
@@ -1,41 +1,23 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, OnceLock},
-};
-
-use crate::{
-    config::nyanpasu::ClashCore,
-    utils::candy::{ReqwestSpeedTestExt, parse_gh_url},
-};
+use crate::config::nyanpasu::ClashCore;
 use anyhow::{Result, anyhow};
-use dashmap::DashMap;
+use futures_util::FutureExt;
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
 use serde::{Deserialize, Serialize};
 use shared::{CoreTypeMeta, get_arch};
 use specta::Type;
-use tokio::sync::RwLock;
+use std::{
+    collections::HashMap,
+    panic::AssertUnwindSafe,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 mod instance;
+pub(crate) mod ports;
 mod shared;
-
-pub use instance::UpdaterSummary;
-
-pub struct UpdaterManager {
-    manifest_version: ManifestVersion,
-    client: reqwest::Client,
-    mirror: Arc<parking_lot::RwLock<Option<(String, u64)>>>,
-    instances: Arc<DashMap<usize, Arc<instance::Updater>>>,
-}
-
-impl Default for UpdaterManager {
-    fn default() -> Self {
-        Self {
-            manifest_version: ManifestVersion::default(),
-            client: crate::utils::candy::get_reqwest_client().unwrap(),
-            mirror: Arc::new(parking_lot::RwLock::new(None)),
-            instances: Arc::new(DashMap::new()),
-        }
-    }
-}
+pub(crate) use instance::HttpUpdaterBackend;
+pub use instance::{UpdaterState, UpdaterSummary};
+use ports::{CoreUpdateInstaller, UpdaterBackend, UpdaterProgress};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct ManifestVersion {
@@ -146,123 +128,327 @@ impl ManifestVersion {
     }
 }
 
-impl UpdaterManager {
-    pub fn new() -> Self {
-        Self::default()
-    }
+const RETENTION: Duration = Duration::from_secs(300);
+const MAX_TASKS: usize = 64;
 
-    pub fn global() -> &'static RwLock<Self> {
-        static INSTANCE: OnceLock<RwLock<UpdaterManager>> = OnceLock::new();
-        INSTANCE.get_or_init(|| RwLock::new(UpdaterManager::new()))
-    }
+enum Message {
+    Fetch(RpcReplyPort<Result<ManifestVersionLatest>>),
+    Fetched(Box<Result<(ManifestVersion, (String, Instant))>>),
+    Start(ClashCore, RpcReplyPort<Result<usize>>),
+    Inspect(usize, RpcReplyPort<Result<UpdaterSummary>>),
+    Progress(
+        usize,
+        UpdaterState,
+        Option<crate::core::download::DownloadStatus>,
+    ),
+    Finished(usize, Result<()>),
+    Prune(Instant),
+    Shutdown(RpcReplyPort<Result<()>>),
+}
 
-    pub fn get_latest_versions(&self) -> ManifestVersionLatest {
-        self.manifest_version.latest.clone()
-    }
-
-    pub fn get_mirror(&self) -> Option<String> {
-        self.mirror.read().clone().map(|(mirror, _)| mirror)
-    }
-
-    async fn get_latest_version_manifest(&self, mirror: &str) -> Result<ManifestVersion> {
-        let url = parse_gh_url(
-            mirror,
-            "/libnyanpasu/clash-nyanpasu/raw/main/manifest/version.json",
-        )?;
-        log::debug!("{url}");
-        let res = self.client.get(url).send().await?;
-        let status_code = res.status();
-        if !status_code.is_success() {
-            anyhow::bail!(
-                "failed to get latest version manifest: response status is {}, expected 200",
-                status_code
-            );
+struct Task {
+    core: ClashCore,
+    summary: UpdaterSummary,
+    worker: Option<tokio::task::JoinHandle<()>>,
+    finished: Option<Instant>,
+}
+struct Args {
+    backend: Arc<dyn UpdaterBackend>,
+    installer: Arc<dyn CoreUpdateInstaller>,
+}
+struct State {
+    args: Args,
+    manifest: ManifestVersion,
+    mirror: Option<(String, Instant)>,
+    tasks: HashMap<usize, Task>,
+    next_id: usize,
+    fetch: Option<tokio::task::JoinHandle<()>>,
+    fetch_waiters: Vec<RpcReplyPort<Result<ManifestVersionLatest>>>,
+    timer: tokio::task::JoinHandle<()>,
+    closing: bool,
+}
+impl Drop for State {
+    fn drop(&mut self) {
+        self.timer.abort();
+        if let Some(task) = self.fetch.take() {
+            task.abort();
         }
-        Ok(res.json::<ManifestVersion>().await?)
-    }
-
-    pub async fn fetch_latest(&mut self) -> Result<()> {
-        self.mirror_speed_test().await?;
-        let mirror = self.get_mirror().unwrap();
-        let latest = self.get_latest_version_manifest(&mirror).await?;
-        log::debug!("latest version: {latest:?}");
-        self.manifest_version = latest;
-        Ok(())
-    }
-
-    // TODO: add user-spec mirror support
-    pub async fn mirror_speed_test(&self) -> Result<()> {
-        {
-            let mirror = self.mirror.read();
-            if let Some((_, timestamp)) = mirror.as_ref()
-                && chrono::Utc::now().timestamp() - (*timestamp as i64) < 3600
-            {
-                return Ok(());
+        for task in self.tasks.values_mut() {
+            if let Some(worker) = task.worker.take() {
+                worker.abort();
             }
         }
-        let mirrors = crate::utils::candy::INTERNAL_MIRRORS;
-        let path = "https://github.com/libnyanpasu/clash-nyanpasu/raw/main/manifest/version.json";
-        let client = crate::utils::candy::get_reqwest_client()?;
-        let results = client.mirror_speed_test(mirrors, path).await?;
-        let (fastest_mirror, speed) = results.first().ok_or(anyhow!("no mirrors found"))?;
-        if speed - 1.0 < 0.0001 {
-            anyhow::bail!("all mirrors are too slow");
-        }
-        tracing::debug!("fastest mirror: {}, speed: {}", fastest_mirror, speed);
-        {
-            let mut mirror = self.mirror.write();
-            *mirror = Some((
-                fastest_mirror.to_string(),
-                chrono::Utc::now().timestamp() as u64,
-            ));
+    }
+}
+struct UpdaterActor;
+impl Actor for UpdaterActor {
+    type Msg = Message;
+    type State = State;
+    type Arguments = Args;
+    async fn pre_start(
+        &self,
+        actor: ActorRef<Message>,
+        args: Args,
+    ) -> Result<State, ActorProcessingErr> {
+        let timer = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                if actor.cast(Message::Prune(Instant::now())).is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(State {
+            args,
+            manifest: ManifestVersion::default(),
+            mirror: None,
+            tasks: HashMap::new(),
+            next_id: 0,
+            fetch: None,
+            fetch_waiters: Vec::new(),
+            timer,
+            closing: false,
+        })
+    }
+    async fn handle(
+        &self,
+        actor: ActorRef<Message>,
+        message: Message,
+        state: &mut State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            Message::Fetch(reply) => {
+                if reply.is_closed() {
+                    return Ok(());
+                }
+                if state.closing || state.fetch_waiters.len() >= MAX_TASKS {
+                    let _ = reply.send(Err(anyhow!("updater is shutting down or busy")));
+                    return Ok(());
+                }
+                state.fetch_waiters.push(reply);
+                if state.fetch.is_none() {
+                    let backend = state.args.backend.clone();
+                    let mirror = state.mirror.clone();
+                    state.fetch = Some(tokio::spawn(async move {
+                        let result = AssertUnwindSafe(backend.fetch_manifest(mirror))
+                            .catch_unwind()
+                            .await
+                            .unwrap_or_else(|_| Err(anyhow!("updater manifest worker panicked")));
+                        let _ = actor.cast(Message::Fetched(Box::new(result)));
+                    }));
+                }
+            }
+            Message::Fetched(result) => {
+                state.fetch.take();
+                let result = (*result).map(|(manifest, mirror)| {
+                    state.manifest = manifest;
+                    state.mirror = Some(mirror);
+                    state.manifest.latest.clone()
+                });
+                for reply in state.fetch_waiters.drain(..) {
+                    let _ = reply.send(
+                        result
+                            .as_ref()
+                            .cloned()
+                            .map_err(|error| anyhow!("{error:#}")),
+                    );
+                }
+            }
+            Message::Start(core, reply) => {
+                if reply.is_closed() {
+                    return Ok(());
+                }
+                if state.closing {
+                    let _ = reply.send(Err(anyhow!("updater is shutting down")));
+                    return Ok(());
+                }
+                // A repeated request observes the admitted operation instead of downloading/installing twice.
+                if let Some(task) = state
+                    .tasks
+                    .values()
+                    .find(|task| task.core == core && task.finished.is_none())
+                {
+                    let _ = reply.send(Ok(task.summary.id));
+                    return Ok(());
+                }
+                if state.tasks.len() >= MAX_TASKS {
+                    let _ = reply.send(Err(anyhow!("too many retained updater tasks")));
+                    return Ok(());
+                }
+                let Some((artifact, tag)) = state.manifest.get_matches(&core) else {
+                    let _ = reply.send(Err(anyhow!(
+                        "fetch latest versions before updating {core:?}"
+                    )));
+                    return Ok(());
+                };
+                let Some((mirror, _)) = state.mirror.clone() else {
+                    let _ = reply.send(Err(anyhow!("updater mirror is unavailable")));
+                    return Ok(());
+                };
+                state.next_id += 1;
+                let id = state.next_id;
+                let backend = state.args.backend.clone();
+                let installer = state.args.installer.clone();
+                let progress_actor = actor.clone();
+                let progress = UpdaterProgress::new(move |status, download| {
+                    let _ = progress_actor.cast(Message::Progress(id, status, download));
+                });
+                let worker = tokio::spawn(async move {
+                    let result = AssertUnwindSafe(async {
+                        let prepared = backend
+                            .prepare(core, mirror, artifact, tag, progress)
+                            .await?;
+                        installer.install(prepared).await
+                    })
+                    .catch_unwind()
+                    .await
+                    .unwrap_or_else(|_| Err(anyhow!("updater worker panicked")));
+                    let _ = actor.cast(Message::Finished(id, result));
+                });
+                state.tasks.insert(
+                    id,
+                    Task {
+                        core,
+                        summary: UpdaterSummary {
+                            id,
+                            state: UpdaterState::Idle,
+                            downloader: crate::core::download::DownloadStatus {
+                                state: Default::default(),
+                                downloaded: 0,
+                                total: 0,
+                                speed: 0.0,
+                            },
+                        },
+                        worker: Some(worker),
+                        finished: None,
+                    },
+                );
+                let _ = reply.send(Ok(id));
+            }
+            Message::Inspect(id, reply) => {
+                let _ = reply.send(
+                    state
+                        .tasks
+                        .get(&id)
+                        .map(|task| task.summary.clone())
+                        .ok_or_else(|| anyhow!("updater does not exist")),
+                );
+            }
+            Message::Progress(id, progress, download) => {
+                if let Some(task) = state.tasks.get_mut(&id) {
+                    // Terminal install notifications remain authoritative after an RPC timeout.
+                    if matches!(task.summary.state, UpdaterState::Done) {
+                        return Ok(());
+                    }
+                    if matches!(progress, UpdaterState::Done | UpdaterState::Failed(_)) {
+                        task.finished = Some(Instant::now());
+                    }
+                    task.summary.state = progress;
+                    if let Some(download) = download {
+                        task.summary.downloader = download;
+                    }
+                }
+            }
+            Message::Finished(id, result) => {
+                if let Some(task) = state.tasks.get_mut(&id) {
+                    task.worker.take();
+                    let pending = result
+                        .as_ref()
+                        .err()
+                        .is_some_and(|error| error.is::<ports::InstallPending>())
+                        && task.finished.is_none();
+                    if !matches!(task.summary.state, UpdaterState::Done) {
+                        task.summary.state = match result {
+                            Ok(()) => UpdaterState::Done,
+                            Err(error) if pending => UpdaterState::Pending(format!("{error:#}")),
+                            Err(error) => UpdaterState::Failed(format!("{error:#}")),
+                        };
+                    }
+                    if !pending {
+                        task.finished = Some(Instant::now());
+                    }
+                }
+            }
+            Message::Prune(now) => {
+                state.tasks.retain(|_, task| {
+                    task.worker.is_some()
+                        || task.finished.is_none_or(|finished| {
+                            now.saturating_duration_since(finished) < RETENTION
+                        })
+                });
+            }
+            Message::Shutdown(reply) => {
+                state.closing = true;
+                state.timer.abort();
+                if let Some(fetch) = state.fetch.take() {
+                    fetch.abort();
+                    let _ = fetch.await;
+                }
+                for waiter in state.fetch_waiters.drain(..) {
+                    let _ = waiter.send(Err(anyhow!("updater is shutting down")));
+                }
+                for task in state.tasks.values_mut() {
+                    if let Some(worker) = task.worker.take() {
+                        worker.abort();
+                        let _ = worker.await;
+                    }
+                    if task.finished.is_none() {
+                        task.summary.state = UpdaterState::Failed("updater shut down".into());
+                        task.finished = Some(Instant::now());
+                    }
+                }
+                let _ = reply.send(Ok(()));
+            }
         }
         Ok(())
     }
-
-    pub async fn update_core(
-        &mut self,
-        core_type: &ClashCore,
-        nyanpasu: crate::client::NyanpasuClient,
-    ) -> Result<usize> {
-        self.mirror_speed_test().await?;
-        let (artifact, tag) = self
-            .manifest_version
-            .get_matches(core_type)
-            .ok_or(anyhow!("no matches found for core type: {:?}", core_type))?;
-        let mirror = self.get_mirror().unwrap();
-        let updater = Arc::new(
-            instance::UpdaterBuilder::new()
-                .set_client(self.client.clone())
-                .set_nyanpasu_client(nyanpasu)
-                .set_core_type(*core_type)
-                .set_mirror(mirror)
-                .set_artifact(artifact)
-                .set_tag(tag)
-                .build()
-                .await?,
-        );
-        let updater_ref = updater.clone();
-        let updater_id = updater.get_updater_id();
-        self.instances.insert(updater_id, updater);
-        tokio::spawn(async move {
-            updater_ref.start().await;
-        });
-        Ok(updater_id)
-    }
-
-    pub fn inspect_updater(&self, updater_id: usize) -> Option<UpdaterSummary> {
-        let updater = self.instances.get(&updater_id)?;
-        let report = updater.get_report();
-        if matches!(
-            report.state,
-            instance::UpdaterState::Done | instance::UpdaterState::Failed(_)
-        ) {
-            let map = self.instances.clone();
-            tokio::spawn(async move {
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                map.remove(&updater_id);
-            });
-        }
-        Some(report)
+}
+struct ClientInner(ActorRef<Message>);
+impl Drop for ClientInner {
+    fn drop(&mut self) {
+        self.0.stop(None);
     }
 }
+#[derive(Clone)]
+pub(crate) struct UpdaterClient(Arc<ClientInner>);
+impl UpdaterClient {
+    pub async fn spawn(
+        backend: Arc<dyn UpdaterBackend>,
+        installer: Arc<dyn CoreUpdateInstaller>,
+    ) -> Result<Self> {
+        let (actor, _) = Actor::spawn(None, UpdaterActor, Args { backend, installer }).await?;
+        Ok(Self(Arc::new(ClientInner(actor))))
+    }
+    async fn call<T: Send + 'static>(
+        &self,
+        message: impl FnOnce(RpcReplyPort<Result<T>>) -> Message,
+    ) -> Result<T> {
+        match self
+            .0
+            .0
+            .call(message, Some(Duration::from_secs(120)))
+            .await?
+        {
+            ractor::rpc::CallResult::Success(result) => result,
+            ractor::rpc::CallResult::Timeout => Err(anyhow!(
+                "updater request timed out; inspect admitted tasks before retrying"
+            )),
+            ractor::rpc::CallResult::SenderError => Err(anyhow!("updater is unavailable")),
+        }
+    }
+    pub async fn fetch_latest(&self) -> Result<ManifestVersionLatest> {
+        self.call(Message::Fetch).await
+    }
+    pub async fn update(&self, core: ClashCore) -> Result<usize> {
+        self.call(|reply| Message::Start(core, reply)).await
+    }
+    pub async fn inspect(&self, id: usize) -> Result<UpdaterSummary> {
+        self.call(|reply| Message::Inspect(id, reply)).await
+    }
+    pub async fn shutdown(&self) -> Result<()> {
+        self.call(Message::Shutdown).await
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/backend/tauri/src/core/updater/ports.rs
+++ b/backend/tauri/src/core/updater/ports.rs
@@ -1,0 +1,69 @@
+use std::{sync::Arc, time::Instant};
+
+use async_trait::async_trait;
+
+use super::{ManifestVersion, instance::UpdaterState, shared::CoreTypeMeta};
+use crate::{
+    client::core_lifecycle::ports::{BinaryInstallProgress, PreparedCoreBinary},
+    config::nyanpasu::ClashCore,
+    core::download::DownloadStatus,
+};
+
+#[derive(Clone)]
+pub struct UpdaterProgress(Arc<dyn Fn(UpdaterState, Option<DownloadStatus>) + Send + Sync>);
+
+impl UpdaterProgress {
+    pub fn new(
+        callback: impl Fn(UpdaterState, Option<DownloadStatus>) + Send + Sync + 'static,
+    ) -> Self {
+        Self(Arc::new(callback))
+    }
+
+    pub fn report(&self, state: UpdaterState, downloader: Option<DownloadStatus>) {
+        (self.0)(state, downloader);
+    }
+}
+
+impl BinaryInstallProgress for UpdaterProgress {
+    fn restarting(&self) {
+        self.report(UpdaterState::Restarting, None);
+    }
+
+    fn finished(&self, error: Option<&str>) {
+        self.report(
+            match error {
+                Some(error) => UpdaterState::Failed(error.to_owned()),
+                None => UpdaterState::Done,
+            },
+            None,
+        );
+    }
+}
+
+#[async_trait]
+pub(crate) trait UpdaterBackend: Send + Sync + 'static {
+    async fn fetch_manifest(
+        &self,
+        mirror: Option<(String, Instant)>,
+    ) -> anyhow::Result<(ManifestVersion, (String, Instant))>;
+
+    async fn prepare(
+        &self,
+        core_type: ClashCore,
+        mirror: String,
+        artifact: String,
+        tag: CoreTypeMeta,
+        progress: UpdaterProgress,
+    ) -> anyhow::Result<PreparedCoreBinary>;
+}
+
+#[async_trait]
+pub(crate) trait CoreUpdateInstaller: Send + Sync + 'static {
+    async fn install(&self, artifact: PreparedCoreBinary) -> anyhow::Result<()>;
+}
+
+/// The lifecycle RPC stopped waiting while the installation may still be admitted.
+/// Keep the task reserved until its authoritative progress callback settles it.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub(crate) struct InstallPending(pub String);

--- a/backend/tauri/src/core/updater/shared.rs
+++ b/backend/tauri/src/core/updater/shared.rs
@@ -16,7 +16,7 @@ pub(super) fn get_arch() -> anyhow::Result<&'static str> {
     }
 }
 
-pub(super) enum CoreTypeMeta {
+pub(crate) enum CoreTypeMeta {
     ClashPremium(String),
     Mihomo(String),
     MihomoAlpha,

--- a/backend/tauri/src/core/updater/tests.rs
+++ b/backend/tauri/src/core/updater/tests.rs
@@ -1,0 +1,410 @@
+use super::*;
+use crate::{
+    client::core_lifecycle::ports::PreparedCoreBinary,
+    core::download::{DownloadStatus, DownloaderState},
+};
+use async_trait::async_trait;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::{Semaphore, mpsc};
+
+#[derive(Debug)]
+enum Event {
+    FetchStarted,
+    Preparing,
+    PrepareDropped,
+}
+
+struct FakeBackend {
+    events: mpsc::UnboundedSender<Event>,
+    fetch_gate: Semaphore,
+    prepare_gate: Semaphore,
+    fetches: AtomicUsize,
+    prepares: AtomicUsize,
+}
+
+struct PreparationGuard(mpsc::UnboundedSender<Event>);
+impl Drop for PreparationGuard {
+    fn drop(&mut self) {
+        let _ = self.0.send(Event::PrepareDropped);
+    }
+}
+
+#[async_trait]
+impl UpdaterBackend for FakeBackend {
+    async fn fetch_manifest(
+        &self,
+        _mirror: Option<(String, Instant)>,
+    ) -> Result<(ManifestVersion, (String, Instant))> {
+        self.fetches.fetch_add(1, Ordering::SeqCst);
+        self.events.send(Event::FetchStarted).unwrap();
+        self.fetch_gate.acquire().await.unwrap().forget();
+        let mut manifest = ManifestVersion::default();
+        manifest.latest.mihomo = "test-version".into();
+        manifest
+            .arch_template
+            .mihomo
+            .insert(get_arch().unwrap().into(), "mihomo-{}.gz".into());
+        Ok((manifest, ("https://github.com".into(), Instant::now())))
+    }
+
+    async fn prepare(
+        &self,
+        _core: ClashCore,
+        _mirror: String,
+        artifact: String,
+        _tag: CoreTypeMeta,
+        progress: UpdaterProgress,
+    ) -> Result<PreparedCoreBinary> {
+        assert_eq!(artifact, "mihomo-test-version.gz");
+        self.prepares.fetch_add(1, Ordering::SeqCst);
+        let _guard = PreparationGuard(self.events.clone());
+        progress.report(
+            UpdaterState::Downloading,
+            Some(DownloadStatus {
+                state: DownloaderState::Downloading,
+                downloaded: 42,
+                total: 100,
+                speed: 12.0,
+            }),
+        );
+        self.events.send(Event::Preparing).unwrap();
+        self.prepare_gate.acquire().await.unwrap().forget();
+        anyhow::bail!("simulated download failure")
+    }
+}
+
+struct UnusedInstaller;
+#[async_trait]
+impl CoreUpdateInstaller for UnusedInstaller {
+    async fn install(&self, _artifact: PreparedCoreBinary) -> Result<()> {
+        panic!("a failed or blocked preparation must never install")
+    }
+}
+
+async fn setup() -> (
+    UpdaterClient,
+    Arc<FakeBackend>,
+    mpsc::UnboundedReceiver<Event>,
+) {
+    let (events, receiver) = mpsc::unbounded_channel();
+    let backend = Arc::new(FakeBackend {
+        events,
+        fetch_gate: Semaphore::new(0),
+        prepare_gate: Semaphore::new(0),
+        fetches: AtomicUsize::new(0),
+        prepares: AtomicUsize::new(0),
+    });
+    let client = UpdaterClient::spawn(backend.clone(), Arc::new(UnusedInstaller))
+        .await
+        .unwrap();
+    (client, backend, receiver)
+}
+
+async fn next_event(events: &mut mpsc::UnboundedReceiver<Event>) -> Event {
+    tokio::time::timeout(Duration::from_secs(5), events.recv())
+        .await
+        .unwrap()
+        .unwrap()
+}
+
+async fn settled_report(client: &UpdaterClient, id: usize) -> UpdaterSummary {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let summary = client.inspect(id).await.unwrap();
+            if matches!(
+                summary.state,
+                UpdaterState::Done | UpdaterState::Failed(_) | UpdaterState::Pending(_)
+            ) {
+                return summary;
+            }
+        }
+    })
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn concurrent_fetches_coalesce_and_queries_remain_responsive() {
+    let (client, backend, mut events) = setup().await;
+    let (first, second, ()) = tokio::join!(client.fetch_latest(), client.fetch_latest(), async {
+        assert!(matches!(next_event(&mut events).await, Event::FetchStarted));
+        // The query acknowledges that both preceding requests were accepted
+        // while their single backend fetch is still blocked.
+        assert!(client.inspect(999).await.is_err());
+        assert_eq!(backend.fetches.load(Ordering::SeqCst), 1);
+        backend.fetch_gate.add_permits(1);
+    });
+    assert_eq!(first.unwrap().mihomo, "test-version");
+    assert_eq!(second.unwrap().mihomo, "test-version");
+    assert_eq!(backend.fetches.load(Ordering::SeqCst), 1);
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn duplicate_admission_reports_progress_failure_and_retention() {
+    let (client, backend, mut events) = setup().await;
+    backend.fetch_gate.add_permits(1);
+    client.fetch_latest().await.unwrap();
+    assert!(matches!(next_event(&mut events).await, Event::FetchStarted));
+    let id = client.update(ClashCore::Mihomo).await.unwrap();
+    assert!(matches!(next_event(&mut events).await, Event::Preparing));
+    assert_eq!(client.update(ClashCore::Mihomo).await.unwrap(), id);
+    assert_eq!(backend.prepares.load(Ordering::SeqCst), 1);
+    let progress = client.inspect(id).await.unwrap();
+    assert!(matches!(progress.state, UpdaterState::Downloading));
+    assert_eq!(progress.downloader.downloaded, 42);
+    assert_eq!(progress.downloader.total, 100);
+    backend.prepare_gate.add_permits(1);
+    let failed = settled_report(&client, id).await;
+    assert!(
+        matches!(failed.state, UpdaterState::Failed(reason) if reason.contains("simulated download failure"))
+    );
+    assert_eq!(failed.downloader.downloaded, 42);
+    client
+        .0
+        .0
+        .cast(Message::Prune(
+            Instant::now() + RETENTION + Duration::from_secs(1),
+        ))
+        .unwrap();
+    assert!(client.inspect(id).await.is_err());
+    let new_id = client.update(ClashCore::Mihomo).await.unwrap();
+    assert_ne!(id, new_id);
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn shutdown_drops_blocked_worker_before_acknowledging() {
+    let (client, backend, mut events) = setup().await;
+    backend.fetch_gate.add_permits(1);
+    client.fetch_latest().await.unwrap();
+    assert!(matches!(next_event(&mut events).await, Event::FetchStarted));
+    let id = client.update(ClashCore::Mihomo).await.unwrap();
+    assert!(matches!(next_event(&mut events).await, Event::Preparing));
+    client.shutdown().await.unwrap();
+    assert!(matches!(events.try_recv().unwrap(), Event::PrepareDropped));
+    assert!(
+        matches!(client.inspect(id).await.unwrap().state, UpdaterState::Failed(reason) if reason.contains("shut down"))
+    );
+    assert!(client.update(ClashCore::Mihomo).await.is_err());
+}
+
+#[tokio::test]
+async fn shutdown_completes_pending_fetch_with_error() {
+    let (client, _backend, mut events) = setup().await;
+    let (fetch, ()) = tokio::join!(client.fetch_latest(), async {
+        assert!(matches!(next_event(&mut events).await, Event::FetchStarted));
+        client.shutdown().await.unwrap();
+    });
+    assert!(fetch.unwrap_err().to_string().contains("shutting down"));
+}
+
+struct ReadyBackend {
+    fetch_panics: AtomicUsize,
+    prepare_panics: AtomicUsize,
+}
+
+impl ReadyBackend {
+    fn new(fetch_panics: usize, prepare_panics: usize) -> Arc<Self> {
+        Arc::new(Self {
+            fetch_panics: AtomicUsize::new(fetch_panics),
+            prepare_panics: AtomicUsize::new(prepare_panics),
+        })
+    }
+}
+
+fn consume_panic(counter: &AtomicUsize) -> bool {
+    counter
+        .try_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+            count.checked_sub(1)
+        })
+        .is_ok()
+}
+
+#[async_trait]
+impl UpdaterBackend for ReadyBackend {
+    async fn fetch_manifest(
+        &self,
+        _mirror: Option<(String, Instant)>,
+    ) -> Result<(ManifestVersion, (String, Instant))> {
+        assert!(
+            !consume_panic(&self.fetch_panics),
+            "simulated manifest panic"
+        );
+        let mut manifest = ManifestVersion::default();
+        manifest.latest.mihomo = "test-version".into();
+        manifest
+            .arch_template
+            .mihomo
+            .insert(get_arch().unwrap().into(), "mihomo-{}.gz".into());
+        Ok((manifest, ("https://github.com".into(), Instant::now())))
+    }
+
+    async fn prepare(
+        &self,
+        core: ClashCore,
+        _mirror: String,
+        _artifact: String,
+        _tag: CoreTypeMeta,
+        progress: UpdaterProgress,
+    ) -> Result<PreparedCoreBinary> {
+        assert!(
+            !consume_panic(&self.prepare_panics),
+            "simulated preparation panic"
+        );
+        let staging = Arc::new(tempfile::TempDir::new()?);
+        let source = staging.path().join("prepared");
+        std::fs::write(&source, b"core binary")?;
+        progress.report(UpdaterState::Replacing, None);
+        Ok(PreparedCoreBinary {
+            target: core,
+            source,
+            destination: staging.path().join("installed"),
+            staging,
+            progress: Arc::new(progress),
+        })
+    }
+}
+
+struct RecordingInstaller {
+    installed: mpsc::UnboundedSender<PreparedCoreBinary>,
+    error: Option<&'static str>,
+}
+
+#[async_trait]
+impl CoreUpdateInstaller for RecordingInstaller {
+    async fn install(&self, artifact: PreparedCoreBinary) -> Result<()> {
+        artifact.progress.restarting();
+        self.installed
+            .send(artifact)
+            .map_err(|_| anyhow!("test installation receiver dropped"))?;
+        match self.error {
+            Some("installation request timed out") => Err(anyhow::Error::new(
+                ports::InstallPending("installation request timed out".into()),
+            )),
+            Some(error) => Err(anyhow!(error)),
+            None => Ok(()),
+        }
+    }
+}
+
+async fn installing_client(
+    backend: Arc<ReadyBackend>,
+    error: Option<&'static str>,
+) -> (UpdaterClient, mpsc::UnboundedReceiver<PreparedCoreBinary>) {
+    let (installed, receiver) = mpsc::unbounded_channel();
+    let client = UpdaterClient::spawn(backend, Arc::new(RecordingInstaller { installed, error }))
+        .await
+        .unwrap();
+    (client, receiver)
+}
+
+#[tokio::test]
+async fn successful_install_finishes_and_keeps_staging_owned_by_installer() {
+    let (client, mut installed) = installing_client(ReadyBackend::new(0, 0), None).await;
+    client.fetch_latest().await.unwrap();
+    let id = client.update(ClashCore::Mihomo).await.unwrap();
+    assert!(matches!(
+        settled_report(&client, id).await.state,
+        UpdaterState::Done
+    ));
+    let prepared = installed.try_recv().unwrap();
+    let staging_path = prepared.staging.path().to_path_buf();
+    assert_eq!(std::fs::read(&prepared.source).unwrap(), b"core binary");
+    drop(prepared);
+    assert!(!staging_path.exists());
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn pending_install_reserves_admission_until_authoritative_completion() {
+    let (client, mut installed) = installing_client(
+        ReadyBackend::new(0, 0),
+        Some("installation request timed out"),
+    )
+    .await;
+    client.fetch_latest().await.unwrap();
+    let id = client.update(ClashCore::Mihomo).await.unwrap();
+    assert!(
+        matches!(settled_report(&client, id).await.state, UpdaterState::Pending(reason) if reason.contains("timed out"))
+    );
+    let prepared = installed.try_recv().unwrap();
+    client
+        .0
+        .0
+        .cast(Message::Prune(
+            Instant::now() + RETENTION + Duration::from_secs(1),
+        ))
+        .unwrap();
+    assert_eq!(client.update(ClashCore::Mihomo).await.unwrap(), id);
+    assert!(matches!(
+        client.inspect(id).await.unwrap().state,
+        UpdaterState::Pending(_)
+    ));
+    prepared.progress.restarting();
+    client
+        .0
+        .0
+        .cast(Message::Prune(
+            Instant::now() + RETENTION + Duration::from_secs(1),
+        ))
+        .unwrap();
+    assert!(matches!(
+        client.inspect(id).await.unwrap().state,
+        UpdaterState::Restarting
+    ));
+    assert_eq!(client.update(ClashCore::Mihomo).await.unwrap(), id);
+    prepared.progress.finished(None);
+    assert!(matches!(
+        client.inspect(id).await.unwrap().state,
+        UpdaterState::Done
+    ));
+    prepared.progress.finished(Some("late stale failure"));
+    assert!(matches!(
+        client.inspect(id).await.unwrap().state,
+        UpdaterState::Done
+    ));
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn panicking_fetch_and_prepare_release_admission_for_retry() {
+    let (client, mut installed) = installing_client(ReadyBackend::new(1, 1), None).await;
+    assert!(
+        client
+            .fetch_latest()
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("panicked")
+    );
+    client.fetch_latest().await.unwrap();
+    let first = client.update(ClashCore::Mihomo).await.unwrap();
+    assert!(
+        matches!(settled_report(&client, first).await.state, UpdaterState::Failed(reason) if reason.contains("panicked"))
+    );
+    let second = client.update(ClashCore::Mihomo).await.unwrap();
+    assert_ne!(first, second);
+    assert!(matches!(
+        settled_report(&client, second).await.state,
+        UpdaterState::Done
+    ));
+    assert!(installed.try_recv().is_ok());
+    client.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn definitive_install_failure_allows_fresh_admission() {
+    let (client, mut installed) =
+        installing_client(ReadyBackend::new(0, 0), Some("permission denied")).await;
+    client.fetch_latest().await.unwrap();
+    let id = client.update(ClashCore::Mihomo).await.unwrap();
+    assert!(
+        matches!(settled_report(&client, id).await.state, UpdaterState::Failed(reason) if reason.contains("permission denied"))
+    );
+    let prepared = installed.try_recv().unwrap();
+    prepared.progress.finished(Some("permission denied"));
+    let retry = client.update(ClashCore::Mihomo).await.unwrap();
+    assert_ne!(id, retry);
+    client.shutdown().await.unwrap();
+}

--- a/backend/tauri/src/ipc.rs
+++ b/backend/tauri/src/ipc.rs
@@ -610,11 +610,10 @@ pub fn open_web_url(url: String) -> Result<()> {
 
 #[tauri::command]
 #[specta::specta]
-pub async fn fetch_latest_core_versions() -> Result<ManifestVersionLatest> {
-    let mut updater = updater::UpdaterManager::global().write().await; // It is intended to block here
-    (updater.fetch_latest().await)?;
-    // TODO: result key should be kebab-case
-    Ok(updater.get_latest_versions())
+pub async fn fetch_latest_core_versions(
+    client: State<'_, NyanpasuClient>,
+) -> Result<ManifestVersionLatest> {
+    Ok(client.fetch_latest_core_versions().await?)
 }
 
 #[tauri::command]
@@ -660,23 +659,16 @@ pub async fn update_core(
     client: State<'_, NyanpasuClient>,
     core_type: nyanpasu::ClashCore,
 ) -> Result<usize> {
-    let event_id = (updater::UpdaterManager::global()
-        .write()
-        .await
-        .update_core(&core_type, client.inner().clone())
-        .await)?;
-    Ok(event_id)
+    Ok(client.download_core_update(core_type).await?)
 }
 
 #[tauri::command]
 #[specta::specta]
-pub async fn inspect_updater(updater_id: usize) -> Result<updater::UpdaterSummary> {
-    let updater = (updater::UpdaterManager::global()
-        .read()
-        .await
-        .inspect_updater(updater_id)
-        .ok_or(anyhow::anyhow!("updater is not exist")))?;
-    Ok(updater)
+pub async fn inspect_updater(
+    client: State<'_, NyanpasuClient>,
+    updater_id: usize,
+) -> Result<updater::UpdaterSummary> {
+    Ok(client.inspect_updater(updater_id).await?)
 }
 
 #[tauri::command]

--- a/frontend/interface/src/ipc/bindings.ts
+++ b/frontend/interface/src/ipc/bindings.ts
@@ -2597,7 +2597,8 @@ export type UpdaterState =
   | 'replacing'
   | 'restarting'
   | 'done'
-  | { failed: string }
+  | ({ pending: string } & { failed?: never })
+  | ({ failed: string } & { pending?: never })
 
 export type UpdaterSummary = {
   id: number

--- a/frontend/nyanpasu/src/pages/(main)/main/settings/clash/_modules/core-manager-card.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/settings/clash/_modules/core-manager-card.tsx
@@ -51,33 +51,32 @@ function useCoreUpdateTask(
       }
 
       await new Promise<void>((resolve, reject) => {
-        const interval = setInterval(async () => {
-          const result = await inspectUpdater(updaterId)
-
-          if (!result) {
-            reject(new Error('Failed to inspect updater'))
-            clearInterval(interval)
-            return
+        let stopped = false
+        const poll = async () => {
+          try {
+            const result = await inspectUpdater(updaterId)
+            setUpdater(result)
+            if (isObject(result.state) && 'failed' in result.state) {
+              throw new Error(result.state.failed)
+            }
+            if (
+              isObject(result.downloader.state) &&
+              'failed' in result.downloader.state
+            ) {
+              throw new Error(result.downloader.state.failed)
+            }
+            if (result.state === 'done') {
+              stopped = true
+              resolve()
+              return
+            }
+          } catch (error) {
+            stopped = true
+            reject(error)
           }
-
-          setUpdater(result)
-
-          if (
-            isObject(result.downloader.state) &&
-            Object.prototype.hasOwnProperty.call(
-              result.downloader.state,
-              'failed',
-            )
-          ) {
-            reject(result.downloader.state.failed)
-            clearInterval(interval)
-          }
-
-          if (result.state === 'done') {
-            resolve()
-            clearInterval(interval)
-          }
-        }, 100)
+          if (!stopped) setTimeout(poll, 100)
+        }
+        poll()
       })
 
       await query.refetch()
@@ -127,7 +126,7 @@ function useCoreUpdateTask(
       return m.settings_clash_core_manager_card_decompressing()
     }
 
-    if (state === 'replacing') {
+    if (state === 'replacing' || (isObject(state) && 'pending' in state)) {
       return m.settings_clash_core_manager_card_replacing()
     }
 

--- a/scripts/architecture-ledger.snapshot.json
+++ b/scripts/architecture-ledger.snapshot.json
@@ -11,14 +11,13 @@
       }
     },
     "service_globals": {
-      "total": 41,
+      "total": 38,
       "byKey": {
         "Handle::global()": 10,
         "Self::global()": 8,
         "Sysopt::global()": 8,
         "WindowManager::global()": 8,
         "Hotkey::global()": 3,
-        "UpdaterManager::global()": 3,
         "Logger::global()": 1
       }
     },


### PR DESCRIPTION
The global updater held a shared write lock across manifest requests and relied on UI polling to schedule task cleanup. An injected UpdaterActor now owns manifest and mirror state, task admission, progress, retention, and shutdown, while managed adapters perform network and filesystem work.

Core installation continues through the existing lifecycle workflow. Uncertain installations remain reserved until their outcome is known; queued rejection publishes terminal progress, requests use the current resolved proxy port, and the UI distinguishes pending installation from definitive failure.

Stack: 1/2, targeting main. Next: #5250 covers proxy and profile connection interruption (PR-6c / PR-6e-4). Merge this PR first, then retarget #5250 to main.

Validation:
- This commit: Cargo test-target compilation and architecture gate passed.
- Full stack: 535 tests passed, 1 ignored; all-targets/all-features Clippy, interface build, frontend TypeScript checks, relevant lint/format checks, and architecture gate passed.
- Rust tests used CARGO_PROFILE_TEST_DEBUG=0 and CARGO_INCREMENTAL=0 to limit disk use.
- Live downloads and GUI smoke testing have not been performed.
