### PR TITLE
fix(profiles): keep chain editor columns in sync with drag state

### DIFF
--- a/frontend/nyanpasu/messages/en.json
+++ b/frontend/nyanpasu/messages/en.json
@@ -234,6 +234,7 @@
   "profile_chain_editor_active_column": "Active Proxy Chain",
   "profile_chain_editor_inactive_column": "Inactive Proxy Chain",
   "profile_chain_editor_apply_message": "Applying proxy chain…",
+  "profile_chain_editor_duplicate_hint": "This profile contains duplicate proxy chain entries. Chain editing is disabled until the duplicates are resolved.",
   "profile_quick_import_placeholder": "Enter URL or paste link to quickly import profile",
   "profile_quick_import_success_message": "Profile imported successfully, please check the list",
   "profile_view_details_title": "Profile Details",

--- a/frontend/nyanpasu/messages/ko.json
+++ b/frontend/nyanpasu/messages/ko.json
@@ -234,6 +234,7 @@
   "profile_chain_editor_active_column": "활성 프록시 체인",
   "profile_chain_editor_inactive_column": "비활성 프록시 체인",
   "profile_chain_editor_apply_message": "프록시 체인 적용 중…",
+  "profile_chain_editor_duplicate_hint": "이 프로필에 중복된 프록시 체인 항목이 있습니다. 중복을 해결해야 체인을 편집할 수 있습니다.",
   "profile_quick_import_placeholder": "URL을 입력하거나 링크를 붙여넣어 프로필을 빠르게 가져오세요",
   "profile_quick_import_success_message": "프로필을 가져왔습니다. 목록을 확인하세요",
   "profile_view_details_title": "프로필 상세 정보",

--- a/frontend/nyanpasu/messages/ru.json
+++ b/frontend/nyanpasu/messages/ru.json
@@ -234,6 +234,7 @@
   "profile_chain_editor_active_column": "Активный профиль",
   "profile_chain_editor_inactive_column": "Неактивный профиль",
   "profile_chain_editor_apply_message": "Применение цепочки прокси…",
+  "profile_chain_editor_duplicate_hint": "Этот профиль содержит повторяющиеся элементы цепочки прокси. Редактирование цепочки недоступно, пока повторы не будут устранены.",
   "profile_quick_import_placeholder": "Введите URL или вставьте ссылку для быстрого импорта профиля",
   "profile_quick_import_success_message": "Профиль успешно импортирован, пожалуйста, проверьте список",
   "profile_view_details_title": "Подробности профиля",

--- a/frontend/nyanpasu/messages/zh-cn.json
+++ b/frontend/nyanpasu/messages/zh-cn.json
@@ -234,6 +234,7 @@
   "profile_chain_editor_active_column": "激活的代理链",
   "profile_chain_editor_inactive_column": "未激活的代理链",
   "profile_chain_editor_apply_message": "正在应用代理链……",
+  "profile_chain_editor_duplicate_hint": "此配置包含重复的代理链条目。解决重复项后才能编辑代理链。",
   "profile_quick_import_placeholder": "键入订阅 URL 或粘贴订阅链接以快速导入配置",
   "profile_quick_import_success_message": "配置导入成功，请检查列表",
   "profile_view_details_title": "配置详情",

--- a/frontend/nyanpasu/messages/zh-tw.json
+++ b/frontend/nyanpasu/messages/zh-tw.json
@@ -234,6 +234,7 @@
   "profile_chain_editor_active_column": "激活的代理链",
   "profile_chain_editor_inactive_column": "未激活的代理链",
   "profile_chain_editor_apply_message": "正在應用代理鏈……",
+  "profile_chain_editor_duplicate_hint": "此設定包含重複的代理鏈項目。解決重複項目後才能編輯代理鏈。",
   "profile_quick_import_placeholder": "輸入訂閱 URL 或貼上訂閱連結以快速匯入設定",
   "profile_quick_import_success_message": "配置導入成功，請檢查列表",
   "profile_view_details_title": "配置詳情",

--- a/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/chian-editor-card.tsx
+++ b/frontend/nyanpasu/src/pages/(main)/main/profiles/$type/detail/_modules/chian-editor-card.tsx
@@ -1,12 +1,12 @@
+import WarningRounded from '~icons/material-symbols/warning-rounded'
 import { AnimatePresence, motion } from 'motion/react'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useBlockTask } from '@/components/providers/block-task-provider'
 import { AnimatedItem } from '@/components/ui/animated-item'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
 import { CircularProgress } from '@/components/ui/progress'
 import TextMarquee from '@/components/ui/text-marquee'
