### PR TITLE
fix(ci): unblock the lint gate and the aarch64 Linux build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -21,6 +21,11 @@
 # The six triples below must stay in sync with the distributed build matrix
 # (target-release-build.yaml / target-dev-build.yaml).
 #
+# This file is invisible to the aarch64 Linux release build: it runs under `cross`,
+# which mounts only the cargo workspace root (`backend/`) into its container, one
+# level below this file. That triple therefore needs a second copy of its flags in
+# `backend/.cargo/config.toml`; see the rationale there before editing either side.
+#
 # Gotcha: a bare RUSTFLAGS env var OVERRIDES (does not merge with) these settings;
 # any build/CI step that sets RUSTFLAGS must also include `target-feature=+aes,...`.
 

--- a/backend/.cargo/config.toml
+++ b/backend/.cargo/config.toml
@@ -1,0 +1,20 @@
+# `cross` bind-mounts ONLY the cargo workspace root (this directory) into its
+# container as `/project`, so the repo-root `.cargo/config.toml` — one level above
+# that mount — does not exist inside the container. Cargo finds no config there and
+# gxhash hits its `compile_error!` for the missing `+aes`/`+neon` target features.
+# This file is the copy `cross` can see.
+#
+# Only `aarch64-unknown-linux-gnu` is listed, because it is the only triple this
+# project builds through `cross` (deps-build-linux.yaml; every other target builds
+# natively on a runner, where the repo-root config is on cargo's lookup path).
+# Deliberately NOT mirroring the other five triples: cargo CONCATENATES rustflags
+# from every config file on the lookup path, so a triple listed in both files gets
+# `-C target-feature=...` twice. rustc merges repeated target-features, so it
+# builds the same, but the doubled array is a different rustflags fingerprint and
+# would force a full rebuild of every host target. Add a triple here only when it
+# starts being built through `cross` too.
+#
+# Rationale for the hardware-AES baseline itself lives in the repo-root copy.
+
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "target-feature=+aes,+neon"]

--- a/scripts/log-viewer-state.test.mjs
+++ b/scripts/log-viewer-state.test.mjs
@@ -1,23 +1,64 @@
-import assert from 'node:assert/strict'
-import test from 'node:test'
-import { advanceCursor, mergeLogRows, LOG_CACHE_ROWS } from '../frontend/interface/src/ipc/log-viewer-state.ts'
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  advanceCursor,
+  LOG_CACHE_ROWS,
+  mergeLogRows,
+} from "../frontend/interface/src/ipc/log-viewer-state.ts";
 
