### PR TITLE
feat(logs): highlight JSON and clarify live following

### DIFF
--- a/frontend/nyanpasu/messages/en.json
+++ b/frontend/nyanpasu/messages/en.json
@@ -457,7 +457,7 @@
   "logs_parse_diagnostics": "Unparsed: {malformed}; truncated/skipped: {truncated}",
   "logs_clear_display": "Clear current display",
   "logs_load_older": "Load earlier records",
-  "logs_follow_latest": "Follow latest",
+  "logs_follow_latest": "Resume live following",
   "logs_filter_placeholder": "Filter message or target (literal text)",
   "logs_search_incomplete": "No matches in this page. Load earlier records to continue searching.",
   "logs_copy": "Copy",

--- a/frontend/nyanpasu/messages/ko.json
+++ b/frontend/nyanpasu/messages/ko.json
@@ -415,7 +415,7 @@
   "logs_parse_diagnostics": "구문 분석 실패: {malformed}; 잘림/건너뜀: {truncated}",
   "logs_clear_display": "현재 표시 지우기",
   "logs_load_older": "이전 기록 불러오기",
-  "logs_follow_latest": "최신 로그 따라가기",
+  "logs_follow_latest": "실시간 따라가기 재개",
   "logs_filter_placeholder": "메시지 또는 target 필터 (일반 텍스트)",
   "logs_search_incomplete": "이 페이지에 일치하는 기록이 없습니다. 이전 기록을 불러와 검색을 계속하세요.",
   "logs_copy": "복사",

--- a/frontend/nyanpasu/messages/ru.json
+++ b/frontend/nyanpasu/messages/ru.json
@@ -419,7 +419,7 @@
   "logs_parse_diagnostics": "Не разобрано: {malformed}; обрезано/пропущено: {truncated}",
   "logs_clear_display": "Очистить текущий просмотр",
   "logs_load_older": "Загрузить ранние записи",
-  "logs_follow_latest": "Следить за новыми",
+  "logs_follow_latest": "Возобновить слежение за журналом",
   "logs_filter_placeholder": "Фильтр сообщения или target (обычный текст)",
   "logs_search_incomplete": "На этой странице совпадений нет. Загрузите ранние записи для продолжения поиска.",
   "logs_copy": "Копировать",

--- a/frontend/nyanpasu/messages/zh-cn.json
+++ b/frontend/nyanpasu/messages/zh-cn.json
@@ -457,7 +457,7 @@
   "logs_parse_diagnostics": "未解析：{malformed}；截断或跳过：{truncated}",
   "logs_clear_display": "清空当前显示",
   "logs_load_older": "加载更早记录",
-  "logs_follow_latest": "跟随最新日志",
+  "logs_follow_latest": "恢复实时跟随",
   "logs_filter_placeholder": "筛选消息或 target（字面文本）",
   "logs_search_incomplete": "本页未匹配，加载更早记录以继续搜索。",
   "logs_copy": "复制",

--- a/frontend/nyanpasu/messages/zh-tw.json
+++ b/frontend/nyanpasu/messages/zh-tw.json
@@ -457,7 +457,7 @@
   "logs_parse_diagnostics": "未解析：{malformed}；截斷或略過：{truncated}",
   "logs_clear_display": "清空目前顯示",
   "logs_load_older": "載入更早記錄",
-  "logs_follow_latest": "跟隨最新日誌",
+  "logs_follow_latest": "恢復即時跟隨",
   "logs_filter_placeholder": "篩選訊息或 target（字面文字）",
   "logs_search_incomplete": "本頁無符合記錄，載入更早記錄以繼續搜尋。",
   "logs_copy": "複製",

--- a/frontend/nyanpasu/src/pages/(main)/main/logs/_modules/log-json.module.d.scss.ts
+++ b/frontend/nyanpasu/src/pages/(main)/main/logs/_modules/log-json.module.d.scss.ts
@@ -1,0 +1,6 @@
+declare const classNames: {
+  readonly viewer: 'viewer'
+  readonly shiki: 'shiki'
+  readonly dark: 'dark'
+}
+export default classNames