-import { useLockFn } from '@/hooks/use-lock-fn'
 import { m } from '@/paraglide/messages'
 import { formatError } from '@/utils'
 import { message } from '@/utils/notification'
@@ -34,49 +34,126 @@ enum ColumnType {
 
 const COLUMN_TYPES = [ColumnType.Active, ColumnType.Inactive] as const
 
-const CHAIN_EDITOR_SORTABLE_GROUP = 'chain-editor-sortable'
+// CollisionPriority.Low in @dnd-kit/abstract 0.5.0, which neither @dnd-kit/react
+// nor @dnd-kit/dom re-exports. A column must lose to the items inside it,
+// otherwise a pointer resting on an item but nearer the column centre drops at
+// the column edge instead.
+const COLUMN_COLLISION_PRIORITY = 1
+
+type ChainColumns = Record<ColumnType, string[]>
+
+type DragSession = {
+  columns: ChainColumns
+  profiles: ScriptOrMergeProfile[]
+}
+
+const sameOrder = (left: string[], right: string[]) =>
+  left.length === right.length &&
+  left.every((uid, index) => uid === right[index])
+
+const sameColumns = (left: ChainColumns, right: ChainColumns) =>
+  COLUMN_TYPES.every((type) => sameOrder(left[type], right[type]))
+
+/** Server order wins; uids without a matching candidate are dropped. */
+const deriveColumns = (
+  transforms: string[],
+  candidateUids: string[],
+): ChainColumns => {
+  const known = new Set(candidateUids)
+  const active = transforms.filter((uid) => known.has(uid))
+  const selected = new Set(active)
+
+  return {
+    [ColumnType.Active]: active,
+    [ColumnType.Inactive]: candidateUids.filter((uid) => !selected.has(uid)),
+  }
+}
+
+/** Keeps the draft order while candidates are added or removed. */
+const reconcileCandidates = (
+  draft: ChainColumns,
+  candidateUids: string[],
+): ChainColumns => {
+  const known = new Set(candidateUids)
+  const active = draft[ColumnType.Active].filter((uid) => known.has(uid))
+  const selected = new Set(active)
+  const inactive = draft[ColumnType.Inactive].filter(
+    (uid) => known.has(uid) && !selected.has(uid),
+  )
+  const present = new Set([...active, ...inactive])
+
+  return {
+    [ColumnType.Active]: active,
+    [ColumnType.Inactive]: [
+      ...inactive,
+      ...candidateUids.filter((uid) => !present.has(uid)),
+    ],
+  }
+}
+
+const ItemButton = ({
+  profile,
+  buttonRef,
+  disabled,
+}: {
+  profile: ScriptOrMergeProfile
+  buttonRef?: (element: Element | null) => void
+  disabled?: boolean
+}) => (
+  <Button
+    className="bg-secondary-container/30 h-14 w-full rounded-2xl text-left"
+    variant="raised"
+    disabled={disabled}
+    asChild
+  >
+    <button ref={buttonRef} disabled={disabled}>
+      <TextMarquee className="pointer-events-none">{profile.name}</TextMarquee>
+    </button>
+  </Button>
+)
 
 const Item = ({
   profile,
   index,
+  column,
+  saving,
 }: {
   profile: ScriptOrMergeProfile
   index: number
+  column: ColumnType
+  saving: boolean
 }) => {
   const { ref } = useSortable({
     id: profile.uid,
     index,
-    group: CHAIN_EDITOR_SORTABLE_GROUP,
+    // The group names the list this item belongs to: move() resolves the target
+    // column by looking the group up as a key of the draft record.
+    group: column,
     type: 'item',
     accept: ['item'],
+    disabled: saving,
   })
 
-  return (
-    <Button
-      className="bg-secondary-container/30 h-14 w-full rounded-2xl text-left"
-      variant="raised"
-      asChild
-    >
-      <button ref={ref}>
-        <TextMarquee className="pointer-events-none">
-          {profile.name}
-        </TextMarquee>
-      </button>
-    </Button>
-  )
+  return <ItemButton profile={profile} buttonRef={ref} disabled={saving} />
 }
 
 const Column = ({
   profiles,
   type,
+  saving,
+  readOnly,
 }: {
   profiles: ScriptOrMergeProfile[]
   type: ColumnType
+  saving: boolean
+  readOnly: boolean
 }) => {
   const { ref } = useDroppable({
     id: type,
     type: 'column',
     accept: ['item'],
+    collisionPriority: COLUMN_COLLISION_PRIORITY,
+    disabled: saving || readOnly,
   })
 
   const message = {
@@ -90,9 +167,25 @@ const Column = ({
         <CardHeader>{message[type]}</CardHeader>
 
         <CardContent>
-          {profiles.map((profile, index) => (
-            <Item key={profile.uid} profile={profile} index={index} />
-          ))}
+          {profiles.map((profile, index) =>
+            readOnly ? (
+              // Duplicate uids would otherwise register two sortables under one
+              // id, so a read-only column renders plain buttons.
+              <ItemButton
+                key={`${profile.uid}-${index}`}
+                profile={profile}
+                disabled
+              />
+            ) : (
+              <Item
+                key={profile.uid}
+                profile={profile}
+                index={index}
+                column={type}
+                saving={saving}
+              />
+            ),
+          )}
         </CardContent>
       </div>
     </Card>
@@ -104,20 +197,29 @@ export default function ChianEditorCard({
 }: {
   profile: ConfigProfile
 }) {
+  // Keyed per profile so a draft cannot leak into another config whose baseline
+  // happens to be identical.
+  return <ChainEditorSession key={profile.uid} profile={profile} />
+}
+
+function ChainEditorSession({ profile }: { profile: ConfigProfile }) {
   const {
     query: { data: profiles },
     replaceDefinition,
   } = useProfile()
 
+  const dataReady = profiles != null
+
   // Candidate chain items = every Transform profile (Overlay / Script).
-  const scriptProfiles = useMemo<ScriptOrMergeProfile[]>(
+  const candidateProfiles = useMemo<ScriptOrMergeProfile[]>(
     () => (profiles?.items ?? []).filter(isChainProfile),
     [profiles?.items],
   )
 
-  const scriptProfileUids = useMemo(() => {
-    return scriptProfiles.map((item) => item.uid)
-  }, [scriptProfiles])
+  const candidateUids = useMemo(
+    () => candidateProfiles.map((item) => item.uid),
+    [candidateProfiles],
+  )
 
   // The edited config item's own scoped transforms (File or Composition).
   const currentTransforms = useMemo(
@@ -125,114 +227,132 @@ export default function ChianEditorCard({
     [profile],
   )
 
-  const [chainsUids, setChainsUids] = useState<Record<ColumnType, string[]>>({
-    [ColumnType.Active]: [],
-    [ColumnType.Inactive]: [],
-  })
+  const serverChains = useMemo(
+    () => deriveColumns(currentTransforms, candidateUids),
+    [currentTransforms, candidateUids],
+  )
 
-  const hasSameOrder = (left: string[], right: string[]) => {
-    if (left.length !== right.length) {
-      return false
+  const [draft, setDraft] = useState<ChainColumns>(serverChains)
+
+  // The draft is checked alongside the config because a corrected server
+  // snapshot lands one commit before the sync effect replaces the draft, and
+  // two sortables sharing a uid clobber each other in the dnd-kit registry.
+  const hasDuplicates =
+    new Set(currentTransforms).size !== currentTransforms.length ||
+    new Set(draft[ColumnType.Active]).size !== draft[ColumnType.Active].length
+
+  const draftRef = useRef(draft)
+  // null until the first server snapshot is adopted, so the initial load wins.
+  const adoptedActiveRef = useRef<string[] | null>(null)
+  const dragSessionRef = useRef<DragSession | null>(null)
+  const [dragSession, setDragSession] = useState<DragSession | null>(null)
+  const savingRef = useRef(false)
+
+  const publishDraft = useCallback((next: ChainColumns) => {
+    draftRef.current = next
+    setDraft(next)
+  }, [])
+
+  useEffect(() => {
+    if (!dataReady || dragSessionRef.current) return
+
+    const serverActive = serverChains[ColumnType.Active]
+    const serverChanged =
+      adoptedActiveRef.current === null ||
+      !sameOrder(adoptedActiveRef.current, serverActive)
+
+    // A changed chain is the server's call; a changed candidate list only adds
+    // or removes entries and must not discard the draft order.
+    const next = serverChanged
+      ? serverChains
+      : reconcileCandidates(draftRef.current, candidateUids)
+
+    adoptedActiveRef.current = serverActive
+
+    if (!sameColumns(next, draftRef.current)) {
+      publishDraft(next)
     }
+  }, [serverChains, candidateUids, dragSession, dataReady, publishDraft])
 
-    return left.every((item, index) => item === right[index])
-  }
-
-  const setChainsUidsIfChanged = (
-    updater: (
-      prev: Record<ColumnType, string[]>,
-    ) => Record<ColumnType, string[]>,
-  ) => {
-    setChainsUids((prev) => {
-      const next = updater(prev)
-      const unchanged = COLUMN_TYPES.every((type) =>
-        hasSameOrder(prev[type], next[type]),
-      )
-
-      return unchanged ? prev : next
-    })
-  }
+  // Snapshot the candidates for the duration of a gesture so a refetch cannot
+  // unmount the element being dragged.
+  const renderedProfiles = dragSession?.profiles ?? candidateProfiles
 
   const chains = useMemo(() => {
-    const active = chainsUids[ColumnType.Active]
-      .map((uid) => scriptProfiles.find((item) => item.uid === uid))
+    const active = draft[ColumnType.Active]
+      .map((uid) => renderedProfiles.find((item) => item.uid === uid))
       .filter((item): item is ScriptOrMergeProfile => Boolean(item))
 
-    const inactive = chainsUids[ColumnType.Inactive]
-      .map((uid) => scriptProfiles.find((item) => item.uid === uid))
+    const inactive = draft[ColumnType.Inactive]
+      .map((uid) => renderedProfiles.find((item) => item.uid === uid))
       .filter((item): item is ScriptOrMergeProfile => Boolean(item))
 
     return {
       [ColumnType.Active]: active,
       [ColumnType.Inactive]: inactive,
     }
-  }, [chainsUids, scriptProfiles])
+  }, [draft, renderedProfiles])
 
-  // sync chains with the config item's scoped transforms and scriptProfiles
-  useEffect(() => {
-    const activeSet = new Set(currentTransforms)
-    const nextActive = scriptProfileUids.filter((uid) => activeSet.has(uid))
-    const nextInactive = scriptProfileUids.filter((uid) => !activeSet.has(uid))
+  // Only the active column is persisted, so reordering the inactive one is not
+  // a pending change.
+  const isChanged = !sameOrder(
+    draft[ColumnType.Active],
+    serverChains[ColumnType.Active],
+  )
 
-    setChainsUids((prev) => {
-      const activeUnchanged = hasSameOrder(prev[ColumnType.Active], nextActive)
+  const blockTask = useBlockTask(
+    `update-chain-${profile.uid}`,
+    async (transforms: string[]) => {
+      try {
+        // Rebuild the config definition with the reordered scoped transforms,
+        // preserving every other field, and replace it atomically.
+        const definition: ProfileDefinition_Deserialize = {
+          type: 'config',
+          config: { ...profile.config, transforms },
+        }
 
-      const inactiveUnchanged = hasSameOrder(
-        prev[ColumnType.Inactive],
-        nextInactive,
-      )
-
-      if (activeUnchanged && inactiveUnchanged) {
-        return prev
+        await replaceDefinition.mutateAsync({ uid: profile.uid, definition })
+      } catch (error) {
+        message(`Update failed: \n ${formatError(error)}`, {
+          title: 'Error',
+          kind: 'error',
+        })
       }
+    },
+  )
 
-      return {
-        [ColumnType.Active]: nextActive,
-        [ColumnType.Inactive]: nextInactive,
-      }
-    })
-  }, [scriptProfileUids, currentTransforms])
+  const saving = blockTask.isPending
+  const editable = dataReady && !hasDuplicates
+  const actionsDisabled = !editable || saving || dragSession !== null
 
-  const isChanged = useMemo(() => {
-    const activeSet = new Set(currentTransforms)
-    const baselineActive = scriptProfileUids.filter((uid) => activeSet.has(uid))
-    const baselineInactive = scriptProfileUids.filter(
-      (uid) => !activeSet.has(uid),
-    )
+  const handleApply = async () => {
+    if (!editable || savingRef.current || dragSessionRef.current) return
 
-    return (
-      !hasSameOrder(chainsUids[ColumnType.Active], baselineActive) ||
-      !hasSameOrder(chainsUids[ColumnType.Inactive], baselineInactive)
-    )
-  }, [chainsUids, currentTransforms, scriptProfileUids])
+    savingRef.current = true
 
-  const blockTask = useBlockTask(`update-chain-${profile.uid}`, async () => {
     try {
-      const nextTransforms = chainsUids[ColumnType.Active]
-      // Rebuild the config definition with the reordered scoped transforms,
-      // preserving every other field, and replace it atomically.
-      const definition: ProfileDefinition_Deserialize = {
-        type: 'config',
-        config: { ...profile.config, transforms: nextTransforms },
-      }
+      const next = reconcileCandidates(draftRef.current, candidateUids)
+      if (!sameColumns(next, draftRef.current)) publishDraft(next)
 
-      await replaceDefinition.mutateAsync({ uid: profile.uid, definition })
-    } catch (error) {
-      message(`Update failed: \n ${formatError(error)}`, {
-        title: 'Error',
-        kind: 'error',
-      })
+      await blockTask.execute(next[ColumnType.Active])
+    } finally {
+      savingRef.current = false
     }
-  })
+  }
 
-  const handleApply = useLockFn(blockTask.execute)
+  const handleReset = () => {
+    if (!editable || savingRef.current || dragSessionRef.current) return
+
+    adoptedActiveRef.current = serverChains[ColumnType.Active]
+    publishDraft(serverChains)
+  }
 
   const loadingMessage = m.profile_chain_editor_apply_message()
 
   return (
     <Card className="relative col-span-2 md:col-span-4">
       <AnimatePresence initial={false}>
-        {blockTask.isPending && (
+        {saving && (
           <motion.div
             data-slot="core-manager-card-mask"
             initial={{ opacity: 0 }}
@@ -250,24 +370,86 @@ export default function ChianEditorCard({
         )}
       </AnimatePresence>
 
+      {hasDuplicates && (
+        <CardContent className="pb-0">
+          <p role="alert" className="text-error flex items-start gap-2 text-sm">
+            <WarningRounded className="mt-0.5 size-4 shrink-0" />
+            {m.profile_chain_editor_duplicate_hint()}
+          </p>
+        </CardContent>
+      )}
+
       <CardContent className="grid sm:grid-cols-2">
         <DragDropProvider
+          onBeforeDragStart={(event) => {
+            if (!editable || savingRef.current) event.preventDefault()
+          }}
+          onDragStart={(_event, manager) => {
+            // dnd-kit awaits a render between beforedragstart and dragstart and
+            // its continuation re-checks neither the source nor the editor, so
+            // a save or a correction can have landed in that window.
+            if (!editable || savingRef.current) {
+              manager.actions.stop({ canceled: true })
+              return
+            }
+
+            const session = {
+              columns: draftRef.current,
+              profiles: candidateProfiles,
+            }
+
+            dragSessionRef.current = session
+            setDragSession(session)
+          }}
+          onDragOver={(event) => {
+            // Synchronous and unconditional: the optimistic sorting plugin only
+            // reads defaultPrevented in a microtask, so this reliably stops it
+            // from relocating React-owned nodes into the other column.
+            event.preventDefault()
+
+            if (!dragSessionRef.current || savingRef.current) return
+
+            const next = move(draftRef.current, event)
+            if (!sameColumns(next, draftRef.current)) publishDraft(next)
+          }}
           onDragEnd={(event) => {
-            setChainsUidsIfChanged((prev) => move(prev, event))
+            const session = dragSessionRef.current
+            if (event.canceled && session) publishDraft(session.columns)
+
+            dragSessionRef.current = null
+            setDragSession(null)
           }}
         >
-          <Column profiles={chains.active} type={ColumnType.Active} />
+          <Column
+            profiles={chains.active}
+            type={ColumnType.Active}
+            saving={saving}
+            readOnly={!editable && !dragSession}
+          />
 
-          <Column profiles={chains.inactive} type={ColumnType.Inactive} />
+          <Column
+            profiles={chains.inactive}
+            type={ColumnType.Inactive}
+            saving={saving}
+            readOnly={!editable && !dragSession}
+          />
         </DragDropProvider>
       </CardContent>
 
       <AnimatePresence>
-        {isChanged && (
+        {dataReady && isChanged && (
           <AnimatedItem>
             <CardFooter className="gap-1">
-              <Button className="flex items-center gap-2" onClick={handleApply}>
+              <Button
+                className="flex items-center gap-2"
+                onClick={handleApply}
+                disabled={actionsDisabled}
+              >
                 {m.common_apply()}
+              </Button>
+
+              <Button onClick={handleReset} disabled={actionsDisabled}>
+                {m.common_reset()}
               </Button>
             </CardFooter>
           </AnimatedItem>


### PR DESCRIPTION
Closes #5264.

## Root cause

The two chain-editor columns shared one sortable group (`'chain-editor-sortable'`), which `@dnd-kit` reads as *the list an item belongs to*, not as *which lists may exchange items*. Three failures followed:

- The optimistic sorting plugin saw both columns as a single list and reordered across them. It moves the feedback placeholder, and the placeholder observer then drags the real React-owned `<button>` into the other column's container, so React's `insertBefore` threw `NotFoundError`.
- `move()` resolves a target list with `getRecordKey(items, source.group)`, so a group that is not a key of the state record never resolved.
- The server chain order was rebuilt by filtering the candidate list, discarding the order stored in the config.

Separately, `useProfile()` rebuilds every profile object on each fetch, so the identity-keyed sync effect reset the draft on any refetch, and dirty/apply disagreed about which column counts.

## What changed

- `group` now names the owning column, matching the draft record's keys.
- `onDragOver` calls `preventDefault()` synchronously and unconditionally, then computes the move. The plugin only reads `defaultPrevented` inside a `queueMicrotask`, so this suppresses it deterministically regardless of listener order. **Tradeoff:** item-level optimistic DOM sorting is given up; the preview is driven by React's transition instead.
- Columns get an explicit low `collisionPriority` so a pointer resting on an item is not stolen by the column it sits in.
- Chain order is derived from the config's scoped transforms. The draft yields only when the server chain order actually differs; a changed candidate list is merged into the draft instead of replacing it.
- Only the active column is persisted, so it alone marks the editor dirty. Inactive stays draggable but is not saved.
- The editor is keyed per profile, so a draft cannot leak into another config with an identical baseline.
- Apply and dragging are mutually exclusive through a synchronous guard; `useLockFn` alone does not coordinate them.
- Duplicate transform ids would register two sortables under one id and clobber each other in the registry, so the editor disables itself and explains why. Dangling ids are silently pruned (the backend rejects them wholesale).
- Adds a Reset action, since a draft was previously only undoable by leaving the page.

## Verification

Green: `lint:ts:nyanpasu`, `prettier --check`, `oxlint`.

The pure helpers (`deriveColumns`, `reconcileCandidates`, `sameOrder`, `sameColumns`) were asserted by transpiling the slice verbatim out of the source file — no frontend test framework is introduced here.

The drag-initialization race was probed against the real `@dnd-kit/abstract@0.5.0` manager with a controlled rendering promise, with a negative control: without the `onDragStart` re-check a drag session **is** established while a save is in flight (status `dragging`); with it, `dragend(canceled=true)` fires and the manager returns to `idle`.

## Still to verify in WebView — why this is a draft

None of the runtime checks have been run. Open DevTools for the first three and confirm no `NotFoundError: Failed to execute 'insertBefore'`:

- [ ] Cross-column drag onto an item, both directions
- [ ] Drop onto an empty column's blank area, at ≥`sm` and again at single-column width
- [ ] Move the last item out and back into an empty column
- [ ] Esc mid-drag returns to the pre-drag state with no stray Apply
- [ ] Reordering only the inactive column does **not** offer Apply
- [ ] Server `[B,A]` with candidates `[A,B,C]` opens as `B→A` with no Apply
- [ ] Draft survives a real refetch, and survives adding/deleting a transform profile
- [ ] Keyboard: Space/Enter then arrows across columns
- [ ] Duplicate transform ids disable the editor; correcting them back to one re-enables it with no React duplicate-key warning
- [ ] Drag feel after the unconditional `preventDefault` — if latency is visible, the fallback is to prevent only on cross-column events and keep optimistic sorting within a column

Backend is unchanged: scoped transforms are a `Vec` with no reordering or deduplication, and `replace_definition` does not reorder.