-const row = (offset, raw = '') => ({ id: `generation:${offset}`, timestamp: null, level: 'info', target: '', message: raw, raw, unparsed: false, truncated: false })
-test('physical ordering and retry deduplication do not depend on timestamps', () => {
-  const rows = mergeLogRows([row(12), row(9)], [row(12), row(100)], null)
-  assert.deepEqual(rows.map((r) => r.id), ['generation:9', 'generation:12', 'generation:100'])
-})
-test('clear floor excludes delayed history and advances a stale live cursor', () => {
-  const floor = { generation: 'generation', offset: '20' }
-  assert.deepEqual(mergeLogRows([], [row(10), row(20), row(30)], floor).map((r) => r.id), ['generation:20', 'generation:30'])
-  assert.deepEqual(advanceCursor({ generation: 'generation', offset: '10' }, floor), floor)
-})
-test('cache bounds both row count and long messages', () => {
-  assert.equal(mergeLogRows([], Array.from({ length: LOG_CACHE_ROWS + 100 }, (_, n) => row(n)), null).length, LOG_CACHE_ROWS)
-  assert.ok(mergeLogRows([], Array.from({ length: 100 }, (_, n) => row(n, 'x'.repeat(100_000))), null).length < 20)
-})
-test('prepending retains the requested older region within the cache budget', () => {
-  const rows = mergeLogRows(Array.from({ length: LOG_CACHE_ROWS }, (_, n) => row(n + 100)), [row(1)], null, true)
-  assert.equal(rows[0].id, 'generation:1')
-  assert.equal(rows.length, LOG_CACHE_ROWS)
-})
+const row = (offset, raw = "") => ({
+  id: `generation:${offset}`,
+  timestamp: null,
+  level: "info",
+  target: "",
+  message: raw,
+  raw,
+  unparsed: false,
+  truncated: false,
+});
+test("physical ordering and retry deduplication do not depend on timestamps", () => {
+  const rows = mergeLogRows([row(12), row(9)], [row(12), row(100)], null);
+  assert.deepEqual(rows.map((r) => r.id), [
+    "generation:9",
+    "generation:12",
+    "generation:100",
+  ]);
+});
+test("clear floor excludes delayed history and advances a stale live cursor", () => {
+  const floor = { generation: "generation", offset: "20" };
+  assert.deepEqual(
+    mergeLogRows([], [row(10), row(20), row(30)], floor).map((r) => r.id),
+    ["generation:20", "generation:30"],
+  );
+  assert.deepEqual(
+    advanceCursor({ generation: "generation", offset: "10" }, floor),
+    floor,
+  );
+});
+test("cache bounds both row count and long messages", () => {
+  assert.equal(
+    mergeLogRows(
+      [],
+      Array.from({ length: LOG_CACHE_ROWS + 100 }, (_, n) => row(n)),
+      null,
+    ).length,
+    LOG_CACHE_ROWS,
+  );
+  assert.ok(
+    mergeLogRows(
+      [],
+      Array.from({ length: 100 }, (_, n) => row(n, "x".repeat(100_000))),
+      null,
+    ).length < 20,
+  );
+});
+test("prepending retains the requested older region within the cache budget", () => {
+  const rows = mergeLogRows(
+    Array.from({ length: LOG_CACHE_ROWS }, (_, n) => row(n + 100)),
+    [row(1)],
+    null,
+    true,
+  );
+  assert.equal(rows[0].id, "generation:1");
+  assert.equal(rows.length, LOG_CACHE_ROWS);
+});


### PR DESCRIPTION
Fixes the two failures on `main`: the lint gate and the aarch64 Linux build.

## `lint:deno` rejected `scripts/log-viewer-state.test.mjs`

`scripts/` is excluded from prettier and formatted by `deno fmt`, but that test
was written in the repo's prettier style, so the gate failed. Because `lint` is
`run-s lint:*`, the failure also meant `lint:architecture-ledger`, `lint:styles`,
`lint:ts`, `lint:clippy` and `lint:rustfmt` never ran on the last few commits —
all of them verified green locally as part of this change.

## gxhash had no `+aes`/`+neon` in the `cross` container

`cross` bind-mounts only the cargo workspace root (`backend/`) into its
container, so the repo-root `.cargo/config.toml` is outside the mount and does
not exist inside it. Cargo finds no configuration and gxhash, which has no
scalar fallback, fails its `compile_error!`:

```
error: Gxhash requires aes and neon intrinsics. ...
  --> gxhash-3.5.0/src/gxhash/platform/arm.rs:2:1
```

This was latent while gxhash was only a dev-dependency that release builds never
compiled; it turned fatal once `nyanpasu-logging` made it a production dependency
of the app, which is why 2026-09-11's developer build was still green.

`backend/.cargo/config.toml` carries only `aarch64-unknown-linux-gnu`, the single
triple built through `cross`. Cargo concatenates rustflags across every config
file on the lookup path, so mirroring the other five would double their
`-C target-feature` and change their rustflags fingerprint, forcing a full
rebuild of every host target for nothing.

Verified by reproducing the container's view of the filesystem — repo-root config
moved aside, cargo invoked from `backend/tauri` — where the build fails exactly as
CI does without this file and succeeds with it.