--- a/frontend/nyanpasu/src/pages/(main)/main/logs/_modules/log-json.module.scss
+++ b/frontend/nyanpasu/src/pages/(main)/main/logs/_modules/log-json.module.scss
@@ -1,0 +1,17 @@
+.viewer pre {
+  margin: 0;
+  font-family: var(--font-mono);
+  line-height: 1.625;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.viewer :global(.shiki),
+.viewer :global(.shiki span) {
+  background-color: transparent !important;
+}
+
+:global(.dark) .viewer :global(.shiki),
+:global(.dark) .viewer :global(.shiki span) {
+  color: var(--shiki-dark) !important;
+}

--- a/frontend/nyanpasu/src/pages/(main)/main/logs/_modules/log-json.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/logs/_modules/log-json.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useMemo, useState } from 'react'
+import styles from './log-json.module.scss'
+
+export default function LogJson({ raw }: { raw: string }) {
+  const code = useMemo(() => {
+    try {
+      return JSON.stringify(JSON.parse(raw), null, 2)
+    } catch {
+      return raw
+    }
+  }, [raw])
+  const [highlighted, setHighlighted] = useState<{
+    code: string
+    html: string
+  }>()
+
+  useEffect(() => {
+    let cancelled = false
+    import('@/utils/shiki')
+      .then(({ highlightJson }) => highlightJson(code))
+      .then((html) => {
+        if (!cancelled) setHighlighted({ code, html })
+      })
+      .catch(() => {
+        if (!cancelled) setHighlighted(undefined)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [code])
+
+  return (
+    <div
+      className={`${styles.viewer} bg-surface-variant/30 text-on-surface mt-2 rounded-xl p-3 text-xs`}
+    >
+      {highlighted?.code === code ? (
+        <div dangerouslySetInnerHTML={{ __html: highlighted.html }} />
+      ) : (
+        <pre>
+          <code>{code}</code>
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/frontend/nyanpasu/src/pages/(main)/main/logs/_modules/log-viewer.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/logs/_modules/log-viewer.tsx
@@ -5,10 +5,11 @@ import DataObjectRounded from '~icons/material-symbols/data-object-rounded'
 import DeleteSweepRounded from '~icons/material-symbols/delete-sweep-rounded'
 import SearchRounded from '~icons/material-symbols/search-rounded'
 import VerticalAlignBottomRounded from '~icons/material-symbols/vertical-align-bottom-rounded'
-import { useId, useMemo, useState, type ReactNode } from 'react'
+import { useId, useState, type ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import HighlightText from '@/components/ui/highlight-text'
 import { m } from '@/paraglide/messages'
+import LogJson from './log-json'
 import LogLevelBadge from './log-level-badge'
 
 export const logPanelClass =
@@ -104,21 +105,6 @@ export function LogFollowButton({
         </span>
       )}
     </Button>
-  )
-}
-
-function LogJson({ raw }: { raw: string }) {
-  const formatted = useMemo(() => {
-    try {
-      return JSON.stringify(JSON.parse(raw), null, 2)
-    } catch {
-      return raw
-    }
-  }, [raw])
-  return (
-    <pre className="bg-surface-variant/30 text-on-surface mt-2 rounded-xl p-3 font-mono text-xs leading-relaxed [overflow-wrap:anywhere] whitespace-pre-wrap">
-      <code>{formatted}</code>
-    </pre>
   )
 }
 

--- a/frontend/nyanpasu/src/utils/shiki.ts
+++ b/frontend/nyanpasu/src/utils/shiki.ts
@@ -37,3 +37,12 @@ export async function highlightYaml(code: string) {
     themes: { light: 'min-light', dark: 'nord' },
   })
 }
+
+export async function highlightJson(code: string) {
+  const instance = await getShikiSingleton()
+  await instance.loadLanguage(import('shiki/langs/json.mjs'))
+  return instance.codeToHtml(code, {
+    lang: 'json',
+    themes: { light: 'min-light', dark: 'nord' },
+  })
+}


### PR DESCRIPTION
Expanded log JSON now uses the existing Shiki highlighter with light/dark themes and lazy JSON grammar loading. Until highlighting finishes (or if it fails), the original text remains readable. JSON is formatted when valid; malformed records stay intact.

The floating action now says "Resume live following" in all five locales. Scrolling back to the bottom still leaves following paused; explicitly clicking the action resumes following and hides it.

Stack: based on #5259 (`feat/logs-compact-layout`). Review this diff against that branch.

Validation: production frontend build, TypeScript and lint passed. Browser checks with real log components and mocked Tauri IPC verified lazy highlighting, light/dark colors, malformed records, escaping of HTML-like log text, and manual-bottom versus explicit-resume behavior. Native Tauri was not exercised.
